### PR TITLE
Rename Port to NodePort

### DIFF
--- a/cmd/glbc/app/init.go
+++ b/cmd/glbc/app/init.go
@@ -53,7 +53,7 @@ func DefaultBackendServicePort(kubeClient kubernetes.Interface) *backends.Servic
 	}
 
 	return &backends.ServicePort{
-		Port:     int64(nodePort),
+		NodePort: int64(nodePort),
 		Protocol: annotations.ProtocolHTTP, // The default backend is HTTP.
 		SvcName:  types.NamespacedName{Namespace: parts[0], Name: parts[1]},
 		SvcPort:  intstr.FromInt(int(port)),

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -64,7 +64,7 @@ func newTestJig(f BackendServices, fakeIGs instances.InstanceGroups, syncWithClo
 	healthCheckProvider := healthchecks.NewFakeHealthCheckProvider()
 	healthChecks := healthchecks.NewHealthChecker(healthCheckProvider, "/", defaultNamer)
 	bp := NewBackendPool(f, negGetter, healthChecks, nodePool, defaultNamer, []int64{}, syncWithCloud)
-	probes := map[ServicePort]*api_v1.Probe{{Port: 443, Protocol: annotations.ProtocolHTTPS}: existingProbe}
+	probes := map[ServicePort]*api_v1.Probe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS}: existingProbe}
 	bp.Init(NewFakeProbeProvider(probes))
 
 	return bp, healthCheckProvider
@@ -76,54 +76,54 @@ func TestBackendPoolAdd(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	testCases := []ServicePort{
-		{Port: 80, Protocol: annotations.ProtocolHTTP},
-		{Port: 443, Protocol: annotations.ProtocolHTTPS},
+		{NodePort: 80, Protocol: annotations.ProtocolHTTP},
+		{NodePort: 443, Protocol: annotations.ProtocolHTTPS},
 	}
 
-	for _, nodePort := range testCases {
+	for _, sp := range testCases {
 		// For simplicity, these tests use 80/443 as nodeports
-		t.Run(fmt.Sprintf("Port:%v Protocol:%v", nodePort.Port, nodePort.Protocol), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Port:%v Protocol:%v", sp.NodePort, sp.Protocol), func(t *testing.T) {
 			// Add a backend for a port, then re-add the same port and
 			// make sure it corrects a broken link from the backend to
 			// the instance group.
-			err := pool.Ensure([]ServicePort{nodePort}, nil)
+			err := pool.Ensure([]ServicePort{sp}, nil)
 			if err != nil {
-				t.Fatalf("Did not find expect error when adding a nodeport: %v, err: %v", nodePort, err)
+				t.Fatalf("Did not find expect error when adding a nodeport: %v, err: %v", sp, err)
 			}
-			beName := defaultNamer.Backend(nodePort.Port)
+			beName := defaultNamer.Backend(sp.NodePort)
 
 			// Check that the new backend has the right port
 			be, err := f.GetGlobalBackendService(beName)
 			if err != nil {
 				t.Fatalf("Did not find expected backend %v", beName)
 			}
-			if be.Port != nodePort.Port {
-				t.Fatalf("Backend %v has wrong port %v, expected %v", be.Name, be.Port, nodePort)
+			if be.Port != sp.NodePort {
+				t.Fatalf("Backend %v has wrong port %v, expected %v", be.Name, be.Port, sp)
 			}
 
 			// Check that the instance group has the new port.
 			ig, err := fakeIGs.GetInstanceGroup(defaultNamer.InstanceGroup(), defaultZone)
 			var found bool
 			for _, port := range ig.NamedPorts {
-				if port.Port == nodePort.Port {
+				if port.Port == sp.NodePort {
 					found = true
 				}
 			}
 			if !found {
-				t.Fatalf("Port %v not added to instance group", nodePort)
+				t.Fatalf("Port %v not added to instance group", sp)
 			}
 
 			// Check the created healthcheck is the correct protocol
-			hc, err := pool.healthChecker.Get(nodePort.Port, false)
+			hc, err := pool.healthChecker.Get(sp.NodePort, false)
 			if err != nil {
 				t.Fatalf("Unexpected err when querying fake healthchecker: %v", err)
 			}
 
-			if hc.Protocol() != nodePort.Protocol {
-				t.Fatalf("Healthcheck scheme does not match nodeport scheme: hc:%v np:%v", hc.Protocol(), nodePort.Protocol)
+			if hc.Protocol() != sp.Protocol {
+				t.Fatalf("Healthcheck scheme does not match nodeport scheme: hc:%v np:%v", hc.Protocol(), sp.Protocol)
 			}
 
-			if nodePort.Port == 443 && hc.RequestPath != "/my-special-path" {
+			if sp.NodePort == 443 && hc.RequestPath != "/my-special-path" {
 				t.Fatalf("Healthcheck for 443 should have special request path from probe")
 			}
 		})
@@ -135,11 +135,11 @@ func TestHealthCheckMigration(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, hcp := newTestJig(f, fakeIGs, false)
 
-	p := ServicePort{Port: 7000, Protocol: annotations.ProtocolHTTP}
+	p := ServicePort{NodePort: 7000, Protocol: annotations.ProtocolHTTP}
 
 	// Create a legacy health check and insert it into the HC provider.
 	legacyHC := &compute.HttpHealthCheck{
-		Name:               defaultNamer.Backend(p.Port),
+		Name:               defaultNamer.Backend(p.NodePort),
 		RequestPath:        "/my-healthz-path",
 		Host:               "k8s.io",
 		Description:        "My custom HC",
@@ -152,7 +152,7 @@ func TestHealthCheckMigration(t *testing.T) {
 	pool.Ensure([]ServicePort{p}, nil)
 
 	// Assert the proper health check was created
-	hc, _ := pool.healthChecker.Get(p.Port, false)
+	hc, _ := pool.healthChecker.Get(p.NodePort, false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -172,9 +172,9 @@ func TestBackendPoolUpdate(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, false)
 
-	p := ServicePort{Port: 3000, Protocol: annotations.ProtocolHTTP}
+	p := ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP}
 	pool.Ensure([]ServicePort{p}, nil)
-	beName := defaultNamer.Backend(p.Port)
+	beName := defaultNamer.Backend(p.NodePort)
 
 	be, err := f.GetGlobalBackendService(beName)
 	if err != nil {
@@ -186,7 +186,7 @@ func TestBackendPoolUpdate(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := pool.healthChecker.Get(p.Port, false)
+	hc, _ := pool.healthChecker.Get(p.NodePort, false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -206,7 +206,7 @@ func TestBackendPoolUpdate(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = pool.healthChecker.Get(p.Port, false)
+	hc, _ = pool.healthChecker.Get(p.NodePort, false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -217,9 +217,9 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, false)
 
-	nodePort := ServicePort{Port: 8080, Protocol: annotations.ProtocolHTTP}
-	pool.Ensure([]ServicePort{nodePort}, nil)
-	beName := defaultNamer.Backend(nodePort.Port)
+	sp := ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP}
+	pool.Ensure([]ServicePort{sp}, nil)
+	beName := defaultNamer.Backend(sp.NodePort)
 
 	be, _ := f.GetGlobalBackendService(beName)
 
@@ -231,7 +231,7 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	f.calls = []int{}
 	f.UpdateGlobalBackendService(be)
 
-	pool.Ensure([]ServicePort{nodePort}, nil)
+	pool.Ensure([]ServicePort{sp}, nil)
 	for _, call := range f.calls {
 		if call == utils.Create {
 			t.Fatalf("Unexpected create for existing backend service")
@@ -260,12 +260,12 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 func TestBackendPoolSync(t *testing.T) {
 	// Call sync on a backend pool with a list of ports, make sure the pool
 	// creates/deletes required ports.
-	svcNodePorts := []ServicePort{{Port: 81, Protocol: annotations.ProtocolHTTP}, {Port: 82, Protocol: annotations.ProtocolHTTPS}, {Port: 83, Protocol: annotations.ProtocolHTTP}}
+	svcNodePorts := []ServicePort{{NodePort: 81, Protocol: annotations.ProtocolHTTP}, {NodePort: 82, Protocol: annotations.ProtocolHTTPS}, {NodePort: 83, Protocol: annotations.ProtocolHTTP}}
 	f := NewFakeBackendServices(noOpErrFunc)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, true)
-	pool.Ensure([]ServicePort{{Port: 81}}, nil)
-	pool.Ensure([]ServicePort{{Port: 90}}, nil)
+	pool.Ensure([]ServicePort{{NodePort: 81}}, nil)
+	pool.Ensure([]ServicePort{{NodePort: 90}}, nil)
 	if err := pool.Ensure(svcNodePorts, nil); err != nil {
 		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
@@ -276,19 +276,19 @@ func TestBackendPoolSync(t *testing.T) {
 		t.Fatalf("Did not expect to find port 90")
 	}
 	for _, port := range svcNodePorts {
-		if _, err := pool.Get(port.Port); err != nil {
+		if _, err := pool.Get(port.NodePort); err != nil {
 			t.Fatalf("Expected to find port %v", port)
 		}
 	}
 
-	svcNodePorts = []ServicePort{{Port: 81}}
-	deletedPorts := []ServicePort{{Port: 82}, {Port: 83}}
+	svcNodePorts = []ServicePort{{NodePort: 81}}
+	deletedPorts := []ServicePort{{NodePort: 82}, {NodePort: 83}}
 	if err := pool.GC(svcNodePorts); err != nil {
 		t.Fatalf("Expected backend pool to GC, err: %v", err)
 	}
 
 	for _, port := range deletedPorts {
-		if _, err := pool.Get(port.Port); err == nil {
+		if _, err := pool.Get(port.NodePort); err == nil {
 			t.Fatalf("Pool contains %v after deletion", port)
 		}
 	}
@@ -304,7 +304,7 @@ func TestBackendPoolSync(t *testing.T) {
 	}
 
 	// This backend should get deleted again since it is managed by this cluster.
-	f.CreateGlobalBackendService(&compute.BackendService{Name: defaultNamer.Backend(deletedPorts[0].Port)})
+	f.CreateGlobalBackendService(&compute.BackendService{Name: defaultNamer.Backend(deletedPorts[0].NodePort)})
 
 	// TODO: Avoid casting.
 	// Repopulate the pool with a cloud list, which now includes the 82 port
@@ -364,7 +364,7 @@ func TestBackendPoolDeleteLegacyHealthChecks(t *testing.T) {
 	})
 
 	// Have pool sync the above backend service
-	bp.Ensure([]ServicePort{{Port: 80, Protocol: annotations.ProtocolHTTPS}}, nil)
+	bp.Ensure([]ServicePort{{NodePort: 80, Protocol: annotations.ProtocolHTTPS}}, nil)
 
 	// Verify the legacy health check has been deleted
 	_, err = hcp.GetHttpHealthCheck(beName)
@@ -390,7 +390,7 @@ func TestBackendPoolShutdown(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	// Add a backend-service and verify that it doesn't exist after Shutdown()
-	pool.Ensure([]ServicePort{{Port: 80}}, nil)
+	pool.Ensure([]ServicePort{{NodePort: 80}}, nil)
 	pool.Shutdown()
 	if _, err := f.GetGlobalBackendService(defaultNamer.Backend(80)); err == nil {
 		t.Fatalf("%v", err)
@@ -403,7 +403,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	// This will add the instance group k8s-ig to the instance pool
-	pool.Ensure([]ServicePort{{Port: 80}}, nil)
+	pool.Ensure([]ServicePort{{NodePort: 80}}, nil)
 
 	be, err := f.GetGlobalBackendService(defaultNamer.Backend(80))
 	if err != nil {
@@ -421,7 +421,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	}
 
 	// Make sure repeated adds don't clobber the inserted instance group
-	pool.Ensure([]ServicePort{{Port: 80}}, nil)
+	pool.Ensure([]ServicePort{{NodePort: 80}}, nil)
 	be, err = f.GetGlobalBackendService(defaultNamer.Backend(80))
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -445,7 +445,7 @@ func TestBackendCreateBalancingMode(t *testing.T) {
 	f := NewFakeBackendServices(noOpErrFunc)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, false)
-	nodePort := ServicePort{Port: 8080}
+	sp := ServicePort{NodePort: 8080}
 	modes := []BalancingMode{Rate, Utilization}
 
 	// block the creation of Backends with the given balancingMode
@@ -461,8 +461,8 @@ func TestBackendCreateBalancingMode(t *testing.T) {
 			return nil
 		}
 
-		pool.Ensure([]ServicePort{nodePort}, nil)
-		be, err := f.GetGlobalBackendService(defaultNamer.Backend(nodePort.Port))
+		pool.Ensure([]ServicePort{sp}, nil)
+		be, err := f.GetGlobalBackendService(defaultNamer.Backend(sp.NodePort))
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -515,7 +515,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 	bp := NewBackendPool(f, fakeNEG, healthChecks, nodePool, defaultNamer, []int64{}, false)
 
 	svcPort := ServicePort{
-		Port:     30001,
+		NodePort: 30001,
 		Protocol: annotations.ProtocolHTTP,
 		SvcName: types.NamespacedName{
 			Namespace: namespace,
@@ -542,7 +542,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 		t.Fatalf("Failed to link backend service to NEG: %v", err)
 	}
 
-	bs, err := f.GetGlobalBackendService(defaultNamer.Backend(svcPort.Port))
+	bs, err := f.GetGlobalBackendService(defaultNamer.Backend(svcPort.NodePort))
 	if err != nil {
 		t.Fatalf("Failed to retrieve backend service: %v", err)
 	}

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -142,7 +142,7 @@ func (c *ClusterManager) Checkpoint(lbs []*loadbalancers.L7RuntimeInfo, nodeName
 func (c *ClusterManager) EnsureInstanceGroupsAndPorts(servicePorts []backends.ServicePort) ([]*compute.InstanceGroup, error) {
 	ports := []int64{}
 	for _, p := range servicePorts {
-		ports = append(ports, p.Port)
+		ports = append(ports, p.NodePort)
 	}
 	igs, err := instances.EnsureInstanceGroupsAndPorts(c.instancePool, c.ClusterNamer, ports)
 	return igs, err
@@ -221,7 +221,7 @@ func NewClusterManager(
 	cluster.healthCheckers = []healthchecks.HealthChecker{healthChecker, defaultBackendHealthChecker}
 
 	// TODO: This needs to change to a consolidated management of the default backend.
-	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{defaultBackendNodePort.Port}, true)
+	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{defaultBackendNodePort.NodePort}, true)
 	defaultBackendPool := backends.NewBackendPool(cloud, cloud, defaultBackendHealthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{}, false)
 	cluster.defaultBackendNodePort = defaultBackendNodePort
 

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	testDefaultBeNodePort = backends.ServicePort{Port: 3000, Protocol: annotations.ProtocolHTTP}
+	testDefaultBeNodePort = backends.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP}
 	testBackendPort       = intstr.IntOrString{Type: intstr.Int, IntVal: 80}
 	testSrcRanges         = []string{"1.1.1.1/20"}
 	testNodePortRanges    = []string{"30000-32767"}

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -150,7 +150,7 @@ func (t *GCE) toGCEBackend(be *extensions.IngressBackend, ns string) (*compute.B
 	if err != nil {
 		return nil, err
 	}
-	backend, err := t.bi.BackendServiceForPort(port.Port)
+	backend, err := t.bi.BackendServiceForPort(port.NodePort)
 	if err != nil {
 		return nil, fmt.Errorf("no GCE backend exists for port %v, kube backend %+v", port, be)
 	}
@@ -207,7 +207,7 @@ PortLoop:
 	}
 
 	p := backends.ServicePort{
-		Port:          int64(port.NodePort),
+		NodePort:      int64(port.NodePort),
 		Protocol:      proto,
 		SvcName:       types.NamespacedName{Namespace: namespace, Name: be.ServiceName},
 		SvcPort:       be.ServicePort,
@@ -388,7 +388,7 @@ OuterLoop:
 			svcPort = sp
 			// only one Service can match this nodePort, try and look up
 			// the readiness probe of the pods behind it
-			if int32(port.Port) == sp.NodePort {
+			if int32(port.NodePort) == sp.NodePort {
 				found = true
 				break OuterLoop
 			}

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -200,7 +200,7 @@ func setInstanceGroupsAnnotation(existing map[string]string, igs []*compute.Inst
 func uniq(nodePorts []backends.ServicePort) []backends.ServicePort {
 	portMap := map[int64]backends.ServicePort{}
 	for _, p := range nodePorts {
-		portMap[p.Port] = p
+		portMap[p.NodePort] = p
 	}
 	nodePorts = make([]backends.ServicePort, 0, len(portMap))
 	for _, sp := range portMap {

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -150,7 +150,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
 			return err
 		}
-		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.Port)
+		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.NodePort)
 		if err != nil {
 			return err
 		}
@@ -189,7 +189,7 @@ func (l *L7s) GC(names []string) error {
 	// This needs to happen after we've deleted all url-maps that might be
 	// using it.
 	if len(names) == 0 {
-		if err := l.defaultBackendPool.Delete(l.defaultBackendNodePort.Port); err != nil {
+		if err := l.defaultBackendPool.Delete(l.defaultBackendNodePort.NodePort); err != nil {
 			return err
 		}
 		l.glbcDefaultBackend = nil

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	testDefaultBeNodePort = backends.ServicePort{Port: 3000, Protocol: annotations.ProtocolHTTP}
+	testDefaultBeNodePort = backends.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP}
 )
 
 func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T, namer *utils.Namer) LoadBalancerPool {


### PR DESCRIPTION
In order to prevent confusion with the `SvcPort` and `SvcTargetPort`, I suggest we be more specific by renaming `Port` to `NodePort`