### PR TITLE
Remove some vars from make push-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ include build/rules.mk
 # Additional rule to build an image of glbc for e2e testing.
 # TODO(rramkumar): Find a way not to use "latest" as the tag.
 push-e2e:
-	@$(MAKE) --no-print-directory REGISTRY=gcr.io/e2e-ingress-gce VERSION=latest CONTAINER_PREFIX=ingress-gce-e2e containers push
+	@$(MAKE) --no-print-directory CONTAINER_PREFIX=ingress-gce-e2e containers push


### PR DESCRIPTION
We now pass these vars through inside of the e2e job config so they are no longer needed in the Makefile.

/assign @bowei 