### PR TITLE
Split sync up 

### DIFF
--- a/pkg/utils/taskqueue.go
+++ b/pkg/utils/taskqueue.go
@@ -85,6 +85,7 @@ func (t *PeriodicTaskQueue) worker() {
 			glog.Errorf("Requeuing %q due to error: %v (%v)", key, err, t.resource)
 			t.queue.AddRateLimited(key)
 		} else {
+			glog.V(4).Infof("Finished syncing %v", key)
 			t.queue.Forget(key)
 		}
 		t.queue.Done(key)


### PR DESCRIPTION
Splitting up sync so we no longer have the defer statement.

Fixing controller tests so we know when the sync func fails.