### PR TITLE
Minor cleanup to instance group management

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -223,7 +223,7 @@ func (b *Backends) Ensure(svcPorts []ServicePort, igs []*compute.InstanceGroup) 
 			ports = append(ports, p.Port)
 		}
 		var err error
-		igs, _, err = instances.EnsureInstanceGroupsAndPorts(b.nodePool, b.namer, ports)
+		igs, err = instances.EnsureInstanceGroupsAndPorts(b.nodePool, b.namer, ports)
 		if err != nil {
 			return err
 		}

--- a/controller/cluster_manager.go
+++ b/controller/cluster_manager.go
@@ -172,7 +172,7 @@ func (c *ClusterManager) EnsureInstanceGroupsAndPorts(servicePorts []backends.Se
 	for _, p := range servicePorts {
 		ports = append(ports, p.Port)
 	}
-	igs, _, err := instances.EnsureInstanceGroupsAndPorts(c.instancePool, c.ClusterNamer, ports)
+	igs, err := instances.EnsureInstanceGroupsAndPorts(c.instancePool, c.ClusterNamer, ports)
 	return igs, err
 }
 

--- a/controller/utils_test.go
+++ b/controller/utils_test.go
@@ -71,7 +71,7 @@ func TestInstancesAddedToZones(t *testing.T) {
 
 	// Create 2 igs, one per zone.
 	testIG := "test-ig"
-	lbc.CloudClusterManager.instancePool.AddInstanceGroup(testIG, []int64{int64(3001)})
+	lbc.CloudClusterManager.instancePool.EnsureInstanceGroupsAndPorts(testIG, []int64{int64(3001)})
 
 	// node pool syncs kube-nodes, this will add them to both igs.
 	lbc.CloudClusterManager.instancePool.Sync([]string{"n1", "n2", "n3"})

--- a/instances/instances_test.go
+++ b/instances/instances_test.go
@@ -34,7 +34,7 @@ func TestNodePoolSync(t *testing.T) {
 	f := NewFakeInstanceGroups(sets.NewString(
 		[]string{"n1", "n2"}...))
 	pool := newNodePool(f, defaultZone)
-	pool.AddInstanceGroup("test", []int64{80})
+	pool.EnsureInstanceGroupsAndPorts("test", []int64{80})
 
 	// KubeNodes: n1
 	// GCENodes: n1, n2
@@ -53,7 +53,7 @@ func TestNodePoolSync(t *testing.T) {
 
 	f = NewFakeInstanceGroups(sets.NewString([]string{"n1"}...))
 	pool = newNodePool(f, defaultZone)
-	pool.AddInstanceGroup("test", []int64{80})
+	pool.EnsureInstanceGroupsAndPorts("test", []int64{80})
 
 	f.calls = []int{}
 	kubeNodes = sets.NewString([]string{"n1", "n2"}...)
@@ -69,7 +69,7 @@ func TestNodePoolSync(t *testing.T) {
 
 	f = NewFakeInstanceGroups(sets.NewString([]string{"n1", "n2"}...))
 	pool = newNodePool(f, defaultZone)
-	pool.AddInstanceGroup("test", []int64{80})
+	pool.EnsureInstanceGroupsAndPorts("test", []int64{80})
 
 	f.calls = []int{}
 	kubeNodes = sets.NewString([]string{"n1", "n2"}...)
@@ -112,7 +112,7 @@ func TestSetNamedPorts(t *testing.T) {
 		// TODO: Add tests to remove named ports when we support that.
 	}
 	for _, test := range testCases {
-		igs, _, err := pool.AddInstanceGroup("ig", test.activePorts)
+		igs, err := pool.EnsureInstanceGroupsAndPorts("ig", test.activePorts)
 		if err != nil {
 			t.Fatalf("unexpected error in setting ports %v to instance group: %s", test.activePorts, err)
 		}

--- a/instances/interfaces.go
+++ b/instances/interfaces.go
@@ -32,7 +32,7 @@ type NodePool interface {
 	Init(zl zoneLister)
 
 	// The following 2 methods operate on instance groups.
-	AddInstanceGroup(name string, ports []int64) ([]*compute.InstanceGroup, []*compute.NamedPort, error)
+	EnsureInstanceGroupsAndPorts(name string, ports []int64) ([]*compute.InstanceGroup, error)
 	DeleteInstanceGroup(name string) error
 
 	// TODO: Refactor for modularity

--- a/instances/utils.go
+++ b/instances/utils.go
@@ -8,6 +8,6 @@ import (
 
 // Helper method to create instance groups.
 // This method exists to ensure that we are using the same logic at all places.
-func EnsureInstanceGroupsAndPorts(nodePool NodePool, namer *utils.Namer, ports []int64) ([]*compute.InstanceGroup, []*compute.NamedPort, error) {
-	return nodePool.AddInstanceGroup(namer.IGName(), ports)
+func EnsureInstanceGroupsAndPorts(nodePool NodePool, namer *utils.Namer, ports []int64) ([]*compute.InstanceGroup, error) {
+	return nodePool.EnsureInstanceGroupsAndPorts(namer.IGName(), ports)
 }


### PR DESCRIPTION
Changes
- Fixed log line which was previously printing a slice of memory addresses instead of port numbers.
https://github.com/kubernetes/ingress-gce/blob/ef0e824a0250c97298b65b87fbf573898d456642/instances/instances.go#L119
- Renamed "AddInstanceGroup" to "EnsureInstanceGroupsAndPorts" to actually reflect the actions of the func
- Split "EnsureInstanceGroups" and created "EnsureInstanceGroupAndPorts" for the actions on a single instance group.
- Removed unused return variable of nodeports from "EnsureInstanceGroupsAndPorts"