### PR TITLE
Release 0.9.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # 0.0 shouldn't clobber any released builds
-TAG=0.9.6
+TAG=0.9.7
 PREFIX=gcr.io/google_containers/glbc
 PKG=k8s.io/ingress-gce
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ So simply delete the replication controller:
 $ kubectl get rc glbc
 CONTROLLER   CONTAINER(S)           IMAGE(S)                                      SELECTOR                    REPLICAS   AGE
 glbc         default-http-backend   gcr.io/google_containers/defaultbackend:1.0   k8s-app=glbc,version=v0.5   1          2m
-             l7-lb-controller       gcr.io/google_containers/glbc:0.9.6
+             l7-lb-controller       gcr.io/google_containers/glbc:0.9.7
 
 $ kubectl delete rc glbc
 replicationcontroller "glbc" deleted

--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -73,7 +73,7 @@ const (
 	alphaNumericChar = "0"
 
 	// Current docker image version. Only used in debug logging.
-	imageVersion = "glbc:0.9.6"
+	imageVersion = "glbc:0.9.7"
 
 	// Key used to persist UIDs to configmaps.
 	uidConfigMapName = "ingress-uid"

--- a/rc.yaml
+++ b/rc.yaml
@@ -24,18 +24,18 @@ metadata:
   name: l7-lb-controller
   labels:
     k8s-app: glbc
-    version: v0.9.6
+    version: v0.9.7
 spec:
   # There should never be more than 1 controller alive simultaneously.
   replicas: 1
   selector:
     k8s-app: glbc
-    version: v0.9.6
+    version: v0.9.7
   template:
     metadata:
       labels:
         k8s-app: glbc
-        version: v0.9.6
+        version: v0.9.7
         name: glbc
     spec:
       terminationGracePeriodSeconds: 600
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - image: gcr.io/google_containers/glbc:0.9.6
+      - image: gcr.io/google_containers/glbc:0.9.7
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Test Cases
 - [x] Basic ingress creation and deletion
 - [x] Existing ingress & add and removing 2 nodes
 - [x] Apply static IP annotation to ingress
 - [x] Ingress creation/deletion with existing ILB service.
    - @nikhiljindal Found an issue with interop between service controller and MC but it's not a release blocker.
 - [x] Existing ingress and add/remove paths
 - [x] Ingress with TLS secret creation & deletion
 - [x] Ingress with HTTPS backend
 - [x] Multi-zone cluster with multiple concurrent ingresses

Test Clusters
- [x] 1.8
- [x] 1.7 (basic ingress test should be sufficient)
- [ ] 1.6 (basic ingress test should be sufficient)

Areas to check
- Named ports of instance groups
- Instances in instance groups
- URL Map matches ingress rules
- Backend health
- Firewall rule update
- GLBC Log for errors


Temporary image for testing
*nicksardo/glbc:0.9.7*