### PR TITLE
Sync one ingress

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -28,7 +28,7 @@ import (
 
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller"
-	neg "k8s.io/ingress-gce/pkg/networkendpointgroup"
+	neg "k8s.io/ingress-gce/pkg/neg"
 
 	"k8s.io/ingress-gce/cmd/glbc/app"
 	"k8s.io/ingress-gce/pkg/flags"

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/instances"
-	"k8s.io/ingress-gce/pkg/networkendpointgroup"
+	"k8s.io/ingress-gce/pkg/neg"
 	"k8s.io/ingress-gce/pkg/storage"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -58,7 +58,7 @@ var (
 )
 
 func newTestJig(f BackendServices, fakeIGs instances.InstanceGroups, syncWithCloud bool) (*Backends, healthchecks.HealthCheckProvider) {
-	negGetter := networkendpointgroup.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
+	negGetter := neg.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	nodePool := instances.NewNodePool(fakeIGs, defaultNamer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	healthCheckProvider := healthchecks.NewFakeHealthCheckProvider()
@@ -333,7 +333,7 @@ func TestBackendPoolSync(t *testing.T) {
 func TestBackendPoolDeleteLegacyHealthChecks(t *testing.T) {
 	f := NewFakeBackendServices(noOpErrFunc)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
-	negGetter := networkendpointgroup.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
+	negGetter := neg.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	nodePool := instances.NewNodePool(fakeIGs, defaultNamer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	hcp := healthchecks.NewFakeHealthCheckProvider()
@@ -507,7 +507,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 	namespace, name, port := "ns", "name", "port"
 	f := NewFakeBackendServices(noOpErrFunc)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
-	fakeNEG := networkendpointgroup.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
+	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	nodePool := instances.NewNodePool(fakeIGs, defaultNamer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	hcp := healthchecks.NewFakeHealthCheckProvider()

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -36,14 +36,17 @@ type ControllerContext struct {
 
 // NewControllerContext returns a new shared set of informers.
 func NewControllerContext(kubeClient kubernetes.Interface, namespace string, resyncPeriod time.Duration, enableEndpointsInformer bool) *ControllerContext {
+	newIndexer := func() cache.Indexers {
+		return cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	}
 	context := &ControllerContext{
-		IngressInformer: informerv1beta1.NewIngressInformer(kubeClient, namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
-		ServiceInformer: informerv1.NewServiceInformer(kubeClient, namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
-		PodInformer:     informerv1.NewPodInformer(kubeClient, namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
-		NodeInformer:    informerv1.NewNodeInformer(kubeClient, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}),
+		IngressInformer: informerv1beta1.NewIngressInformer(kubeClient, namespace, resyncPeriod, newIndexer()),
+		ServiceInformer: informerv1.NewServiceInformer(kubeClient, namespace, resyncPeriod, newIndexer()),
+		PodInformer:     informerv1.NewPodInformer(kubeClient, namespace, resyncPeriod, newIndexer()),
+		NodeInformer:    informerv1.NewNodeInformer(kubeClient, resyncPeriod, newIndexer()),
 	}
 	if enableEndpointsInformer {
-		context.EndpointInformer = informerv1.NewEndpointsInformer(kubeClient, namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		context.EndpointInformer = informerv1.NewEndpointsInformer(kubeClient, namespace, resyncPeriod, newIndexer())
 	}
 	return context
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -51,6 +51,26 @@ func NewControllerContext(kubeClient kubernetes.Interface, namespace string, res
 	return context
 }
 
+// HasSynced returns true if all relevant informers has been synced.
+func (ctx *ControllerContext) HasSynced() bool {
+
+	funcs := []func() bool{
+		ctx.IngressInformer.HasSynced,
+		ctx.ServiceInformer.HasSynced,
+		ctx.PodInformer.HasSynced,
+		ctx.NodeInformer.HasSynced,
+	}
+	if ctx.EndpointInformer != nil {
+		funcs = append(funcs, ctx.EndpointInformer.HasSynced)
+	}
+	for _, f := range funcs {
+		if !f() {
+			return false
+		}
+	}
+	return true
+}
+
 // Start all of the informers.
 func (ctx *ControllerContext) Start(stopCh chan struct{}) {
 	go ctx.IngressInformer.Run(stopCh)

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -174,15 +174,17 @@ func (c *ClusterManager) GC(lbNames []string, nodePorts []backends.ServicePort) 
 	}
 
 	// TODO(ingress#120): Move this to the backend pool so it mirrors creation
-	var igErr error
 	if len(lbNames) == 0 {
 		igName := c.ClusterNamer.InstanceGroup()
 		glog.Infof("Deleting instance group %v", igName)
-		igErr = c.instancePool.DeleteInstanceGroup(igName)
+		if err := c.instancePool.DeleteInstanceGroup(igName); err != err {
+			return err
+		}
 	}
-	if igErr != nil {
-		return igErr
+	if len(lbNames) == 0 {
+		c.firewallPool.Shutdown()
 	}
+
 	return nil
 }
 

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -105,6 +105,8 @@ func (c *ClusterManager) shutdown() error {
 // If in performing the checkpoint the cluster manager runs out of quota, a
 // googleapi 403 is returned.
 func (c *ClusterManager) Checkpoint(lbs []*loadbalancers.L7RuntimeInfo, nodeNames []string, backendServicePorts []backends.ServicePort, namedPorts []backends.ServicePort, firewallPorts []int64) ([]*compute.InstanceGroup, error) {
+	glog.V(4).Infof("Checkpoint %q, len(lbs)=%v, len(nodeNames)=%v, lne(backendServicePorts)=%v, len(namedPorts)=%v, len(firewallPorts)=%v", len(lbs), len(nodeNames), len(backendServicePorts), len(namedPorts), len(firewallPorts))
+
 	if len(namedPorts) != 0 {
 		// Add the default backend node port to the list of named ports for instance groups.
 		namedPorts = append(namedPorts, c.defaultBackendNodePort)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -176,7 +176,7 @@ func newPortManager(st, end int, namer *utils.Namer) *nodePortManager {
 // a nodePortManager is supplied, it also adds all backends to the service store
 // with a nodePort acquired through it.
 func addIngress(lbc *LoadBalancerController, ing *extensions.Ingress, pm *nodePortManager) {
-	lbc.ingLister.Store.Add(ing)
+	lbc.ctx.IngressInformer.GetIndexer().Add(ing)
 	if pm == nil {
 		return
 	}
@@ -197,7 +197,7 @@ func addIngress(lbc *LoadBalancerController, ing *extensions.Ingress, pm *nodePo
 			}
 			svcPort.NodePort = int32(pm.getNodePort(path.Backend.ServiceName))
 			svc.Spec.Ports = []api_v1.ServicePort{svcPort}
-			lbc.svcLister.Add(svc)
+			lbc.ctx.ServiceInformer.GetIndexer().Add(svc)
 		}
 	}
 }

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
-	"k8s.io/ingress-gce/pkg/networkendpointgroup"
+	"k8s.io/ingress-gce/pkg/neg"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
@@ -52,7 +52,7 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
 	fakeHCP := healthchecks.NewFakeHealthCheckProvider()
-	fakeNEG := networkendpointgroup.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")
+	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")
 
 	nodePool := instances.NewNodePool(fakeIGs, namer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{"zone-a"}})

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	nodeResyncPeriod = 1 * time.Second
+)
+
+// NodeController synchronizes the state of the nodes to the unmanaged instance
+// groups.
+type NodeController struct {
+	lister cache.Indexer
+	queue  utils.TaskQueue
+	cm     *ClusterManager
+}
+
+// NewNodeController returns a new node update controller.
+func NewNodeController(ctx *context.ControllerContext, cm *ClusterManager) *NodeController {
+	c := &NodeController{
+		lister: ctx.NodeInformer.GetIndexer(),
+		cm:     cm,
+	}
+	c.queue = utils.NewPeriodicTaskQueue("nodes", c.sync)
+
+	ctx.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.queue.Enqueue,
+		DeleteFunc: c.queue.Enqueue,
+	})
+
+	return c
+}
+
+// Run a go routine to process updates for the controller.
+func (c *NodeController) Run(stopCh chan struct{}) {
+	go c.queue.Run(nodeResyncPeriod, stopCh)
+}
+
+// Run a go routine to process updates for the controller.
+func (c *NodeController) Shutdown() {
+	c.queue.Shutdown()
+}
+
+func (c *NodeController) sync(key string) error {
+	nodeNames, err := getReadyNodeNames(listers.NewNodeLister(c.lister))
+	if err != nil {
+		return err
+	}
+	return c.cm.instancePool.Sync(nodeNames)
+}

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -342,9 +342,10 @@ func (t *GCE) GatherFirewallPorts(svcPorts []backends.ServicePort, includeDefaul
 	if includeDefaultBackend {
 		svcPorts = append(svcPorts, *t.bi.DefaultBackendNodePort())
 	}
+
 	portMap := map[int64]bool{}
 	for _, p := range svcPorts {
-		if p.NEGEnabled {
+		if t.negEnabled && p.NEGEnabled {
 			// For NEG backend, need to open firewall to all endpoint target ports
 			// TODO(mixia): refactor firewall syncing into a separate go routine with different trigger.
 			// With NEG, endpoint changes may cause firewall ports to be different if user specifies inconsistent backends.

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/client-go/tools/record"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
@@ -43,14 +44,20 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
+// BackendInfo is an interface to return information about the backends.
 type BackendInfo interface {
 	BackendServiceForPort(port int64) (*compute.BackendService, error)
 	DefaultBackendNodePort() *backends.ServicePort
 }
 
-func New(recorder record.EventRecorder, bi BackendInfo, svcLister cache.Indexer, nodeLister cache.Indexer, podLister cache.Indexer, endpointLister cache.Indexer, negEnabled bool) *GCE {
+type recorderSource interface {
+	Recorder(ns string) record.EventRecorder
+}
+
+// New returns a new ControllerContext.
+func New(recorders recorderSource, bi BackendInfo, svcLister cache.Indexer, nodeLister cache.Indexer, podLister cache.Indexer, endpointLister cache.Indexer, negEnabled bool) *GCE {
 	return &GCE{
-		recorder,
+		recorders,
 		bi,
 		svcLister,
 		nodeLister,
@@ -62,7 +69,8 @@ func New(recorder record.EventRecorder, bi BackendInfo, svcLister cache.Indexer,
 
 // GCE helps with kubernetes -> gce api conversion.
 type GCE struct {
-	recorder       record.EventRecorder
+	recorders recorderSource
+
 	bi             BackendInfo
 	svcLister      cache.Indexer
 	nodeLister     cache.Indexer
@@ -87,7 +95,7 @@ func (t *GCE) ToURLMap(ing *extensions.Ingress) (utils.GCEURLMap, error) {
 				// to all other services under the assumption that the user will
 				// modify nodeport.
 				if _, ok := err.(errors.ErrNodePortNotFound); ok {
-					t.recorder.Eventf(ing, api_v1.EventTypeWarning, "Service", err.(errors.ErrNodePortNotFound).Error())
+					t.recorders.Recorder(ing.Namespace).Eventf(ing, api_v1.EventTypeWarning, "Service", err.(errors.ErrNodePortNotFound).Error())
 					continue
 				}
 
@@ -121,12 +129,14 @@ func (t *GCE) ToURLMap(ing *extensions.Ingress) (utils.GCEURLMap, error) {
 			if _, ok := err.(errors.ErrNodePortNotFound); ok {
 				msg = fmt.Sprintf("couldn't find nodeport for %v/%v", ing.Namespace, ing.Spec.Backend.ServiceName)
 			}
-			t.recorder.Eventf(ing, api_v1.EventTypeWarning, "Service", fmt.Sprintf("failed to identify user specified default backend, %v, using system default", msg))
+			msg = fmt.Sprintf("failed to identify user specified default backend, %v, using system default", msg)
+			t.recorders.Recorder(ing.Namespace).Eventf(ing, api_v1.EventTypeWarning, "Service", msg)
 		} else if defaultBackend != nil {
-			t.recorder.Eventf(ing, api_v1.EventTypeNormal, "Service", fmt.Sprintf("default backend set to %v:%v", ing.Spec.Backend.ServiceName, defaultBackend.Port))
+			msg := fmt.Sprintf("default backend set to %v:%v", ing.Spec.Backend.ServiceName, defaultBackend.Port)
+			t.recorders.Recorder(ing.Namespace).Eventf(ing, api_v1.EventTypeNormal, "Service", msg)
 		}
 	} else {
-		t.recorder.Eventf(ing, api_v1.EventTypeNormal, "Service", "no user specified default backend, using system default")
+		t.recorders.Recorder(ing.Namespace).Eventf(ing, api_v1.EventTypeNormal, "Service", "no user specified default backend, using system default")
 	}
 	hostPathBackend.PutDefaultBackend(defaultBackend)
 	return hostPathBackend, nil

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	unversionedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 
@@ -63,7 +62,7 @@ func gceForTest(negEnabled bool) *GCE {
 
 	ctx := context.NewControllerContext(client, apiv1.NamespaceAll, 1*time.Second, negEnabled)
 	gce := &GCE{
-		recorder:   broadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{Component: "loadbalancer-controller"}),
+		recorders:  ctx,
 		bi:         &fakeBackendInfo{},
 		svcLister:  ctx.ServiceInformer.GetIndexer(),
 		nodeLister: ctx.NodeInformer.GetIndexer(),

--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -54,6 +54,7 @@ func NewFirewallPool(cloud Firewall, namer *utils.Namer) SingleFirewallPool {
 
 // Sync sync firewall rules with the cloud.
 func (fr *FirewallRules) Sync(nodePorts []int64, nodeNames []string) error {
+	glog.V(4).Infof("Sync(%v, %v)", nodePorts, nodeNames)
 	if len(nodePorts) == 0 {
 		return fr.Shutdown()
 	}
@@ -99,7 +100,7 @@ func (fr *FirewallRules) Sync(nodePorts []int64, nodeNames []string) error {
 // Shutdown shuts down this firewall rules manager.
 func (fr *FirewallRules) Shutdown() error {
 	name := fr.namer.FirewallRule()
-	glog.Infof("Deleting firewall %v", name)
+	glog.V(0).Infof("Deleting firewall %v", name)
 	return fr.deleteFirewall(name)
 }
 

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/golang/glog"
@@ -32,12 +31,10 @@ import (
 
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
-	"k8s.io/ingress-gce/pkg/storage"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
 const (
-
 	// The gce api uses the name of a path rule to match a host rule.
 	hostRulePrefix = "host"
 
@@ -52,183 +49,6 @@ const (
 	httpDefaultPortRange  = "80-80"
 	httpsDefaultPortRange = "443-443"
 )
-
-// L7s implements LoadBalancerPool.
-type L7s struct {
-	cloud       LoadBalancers
-	snapshotter storage.Snapshotter
-	// TODO: Remove this field and always ask the BackendPool using the NodePort.
-	glbcDefaultBackend     *compute.BackendService
-	defaultBackendPool     backends.BackendPool
-	defaultBackendNodePort backends.ServicePort
-	namer                  *utils.Namer
-}
-
-// GLBCDefaultBackend returns the BackendService used when no path
-// rules match.
-func (l *L7s) GLBCDefaultBackend() *compute.BackendService {
-	return l.glbcDefaultBackend
-}
-
-// Namer returns the namer associated with the L7s.
-func (l *L7s) Namer() *utils.Namer {
-	return l.namer
-}
-
-// NewLoadBalancerPool returns a new loadbalancer pool.
-// - cloud: implements LoadBalancers. Used to sync L7 loadbalancer resources
-//	 with the cloud.
-// - defaultBackendPool: a BackendPool used to manage the GCE BackendService for
-//   the default backend.
-// - defaultBackendNodePort: The nodePort of the Kubernetes service representing
-//   the default backend.
-func NewLoadBalancerPool(
-	cloud LoadBalancers,
-	defaultBackendPool backends.BackendPool,
-	defaultBackendNodePort backends.ServicePort, namer *utils.Namer) LoadBalancerPool {
-	return &L7s{cloud, storage.NewInMemoryPool(), nil, defaultBackendPool, defaultBackendNodePort, namer}
-}
-
-func (l *L7s) create(ri *L7RuntimeInfo) (*L7, error) {
-	if l.glbcDefaultBackend == nil {
-		glog.Warningf("Creating l7 without a default backend")
-	}
-	return &L7{
-		runtimeInfo:        ri,
-		Name:               l.namer.LoadBalancer(ri.Name),
-		cloud:              l.cloud,
-		glbcDefaultBackend: l.glbcDefaultBackend,
-		namer:              l.namer,
-		sslCert:            nil,
-	}, nil
-}
-
-// Get returns the loadbalancer by name.
-func (l *L7s) Get(name string) (*L7, error) {
-	name = l.namer.LoadBalancer(name)
-	lb, exists := l.snapshotter.Get(name)
-	if !exists {
-		return nil, fmt.Errorf("loadbalancer %v not in pool", name)
-	}
-	return lb.(*L7), nil
-}
-
-// Add gets or creates a loadbalancer.
-// If the loadbalancer already exists, it checks that its edges are valid.
-func (l *L7s) Add(ri *L7RuntimeInfo) (err error) {
-	name := l.namer.LoadBalancer(ri.Name)
-
-	lb, _ := l.Get(name)
-	if lb == nil {
-		glog.Infof("Creating l7 %v", name)
-		lb, err = l.create(ri)
-		if err != nil {
-			return err
-		}
-	} else {
-		if !reflect.DeepEqual(lb.runtimeInfo, ri) {
-			glog.Infof("LB %v runtime info changed, old %+v new %+v", lb.Name, lb.runtimeInfo, ri)
-			lb.runtimeInfo = ri
-		}
-	}
-	// Add the lb to the pool, in case we create an UrlMap but run out
-	// of quota in creating the ForwardingRule we still need to cleanup
-	// the UrlMap during GC.
-	defer l.snapshotter.Add(name, lb)
-
-	// Why edge hop for the create?
-	// The loadbalancer is a fictitious resource, it doesn't exist in gce. To
-	// make it exist we need to create a collection of gce resources, done
-	// through the edge hop.
-	if err := lb.edgeHop(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Delete deletes a loadbalancer by name.
-func (l *L7s) Delete(name string) error {
-	name = l.namer.LoadBalancer(name)
-	lb, err := l.Get(name)
-	if err != nil {
-		return err
-	}
-	glog.Infof("Deleting lb %v", name)
-	if err := lb.Cleanup(); err != nil {
-		return err
-	}
-	l.snapshotter.Delete(name)
-	return nil
-}
-
-// Sync loadbalancers with the given runtime info from the controller.
-func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
-	glog.V(3).Infof("Syncing loadbalancers %v", lbs)
-
-	if len(lbs) != 0 {
-		// Lazily create a default backend so we don't tax users who don't care
-		// about Ingress by consuming 1 of their 3 GCE BackendServices. This
-		// BackendService is GC'd when there are no more Ingresses.
-		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
-			return err
-		}
-		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.Port)
-		if err != nil {
-			return err
-		}
-		l.glbcDefaultBackend = defaultBackend
-	}
-	// create new loadbalancers, validate existing
-	for _, ri := range lbs {
-		if err := l.Add(ri); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// GC garbage collects loadbalancers not in the input list.
-func (l *L7s) GC(names []string) error {
-	knownLoadBalancers := sets.NewString()
-	for _, n := range names {
-		knownLoadBalancers.Insert(l.namer.LoadBalancer(n))
-	}
-	pool := l.snapshotter.Snapshot()
-
-	// Delete unknown loadbalancers
-	for name := range pool {
-		if knownLoadBalancers.Has(name) {
-			continue
-		}
-		glog.V(3).Infof("GCing loadbalancer %v", name)
-		if err := l.Delete(name); err != nil {
-			return err
-		}
-	}
-	// Tear down the default backend when there are no more loadbalancers.
-	// This needs to happen after we've deleted all url-maps that might be
-	// using it.
-	if len(names) == 0 {
-		if err := l.defaultBackendPool.Delete(l.defaultBackendNodePort.Port); err != nil {
-			return err
-		}
-		l.glbcDefaultBackend = nil
-	}
-	return nil
-}
-
-// Shutdown logs whether or not the pool is empty.
-func (l *L7s) Shutdown() error {
-	if err := l.GC([]string{}); err != nil {
-		return err
-	}
-	if err := l.defaultBackendPool.Shutdown(); err != nil {
-		return err
-	}
-	glog.Infof("Loadbalancer pool shutdown.")
-	return nil
-}
 
 // TLSCerts encapsulates .pem encoded TLS information.
 type TLSCerts struct {

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/ingress-gce/pkg/backends"
+	"k8s.io/ingress-gce/pkg/storage"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// L7s implements LoadBalancerPool.
+type L7s struct {
+	cloud       LoadBalancers
+	snapshotter storage.Snapshotter
+	// TODO: Remove this field and always ask the BackendPool using the NodePort.
+	glbcDefaultBackend     *compute.BackendService
+	defaultBackendPool     backends.BackendPool
+	defaultBackendNodePort backends.ServicePort
+	namer                  *utils.Namer
+}
+
+// GLBCDefaultBackend returns the BackendService used when no path
+// rules match.
+func (l *L7s) GLBCDefaultBackend() *compute.BackendService {
+	return l.glbcDefaultBackend
+}
+
+// Namer returns the namer associated with the L7s.
+func (l *L7s) Namer() *utils.Namer {
+	return l.namer
+}
+
+// NewLoadBalancerPool returns a new loadbalancer pool.
+// - cloud: implements LoadBalancers. Used to sync L7 loadbalancer resources
+//	 with the cloud.
+// - defaultBackendPool: a BackendPool used to manage the GCE BackendService for
+//   the default backend.
+// - defaultBackendNodePort: The nodePort of the Kubernetes service representing
+//   the default backend.
+func NewLoadBalancerPool(
+	cloud LoadBalancers,
+	defaultBackendPool backends.BackendPool,
+	defaultBackendNodePort backends.ServicePort, namer *utils.Namer) LoadBalancerPool {
+	return &L7s{cloud, storage.NewInMemoryPool(), nil, defaultBackendPool, defaultBackendNodePort, namer}
+}
+
+func (l *L7s) create(ri *L7RuntimeInfo) (*L7, error) {
+	if l.glbcDefaultBackend == nil {
+		glog.Warningf("Creating l7 without a default backend")
+	}
+	return &L7{
+		runtimeInfo:        ri,
+		Name:               l.namer.LoadBalancer(ri.Name),
+		cloud:              l.cloud,
+		glbcDefaultBackend: l.glbcDefaultBackend,
+		namer:              l.namer,
+		sslCert:            nil,
+	}, nil
+}
+
+// Get returns the loadbalancer by name.
+func (l *L7s) Get(name string) (*L7, error) {
+	name = l.namer.LoadBalancer(name)
+	lb, exists := l.snapshotter.Get(name)
+	if !exists {
+		return nil, fmt.Errorf("loadbalancer %v not in pool", name)
+	}
+	return lb.(*L7), nil
+}
+
+// Add gets or creates a loadbalancer.
+// If the loadbalancer already exists, it checks that its edges are valid.
+func (l *L7s) Add(ri *L7RuntimeInfo) (err error) {
+	name := l.namer.LoadBalancer(ri.Name)
+
+	lb, _ := l.Get(name)
+	if lb == nil {
+		glog.Infof("Creating l7 %v", name)
+		lb, err = l.create(ri)
+		if err != nil {
+			return err
+		}
+	} else {
+		if !reflect.DeepEqual(lb.runtimeInfo, ri) {
+			glog.Infof("LB %v runtime info changed, old %+v new %+v", lb.Name, lb.runtimeInfo, ri)
+			lb.runtimeInfo = ri
+		}
+	}
+	// Add the lb to the pool, in case we create an UrlMap but run out
+	// of quota in creating the ForwardingRule we still need to cleanup
+	// the UrlMap during GC.
+	defer l.snapshotter.Add(name, lb)
+
+	// Why edge hop for the create?
+	// The loadbalancer is a fictitious resource, it doesn't exist in gce. To
+	// make it exist we need to create a collection of gce resources, done
+	// through the edge hop.
+	if err := lb.edgeHop(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete deletes a loadbalancer by name.
+func (l *L7s) Delete(name string) error {
+	name = l.namer.LoadBalancer(name)
+	lb, err := l.Get(name)
+	if err != nil {
+		return err
+	}
+	glog.Infof("Deleting lb %v", name)
+	if err := lb.Cleanup(); err != nil {
+		return err
+	}
+	l.snapshotter.Delete(name)
+	return nil
+}
+
+// Sync loadbalancers with the given runtime info from the controller.
+func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
+	glog.V(3).Infof("Syncing loadbalancers %v", lbs)
+
+	if len(lbs) != 0 {
+		// Lazily create a default backend so we don't tax users who don't care
+		// about Ingress by consuming 1 of their 3 GCE BackendServices. This
+		// BackendService is GC'd when there are no more Ingresses.
+		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
+			return err
+		}
+		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.Port)
+		if err != nil {
+			return err
+		}
+		l.glbcDefaultBackend = defaultBackend
+	}
+	// create new loadbalancers, validate existing
+	for _, ri := range lbs {
+		if err := l.Add(ri); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GC garbage collects loadbalancers not in the input list.
+func (l *L7s) GC(names []string) error {
+	glog.V(4).Infof("GC(%v)", names)
+
+	knownLoadBalancers := sets.NewString()
+	for _, n := range names {
+		knownLoadBalancers.Insert(l.namer.LoadBalancer(n))
+	}
+	pool := l.snapshotter.Snapshot()
+
+	// Delete unknown loadbalancers
+	for name := range pool {
+		if knownLoadBalancers.Has(name) {
+			continue
+		}
+		glog.V(2).Infof("GCing loadbalancer %v", name)
+		if err := l.Delete(name); err != nil {
+			return err
+		}
+	}
+	// Tear down the default backend when there are no more loadbalancers.
+	// This needs to happen after we've deleted all url-maps that might be
+	// using it.
+	if len(names) == 0 {
+		if err := l.defaultBackendPool.Delete(l.defaultBackendNodePort.Port); err != nil {
+			return err
+		}
+		l.glbcDefaultBackend = nil
+	}
+	return nil
+}
+
+// Shutdown logs whether or not the pool is empty.
+func (l *L7s) Shutdown() error {
+	if err := l.GC([]string{}); err != nil {
+		return err
+	}
+	if err := l.defaultBackendPool.Shutdown(); err != nil {
+		return err
+	}
+	glog.Infof("Loadbalancer pool shutdown.")
+	return nil
+}

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/instances"
-	"k8s.io/ingress-gce/pkg/networkendpointgroup"
+	"k8s.io/ingress-gce/pkg/neg"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
@@ -43,7 +43,7 @@ func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T, namer *utils.Namer) 
 	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
 	fakeHCP := healthchecks.NewFakeHealthCheckProvider()
-	fakeNEG := networkendpointgroup.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")
+	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")
 	healthChecker := healthchecks.NewHealthChecker(fakeHCP, "/", namer)
 	nodePool := instances.NewNodePool(fakeIGs, namer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"fmt"
@@ -77,7 +77,7 @@ func NewController(
 		Interface: kubeClient.Core().Events(""),
 	})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme,
-		apiv1.EventSource{Component: "networkendpointgroup-controller"})
+		apiv1.EventSource{Component: "neg-controller"})
 
 	manager := newSyncerManager(namer,
 		recorder,

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"testing"

--- a/pkg/neg/fakes.go
+++ b/pkg/neg/fakes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"fmt"

--- a/pkg/neg/interfaces.go
+++ b/pkg/neg/interfaces.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	computealpha "google.golang.org/api/compute/v0.alpha"

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"fmt"

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"testing"

--- a/pkg/neg/syncer.go
+++ b/pkg/neg/syncer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package networkendpointgroup
+package neg
 
 import (
 	"fmt"

--- a/pkg/neg/syncer_test.go
+++ b/pkg/neg/syncer_test.go
@@ -1,4 +1,4 @@
-package networkendpointgroup
+package neg
 
 import (
 	"reflect"


### PR DESCRIPTION
A bunch of patches:
* A lot of clean up and movement
* Sync one ingress (as opposed to all) in Checkpoint
* Call GC explicitly when an Ingress is deleted
* Shutdown() firewall when there are no more Ingresses