### PR TITLE
Change naming of SSL certs

### DIFF
--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -76,7 +76,6 @@ func (l *L7s) create(ri *L7RuntimeInfo) (*L7, error) {
 		cloud:              l.cloud,
 		glbcDefaultBackend: l.glbcDefaultBackend,
 		namer:              l.namer,
-		sslCertPrefix:      l.namer.SSLCertPrefix(ri.Name),
 	}, nil
 }
 


### PR DESCRIPTION
Changes
 - Rename SSL certs from `k8s-ssl-{nameHash}--{clusterId}-{secretHash}` to `k8s-ssl-{nameHash}-{secretHash}--{clusterId}` to be consistent with other resources.
 - Get rid of `sslCertPrefix` for simplification.