### PR TITLE
Add ListGlobalForwardingRules to the LoadBalancers interface.

### DIFF
--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -116,6 +116,12 @@ func (f *FakeLoadBalancers) GetGlobalForwardingRule(name string) (*compute.Forwa
 	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
+func (f *FakeLoadBalancers) ListGlobalForwardingRules() (*compute.ForwardingRuleList, error) {
+	ruleList := &compute.ForwardingRuleList{}
+	ruleList.Items = f.Fw
+	return ruleList, nil
+}
+
 // CreateGlobalForwardingRule fakes forwarding rule creation.
 func (f *FakeLoadBalancers) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
 	f.calls = append(f.calls, "CreateGlobalForwardingRule")

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -31,6 +31,7 @@ type LoadBalancers interface {
 	CreateGlobalForwardingRule(rule *compute.ForwardingRule) error
 	DeleteGlobalForwardingRule(name string) error
 	SetProxyForGlobalForwardingRule(fw, proxy string) error
+	ListGlobalForwardingRules() (*compute.ForwardingRuleList, error)
 
 	// UrlMaps
 	GetUrlMap(name string) (*compute.UrlMap, error)


### PR DESCRIPTION
I have an upcoming commit in the k8s-multicluster-ingress repo where I will use this.

cc @bowei @nicksardo @nikhiljindal 