### PR TITLE
Ensure .go/cache in build

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -115,6 +115,7 @@ $(GO_BINARIES): build-dirs
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$(ARCH):/go/bin/linux_$(ARCH)                       \
 	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
+	    -v $$(pwd)/.go/cache:/.cache/go-build                              \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/sh -c "                                                       \
@@ -191,6 +192,7 @@ test: build-dirs
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
 	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
+	    -v $$(pwd)/.go/cache:/.cache/go-build                              \
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/sh -c "                                                       \
@@ -235,7 +237,7 @@ version:
 .PHONY: build-dirs
 build-dirs:
 	@mkdir -p bin/$(ARCH)
-	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH)
+	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/$(ARCH) .go/cache
 
 .PHONY: clean
 clean: container-clean bin-clean images-clean


### PR DESCRIPTION
Patch from https://github.com/kubernetes/contrib/pull/2877. Local test (`make test`) is failing without this:
```
Checking go vet: FAIL                                                                         
go: disabling cache (/.cache/go-build) due to initialization failure: mkdir /.cache: permission denied
```