### PR TITLE
Updating backends/fakes to return 404 in the same way as all other fakes

### DIFF
--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -17,8 +17,6 @@ limitations under the License.
 package backends
 
 import (
-	"fmt"
-
 	compute "google.golang.org/api/compute/v1"
 	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -49,7 +47,7 @@ func (f *FakeBackendServices) GetGlobalBackendService(name string) (*compute.Bac
 	f.calls = append(f.calls, utils.Get)
 	obj, exists, err := f.backendServices.GetByKey(name)
 	if !exists {
-		return nil, fmt.Errorf("backend service %v not found", name)
+		return nil, utils.FakeGoogleAPINotFoundErr()
 	}
 	if err != nil {
 		return nil, err
@@ -59,7 +57,7 @@ func (f *FakeBackendServices) GetGlobalBackendService(name string) (*compute.Bac
 	if name == svc.Name {
 		return svc, nil
 	}
-	return nil, fmt.Errorf("backend service %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateGlobalBackendService fakes backend service creation.
@@ -79,7 +77,7 @@ func (f *FakeBackendServices) DeleteGlobalBackendService(name string) error {
 	f.calls = append(f.calls, utils.Delete)
 	svc, exists, err := f.backendServices.GetByKey(name)
 	if !exists {
-		return fmt.Errorf("backend service %v not found", name)
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 	if err != nil {
 		return err

--- a/pkg/healthchecks/fakes.go
+++ b/pkg/healthchecks/fakes.go
@@ -18,12 +18,9 @@ package healthchecks
 
 import (
 	compute "google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
-)
 
-func fakeNotFoundErr() *googleapi.Error {
-	return &googleapi.Error{Code: 404}
-}
+	"k8s.io/ingress-gce/pkg/utils"
+)
 
 // NewFakeHealthCheckProvider returns a new FakeHealthChecks.
 func NewFakeHealthCheckProvider() *FakeHealthCheckProvider {
@@ -53,13 +50,13 @@ func (f *FakeHealthCheckProvider) GetHttpHealthCheck(name string) (*compute.Http
 		return &hc, nil
 	}
 
-	return nil, fakeNotFoundErr()
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteHttpHealthCheck fakes out deleting a http health check.
 func (f *FakeHealthCheckProvider) DeleteHttpHealthCheck(name string) error {
 	if _, exists := f.http[name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	delete(f.http, name)
@@ -69,7 +66,7 @@ func (f *FakeHealthCheckProvider) DeleteHttpHealthCheck(name string) error {
 // UpdateHttpHealthCheck sends the given health check as an update.
 func (f *FakeHealthCheckProvider) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	if _, exists := f.http[hc.Name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	f.http[hc.Name] = *hc
@@ -90,13 +87,13 @@ func (f *FakeHealthCheckProvider) GetHealthCheck(name string) (*compute.HealthCh
 		return &hc, nil
 	}
 
-	return nil, fakeNotFoundErr()
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteHealthCheck fakes out deleting a http health check.
 func (f *FakeHealthCheckProvider) DeleteHealthCheck(name string) error {
 	if _, exists := f.generic[name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	delete(f.generic, name)
@@ -106,7 +103,7 @@ func (f *FakeHealthCheckProvider) DeleteHealthCheck(name string) error {
 // UpdateHealthCheck sends the given health check as an update.
 func (f *FakeHealthCheckProvider) UpdateHealthCheck(hc *compute.HealthCheck) error {
 	if _, exists := f.generic[hc.Name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	f.generic[hc.Name] = *hc


### PR DESCRIPTION
Updating `pkg/backends/fakes.go` to return 404 when object does not exist.
Verified that all other packages (`pkg/firewalls`, `pkg/healthchecks` and `pkg/instances`) return 404s in the same way.

Updated `pkg/healthchecks/fakes.go` to use the same util method as all other packages.

cc @nicksardo @bowei 