### PR TITLE
Ingress HTTP/2 Support

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -43,6 +43,8 @@ const (
 	ProtocolHTTP AppProtocol = "HTTP"
 	// ProtocolHTTPS protocol for a service
 	ProtocolHTTPS AppProtocol = "HTTPS"
+	// ProtocolHTTP2 protocol for a service
+	ProtocolHTTP2 AppProtocol = "HTTP2"
 )
 
 // AppProtocol describes the service protocol.
@@ -72,7 +74,7 @@ func (svc Service) ApplicationProtocols() (map[string]AppProtocol, error) {
 	// Verify protocol is an accepted value
 	for _, proto := range portToProtos {
 		switch proto {
-		case ProtocolHTTP, ProtocolHTTPS:
+		case ProtocolHTTP, ProtocolHTTPS, ProtocolHTTP2:
 		default:
 			return nil, fmt.Errorf("invalid port application protocol: %v", proto)
 		}

--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -49,6 +49,16 @@ func TestService(t *testing.T) {
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
+						ServiceApplicationProtocolKey: `{"443": "HTTP2"}`,
+					},
+				},
+			},
+			appProtocols: map[string]AppProtocol{"443": "HTTP2"},
+		},
+		{
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
 						NetworkEndpointGroupAlphaAnnotation: "true",
 					},
 				},

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -433,10 +433,16 @@ func (b *Backends) ensureBackendService(p ServicePort, igs []*compute.InstanceGr
 // edgeHop checks the links of the given backend by executing an edge hop.
 // It fixes broken links and updates the Backend accordingly.
 func (b *Backends) edgeHop(be *BackendService, igs []*compute.InstanceGroup) error {
-	addIGs := getInstanceGroupsToAdd(be, igs)
+	addIGs := []*compute.InstanceGroup{}
+	if be.Alpha != nil {
+		addIGs = getAlphaInstanceGroupsToAdd(be, igs)
+	} else {
+		addIGs = getInstanceGroupsToAdd(be, igs)
+	}
 	if len(addIGs) == 0 {
 		return nil
 	}
+
 	originalAlphaIGBackends := []*computealpha.Backend{}
 	originalGaIGBackends := []*compute.Backend{}
 	if be.Alpha != nil {
@@ -595,6 +601,34 @@ func getInstanceGroupsToAdd(be *BackendService, igs []*compute.InstanceGroup) []
 	beName := be.Ga.Name
 	beIGs := sets.String{}
 	for _, existingBe := range be.Ga.Backends {
+		beIGs.Insert(comparableGroupPath(existingBe.Group))
+	}
+
+	expectedIGs := sets.String{}
+	for _, ig := range igs {
+		expectedIGs.Insert(comparableGroupPath(ig.SelfLink))
+	}
+
+	if beIGs.IsSuperset(expectedIGs) {
+		return nil
+	}
+	glog.V(2).Infof("Expected igs for backend service %v: %+v, current igs %+v",
+		beName, expectedIGs.List(), beIGs.List())
+
+	var addIGs []*compute.InstanceGroup
+	for _, ig := range igs {
+		if !beIGs.Has(comparableGroupPath(ig.SelfLink)) {
+			addIGs = append(addIGs, ig)
+		}
+	}
+
+	return addIGs
+}
+
+func getAlphaInstanceGroupsToAdd(be *BackendService, igs []*compute.InstanceGroup) []*compute.InstanceGroup {
+	beName := be.Alpha.Name
+	beIGs := sets.String{}
+	for _, existingBe := range be.Alpha.Backends {
 		beIGs.Insert(comparableGroupPath(existingBe.Group))
 	}
 

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -32,7 +32,7 @@ type ProbeProvider interface {
 type BackendPool interface {
 	Init(p ProbeProvider)
 	Ensure(ports []ServicePort, igs []*compute.InstanceGroup) error
-	Get(port int64) (*compute.BackendService, error)
+	Get(port int64) (*BackendService, error)
 	Delete(port int64) error
 	GC(ports []ServicePort) error
 	Shutdown() error
@@ -48,6 +48,7 @@ type BackendServices interface {
 	UpdateGlobalBackendService(bg *compute.BackendService) error
 	UpdateAlphaGlobalBackendService(bg *computealpha.BackendService) error
 	CreateGlobalBackendService(bg *compute.BackendService) error
+	CreateAlphaGlobalBackendService(bg *computealpha.BackendService) error
 	DeleteGlobalBackendService(name string) error
 	ListGlobalBackendServices() ([]*compute.BackendService, error)
 	GetGlobalBackendServiceHealth(name, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error)

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -32,7 +32,7 @@ type ProbeProvider interface {
 type BackendPool interface {
 	Init(p ProbeProvider)
 	Ensure(ports []ServicePort, igs []*compute.InstanceGroup) error
-	Get(port int64) (*BackendService, error)
+	Get(port int64, isAlpha bool) (*BackendService, error)
 	Delete(port int64) error
 	GC(ports []ServicePort) error
 	Shutdown() error

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -189,7 +189,8 @@ func (c *ClusterManager) GC(lbNames []string, nodePorts []backends.ServicePort) 
 }
 
 func (c *ClusterManager) BackendServiceForPort(port int64) (*compute.BackendService, error) {
-	return c.backendPool.Get(port)
+	bs, err := c.backendPool.Get(port)
+	return bs.Ga, err
 }
 
 func (c *ClusterManager) DefaultBackendNodePort() *backends.ServicePort {

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -189,7 +189,7 @@ func (c *ClusterManager) GC(lbNames []string, nodePorts []backends.ServicePort) 
 }
 
 func (c *ClusterManager) BackendServiceForPort(port int64) (*compute.BackendService, error) {
-	bs, err := c.backendPool.Get(port)
+	bs, err := c.backendPool.Get(port, false)
 	return bs.Ga, err
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -261,7 +261,7 @@ func TestLbCreateDelete(t *testing.T) {
 	}
 
 	for _, port := range unexpected {
-		if be, err := cm.backendPool.Get(int64(port)); err == nil {
+		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}
@@ -272,7 +272,7 @@ func TestLbCreateDelete(t *testing.T) {
 	// No cluster resources (except the defaults used by the cluster manager)
 	// should exist at this point.
 	for _, port := range expected {
-		if be, err := cm.backendPool.Get(int64(port)); err == nil {
+		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -51,7 +51,7 @@ type fakeClusterManager struct {
 func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager {
 	namer := utils.NewNamer(clusterName, firewallName)
 	fakeLbs := loadbalancers.NewFakeLoadBalancers(clusterName, namer)
-	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
+	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil }, false)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
 	fakeHCP := healthchecks.NewFakeHealthCheckProvider()
 	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -254,6 +254,49 @@ func TestHealthCheckUpdate(t *testing.T) {
 	if hc.Protocol() != annotations.ProtocolHTTP2 {
 		t.Fatalf("expected check to be of type HTTP2")
 	}
+
+	// Change to NEG Health Check
+	hc.ForNEG = true
+	hc.PortSpecification = UseServingPortSpecification
+	_, err = healthChecks.Sync(hc)
+
+	if err != nil {
+		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
+	}
+
+	// Verify the health check exists.
+	hc, err = healthChecks.Get(3000, true)
+	if err != nil {
+		t.Fatalf("expected the health check to exist, err: %v", err)
+	}
+
+	if hc.Port != 0 {
+		t.Fatalf("expected health check with PortSpecification to have no Port, got %v", hc.Port)
+	}
+
+	// Change back to regular Health Check
+	hc.ForNEG = false
+	hc.Port = 3000
+	hc.PortSpecification = ""
+
+	_, err = healthChecks.Sync(hc)
+	if err != nil {
+		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
+	}
+
+	// Verify the health check exists.
+	hc, err = healthChecks.Get(3000, true)
+	if err != nil {
+		t.Fatalf("expected the health check to exist, err: %v", err)
+	}
+
+	if len(hc.PortSpecification) != 0 {
+		t.Fatalf("expected health check with Port to have no PortSpecification, got %+v", hc)
+	}
+
+	if hc.Port == 0 {
+		t.Fatalf("expected health check with PortSpecification to have Port")
+	}
 }
 
 func TestHealthCheckDeleteLegacy(t *testing.T) {

--- a/pkg/instances/fakes.go
+++ b/pkg/instances/fakes.go
@@ -81,7 +81,7 @@ func (f *FakeInstanceGroups) GetInstanceGroup(name, zone string) (*compute.Insta
 
 // CreateInstanceGroup fakes instance group creation.
 func (f *FakeInstanceGroups) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
-	ig.SelfLink = ig.Name
+	ig.SelfLink = fmt.Sprintf("/zones/%s/instanceGroups/%s", zone, ig.Name)
 	ig.Zone = zone
 	f.instanceGroups = append(f.instanceGroups, ig)
 	return nil

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -154,7 +154,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		if err != nil {
 			return err
 		}
-		l.glbcDefaultBackend = defaultBackend
+		l.glbcDefaultBackend = defaultBackend.Ga
 	}
 	// create new loadbalancers, validate existing
 	for _, ri := range lbs {

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -150,7 +150,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
 			return err
 		}
-		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.NodePort)
+		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.NodePort, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T, namer *utils.Namer) LoadBalancerPool {
-	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
+	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil }, false)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
 	fakeHCP := healthchecks.NewFakeHealthCheckProvider()
 	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")


### PR DESCRIPTION
- Adds HTTP2 annotation to Service
- Creates alpha HealthCheck and BackendService resources when the protocol is HTTP/2, by using a composite BackendService type
- Tests for HealthCheck/BackendServices using HTTP/2