### PR TITLE
Sync ingress-specific backends and minor logging changes

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -338,7 +338,7 @@ func (t *GCE) getHTTPProbe(svc api_v1.Service, targetPort intstr.IntOrString, pr
 				}
 			}
 		}
-		glog.V(4).Infof("%v: lacks a matching HTTP probe for use in health checks.", logStr)
+		glog.V(5).Infof("%v: lacks a matching HTTP probe for use in health checks.", logStr)
 	}
 	return nil, nil
 }


### PR DESCRIPTION

## Changes
- Backend service pool only syncs the list of service ports used for the respective ingress.
- Consolidate all ingress references to a single object which was deep copied.
- Changing log level of a frequently printed line from 4->5.
- Minor modifications to event handlers

#### Example with two ingresses in separate namespaces:
Before
```
# While syncing any ingress
I0205 23:03:18.031082       1 backends.go:216] Sync: backends [{30466 HTTP testing/my-echo-svc {1 0 my-http-port}} {32349 HTTP default/my-echo-svc {1 0 my-http-port}}]
```

After
```
# While syncing default/my-echo-svc
I0205 22:59:43.566574       1 backends.go:224] Sync: backends [{32349 HTTP default/my-echo-svc {1 0 my-http-port} 80 false}]
# While syncing testing/my-echo-svc
I0205 22:59:45.215794       1 backends.go:224] Sync: backends [{30466 HTTP testing/my-echo-svc {1 0 my-http-port} 80 false}]
```