### PR TITLE
Modify VERSION to use "latest" in push-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,6 @@ VERBOSE ?= 0
 include build/rules.mk
 
 # Additional rule to build an image of glbc for e2e testing.
+# TODO(rramkumar): Find a way not to use "latest" as the tag.
 push-e2e:
-	@$(MAKE) --no-print-directory REGISTRY=gcr.io/e2e-ingress-gce CONTAINER_PREFIX=ingress-gce-e2e containers push
+	@$(MAKE) --no-print-directory REGISTRY=gcr.io/e2e-ingress-gce VERSION=latest CONTAINER_PREFIX=ingress-gce-e2e containers push


### PR DESCRIPTION
Using latest as the tag for our e2e testing image will allow the e2e jobs in Prow to simply pull using the tag "latest".  This is not ideal but it fixes our jobs for now. 