### PR TITLE
Add build, coverage and report badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # GLBC
 
+[![Build Status](https://travis-ci.org/kubernetes/ingress-gce.svg?branch=master)](https://travis-ci.org/kubernetes/ingress-gce)
+[![Coverage Status](https://coveralls.io/repos/github/kubernetes/ingress-gce/badge.svg?branch=master)](https://coveralls.io/github/kubernetes/ingress-gce?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/ingress-gce)](https://goreportcard.com/report/github.com/kubernetes/ingress-gce)
+
 GLBC is a GCE L7 load balancer controller that manages external loadbalancers configured through the Kubernetes Ingress API.
 
 ## A word to the wise


### PR DESCRIPTION
As what we had for [kubernetes/dns](https://github.com/kubernetes/dns). The coverage result should be available at the next build.