### PR TITLE
Fix the glbc build by removing 'godeps' from command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX=gcr.io/google_containers/glbc
 PKG=k8s.io/ingress-gce
 
 server:
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o  glbc ${PKG}/cmd/glbc
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o glbc ${PKG}/cmd/glbc
 
 container: server
 	docker build --pull -t $(PREFIX):$(TAG) .


### PR DESCRIPTION
We no longer should invoke 'godeps' after the recent shuffling of repos (ingress -> ingress-gce/ingress-nginx split) and Makefiles.