### PR TITLE
Always set -logtostderr (this matches the original behavior)

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -42,6 +42,10 @@ func main() {
 		flag.Set("v", "4")
 	}
 
+	// TODO: remove this when we do a release so the -logtostderr can be
+	// used as a proper argument.
+	go_flag.Lookup("logtostderr").Value.Set("true")
+
 	if flags.F.Version {
 		fmt.Printf("Controller version: %s\n", version.Version)
 		os.Exit(0)


### PR DESCRIPTION
We will remove this when a release can be cut to support logging to
stderr.