### PR TITLE
Use given name rather than regenerating it in UrlMap fake

### DIFF
--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -192,7 +192,7 @@ func (f *FakeLoadBalancers) GetUrlMap(name string) (*compute.UrlMap, error) {
 func (f *FakeLoadBalancers) CreateUrlMap(urlMap *compute.UrlMap) error {
 	glog.V(4).Infof("CreateUrlMap %+v", urlMap)
 	f.calls = append(f.calls, "CreateUrlMap")
-	urlMap.SelfLink = f.UMName()
+	urlMap.SelfLink = urlMap.Name
 	f.Um = append(f.Um, urlMap)
 	return nil
 }


### PR DESCRIPTION
This is what we do for all other resources like forwarding rule, target proxies, etc.
UrlMap is the only resource for which we use namer again.
Fixing this inconsistency.

Found while writing a test for https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145 for kubemci. We pass a nil namer while instantiating FakeLoadBalancers in our tests.

cc @bowei @nicksardo @G-Harmon 