### PR TITLE
Initial implementation for ingress rate limiting

### DIFF
--- a/cmd/glbc/app/clients.go
+++ b/cmd/glbc/app/clients.go
@@ -36,6 +36,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/ratelimit"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
@@ -95,6 +96,12 @@ func NewGCEClient() *gce.GCECloud {
 		provider, err := cloudprovider.GetCloudProvider("gce", configReader())
 		if err == nil {
 			cloud := provider.(*gce.GCECloud)
+			// Configure GCE rate limiting
+			rl, err := ratelimit.NewGCERateLimiter(flags.F.GCERateLimit.Values())
+			if err != nil {
+				glog.Errorf("Error in configuring rate limiting: %v", err)
+			}
+			cloud.SetRateLimiter(rl)
 			// If this controller is scheduled on a node without compute/rw
 			// it won't be allowed to list backends. We can assume that the
 			// user has no need for Ingress in this case. If they grant

--- a/cmd/glbc/app/clients.go
+++ b/cmd/glbc/app/clients.go
@@ -99,7 +99,7 @@ func NewGCEClient() *gce.GCECloud {
 			// Configure GCE rate limiting
 			rl, err := ratelimit.NewGCERateLimiter(flags.F.GCERateLimit.Values())
 			if err != nil {
-				glog.Errorf("Error in configuring rate limiting: %v", err)
+				glog.Fatalf("Error configuring rate limiting: %v", err)
 			}
 			cloud.SetRateLimiter(rl)
 			// If this controller is scheduled on a node without compute/rw

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -33,8 +33,6 @@ const (
 	// DefaultNodePortRange is the list of ports or port ranges used by kubernetes for
 	// allocating NodePort services.
 	DefaultNodePortRange = "30000-32767"
-	// DefaultGCERateLimit is the default rate limit spec.
-	DefaultGCERateLimit = "*.Operation.Get,qps,10,100"
 )
 
 var (
@@ -61,7 +59,7 @@ var (
 
 func init() {
 	F.NodePortRanges.ports = []string{DefaultNodePortRange}
-	F.GCERateLimit.specs = []string{DefaultGCERateLimit}
+	F.GCERateLimit.specs = []string{}
 }
 
 // Register flags with the command line parser.
@@ -91,7 +89,8 @@ normal environments the controller should only delete a loadbalancer if the
 associated Ingress is deleted.`)
 	flag.Var(&F.GCERateLimit, "gce-ratelimit",
 		`Optional, can be used to rate limit certain GCE API calls. Example usage:
---gce-ratelimit=ga.Addresses.Get,qps,1.5,5 (limit ga.Addresses.Get to maximum of 1.5 qps with a burst of 5).
+--gce-ratelimit=ga.Addresses.Get,qps,1.5,5
+(limit ga.Addresses.Get to maximum of 1.5 qps with a burst of 5).
 Use the flag more than once to rate limit more than one call.`)
 	flag.StringVar(&F.HealthCheckPath, "health-check-path", "/",
 		`Path used to health-check a backend service. All Services must serve a
@@ -123,7 +122,6 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 
 type RateLimitSpecs struct {
 	specs []string
-	isSet bool
 }
 
 // Part of the flag.Value interface.
@@ -133,12 +131,6 @@ func (r *RateLimitSpecs) String() string {
 
 // Set supports the flag being repeated multiple times. Part of the flag.Value interface.
 func (r *RateLimitSpecs) Set(value string) error {
-	// On first Set(), clear the default. On subsequent Set()'s, append.
-	if !r.isSet {
-		r.isSet = true
-		// Remove the default
-		r.specs = []string{}
-	}
 	r.specs = append(r.specs, value)
 	return nil
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -59,7 +59,7 @@ var (
 
 func init() {
 	F.NodePortRanges.ports = []string{DefaultNodePortRange}
-	F.GCERateLimit.specs = []string{}
+	F.GCERateLimit.specs = []string{"alpha.Operations.Get,qps,10,100", "beta.Operations.Get,qps,10,100", "ga.Operations.Get,qps,10,100"}
 }
 
 // Register flags with the command line parser.
@@ -91,7 +91,11 @@ associated Ingress is deleted.`)
 		`Optional, can be used to rate limit certain GCE API calls. Example usage:
 --gce-ratelimit=ga.Addresses.Get,qps,1.5,5
 (limit ga.Addresses.Get to maximum of 1.5 qps with a burst of 5).
-Use the flag more than once to rate limit more than one call.`)
+Use the flag more than once to rate limit more than one call. If you do not
+specify this flag, the default is to rate limit Operations.Get for all versions.
+If you do specify this flag one or more times, this default will be overwritten.
+If you want to still use the default, simply specify it along with your other
+values.`)
 	flag.StringVar(&F.HealthCheckPath, "health-check-path", "/",
 		`Path used to health-check a backend service. All Services must serve a
 200 page on this path. Currently this is only configurable globally.`)
@@ -122,6 +126,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 
 type RateLimitSpecs struct {
 	specs []string
+	isSet bool
 }
 
 // Part of the flag.Value interface.
@@ -131,6 +136,12 @@ func (r *RateLimitSpecs) String() string {
 
 // Set supports the flag being repeated multiple times. Part of the flag.Value interface.
 func (r *RateLimitSpecs) Set(value string) error {
+	// On first Set(), clear the original defaults
+	// On subsequent Set()'s, append.
+	if !r.isSet {
+		r.specs = []string{}
+		r.isSet = true
+	}
 	r.specs = append(r.specs, value)
 	return nil
 }

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
+)
+
+// GCERateLimiter implements cloud.RateLimiter
+type GCERateLimiter struct {
+	// Map a RateLimitKey to its rate limiter implementation.
+	rateLimitImpls map[*cloud.RateLimitKey]flowcontrol.RateLimiter
+}
+
+// NewGCERateLimiter parses the list of rate limiting specs passed in and
+// returns a properly configured cloud.RateLimiter implementation.
+// Expected format of specs: {"[version].[service].[operation],[type],[param1],[param2],..", "..."}
+func NewGCERateLimiter(specs []string) (*GCERateLimiter, error) {
+	rateLimitImpls := make(map[*cloud.RateLimitKey]flowcontrol.RateLimiter)
+	// Within each specification, split on comma to get the operation,
+	// rate limiter type, and extra parameters.
+	for _, spec := range specs {
+		params := strings.Split(spec, ",")
+		if len(params) < 2 {
+			return nil, fmt.Errorf("Must at least specify operation and rate limiter type.")
+		}
+		// params[0] should consist of the operation to rate limit.
+		key, err := constructRateLimitKey(params[0])
+		if err != nil {
+			return nil, err
+		}
+		// params[1:] should consist of the rate limiter type and extra params.
+		impl, err := constructRateLimitImpl(params[1:])
+		if err != nil {
+			return nil, err
+		}
+		rateLimitImpls[key] = impl
+		glog.Infof("Configured rate limiting for: %v", key)
+	}
+	if len(rateLimitImpls) == 0 {
+		return nil, nil
+	}
+	return &GCERateLimiter{rateLimitImpls}, nil
+}
+
+// Implementation of cloud.RateLimiter
+func (l *GCERateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) error {
+	ch := make(chan struct{})
+	go func() {
+		// Call flowcontrol.RateLimiter implementation.
+		impl := l.rateLimitImpl(key)
+		if impl != nil {
+			impl.Accept()
+		}
+		close(ch)
+	}()
+	select {
+	case <-ch:
+		break
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+// rateLimitImpl returns the flowcontrol.RateLimiter implementation
+// associated with the passed in key.
+func (l *GCERateLimiter) rateLimitImpl(key *cloud.RateLimitKey) flowcontrol.RateLimiter {
+	// Since the passed in key will have the ProjectID field filled in, we need to
+	// create a copy which does not, so that retreiving the rate limiter implementation
+	// through the map works as expected.
+	keyCopy := &cloud.RateLimitKey{
+		ProjectID: "",
+		Operation: key.Operation,
+		Version:   key.Version,
+		Service:   key.Service,
+	}
+	return l.rateLimitImpls[keyCopy]
+}
+
+// Expected format of param is [version].[service].[operation]
+func constructRateLimitKey(param string) (*cloud.RateLimitKey, error) {
+	params := strings.Split(param, ".")
+	if len(params) != 3 {
+		return nil, fmt.Errorf("Must specify operation in [version].[service].[operation] format.")
+	}
+	// TODO(rramkumar): Add another layer of validation here?
+	version := meta.Version(params[0])
+	service := params[1]
+	operation := params[2]
+	return &cloud.RateLimitKey{
+		ProjectID: "",
+		Operation: operation,
+		Version:   version,
+		Service:   service,
+	}, nil
+}
+
+// constructRateLimitImpl parses the slice and returns a flowcontrol.RateLimiter
+// Expected format is [type],[param1],[param2],...
+func constructRateLimitImpl(params []string) (flowcontrol.RateLimiter, error) {
+	// For now, only the "qps" type is supported.
+	rlType := params[0]
+	implArgs := params[1:]
+	if rlType == "qps" {
+		if len(implArgs) != 2 {
+			return nil, fmt.Errorf("Invalid number of args for rate limiter type %v. Expected %d, Got %v", rlType, 2, len(implArgs))
+		}
+		qps, err := strconv.ParseFloat(implArgs[0], 32)
+		if err != nil || qps <= 0 {
+			return nil, fmt.Errorf("Invalid argument for rate limiter type %v. Either %v is not a float or not greater than 0.", rlType, implArgs[0])
+		}
+		burst, err := strconv.Atoi(implArgs[1])
+		if err != nil {
+			return nil, fmt.Errorf("Invalid argument for rate limiter type %v. Expected %v to be a int.", rlType, implArgs[1])
+		}
+		return flowcontrol.NewTokenBucketRateLimiter(float32(qps), burst), nil
+	}
+	return nil, fmt.Errorf("Invalid rate limiter type provided: %v", rlType)
+}

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -47,7 +47,7 @@ func NewGCERateLimiter(specs []string) (*GCERateLimiter, error) {
 			return nil, fmt.Errorf("Must at least specify operation and rate limiter type.")
 		}
 		// params[0] should consist of the operation to rate limit.
-		keys, err := constructRateLimitKeys(params[0])
+		key, err := constructRateLimitKey(params[0])
 		if err != nil {
 			return nil, err
 		}
@@ -56,11 +56,8 @@ func NewGCERateLimiter(specs []string) (*GCERateLimiter, error) {
 		if err != nil {
 			return nil, err
 		}
-		// For each spec, the rate limiter type is the same for all keys generated.
-		for _, key := range keys {
-			rateLimitImpls[key] = impl
-			glog.Infof("Configured rate limiting for: %v", key)
-		}
+		rateLimitImpls[key] = impl
+		glog.Infof("Configured rate limiting for: %v", key)
 	}
 	if len(rateLimitImpls) == 0 {
 		return nil, nil
@@ -70,7 +67,6 @@ func NewGCERateLimiter(specs []string) (*GCERateLimiter, error) {
 
 // Implementation of cloud.RateLimiter
 func (l *GCERateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) error {
-	// If the rate limiter is empty, the do some default
 	ch := make(chan struct{})
 	go func() {
 		// Call flowcontrol.RateLimiter implementation.
@@ -105,75 +101,21 @@ func (l *GCERateLimiter) rateLimitImpl(key *cloud.RateLimitKey) flowcontrol.Rate
 }
 
 // Expected format of param is [version].[service].[operation]
-// this could return more than one cloud.RateLimitKey if "*" is used for either
-// version, service, or operation (or more than one of those).
-func constructRateLimitKeys(param string) ([]*cloud.RateLimitKey, error) {
+func constructRateLimitKey(param string) (*cloud.RateLimitKey, error) {
 	params := strings.Split(param, ".")
 	if len(params) != 3 {
 		return nil, fmt.Errorf("Must specify operation in [version].[service].[operation] format.")
 	}
-	keys := []*cloud.RateLimitKey{}
-
-	// First parse the version.
-	versions := []meta.Version{}
-	if params[0] == "*" {
-		versions = meta.AllVersions
-	} else {
-		// Validate that the full provided version exists
-		if versionExists(params[0]) {
-			versions = append(versions, meta.Version(params[0]))
-		} else {
-			return nil, fmt.Errorf("Invalid version specified: %v", params[0])
-		}
-	}
-	// For each version we get, parse the service.
-	for _, version := range versions {
-		// Construct a list of all possible services for the version.
-		services := []string{}
-		if params[1] == "*" {
-			for _, serviceInfo := meta.AllServices {
-				// Only include in the list of possible services if the service is
-				// available at the particular version we are looking at now.
-				if serviceInfo.Version() == version {
-						services = append(services, serviceInfo.Service)
-				}
-			}
-		} else {
-			// Validate that the full provided service exists.
-			if serviceExists(params[1]) {
-				services = append(services, params[1])
-			} else {
-				return nil, fmt.Errorf("Invalid service specified: %v", params[1])
-			}
-		}
-		// For each service we get, parse the operation.
-		for _, service := range services {
-			// These operation exist for every service.
-			operations := []string{}
-			if params[2] == "*" {
-				// Default for every service, regardless of version.
-				// TODO(rramkumar): Implement support for additional methods.
-				operations = []string{"Get", "List", "Insert", "Delete"}
-			} else {
-				// Validate that the full provided operation exists.
-				if operationExists(params[2]) {
-					operations = append(operations, params[2])
-				} else {
-					return nil, fmt.Errorf("Invalid operation specified: %v", params[2])
-				}
-			}
-			for _, operation := range operations {
-				key := &cloud.RateLimitKey{
-					ProjectID: "",
-					Operation: operation,
-					Version: version,
-					Service: service,
-				}
-				keys = append(keys, key)
-			}
-		}
-	}
-	return keys, nil
+	// TODO(rramkumar): Add another layer of validation here?
+	version := meta.Version(params[0])
+	service := params[1]
+	operation := params[2]
+	return &cloud.RateLimitKey{
+		ProjectID: "",
+		Operation: operation,
+		Version:   version,
+		Service:   service,
+	}, nil
 }
 
 // constructRateLimitImpl parses the slice and returns a flowcontrol.RateLimiter
@@ -197,36 +139,4 @@ func constructRateLimitImpl(params []string) (flowcontrol.RateLimiter, error) {
 		return flowcontrol.NewTokenBucketRateLimiter(float32(qps), burst), nil
 	}
 	return nil, fmt.Errorf("Invalid rate limiter type provided: %v", rlType)
-}
-
-// versionExists returns true if the passed in string is a valid meta.Version.
-func versionExists(s string) bool {
-	for _, version := range meta.AllVersions {
-		if meta.Version(s) == version {
-			return true
-		}
-	}
-	return false
-}
-
-// serviceExists returns true if the passed in string refers to a valid GCE service.
-func serviceExists(s string) bool {
-	for _, serviceInfo := range meta.AllServices {
-		if s == serviceInfo.Service {
-			return true
-		}
-	}
-	return false
-}
-
-// operationExists returns true if the passed string refers to a valid operation.
-// Current valid operations are "Get", "List", "Insert", "Delete"
-// TODO(rramkumar): Implement support for more methods.
-func operationExists(s string) bool {
-	for _, operation := []string{"Get", "List", "Insert", "Delete"} {
-		if s == operation {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -25,7 +25,6 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		[]string{"ga.Addresses.Get,qps,1.5,5"},
 		[]string{"ga.Addresses.List,qps,2,10"},
 		[]string{"ga.Addresses.Get,qps,1.5,5", "ga.Firewalls.Get,qps,1.5,5"},
-		[]string{"ga.Operations.Get,qps,10,100"},
 	}
 	invalidTestCases := [][]string{
 		[]string{"gaAddresses.Get,qps,1.5,5"},
@@ -45,7 +44,6 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		if err != nil {
 			t.Errorf("Did not expect an error for test case: %v", testCase)
 		}
-		// TODO(rramkumar): Verify the internal map for the GCERateLimiter
 	}
 
 	for _, testCase := range invalidTestCases {
@@ -53,6 +51,5 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected an error for test case: %v", testCase)
 		}
-		// TODO(rramkumar): Verify the internal map for the GCERateLimiter
 	}
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -25,6 +25,7 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		[]string{"ga.Addresses.Get,qps,1.5,5"},
 		[]string{"ga.Addresses.List,qps,2,10"},
 		[]string{"ga.Addresses.Get,qps,1.5,5", "ga.Firewalls.Get,qps,1.5,5"},
+		[]string{"ga.Operations.Get,qps,10,100"},
 	}
 	invalidTestCases := [][]string{
 		[]string{"gaAddresses.Get,qps,1.5,5"},

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"testing"
+)
+
+func TestConfigureGCERateLimiting(t *testing.T) {
+	validTestCases := [][]string{
+		[]string{"ga.Addresses.Get,qps,1.5,5"},
+		[]string{"ga.Addresses.List,qps,2,10"},
+		[]string{"ga.Addresses.Get,qps,1.5,5", "ga.Firewalls.Get,qps,1.5,5"},
+	}
+	invalidTestCases := [][]string{
+		[]string{"gaAddresses.Get,qps,1.5,5"},
+		[]string{"gaAddresses.Get,qps,0,5"},
+		[]string{"gaAddresses.Get,qps,-1,5"},
+		[]string{"ga.Addresses.Get,qps,1.5.5"},
+		[]string{"gaAddresses.Get,qps,1.5,5.5"},
+		[]string{"gaAddressesGet,qps,1.5,5.5"},
+		[]string{"gaAddressesGet,qps,1.5"},
+		[]string{"ga.Addresses.Get,foo,1.5,5"},
+		[]string{"ga.Addresses.Get,1.5,5"},
+		[]string{"ga.Addresses.Get,qps,1.5,5", "gaFirewalls.Get,qps,1.5,5"},
+	}
+
+	for _, testCase := range validTestCases {
+		_, err := NewGCERateLimiter(testCase)
+		if err != nil {
+			t.Errorf("Did not expect an error for test case: %v", testCase)
+		}
+	}
+
+	for _, testCase := range invalidTestCases {
+		_, err := NewGCERateLimiter(testCase)
+		if err == nil {
+			t.Errorf("Expected an error for test case: %v", testCase)
+		}
+	}
+}

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -25,6 +25,7 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		[]string{"ga.Addresses.Get,qps,1.5,5"},
 		[]string{"ga.Addresses.List,qps,2,10"},
 		[]string{"ga.Addresses.Get,qps,1.5,5", "ga.Firewalls.Get,qps,1.5,5"},
+		[]string{"ga.Operations.Get,qps,10,100"},
 	}
 	invalidTestCases := [][]string{
 		[]string{"gaAddresses.Get,qps,1.5,5"},
@@ -44,6 +45,7 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		if err != nil {
 			t.Errorf("Did not expect an error for test case: %v", testCase)
 		}
+		// TODO(rramkumar): Verify the internal map for the GCERateLimiter
 	}
 
 	for _, testCase := range invalidTestCases {
@@ -51,5 +53,6 @@ func TestConfigureGCERateLimiting(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected an error for test case: %v", testCase)
 		}
+		// TODO(rramkumar): Verify the internal map for the GCERateLimiter
 	}
 }

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
@@ -151,6 +151,9 @@ type GCECloud struct {
 
 	// New code generated interface to the GCE compute library.
 	c cloud.Cloud
+
+	// Keep a reference of this around so we can inject a new cloud.RateLimiter implementation.
+	s *cloud.Service
 }
 
 // TODO: replace gcfg with json
@@ -515,15 +518,25 @@ func CreateGCECloud(config *CloudConfig) (*GCECloud, error) {
 	}
 
 	gce.manager = &gceServiceManager{gce}
-	gce.c = cloud.NewGCE(&cloud.Service{
+	gce.s = &cloud.Service{
 		GA:            service,
 		Alpha:         serviceAlpha,
 		Beta:          serviceBeta,
 		ProjectRouter: &gceProjectRouter{gce},
 		RateLimiter:   &gceRateLimiter{gce},
-	})
+	}
+	gce.c = cloud.NewGCE(gce.s)
 
 	return gce, nil
+}
+
+// SetRateLimiter adds a custom cloud.RateLimiter implementation.
+// WARNING: Calling this could have unexpected behavior if you have in-flight
+// requests. It is best to use this immediately after creating a GCECloud.
+func (g *GCECloud) SetRateLimiter(rl cloud.RateLimiter) {
+	if rl != nil {
+		g.s.RateLimiter = rl
+	}
 }
 
 // determineSubnetURL queries for all subnetworks in a region for a given network and returns


### PR DESCRIPTION
This PR adds support for rate limiting certain GCE API call's that are made by the controller. Currently, the cloud provider layer does not rate limit any standard controller calls (such as BackendService Get). As a result, in some cases when API calls are frequent, we are blowing through project quota and getting rate limited on the GCE side. This could also cause the controller to slow down. By allowing for customization of what calls can be rate limited, we can prevent blowing through project quota and we can intelligently rate limit so that we do not experience slowdown.  

Will add unit tests once the overall approach is LGTM'd.

/assign @nicksardo @bowei 