### PR TITLE
Fix issue when setting instance group named ports

### DIFF
--- a/instances/instances.go
+++ b/instances/instances.go
@@ -63,7 +63,8 @@ func (i *Instances) Init(zl zoneLister) {
 // all of which have the exact same named ports.
 func (i *Instances) AddInstanceGroup(name string, ports []int64) ([]*compute.InstanceGroup, []*compute.NamedPort, error) {
 	igs := []*compute.InstanceGroup{}
-	namedPorts := []*compute.NamedPort{}
+
+	var namedPorts []*compute.NamedPort
 	for _, port := range ports {
 		namedPorts = append(namedPorts, utils.GetNamedPort(port))
 	}
@@ -109,14 +110,14 @@ func (i *Instances) AddInstanceGroup(name string, ports []int64) ([]*compute.Ins
 		var newPorts []*compute.NamedPort
 		for _, np := range namedPorts {
 			if existingPorts[np.Port] {
-				glog.V(3).Infof("Instance group %v already has named port %+v", ig.Name, np)
+				glog.V(5).Infof("Instance group %v already has named port %+v", ig.Name, np)
 				continue
 			}
 			newPorts = append(newPorts, np)
 		}
 		if len(newPorts) > 0 {
-			glog.V(5).Infof("Instance group %v/%v does not have ports %+v, adding them now.", zone, name, namedPorts)
-			if err := i.cloud.SetNamedPortsOfInstanceGroup(ig.Name, zone, append(ig.NamedPorts, namedPorts...)); err != nil {
+			glog.V(3).Infof("Instance group %v/%v does not have ports %+v, adding them now.", zone, name, newPorts)
+			if err := i.cloud.SetNamedPortsOfInstanceGroup(ig.Name, zone, append(ig.NamedPorts, newPorts...)); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/instances/instances_test.go
+++ b/instances/instances_test.go
@@ -86,30 +86,35 @@ func TestSetNamedPorts(t *testing.T) {
 	pool := newNodePool(f, defaultZone)
 
 	testCases := []struct {
-		newPorts      []int64
+		activePorts   []int64
 		expectedPorts []int64
 	}{
 		{
-			// Verify adding a port works as expected.
+			// Verify setting a port works as expected.
 			[]int64{80},
 			[]int64{80},
 		},
 		{
-			// Verify adding multiple ports at once works as expected.
+			// Utilizing multiple new ports
 			[]int64{81, 82},
 			[]int64{80, 81, 82},
 		},
 		{
-			// Adding existing ports should have no impact.
+			// Utilizing existing ports
 			[]int64{80, 82},
 			[]int64{80, 81, 82},
+		},
+		{
+			// Utilizing a new port and an old port
+			[]int64{80, 83},
+			[]int64{80, 81, 82, 83},
 		},
 		// TODO: Add tests to remove named ports when we support that.
 	}
 	for _, test := range testCases {
-		igs, _, err := pool.AddInstanceGroup("ig", test.newPorts)
+		igs, _, err := pool.AddInstanceGroup("ig", test.activePorts)
 		if err != nil {
-			t.Fatalf("unexpected error in adding ports %v to instance group: %s", test.newPorts, err)
+			t.Fatalf("unexpected error in setting ports %v to instance group: %s", test.activePorts, err)
 		}
 		if len(igs) != 1 {
 			t.Fatalf("expected a single instance group, got: %v", igs)


### PR DESCRIPTION
Found an issue regarding the recent change to setting named ports. The wrong list was used when being appended to the instance group's existing list of ports. If you run the added test case, the unit test shows that ports get duplicated. 