### PR TITLE
Verbose flag: set v=3

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -39,7 +39,7 @@ func main() {
 	flags.Register()
 	flag.Parse()
 	if flags.F.Verbose {
-		flag.Set("v", "4")
+		flag.Set("v", "3")
 	}
 
 	// TODO: remove this when we do a release so the -logtostderr can be


### PR DESCRIPTION
V=3 for 0.9.8 is more or less equivalent to v=4 for 0.9.7. This change will allow us to change the glbc.manifest to use `--verbose` and be backwards compatible with the 0.9.7 image.


cc @rramkumar1 