### PR TITLE
Update annotations.md

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -24,7 +24,7 @@ Key:
 | `force-ssl-redirect` | Redirect non-TLS requests to TLS even when TLS is not configured. | `false` | nginx, trafficserver
 | `secure-backends` | Use TLS to communicate with origin (pods). | `false` | nginx, haproxy, trafficserver
 | `kubernetes.io/ingress.allow-http` | Whether to accept non-TLS HTTP connections. | `true` | gce
-| `pre-shared-cert` | Name of the TLS certificate in GCP to use when provisioning the HTTPS load balancer. | empty string | gce
+| `ingress.gcp.kubernetes.io/pre-shared-cert` | Name of the TLS certificate in GCP to use when provisioning the HTTPS load balancer. | empty string | gce
 | `hsts-max-age` | Set an HSTS header with this lifetime. | | trafficserver
 | `hsts-include-subdomains` | Add includeSubdomains to the HSTS header. | | trafficserver
 


### PR DESCRIPTION
This documentation mistakingly implies the prefix for `pre-shared-cert` is `ingress.kubernetes.io`, when it is actually `ingress.gcp.kubernetes.io`. Using the former will not create an HTTPS mapping in the GCLB, and does not emit any errors indicating there is an issue with the annotation.