### PR TITLE
Extracting out annotations to a separate package to allow reuse

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	// AllowHTTPKey tells the Ingress controller to allow/block HTTP access.
+	// If either unset or set to true, the controller will create a
+	// forwarding-rule for port 80, and any additional rules based on the TLS
+	// section of the Ingress. If set to false, the controller will only create
+	// rules for port 443 based on the TLS section.
+	AllowHTTPKey = "kubernetes.io/ingress.allow-http"
+
+	// StaticIPNameKey tells the Ingress controller to use a specific GCE
+	// static ip for its forwarding rules. If specified, the Ingress controller
+	// assigns the static ip by this name to the forwarding rules of the given
+	// Ingress. The controller *does not* manage this ip, it is the users
+	// responsibility to create/delete it.
+	StaticIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
+
+	// PreSharedCertKey represents the specific pre-shared SSL
+	// certicate for the Ingress controller to use. The controller *does not*
+	// manage this certificate, it is the users responsibility to create/delete it.
+	// In GCP, the Ingress controller assigns the SSL certificate with this name
+	// to the target proxies of the Ingress.
+	PreSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
+
+	// ServiceApplicationProtocolKey is a stringified JSON map of port names to
+	// protocol strings. Possible values are HTTP, HTTPS
+	// Example:
+	// '{"my-https-port":"HTTPS","my-http-port":"HTTP"}'
+	ServiceApplicationProtocolKey = "service.alpha.kubernetes.io/app-protocols"
+
+	// IngressClassKey picks a specific "class" for the Ingress. The controller
+	// only processes Ingresses with this annotation either unset, or set
+	// to either gceIngessClass or the empty string.
+	IngressClassKey      = "kubernetes.io/ingress.class"
+	GceIngressClass      = "gce"
+	GceMultiIngressClass = "gce-multi-cluster"
+
+	// Label key to denote which GCE zone a Kubernetes node is in.
+	ZoneKey     = "failure-domain.beta.kubernetes.io/zone"
+	DefaultZone = ""
+
+	// InstanceGroupsAnnotationKey is the annotation key used by controller to
+	// specify the name and zone of instance groups created for the ingress.
+	// This is read only for users. Controller will overrite any user updates.
+	// This is only set for ingresses with ingressClass = "gce-multi-cluster"
+	InstanceGroupsAnnotationKey = "ingress.gcp.kubernetes.io/instance-groups"
+)
+
+// IngAnnotations represents ingress annotations.
+type IngAnnotations map[string]string
+
+// AllowHTTP returns the allowHTTP flag. True by default.
+func (ing IngAnnotations) AllowHTTP() bool {
+	val, ok := ing[AllowHTTPKey]
+	if !ok {
+		return true
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return true
+	}
+	return v
+}
+
+// UseNamedTLS returns the name of the GCE SSL certificate. Empty by default.
+func (ing IngAnnotations) UseNamedTLS() string {
+	val, ok := ing[PreSharedCertKey]
+	if !ok {
+		return ""
+	}
+
+	return val
+}
+
+func (ing IngAnnotations) StaticIPName() string {
+	val, ok := ing[StaticIPNameKey]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+func (ing IngAnnotations) IngressClass() string {
+	val, ok := ing[IngressClassKey]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// SvcAnnotations represents Service annotations.
+type SvcAnnotations map[string]string
+
+func (svc SvcAnnotations) ApplicationProtocols() (map[string]utils.AppProtocol, error) {
+	val, ok := svc[ServiceApplicationProtocolKey]
+	if !ok {
+		return map[string]utils.AppProtocol{}, nil
+	}
+
+	var portToProtos map[string]utils.AppProtocol
+	err := json.Unmarshal([]byte(val), &portToProtos)
+
+	// Verify protocol is an accepted value
+	for _, proto := range portToProtos {
+		switch proto {
+		case utils.ProtocolHTTP, utils.ProtocolHTTPS:
+		default:
+			return nil, fmt.Errorf("invalid port application protocol: %v", proto)
+		}
+	}
+
+	return portToProtos, err
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/api"
 
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
@@ -429,7 +430,7 @@ func TestLbChangeStaticIP(t *testing.T) {
 		t.Fatalf("Expected 2 forwarding rules with the same IP.")
 	}
 
-	ing.Annotations = map[string]string{staticIPNameKey: "testip"}
+	ing.Annotations = map[string]string{annotations.StaticIPNameKey: "testip"}
 	cm.fakeLbs.ReserveGlobalAddress(&compute.Address{Name: "testip", Address: "1.2.3.4"})
 
 	// Second sync reassigns 1.2.3.4 to existing forwarding rule (by recreating it)

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -27,6 +27,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -242,7 +243,7 @@ func addNodes(lbc *LoadBalancerController, zoneToNode map[string][]string) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: node,
 					Labels: map[string]string{
-						zoneKey: zone,
+						annotations.ZoneKey: zone,
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -290,13 +291,13 @@ func TestAddInstanceGroupsAnnotation(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		annotations := map[string]string{}
-		err := setInstanceGroupsAnnotation(annotations, c.Igs)
+		ingAnnotations := map[string]string{}
+		err := setInstanceGroupsAnnotation(ingAnnotations, c.Igs)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		if annotations[instanceGroupsAnnotationKey] != c.ExpectedAnnotation {
-			t.Fatalf("Unexpected annotation value: %s, expected: %s", annotations[instanceGroupsAnnotationKey], c.ExpectedAnnotation)
+		if ingAnnotations[annotations.InstanceGroupsAnnotationKey] != c.ExpectedAnnotation {
+			t.Fatalf("Unexpected annotation value: %s, expected: %s", ingAnnotations[annotations.InstanceGroupsAnnotationKey], c.ExpectedAnnotation)
 		}
 	}
 }


### PR DESCRIPTION
Extracting out annotations related code from `pkg/controller/utils.go` into a separate `pkg/annotations` package. This will allow reusing annotation keys rather than duplicating them everywhere.

cc @bowei @nicksardo @csbell @G-Harmon 