### PR TITLE
Support for multiple tls certificates

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -405,7 +405,7 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *extensions.Ingress) (*load
 		return nil, fmt.Errorf("cannot get key for Ingress %v/%v: %v", ing.Namespace, ing.Name, err)
 	}
 
-	var tls *loadbalancers.TLSCerts
+	var tls []*loadbalancers.TLSCerts
 
 	annotations := annotations.FromIngress(ing)
 	// Load the TLS cert from the API Spec if it is not specified in the annotation.

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -313,13 +313,19 @@ func (f *FakeLoadBalancers) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHt
 }
 
 // SetSslCertificateForTargetHttpsProxy fakes out setting certificates.
-func (f *FakeLoadBalancers) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, SSLCert *compute.SslCertificate) error {
+func (f *FakeLoadBalancers) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, SSLCerts []*compute.SslCertificate) error {
 	f.calls = append(f.calls, "SetSslCertificateForTargetHttpsProxy")
 	found := false
+	var certs []string
+	for _, cert := range SSLCerts {
+		certs = append(certs, cert.SelfLink)
+	}
+
 	for i := range f.Tps {
 		if f.Tps[i].Name == proxy.Name {
-			f.Tps[i].SslCertificates = []string{SSLCert.SelfLink}
+			f.Tps[i].SslCertificates = certs
 			found = true
+			break
 		}
 	}
 	if !found {
@@ -436,10 +442,19 @@ func (f *FakeLoadBalancers) GetSslCertificate(name string) (*compute.SslCertific
 	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
+func (f *FakeLoadBalancers) ListSslCertificates() ([]*compute.SslCertificate, error) {
+	f.calls = append(f.calls, "ListSslCertificates")
+	return f.Certs, nil
+}
+
 // CreateSslCertificate fakes out certificate creation.
 func (f *FakeLoadBalancers) CreateSslCertificate(cert *compute.SslCertificate) (*compute.SslCertificate, error) {
 	f.calls = append(f.calls, "CreateSslCertificate")
 	cert.SelfLink = cert.Name
+	if len(f.Certs) == TargetProxyCertLimit {
+		// Simulate cert creation failure
+		return nil, fmt.Errorf("Unable to create cert, Exceeded cert limit of %d.", TargetProxyCertLimit)
+	}
 	f.Certs = append(f.Certs, cert)
 	return cert, nil
 }

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -50,10 +50,11 @@ type LoadBalancers interface {
 	CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error
 	DeleteTargetHttpsProxy(name string) error
 	SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, urlMap *compute.UrlMap) error
-	SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, SSLCerts *compute.SslCertificate) error
+	SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, SSLCerts []*compute.SslCertificate) error
 
 	// SslCertificates
 	GetSslCertificate(name string) (*compute.SslCertificate, error)
+	ListSslCertificates() ([]*compute.SslCertificate, error)
 	CreateSslCertificate(certs *compute.SslCertificate) (*compute.SslCertificate, error)
 	DeleteSslCertificate(name string) error
 

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -197,7 +197,7 @@ func (l *L7) deleteOldSSLCerts() (err error) {
 	}
 	certsMap := getMapfromCertList(l.sslCerts)
 	for _, cert := range l.oldSSLCerts {
-		if !l.IsSSLCert(cert.Name) && !l.namer.IsLegacySSLCert(cert.Name) {
+		if !l.isSSLCert(cert.Name) && !l.namer.IsLegacySSLCert(l.Name, cert.Name) {
 			// retain cert if it is managed by GCE(non-ingress)
 			continue
 		}
@@ -261,8 +261,8 @@ func (l *L7) usePreSharedCert() (bool, error) {
 	return true, nil
 }
 
-// IsSSLCert returns true if name is ingress managed, specifically by this loadbalancer instance
-func (l *L7) IsSSLCert(name string) bool {
+// isSSLCert returns true if name is ingress managed, specifically by this loadbalancer instance
+func (l *L7) isSSLCert(name string) bool {
 	return strings.HasPrefix(name, l.sslCertPrefix)
 }
 
@@ -287,7 +287,7 @@ func (l *L7) populateSSLCert() error {
 		return utils.IgnoreHTTPNotFound(err)
 	}
 	for _, c := range certs {
-		if l.IsSSLCert(c.Name) {
+		if l.isSSLCert(c.Name) {
 			glog.Infof("Populating ssl cert %s for l7 %s", c.Name, l.Name)
 			l.sslCerts = append(l.sslCerts, c)
 		}
@@ -299,7 +299,7 @@ func (l *L7) populateSSLCert() error {
 		for _, link := range expectedCertNames {
 			// Retrieve the certificate and ignore error if certificate wasn't found
 			name := getResourceNameFromLink(link)
-			if !l.namer.IsLegacySSLCert(name) {
+			if !l.namer.IsLegacySSLCert(l.Name, name) {
 				continue
 			}
 			cert, _ := l.cloud.GetSslCertificate(getResourceNameFromLink(name))

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -29,6 +29,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"crypto/sha256"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -48,6 +49,9 @@ const (
 
 	httpDefaultPortRange  = "80-80"
 	httpsDefaultPortRange = "443-443"
+
+	// Every target https proxy accepts upto 10 ssl certificates.
+	TargetProxyCertLimit = 10
 )
 
 // TLSCerts encapsulates .pem encoded TLS information.
@@ -58,6 +62,9 @@ type TLSCerts struct {
 	Cert string
 	// Chain is a certificate chain.
 	Chain string
+	Name  string
+	// md5 hash(first 8 bytes) of the cert contents
+	CertHash string
 }
 
 // L7RuntimeInfo is info passed to this module from the controller runtime.
@@ -67,8 +74,8 @@ type L7RuntimeInfo struct {
 	// IP is the desired ip of the loadbalancer, eg from a staticIP.
 	IP string
 	// TLS are the tls certs to use in termination.
-	TLS *TLSCerts
-	// TLSName is the name of/for the tls cert to use.
+	TLS []*TLSCerts
+	// TLSName is the name of the preshared cert to use. Multiple certs can be specified as a comma-separated string
 	TLSName string
 	// AllowHTTP will not setup :80, if TLS is nil and AllowHTTP is set,
 	// no loadbalancer is created.
@@ -102,14 +109,15 @@ type L7 struct {
 	fws *compute.ForwardingRule
 	// ip is the static-ip associated with both GlobalForwardingRules.
 	ip *compute.Address
-	// sslCert is the ssl cert associated with the targetHTTPSProxy.
-	// TODO: Make this a custom type that contains crt+key
-	sslCert *compute.SslCertificate
-	// oldSSLCert is the certificate that used to be hooked up to the
+	// prefix to use in ssl cert names
+	sslCertPrefix string
+	// sslCerts is the list of ssl certs associated with the targetHTTPSProxy.
+	sslCerts []*compute.SslCertificate
+	// oldSSLCerts is the list of certs that used to be hooked up to the
 	// targetHTTPSProxy. We can't update a cert in place, so we need
-	// to create - update - delete and storing the old cert in a field
+	// to create - update - delete and storing the old certs in a list
 	// prevents leakage if there's a failure along the way.
-	oldSSLCert *compute.SslCertificate
+	oldSSLCerts []*compute.SslCertificate
 	// glbcDefaultBacked is the backend to use if no path rules match.
 	// TODO: Expose this to users.
 	glbcDefaultBackend *compute.BackendService
@@ -183,16 +191,27 @@ func (l *L7) checkProxy() (err error) {
 	return nil
 }
 
-func (l *L7) deleteOldSSLCert() (err error) {
-	if l.oldSSLCert == nil || l.sslCert == nil || l.oldSSLCert.Name == l.sslCert.Name || !l.namer.IsSSLCert(l.oldSSLCert.Name) {
+func (l *L7) deleteOldSSLCerts() (err error) {
+	if len(l.oldSSLCerts) == 0 {
 		return nil
 	}
-	glog.Infof("Cleaning up old SSL Certificate %v, current name %v", l.oldSSLCert.Name, l.sslCert.Name)
-	if err := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(l.oldSSLCert.Name)); err != nil {
-		return err
+	certsMap := getMapfromCertList(l.sslCerts)
+	for _, cert := range l.oldSSLCerts {
+		if !l.IsSSLCert(cert.Name) && !l.namer.IsLegacySSLCert(cert.Name) {
+			// retain cert if it is managed by GCE(non-ingress)
+			continue
+		}
+		if _, ok := certsMap[cert.Name]; ok {
+			// cert found in current map
+			continue
+		}
+		glog.Infof("Cleaning up old SSL Certificate %s", cert.Name)
+		if certErr := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(cert.Name)); certErr != nil {
+			glog.Errorf("Old cert delete failed - %v", certErr)
+			err = certErr
+		}
 	}
-	l.oldSSLCert = nil
-	return nil
+	return err
 }
 
 // Returns the name portion of a link - which is the last section
@@ -210,54 +229,87 @@ func (l *L7) usePreSharedCert() (bool, error) {
 	if preSharedCertName == "" {
 		return false, nil
 	}
-
-	// Ask GCE for the cert, checking for problems and existence.
-	cert, err := l.cloud.GetSslCertificate(preSharedCertName)
-	if err != nil {
-		return true, err
-	}
-	if cert == nil {
-		return true, fmt.Errorf("cannot find existing sslCertificate %v for %v", preSharedCertName, l.Name)
+	preSharedCerts := strings.Split(preSharedCertName, ",")
+	if len(preSharedCerts) > TargetProxyCertLimit {
+		glog.Warningf("Specified %d preshared certs, limit is %d, rest will be ignored",
+			len(preSharedCerts), TargetProxyCertLimit)
+		preSharedCerts = preSharedCerts[:TargetProxyCertLimit]
 	}
 
-	glog.V(2).Infof("Using existing sslCertificate %v for %v", preSharedCertName, l.Name)
-	l.sslCert = cert
+	l.sslCerts = make([]*compute.SslCertificate, 0, len(preSharedCerts))
+	var failedCerts []string
+
+	for _, sharedCert := range preSharedCerts {
+		// Ask GCE for the cert, checking for problems and existence.
+		sharedCert = strings.TrimSpace(sharedCert)
+		cert, err := l.cloud.GetSslCertificate(sharedCert)
+		if err != nil {
+			failedCerts = append(failedCerts, sharedCert+" Error: "+err.Error())
+			continue
+		}
+		if cert == nil {
+			failedCerts = append(failedCerts, sharedCert+" Error: unable to find existing sslCertificate")
+			continue
+		}
+
+		glog.V(2).Infof("Using existing sslCertificate %v for %v", sharedCert, l.Name)
+		l.sslCerts = append(l.sslCerts, cert)
+	}
+	if len(failedCerts) != 0 {
+		return true, fmt.Errorf("PreSharedCert errors - %s", strings.Join(failedCerts, ","))
+	}
 	return true, nil
 }
 
-func (l *L7) populateSSLCert() error {
-	// Determine what certificate name is being used
-	var expectedCertName string
-	if l.sslCert != nil {
-		expectedCertName = l.sslCert.Name
-	} else {
-		// Retrieve the ssl certificate in use by the expected target proxy (if exists)
-		expectedCertName = getResourceNameFromLink(l.getSslCertLinkInUse())
-	}
+// IsSSLCert returns true if name is ingress managed, specifically by this loadbalancer instance
+func (l *L7) IsSSLCert(name string) bool {
+	return strings.HasPrefix(name, l.sslCertPrefix)
+}
 
-	var err error
-	if expectedCertName != "" {
-		// Retrieve the certificate and ignore error if certificate wasn't found
-		l.sslCert, err = l.cloud.GetSslCertificate(expectedCertName)
-		if err != nil {
-			return utils.IgnoreHTTPNotFound(err)
+func getMapfromCertList(certs []*compute.SslCertificate) map[string]*compute.SslCertificate {
+	if len(certs) == 0 {
+		return nil
+	}
+	certMap := make(map[string]*compute.SslCertificate)
+	for _, cert := range certs {
+		certMap[cert.Name] = cert
+	}
+	return certMap
+}
+
+func (l *L7) populateSSLCert() error {
+	l.sslCerts = make([]*compute.SslCertificate, 0)
+	// Currently we list all certs available in gcloud and filter the ones managed by this loadbalancer instance. This is
+	// to make sure we garbage collect any old certs that this instance might have lost track of due to crashes.
+	// Can be a performance issue if there are too many global certs, default quota is only 10.
+	certs, err := l.cloud.ListSslCertificates()
+	if err != nil {
+		return utils.IgnoreHTTPNotFound(err)
+	}
+	for _, c := range certs {
+		if l.IsSSLCert(c.Name) {
+			glog.Infof("Populating ssl cert %s for l7 %s", c.Name, l.Name)
+			l.sslCerts = append(l.sslCerts, c)
+		}
+	}
+	if len(l.sslCerts) == 0 {
+		// Check for legacy cert since that follows a different naming convention
+		glog.Infof("Looking for legacy ssl certs")
+		expectedCertNames := l.getSslCertLinkInUse()
+		for _, link := range expectedCertNames {
+			// Retrieve the certificate and ignore error if certificate wasn't found
+			name := getResourceNameFromLink(link)
+			if !l.namer.IsLegacySSLCert(name) {
+				continue
+			}
+			cert, _ := l.cloud.GetSslCertificate(getResourceNameFromLink(name))
+			if cert != nil {
+				glog.Infof("Populating legacy ssl cert %s for l7 %s", cert.Name, l.Name)
+				l.sslCerts = append(l.sslCerts, cert)
+			}
 		}
 	}
 	return nil
-}
-
-func (l *L7) nextCertificateName() string {
-	// The name of the cert for this lb flip-flops between these 2 on
-	// every certificate update. We don't append the index at the end so we're
-	// sure it isn't truncated.
-	// TODO: Clean this code up into a ring buffer.
-	primaryCertName := l.namer.SSLCert(l.Name, true)
-	secondaryCertName := l.namer.SSLCert(l.Name, false)
-
-	if l.sslCert != nil && l.sslCert.Name == primaryCertName {
-		return secondaryCertName
-	}
-	return primaryCertName
 }
 
 func (l *L7) checkSSLCert() error {
@@ -271,72 +323,84 @@ func (l *L7) checkSSLCert() error {
 		return err
 	}
 
-	// TODO: Currently, GCE only supports a single certificate per static IP
-	// so we don't need to bother with disambiguation. Naming the cert after
-	// the loadbalancer is a simplification.
-	ingCert := l.runtimeInfo.TLS.Cert
-	ingKey := l.runtimeInfo.TLS.Key
+	var newCerts []*compute.SslCertificate
+	// mapping of currently configured certs
+	certsMap := getMapfromCertList(l.sslCerts)
+	var failedCerts []string
 
-	// PrivateKey is write only, so compare certs alone. We're assuming that
-	// no one will change just the key. We can remember the key and compare,
-	// but a bug could end up leaking it, which feels worse.
-	if l.sslCert != nil && ingCert == l.sslCert.Certificate {
-		return nil
+	for _, tlsCert := range l.runtimeInfo.TLS {
+		ingCert := tlsCert.Cert
+		ingKey := tlsCert.Key
+		newCertName := l.namer.SSLCertName(l.sslCertPrefix, tlsCert.CertHash)
+
+		// PrivateKey is write only, so compare certs alone. We're assuming that
+		// no one will change just the key. We can remember the key and compare,
+		// but a bug could end up leaking it, which feels worse.
+		// If the cert contents have changed, its hash would be different, so would be the cert name. So it is enough
+		// to check if this cert name exists in the map.
+		if certsMap != nil {
+			if cert, ok := certsMap[newCertName]; ok {
+				glog.Infof("Retaining cert - %s", tlsCert.Name)
+				newCerts = append(newCerts, cert)
+				continue
+			}
+		}
+		// Controller needs to create the certificate, no need to check if it exists and delete. If it did exist, it
+		// would have been listed in the populateSSLCert function and matched in the check above.
+		glog.V(2).Infof("Creating new sslCertificate %v for %v", newCertName, l.Name)
+		cert, err := l.cloud.CreateSslCertificate(&compute.SslCertificate{
+			Name:        newCertName,
+			Certificate: ingCert,
+			PrivateKey:  ingKey,
+		})
+		if err != nil {
+			glog.Errorf("Failed to create new sslCertificate %v for %v - %s", newCertName, l.Name, err)
+			failedCerts = append(failedCerts, newCertName+" Error:"+err.Error())
+			continue
+		}
+		newCerts = append(newCerts, cert)
 	}
 
-	// Controller needs to create or update the certificate.
-	// Generate the next certificate name to use.
-	newCertName := l.nextCertificateName()
-
-	// Perform a delete in case a certificate exists with the exact name
-	// This certificate should be unused since we check the target proxy's certificate prior
-	// to this point. Although, it's possible an actor pointed a target proxy to this certificate.
-	if err := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(newCertName)); err != nil {
-		return fmt.Errorf("unable to delete ssl certificate with name %q, expected it to be unused. err: %v", newCertName, err)
+	// Save the old certs for cleanup after we update the target proxy.
+	l.oldSSLCerts = l.sslCerts
+	l.sslCerts = newCerts
+	if len(failedCerts) > 0 {
+		return fmt.Errorf("Cert creation failures - %s", strings.Join(failedCerts, ","))
 	}
-
-	glog.V(2).Infof("Creating new sslCertificate %v for %v", newCertName, l.Name)
-	cert, err := l.cloud.CreateSslCertificate(&compute.SslCertificate{
-		Name:        newCertName,
-		Certificate: ingCert,
-		PrivateKey:  ingKey,
-	})
-	if err != nil {
-		return err
-	}
-	// Save the current cert for cleanup after we update the target proxy.
-	l.oldSSLCert = l.sslCert
-	l.sslCert = cert
-
 	return nil
 }
 
-func (l *L7) getSslCertLinkInUse() string {
+func (l *L7) getSslCertLinkInUse() []string {
 	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
 	proxy, _ := l.cloud.GetTargetHttpsProxy(proxyName)
 	if proxy != nil && len(proxy.SslCertificates) > 0 {
-		return proxy.SslCertificates[0]
+		return proxy.SslCertificates
 	}
-	return ""
+	return nil
 }
 
 func (l *L7) checkHttpsProxy() (err error) {
-	if l.sslCert == nil {
+	if len(l.sslCerts) == 0 {
 		glog.V(3).Infof("No SSL certificates for %v, will not create HTTPS proxy.", l.Name)
 		return nil
 	}
 	if l.um == nil {
 		return fmt.Errorf("no UrlMap for %v, will not create HTTPS proxy", l.Name)
 	}
+
 	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
 	proxy, _ := l.cloud.GetTargetHttpsProxy(proxyName)
 	if proxy == nil {
 		glog.Infof("Creating new https proxy for urlmap %v", l.um.Name)
 		newProxy := &compute.TargetHttpsProxy{
-			Name:            proxyName,
-			UrlMap:          l.um.SelfLink,
-			SslCertificates: []string{l.sslCert.SelfLink},
+			Name:   proxyName,
+			UrlMap: l.um.SelfLink,
 		}
+
+		for _, c := range l.sslCerts {
+			newProxy.SslCertificates = append(newProxy.SslCertificates, c.SelfLink)
+		}
+
 		if err = l.cloud.CreateTargetHttpsProxy(newProxy); err != nil {
 			return err
 		}
@@ -356,17 +420,40 @@ func (l *L7) checkHttpsProxy() (err error) {
 			return err
 		}
 	}
-	cert := proxy.SslCertificates[0]
-	if !utils.CompareLinks(cert, l.sslCert.SelfLink) {
+
+	if !l.compareCerts(proxy.SslCertificates) {
 		glog.Infof("Https proxy %v has the wrong ssl certs, setting %v overwriting %v",
-			proxy.Name, l.sslCert.SelfLink, cert)
-		if err := l.cloud.SetSslCertificateForTargetHttpsProxy(proxy, l.sslCert); err != nil {
+			proxy.Name, l.sslCerts, proxy.SslCertificates)
+		if err := l.cloud.SetSslCertificateForTargetHttpsProxy(proxy, l.sslCerts); err != nil {
 			return err
 		}
+
 	}
 	glog.V(3).Infof("Created target https proxy %v", proxy.Name)
 	l.tps = proxy
 	return nil
+}
+
+// Returns true if the input array of certs is identical to the certs in the L7 config.
+// Returns false if there is any mismatch
+func (l *L7) compareCerts(certLinks []string) bool {
+	certsMap := getMapfromCertList(l.sslCerts)
+	if len(certLinks) != len(certsMap) {
+		glog.Infof("Loadbalancer has %d certs, target proxy has %d certs", len(certsMap), len(certLinks))
+		return false
+	}
+	var certName string
+	for _, linkName := range certLinks {
+		certName = getResourceNameFromLink(linkName)
+		if cert, ok := certsMap[certName]; !ok {
+			glog.Infof("Cannot find cert with name %s in certsMap %+v", certName, certsMap)
+			return false
+		} else if ok && !utils.CompareLinks(linkName, cert.SelfLink) {
+			glog.Infof("Selflink compare failed for certs - %s in loadbalancer, %s in targetproxy", cert.SelfLink, linkName)
+			return false
+		}
+	}
+	return true
 }
 
 func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *compute.ForwardingRule, err error) {
@@ -555,7 +642,7 @@ func (l *L7) edgeHopHttps() error {
 	if err := l.checkHttpsForwardingRule(); err != nil {
 		return err
 	}
-	if err := l.deleteOldSSLCert(); err != nil {
+	if err := l.deleteOldSSLCerts(); err != nil {
 		return err
 	}
 	return nil
@@ -784,12 +871,20 @@ func (l *L7) Cleanup() error {
 		l.tps = nil
 	}
 	// Delete the SSL cert if it is from a secret, not referencing a pre-created GCE cert.
-	if l.sslCert != nil && l.runtimeInfo.TLSName == "" {
-		glog.V(2).Infof("Deleting sslcert %v", l.sslCert.Name)
-		if err := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(l.sslCert.Name)); err != nil {
-			return err
+	if len(l.sslCerts) != 0 && l.runtimeInfo.TLSName == "" {
+		var certErr error
+		for _, cert := range l.sslCerts {
+			glog.V(2).Infof("Deleting sslcert %s", cert.Name)
+			if err := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(cert.Name)); err != nil {
+				glog.Errorf("Old cert delete failed - %v", err)
+				certErr = err
+			}
+
 		}
-		l.sslCert = nil
+		l.sslCerts = nil
+		if certErr != nil {
+			return certErr
+		}
 	}
 	if l.tp != nil {
 		glog.V(2).Infof("Deleting target http proxy %v", l.tp.Name)
@@ -850,6 +945,11 @@ func GetLBAnnotations(l7 *L7, existing map[string]string, backendPool backends.B
 	if err == nil {
 		jsonBackendState = string(b)
 	}
+	certs := []string{}
+	for _, cert := range l7.sslCerts {
+		certs = append(certs, cert.Name)
+	}
+
 	existing[fmt.Sprintf("%v/url-map", annotations.StatusPrefix)] = l7.um.Name
 	// Forwarding rule and target proxy might not exist if allowHTTP == false
 	if l7.fw != nil {
@@ -868,8 +968,8 @@ func GetLBAnnotations(l7 *L7, existing map[string]string, backendPool backends.B
 	if l7.ip != nil {
 		existing[fmt.Sprintf("%v/static-ip", annotations.StatusPrefix)] = l7.ip.Name
 	}
-	if l7.sslCert != nil {
-		existing[fmt.Sprintf("%v/ssl-cert", annotations.StatusPrefix)] = l7.sslCert.Name
+	if len(certs) > 0 {
+		existing[fmt.Sprintf("%v/ssl-cert", annotations.StatusPrefix)] = strings.Join(certs, ",")
 	}
 	// TODO: We really want to know *when* a backend flipped states.
 	existing[fmt.Sprintf("%v/backends", annotations.StatusPrefix)] = jsonBackendState
@@ -884,4 +984,8 @@ func GCEResourceName(ingAnnotations map[string]string, resourceName string) stri
 	// parsing logic in a single location.
 	resourceName, _ = ingAnnotations[fmt.Sprintf("%v/%v", annotations.StatusPrefix, resourceName)]
 	return resourceName
+}
+
+func GetCertHash(contents string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents)))[:16]
 }

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -76,7 +76,7 @@ func (l *L7s) create(ri *L7RuntimeInfo) (*L7, error) {
 		cloud:              l.cloud,
 		glbcDefaultBackend: l.glbcDefaultBackend,
 		namer:              l.namer,
-		sslCert:            nil,
+		sslCertPrefix:      l.namer.SSLCertPrefix(ri.Name),
 	}, nil
 }
 

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/neg"
 	"k8s.io/ingress-gce/pkg/utils"
+	"strconv"
+	"strings"
 )
 
 const (
@@ -99,7 +101,7 @@ func TestCreateHTTPSLoadBalancer(t *testing.T) {
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
 		AllowHTTP: false,
-		TLS:       &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:       []*TLSCerts{createCert("key", "cert", "name")},
 	}
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	pool := newFakeLoadBalancerPool(f, t, namer)
@@ -127,13 +129,14 @@ func TestCreateHTTPSLoadBalancer(t *testing.T) {
 // and the proxy is updated to another cert when the provided cert changes
 func TestCertUpdate(t *testing.T) {
 	namer := utils.NewNamer("uid1", "fw1")
-	primaryCertName := namer.SSLCert(namer.LoadBalancer("test"), true)
-	secondaryCertName := namer.SSLCert(namer.LoadBalancer("test"), false)
+	sslCertPrefix := namer.SSLCertPrefix("test")
+	certName1 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert"))
+	certName2 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert2"))
 
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
 		AllowHTTP: false,
-		TLS:       &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:       []*TLSCerts{createCert("key", "cert", "name")},
 	}
 
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
@@ -141,92 +144,256 @@ func TestCertUpdate(t *testing.T) {
 
 	// Sync first cert
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	t.Logf("name=%q", primaryCertName)
-	verifyCertAndProxyLink(primaryCertName, lbInfo.TLS.Cert, f, t)
+	t.Logf("name=%q", certName1)
+	expectCerts := map[string]string{certName1: lbInfo.TLS[0].Cert}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 
 	// Sync with different cert
-	lbInfo.TLS = &TLSCerts{Key: "key2", Cert: "cert2"}
+	lbInfo.TLS = []*TLSCerts{createCert("key2", "cert2", "name")}
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(secondaryCertName, lbInfo.TLS.Cert, f, t)
+	expectCerts = map[string]string{certName2: lbInfo.TLS[0].Cert}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 }
 
 // Tests that controller can overwrite existing, unused certificates
 func TestCertCreationWithCollision(t *testing.T) {
 	namer := utils.NewNamer("uid1", "fw1")
-	primaryCertName := namer.SSLCert(namer.LoadBalancer("test"), true)
-	secondaryCertName := namer.SSLCert(namer.LoadBalancer("test"), false)
+	sslCertPrefix := namer.SSLCertPrefix("test")
+	certName1 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert"))
+	certName2 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert2"))
 
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
 		AllowHTTP: false,
-		TLS:       &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:       []*TLSCerts{createCert("key", "cert", "name")},
 	}
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	pool := newFakeLoadBalancerPool(f, t, namer)
 
-	// Have both names already used by orphaned certs
+	// Have the same name used by orphaned cert
+	// Since name of the cert is the same, the contents of Certificate have to be the same too, since name contains a
+	// hash of the contents.
 	f.CreateSslCertificate(&compute.SslCertificate{
-		Name:        primaryCertName,
-		Certificate: "abc",
-		SelfLink:    "existing",
-	})
-	f.CreateSslCertificate(&compute.SslCertificate{
-		Name:        secondaryCertName,
-		Certificate: "xyz",
+		Name:        certName1,
+		Certificate: "cert",
 		SelfLink:    "existing",
 	})
 
 	// Sync first cert
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(primaryCertName, lbInfo.TLS.Cert, f, t)
+	expectCerts := map[string]string{certName1: lbInfo.TLS[0].Cert}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+
+	// Create another cert where the name matches that of another cert, but contents are different - xyz != cert2.
+	// Simulates a hash collision
+	f.CreateSslCertificate(&compute.SslCertificate{
+		Name:        certName2,
+		Certificate: "xyz",
+		SelfLink:    "existing",
+	})
 
 	// Sync with different cert
-	lbInfo.TLS = &TLSCerts{Key: "key2", Cert: "cert2"}
+	lbInfo.TLS = []*TLSCerts{createCert("key2", "cert2", "name")}
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(secondaryCertName, lbInfo.TLS.Cert, f, t)
+	expectCerts = map[string]string{certName2: "xyz"}
+	// xyz instead of cert2 because the name collided and cert did not get updated.
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 }
 
-func TestCertRetentionAfterRestart(t *testing.T) {
+func TestMultipleCertRetentionAfterRestart(t *testing.T) {
 	namer := utils.NewNamer("uid1", "fw1")
-	primaryCertName := namer.SSLCert(namer.LoadBalancer("test"), true)
-	secondaryCertName := namer.SSLCert(namer.LoadBalancer("test"), false)
+	sslCertPrefix := namer.SSLCertPrefix("test")
+	cert1 := createCert("key", "cert", "name")
+	cert2 := createCert("key2", "cert2", "name2")
+	cert3 := createCert("key3", "cert3", "name3")
+	certName1 := namer.SSLCertName(sslCertPrefix, cert1.CertHash)
+	certName2 := namer.SSLCertName(sslCertPrefix, cert2.CertHash)
+	certName3 := namer.SSLCertName(sslCertPrefix, cert3.CertHash)
+
+	expectCerts := map[string]string{}
 
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
 		AllowHTTP: false,
-		TLS:       &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:       []*TLSCerts{cert1},
 	}
+	expectCerts[certName1] = cert1.Cert
 
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	firstPool := newFakeLoadBalancerPool(f, t, namer)
 
-	// Sync twice so the expected certificate uses the secondary name
 	firstPool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(primaryCertName, lbInfo.TLS.Cert, f, t)
-	lbInfo.TLS = &TLSCerts{Key: "key2", Cert: "cert2"}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+	// Update config to use 2 certs
+	lbInfo.TLS = []*TLSCerts{cert1, cert2}
+	expectCerts[certName2] = cert2.Cert
 	firstPool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(secondaryCertName, lbInfo.TLS.Cert, f, t)
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 
 	// Restart of controller represented by a new pool
 	secondPool := newFakeLoadBalancerPool(f, t, namer)
 	secondPool.Sync([]*L7RuntimeInfo{lbInfo})
 
-	// Verify second name is still used
-	verifyCertAndProxyLink(secondaryCertName, lbInfo.TLS.Cert, f, t)
+	// Verify both certs are still present
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 
-	// Update cert one more time to verify loop
-	lbInfo.TLS = &TLSCerts{Key: "key3", Cert: "cert3"}
+	// Replace the 2 certs with a different, single cert
+	lbInfo.TLS = []*TLSCerts{cert3}
+	expectCerts = map[string]string{certName3: cert3.Cert}
 	secondPool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(primaryCertName, lbInfo.TLS.Cert, f, t)
+	// Only the new cert should be present
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+}
 
+//TestUpgradeToNewCertNames verifies that certs uploaded using the old naming convention
+// are picked up and deleted when upgrading to the new scheme.
+func TestUpgradeToNewCertNames(t *testing.T) {
+	namer := utils.NewNamer("uid1", "fw1")
+	lbInfo := &L7RuntimeInfo{
+		Name:      namer.LoadBalancer("test"),
+		AllowHTTP: false,
+	}
+	oldCertName := "k8s-ssl-" + lbInfo.Name
+	tlsCert := createCert("key", "cert", "name")
+	lbInfo.TLS = []*TLSCerts{tlsCert}
+	newCertName := namer.SSLCertName(namer.SSLCertPrefix("test"), tlsCert.CertHash)
+	f := NewFakeLoadBalancers(lbInfo.Name, namer)
+	pool := newFakeLoadBalancerPool(f, t, namer)
+
+	// Manually create a target proxy and assign a legacy cert to it.
+	sslCert := &compute.SslCertificate{Name: oldCertName, Certificate: "cert"}
+	f.CreateSslCertificate(sslCert)
+	tpName := f.TPName(true)
+	newProxy := &compute.TargetHttpsProxy{Name: tpName, SslCertificates: []string{sslCert.SelfLink}}
+	err := f.CreateTargetHttpsProxy(newProxy)
+	if err != nil {
+		t.Fatalf("Failed to create Target proxy %v - %v", newProxy, err)
+	}
+	proxyCerts, err := f.ListSslCertificates()
+	if err != nil {
+		t.Fatalf("Failed to list certs for load balancer %v - %v", f, err)
+	}
+	if len(proxyCerts) != 1 {
+		t.Fatalf("Unexpected number of certs - Expected 1, got %d", len(proxyCerts))
+	}
+
+	if proxyCerts[0].Name != oldCertName {
+		t.Fatalf("Expected cert with name %s, Got %s", oldCertName, proxyCerts[0].Name)
+	}
+	// Sync should replace this oldCert with one following the new naming scheme
+	pool.Sync([]*L7RuntimeInfo{lbInfo})
+	// We expect to see only the new cert linked to the proxy and available in the load balancer.
+	expectCerts := map[string]string{newCertName: tlsCert.Cert}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+}
+
+// Tests uploading 10 certs which is the global limit today. Ensures that creation of the 11th cert fails.
+func TestMaxCertsUpload(t *testing.T) {
+	var tlsCerts []*TLSCerts
+	expectCerts := make(map[string]string)
+	namer := utils.NewNamer("uid1", "fw1")
+	certPrefix := namer.SSLCertPrefix("test")
+
+	for ix := 0; ix < TargetProxyCertLimit; ix++ {
+		str := strconv.Itoa(ix)
+		tlsCerts = append(tlsCerts, createCert("key-"+str, "cert-"+str, "name-"+str))
+		certName := namer.SSLCertName(certPrefix, GetCertHash("cert-"+str))
+		expectCerts[certName] = "cert-" + str
+	}
+	lbInfo := &L7RuntimeInfo{
+		Name:      namer.LoadBalancer("test"),
+		AllowHTTP: false,
+		TLS:       tlsCerts,
+	}
+	f := NewFakeLoadBalancers(lbInfo.Name, namer)
+	pool := newFakeLoadBalancerPool(f, t, namer)
+	pool.Sync([]*L7RuntimeInfo{lbInfo})
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+	failCert := createCert("key100", "cert100", "name100")
+	lbInfo.TLS = append(lbInfo.TLS, failCert)
+	pool.Sync([]*L7RuntimeInfo{lbInfo})
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+}
+
+// In case multiple certs for the same subject/hostname are uploaded, the certs will be sent in the same order they were
+// specified, to the targetproxy. The targetproxy will present the first occuring cert for a given hostname to the client.
+// This test verifies this behavior.
+func TestIdenticalHostnameCerts(t *testing.T) {
+	var tlsCerts []*TLSCerts
+	expectCerts := make(map[string]string)
+	namer := utils.NewNamer("uid1", "fw1")
+	certPrefix := namer.SSLCertPrefix("test")
+	contents := ""
+
+	for ix := 0; ix < 3; ix++ {
+		str := strconv.Itoa(ix)
+		contents = "cert-" + str + " foo.com"
+		tlsCerts = append(tlsCerts, createCert("key-"+str, contents, "name-"+str))
+		certName := namer.SSLCertName(certPrefix, GetCertHash(contents))
+		expectCerts[certName] = contents
+	}
+	lbInfo := &L7RuntimeInfo{
+		Name:      namer.LoadBalancer("test"),
+		AllowHTTP: false,
+		TLS:       tlsCerts,
+	}
+	f := NewFakeLoadBalancers(lbInfo.Name, namer)
+	pool := newFakeLoadBalancerPool(f, t, namer)
+	// Sync multiple times to make sure ordering is preserved
+	for i := 0; i < 10; i++ {
+		pool.Sync([]*L7RuntimeInfo{lbInfo})
+		verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+		// Fetch the target proxy certs and go through in order
+		verifyProxyCertsInOrder(" foo.com", f, t)
+		pool.Delete(lbInfo.Name)
+	}
+}
+
+func TestIdenticalHostnameCertsPreShared(t *testing.T) {
+	namer := utils.NewNamer("uid1", "fw1")
+	lbInfo := &L7RuntimeInfo{
+		Name:      namer.LoadBalancer("test"),
+		AllowHTTP: false,
+	}
+	f := NewFakeLoadBalancers(lbInfo.Name, namer)
+	pool := newFakeLoadBalancerPool(f, t, namer)
+	// Prepare pre-shared certs.
+	preSharedCert1, _ := f.CreateSslCertificate(&compute.SslCertificate{
+		Name:        "test-pre-shared-cert",
+		Certificate: "cert-0 foo.com",
+		SelfLink:    "existing",
+	})
+	preSharedCert2, _ := f.CreateSslCertificate(&compute.SslCertificate{
+		Name:        "test-pre-shared-cert1",
+		Certificate: "cert-1 foo.com",
+		SelfLink:    "existing",
+	})
+	preSharedCert3, _ := f.CreateSslCertificate(&compute.SslCertificate{
+		Name:        "test-pre-shared-cert2",
+		Certificate: "cert2",
+		SelfLink:    "existing",
+	})
+	expectCerts := map[string]string{preSharedCert1.Name: preSharedCert1.Certificate,
+		preSharedCert2.Name: preSharedCert2.Certificate, preSharedCert3.Name: preSharedCert3.Certificate}
+
+	lbInfo.TLSName = preSharedCert1.Name + "," + preSharedCert2.Name + "," + preSharedCert3.Name
+	// Sync multiple times to make sure ordering is preserved
+	for i := 0; i < 10; i++ {
+		pool.Sync([]*L7RuntimeInfo{lbInfo})
+		verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
+		// Fetch the target proxy certs and go through in order
+		verifyProxyCertsInOrder(" foo.com", f, t)
+		pool.Delete(lbInfo.Name)
+	}
 }
 
 // TestPreSharedToSecretBasedCertUpdate updates from pre-shared cert
 // to secret based cert and verifies the pre-shared cert is retained.
 func TestPreSharedToSecretBasedCertUpdate(t *testing.T) {
 	namer := utils.NewNamer("uid1", "fw1")
-	primaryCertName := namer.SSLCert(namer.LoadBalancer("test"), true)
-	secondaryCertName := namer.SSLCert(namer.LoadBalancer("test"), false)
+	sslCertPrefix := namer.SSLCertPrefix("test")
+	certName1 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert"))
+	certName2 := namer.SSLCertName(sslCertPrefix, GetCertHash("cert2"))
 
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
@@ -236,57 +403,124 @@ func TestPreSharedToSecretBasedCertUpdate(t *testing.T) {
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	pool := newFakeLoadBalancerPool(f, t, namer)
 
-	// Prepare pre-shared cert.
-	preSharedCert, _ := f.CreateSslCertificate(&compute.SslCertificate{
+	// Prepare pre-shared certs.
+	preSharedCert1, _ := f.CreateSslCertificate(&compute.SslCertificate{
 		Name:        "test-pre-shared-cert",
 		Certificate: "abc",
 		SelfLink:    "existing",
 	})
-	lbInfo.TLSName = preSharedCert.Name
+	// Prepare pre-shared certs.
+	preSharedCert2, _ := f.CreateSslCertificate(&compute.SslCertificate{
+		Name:        "test-pre-shared-cert2",
+		Certificate: "xyz",
+		SelfLink:    "existing",
+	})
 
-	// Sync pre-shared cert.
+	lbInfo.TLSName = preSharedCert1.Name + "," + preSharedCert2.Name
+
+	// Sync pre-shared certs.
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(preSharedCert.Name, preSharedCert.Certificate, f, t)
+	expectCerts := map[string]string{preSharedCert1.Name: preSharedCert1.Certificate,
+		preSharedCert2.Name: preSharedCert2.Certificate}
+	verifyCertAndProxyLink(expectCerts, expectCerts, f, t)
 
 	// Updates from pre-shared cert to secret based cert.
-	lbInfo.TLS = &TLSCerts{Key: "key", Cert: "cert"}
+	lbInfo.TLS = []*TLSCerts{createCert("key", "cert", "name")}
 	lbInfo.TLSName = ""
-	// Sync primary cert.
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(primaryCertName, lbInfo.TLS.Cert, f, t)
+	expectCerts[certName1] = lbInfo.TLS[0].Cert
+	// fakeLoadBalancer contains the preshared certs as well, but proxy will use only certName1
+	expectCertsProxy := map[string]string{certName1: lbInfo.TLS[0].Cert}
+	verifyCertAndProxyLink(expectCerts, expectCertsProxy, f, t)
 
-	// Sync secondary cert.
-	lbInfo.TLS = &TLSCerts{Key: "key2", Cert: "cert2"}
+	// Sync a different cert.
+	lbInfo.TLS = []*TLSCerts{createCert("key2", "cert2", "name")}
 	pool.Sync([]*L7RuntimeInfo{lbInfo})
-	verifyCertAndProxyLink(secondaryCertName, lbInfo.TLS.Cert, f, t)
+	delete(expectCerts, certName1)
+	expectCerts[certName2] = lbInfo.TLS[0].Cert
+	expectCertsProxy = map[string]string{certName2: lbInfo.TLS[0].Cert}
+	verifyCertAndProxyLink(expectCerts, expectCertsProxy, f, t)
 
-	// Check if pre-shared cert is retained.
-	if cert, err := f.GetSslCertificate(preSharedCert.Name); err != nil || cert == nil {
-		t.Fatalf("Want pre-shared certificate %v to exist, got none, err: %v", preSharedCert.Name, err)
+	// Check if pre-shared certs are retained.
+	if cert, err := f.GetSslCertificate(preSharedCert1.Name); err != nil || cert == nil {
+		t.Fatalf("Want pre-shared certificate %v to exist, got none, err: %v", preSharedCert1.Name, err)
+	}
+	if cert, err := f.GetSslCertificate(preSharedCert2.Name); err != nil || cert == nil {
+		t.Fatalf("Want pre-shared certificate %v to exist, got none, err: %v", preSharedCert2.Name, err)
 	}
 }
 
-func verifyCertAndProxyLink(certName, certValue string, f *FakeLoadBalancers, t *testing.T) {
+func verifyProxyCertsInOrder(hostname string, f *FakeLoadBalancers, t *testing.T) {
+	t.Helper()
+	t.Logf("f =\n%s", f)
+
+	tps, err := f.GetTargetHttpsProxy(f.TPName(true))
+	if err != nil {
+		t.Fatalf("expected https proxy to exist: %v, err: %v", f.TPName(true), err)
+	}
+	count := 0
+	tmp := ""
+
+	for _, linkName := range tps.SslCertificates {
+		cert, err := f.GetSslCertificate(getResourceNameFromLink(linkName))
+		if err != nil {
+			t.Fatalf("Failed to fetch certificate from link %s - %v", linkName, err)
+		}
+		if strings.HasSuffix(cert.Certificate, hostname) {
+			// cert contents will be of the form "cert-<number> <hostname>", we want the certs with the smaller number
+			// to show up first
+			tmp = strings.TrimSuffix(cert.Certificate, hostname)
+			if int(tmp[len(tmp)-1]-'0') != count {
+				t.Fatalf("Found cert with index %c, contents - %s, Expected index %d", tmp[len(tmp)-1],
+					cert.Certificate, count)
+			}
+			count++
+		}
+	}
+}
+
+// expectCerts is the mapping of certs expected in the FakeLoadBalancer. expectCertsProxy is the mapping of certs expected
+// to be in use by the target proxy. Both values will be different for the PreSharedToSecretBasedCertUpdate test.
+// f will contain the preshared as well as secret-based certs, but target proxy will contain only one or the other.
+func verifyCertAndProxyLink(expectCerts map[string]string, expectCertsProxy map[string]string, f *FakeLoadBalancers,
+	t *testing.T) {
 	t.Helper()
 
 	t.Logf("f =\n%s", f)
 
-	cert, err := f.GetSslCertificate(certName)
+	// f needs to contain only the certs in expectCerts, nothing more, nothing less
+	allCerts, err := f.ListSslCertificates()
 	if err != nil {
-		t.Fatalf("expected ssl certificate to exist: %v, err: %v", certName, err)
+		t.Fatalf("Failed to list certificates for %v - %v", f, err)
+	}
+	if len(expectCerts) != len(allCerts) {
+		t.Fatalf("Unexpected number of certs in FakeLoadBalancer %v, expected %d, actual %d", f, len(expectCerts),
+			len(allCerts))
+	}
+	for certName, certValue := range expectCerts {
+		cert, err := f.GetSslCertificate(certName)
+		if err != nil {
+			t.Fatalf("expected ssl certificate to exist: %v, err: %v", certName, err)
+		}
+
+		if cert.Certificate != certValue {
+			t.Fatalf("unexpected certificate value for cert %s; expected %v, actual %v", certName, certValue, cert.Certificate)
+		}
 	}
 
-	if cert.Certificate != certValue {
-		t.Fatalf("unexpected certificate value; expected %v, actual %v", certValue, cert.Certificate)
-	}
-
+	// httpsproxy needs to contain only the certs in expectCerts, nothing more, nothing less
 	tps, err := f.GetTargetHttpsProxy(f.TPName(true))
 	if err != nil {
-		t.Fatalf("expected https proxy to exist: %v, err: %v", certName, err)
+		t.Fatalf("expected https proxy to exist: %v, err: %v", f.TPName(true), err)
 	}
-
-	if len(tps.SslCertificates) == 0 || tps.SslCertificates[0] != cert.SelfLink {
-		t.Fatalf("expected ssl certificate to be linked in target proxy; Cert Link: %q; Target Proxy Certs: %v", cert.SelfLink, tps.SslCertificates)
+	if len(tps.SslCertificates) != len(expectCertsProxy) {
+		t.Fatalf("Expected https proxy to have %d certs, actual %d", len(expectCertsProxy), len(tps.SslCertificates))
+	}
+	for _, linkName := range tps.SslCertificates {
+		if _, ok := expectCerts[getResourceNameFromLink(linkName)]; !ok {
+			t.Fatalf("unexpected ssl certificate linked in target proxy; Expected : %v; Target Proxy Certs: %v",
+				expectCertsProxy, tps.SslCertificates)
+		}
 	}
 }
 
@@ -335,7 +569,7 @@ func TestCreateBothLoadBalancers(t *testing.T) {
 	lbInfo := &L7RuntimeInfo{
 		Name:      namer.LoadBalancer("test"),
 		AllowHTTP: true,
-		TLS:       &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:       []*TLSCerts{{Key: "key", Cert: "cert"}},
 	}
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	pool := newFakeLoadBalancerPool(f, t, namer)
@@ -488,7 +722,7 @@ func TestClusterNameChange(t *testing.T) {
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{
 		Name: namer.LoadBalancer("test"),
-		TLS:  &TLSCerts{Key: "key", Cert: "cert"},
+		TLS:  []*TLSCerts{{Key: "key", Cert: "cert"}},
 	}
 	f := NewFakeLoadBalancers(lbInfo.Name, namer)
 	pool := newFakeLoadBalancerPool(f, t, namer)
@@ -558,4 +792,8 @@ func TestInvalidClusterNameChange(t *testing.T) {
 		}
 	}
 
+}
+
+func createCert(key string, contents string, name string) *TLSCerts {
+	return &TLSCerts{Key: key, Cert: contents, Name: name, CertHash: GetCertHash(contents)}
 }

--- a/pkg/utils/namer.go
+++ b/pkg/utils/namer.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"crypto/sha256"
 	"github.com/golang/glog"
 )
 
@@ -209,6 +210,10 @@ func (n *Namer) ParseName(name string) *NameComponents {
 	if len(c) >= 2 {
 		resource = c[1]
 	}
+	if resource == sslCertPrefix {
+		// For ssl certs, the cluster uid is followed by a hypen and the cert hash, so one more string split needed.
+		uid = strings.Split(uid, "-")[0]
+	}
 	return &NameComponents{
 		ClusterName: uid,
 		Resource:    resource,
@@ -221,18 +226,9 @@ func (n *Namer) NameBelongsToCluster(name string) bool {
 	if !strings.HasPrefix(name, n.prefix+"-") {
 		return false
 	}
-
-	parts := strings.Split(name, clusterNameDelimiter)
 	clusterName := n.UID()
-	if len(parts) == 1 {
-		return clusterName == ""
-	}
-
-	if len(parts) > 2 {
-		return false
-	}
-
-	return parts[1] == clusterName
+	components := n.ParseName(name)
+	return components.ClusterName == clusterName
 }
 
 // BeName constructs the name for a backend.
@@ -304,18 +300,31 @@ func (n *Namer) TargetProxy(lbName string, protocol NamerProtocol) string {
 	return "invalid"
 }
 
-// IsSSLCert returns true if certName is an Ingress managed name.
-func (n *Namer) IsSSLCert(name string) bool {
+// IsLegacySSLCert returns true if certName is an Ingress managed name following the older naming convention.
+func (n *Namer) IsLegacySSLCert(name string) bool {
 	return strings.HasPrefix(name, n.prefix+"-"+sslCertPrefix)
 }
 
-// SSLCert returns the name of the certificate. isPrimary denotes
-// whether the name is for a primary certificate or secondary.
-func (n *Namer) SSLCert(lbName string, isPrimary bool) string {
-	if isPrimary {
-		return truncate(fmt.Sprintf("%v-%v-%v", n.prefix, sslCertPrefix, lbName))
+func (n *Namer) SSLCertPrefix(lbKey string) string {
+	// lbKey is of the form namespace/ingressname. Cert prefix will use the 8 byte(16 chars) hash of namespace-ingressname
+	// followed by the cluster id(also 16 char). We use hash instead of the actual name so that the cert prefix is of a
+	// fixed length and at the same time unique for a given loadbalancer instance.
+
+	parts := strings.Split(lbKey, clusterNameDelimiter)
+	scrubbedName := strings.Replace(lbKey, "/", "-", -1)
+	clusterName := n.UID()
+	if parts[len(parts)-1] == clusterName {
+		scrubbedName = strings.TrimSuffix(scrubbedName, clusterNameDelimiter+clusterName)
 	}
-	return truncate(fmt.Sprintf("%v-%v-%d-%v", n.prefix, sslCertPrefix, 1, lbName))
+	// sha256 is 32 bytes(64 chars) long, truncating to first 8 bytes still results in low probability of collision
+	namespaceHash := fmt.Sprintf("%x", sha256.Sum256([]byte(scrubbedName)))
+	clusterPrefix := namespaceHash[:16] + clusterNameDelimiter + clusterName
+	return fmt.Sprintf("%s-%s-%s", n.prefix, sslCertPrefix, clusterPrefix)
+}
+
+// SSLCertName returns the name of the certificate.
+func (n *Namer) SSLCertName(prefix string, secretHash string) string {
+	return truncate(prefix + "-" + secretHash)
 }
 
 // ForwardingRule returns the name of the forwarding rule prefix.

--- a/pkg/utils/namer_test.go
+++ b/pkg/utils/namer_test.go
@@ -229,7 +229,7 @@ func TestIsSSLCert(t *testing.T) {
 		{"mci", "mci-ssl-foo--uid", true},
 	} {
 		namer := NewNamerWithPrefix(tc.prefix, "uid", "fw")
-		res := namer.IsLegacySSLCert(tc.in)
+		res := namer.IsLegacySSLCert("foo", tc.in)
 		if res != tc.want {
 			t.Errorf("with prefix = %q, namer.IsLegacySSLCert(%q) = %v, want %v", tc.prefix, tc.in, res, tc.want)
 		}

--- a/pkg/utils/namer_test.go
+++ b/pkg/utils/namer_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package utils
 
-import "testing"
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
 
 const (
 	clusterId = "0123456789abcdef"
@@ -90,7 +94,8 @@ func TestNamerParseName(t *testing.T) {
 	const uid = "uid1"
 	namer := NewNamer(uid, "fw1")
 	lbName := namer.LoadBalancer("key1")
-
+	certPrefix := namer.SSLCertPrefix("key1")
+	secretHash := fmt.Sprintf("%x", sha256.Sum256([]byte("test123")))[:16]
 	for _, tc := range []struct {
 		in   string
 		want *NameComponents
@@ -100,8 +105,8 @@ func TestNamerParseName(t *testing.T) {
 		{namer.InstanceGroup(), &NameComponents{uid, "ig", ""}},
 		{namer.TargetProxy(lbName, HTTPProtocol), &NameComponents{uid, "tp", ""}},
 		{namer.TargetProxy(lbName, HTTPSProtocol), &NameComponents{uid, "tps", ""}},
-		{namer.SSLCert(lbName, true), &NameComponents{uid, "ssl", ""}},
-		{namer.SSLCert(lbName, false), &NameComponents{uid, "ssl", ""}},
+		{namer.SSLCertName(certPrefix, secretHash), &NameComponents{uid, "ssl", ""}},
+		{namer.SSLCertName(certPrefix, secretHash), &NameComponents{uid, "ssl", ""}},
 		{namer.ForwardingRule(lbName, HTTPProtocol), &NameComponents{uid, "fw", ""}},
 		{namer.ForwardingRule(lbName, HTTPSProtocol), &NameComponents{uid, "fws", ""}},
 		{namer.UrlMap(lbName), &NameComponents{uid, "um", ""}},
@@ -115,19 +120,20 @@ func TestNamerParseName(t *testing.T) {
 
 func TestNameBelongsToCluster(t *testing.T) {
 	const uid = "uid1"
+	secretHash := fmt.Sprintf("%x", sha256.Sum256([]byte("test123")))[:16]
 
 	for _, prefix := range []string{defaultPrefix, "mci"} {
 		namer := NewNamerWithPrefix(prefix, uid, "fw1")
 		lbName := namer.LoadBalancer("key1")
-
+		certPrefix := namer.SSLCertPrefix("key1")
 		// Positive cases.
 		for _, tc := range []string{
 			namer.Backend(80),
 			namer.InstanceGroup(),
 			namer.TargetProxy(lbName, HTTPProtocol),
 			namer.TargetProxy(lbName, HTTPSProtocol),
-			namer.SSLCert(lbName, true),
-			namer.SSLCert(lbName, false),
+			namer.SSLCertName(certPrefix, secretHash),
+			namer.SSLCertName(certPrefix, secretHash),
 			namer.ForwardingRule(lbName, HTTPProtocol),
 			namer.ForwardingRule(lbName, HTTPSProtocol),
 			namer.UrlMap(lbName),
@@ -223,9 +229,9 @@ func TestIsSSLCert(t *testing.T) {
 		{"mci", "mci-ssl-foo--uid", true},
 	} {
 		namer := NewNamerWithPrefix(tc.prefix, "uid", "fw")
-		res := namer.IsSSLCert(tc.in)
+		res := namer.IsLegacySSLCert(tc.in)
 		if res != tc.want {
-			t.Errorf("with prefix = %q, namer.IsSSLCert(%q) = %v, want %v", tc.prefix, tc.in, res, tc.want)
+			t.Errorf("with prefix = %q, namer.IsLegacySSLCert(%q) = %v, want %v", tc.prefix, tc.in, res, tc.want)
 		}
 	}
 }
@@ -262,14 +268,16 @@ func TestNamerFirewallRule(t *testing.T) {
 }
 
 func TestNamerLoadBalancer(t *testing.T) {
+	secretHash := fmt.Sprintf("%x", sha256.Sum256([]byte("test123")))[:16]
+	// namespaceHash is calculated the same way as cert hash
+	namespaceHash := fmt.Sprintf("%x", sha256.Sum256([]byte("key1")))[:16]
 	for _, tc := range []struct {
 		prefix string
 
 		lbName              string
 		targetHTTPProxy     string
 		targetHTTPSProxy    string
-		sslCertPrimary      string
-		sslCertSecondary    string
+		sslCert             string
 		forwardingRuleHTTP  string
 		forwardingRuleHTTPS string
 		urlMap              string
@@ -279,8 +287,7 @@ func TestNamerLoadBalancer(t *testing.T) {
 			"key1--uid1",
 			"k8s-tp-key1--uid1",
 			"k8s-tps-key1--uid1",
-			"k8s-ssl-key1--uid1",
-			"k8s-ssl-1-key1--uid1",
+			fmt.Sprintf("k8s-ssl-%s--uid1-%s", namespaceHash, secretHash),
 			"k8s-fw-key1--uid1",
 			"k8s-fws-key1--uid1",
 			"k8s-um-key1--uid1",
@@ -290,8 +297,7 @@ func TestNamerLoadBalancer(t *testing.T) {
 			"key1--uid1",
 			"mci-tp-key1--uid1",
 			"mci-tps-key1--uid1",
-			"mci-ssl-key1--uid1",
-			"mci-ssl-1-key1--uid1",
+			fmt.Sprintf("mci-ssl-%s--uid1-%s", namespaceHash, secretHash),
 			"mci-fw-key1--uid1",
 			"mci-fws-key1--uid1",
 			"mci-um-key1--uid1",
@@ -299,6 +305,7 @@ func TestNamerLoadBalancer(t *testing.T) {
 	} {
 		namer := NewNamerWithPrefix(tc.prefix, "uid1", "fw1")
 		lbName := namer.LoadBalancer("key1")
+		certPrefix := namer.SSLCertPrefix("key1")
 		if lbName != tc.lbName {
 			t.Errorf("lbName = %q, want %q", lbName, "key1--uid1")
 		}
@@ -311,13 +318,9 @@ func TestNamerLoadBalancer(t *testing.T) {
 		if name != tc.targetHTTPSProxy {
 			t.Errorf("namer.TargetProxy(%q, HTTPSProtocol) = %q, want %q", lbName, name, tc.targetHTTPSProxy)
 		}
-		name = namer.SSLCert(lbName, true)
-		if name != tc.sslCertPrimary {
-			t.Errorf("namer.SSLCert(%q, true) = %q, want %q", lbName, name, tc.sslCertPrimary)
-		}
-		name = namer.SSLCert(lbName, false)
-		if name != tc.sslCertSecondary {
-			t.Errorf("namer.SSLCert(%q, false) = %q, want %q", lbName, name, tc.sslCertSecondary)
+		name = namer.SSLCertName(certPrefix, secretHash)
+		if name != tc.sslCert {
+			t.Errorf("namer.SSLCertName(%q, true) = %q, want %q", lbName, name, tc.sslCert)
 		}
 		name = namer.ForwardingRule(lbName, HTTPProtocol)
 		if name != tc.forwardingRuleHTTP {

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -85,10 +85,14 @@ func (gce *GCECloud) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProx
 }
 
 // SetSslCertificateForTargetHttpsProxy sets the given SslCertificate for the given TargetHttpsProxy.
-func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, sslCert *compute.SslCertificate) error {
+func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, sslCerts []*compute.SslCertificate) error {
 	mc := newTargetProxyMetricContext("set_ssl_cert")
+	var allCerts []string
+	for _, cert := range sslCerts {
+		allCerts = append(allCerts, cert.SelfLink)
+	}
 	req := &compute.TargetHttpsProxiesSetSslCertificatesRequest{
-		SslCertificates: []string{sslCert.SelfLink},
+		SslCertificates: allCerts,
 	}
 	return mc.Observe(gce.c.TargetHttpsProxies().SetSslCertificates(context.Background(), meta.GlobalKey(proxy.Name), req))
 }


### PR DESCRIPTION
Currently, the api accepts multiple tls secrets, but only the first one is used. This change supports multiple tls secrets as well as multiple preshared certs specified as a comma-separated annotation string.