### PR TITLE
Add support for logging latest commit hash of GLBC build being used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ PKG := k8s.io/ingress-gce
 # for each BINARY.
 CONTAINER_BINARIES := glbc
 
+# Latest commit hash for current branch.
+GIT_COMMIT := $(shell git rev-parse HEAD)
+
 # Registry to push to.
 REGISTRY ?= gcr.io/google_containers
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -29,6 +29,11 @@ fi
 if [ -z "${VERSION}" ]; then
     echo "VERSION must be set"
     exit 1
+
+fi
+if [ -z "${GIT_COMMIT}" ]; then
+    echo "GIT_COMMIT must be set"
+    exit 1
 fi
 
 export CGO_ENABLED=0
@@ -37,7 +42,7 @@ if [ $GOARCH == "amd64" ]; then
     export GOBIN="$GOPATH/bin/linux_amd64"
 fi
 
-go install                                                         \
-    -installsuffix "static"                                        \
-    -ldflags "-X ${PKG}/pkg/version.Version=${VERSION}"            \
+go install                                                                                             \
+    -installsuffix "static"                                                                            \
+    -ldflags "-X ${PKG}/pkg/version.Version=${VERSION} -X ${PKG}/pkg/version.GitCommit=${GIT_COMMIT}"  \
     ./...

--- a/build/rules.mk
+++ b/build/rules.mk
@@ -122,6 +122,7 @@ $(GO_BINARIES): build-dirs
 	        ARCH=$(ARCH)                                                   \
 	        VERSION=$(VERSION)                                             \
 	        PKG=$(PKG)                                                     \
+		GIT_COMMIT=$(GIT_COMMIT)                                       \
 	        ./build/build.sh                                               \
 	    "
 

--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -52,6 +52,7 @@ func main() {
 	}
 
 	glog.V(0).Infof("Starting GLBC image: %q, cluster name %q", version.Version, flags.F.ClusterName)
+	glog.V(0).Infof("Latest commit hash: %q", version.GitCommit)
 	for i, a := range os.Args {
 		glog.V(0).Infof("argv[%d]: %q", i, a)
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,3 +19,7 @@ package version
 // Version is a version string populated by the build using -ldflags "-X
 // ${PKG}/pkg/version.Version=${VERSION}".
 var Version = "UNKNOWN"
+
+// GitCommit is the latest git commit hash populated by the build using
+// -ldflags "-X ${PKG}/pkg/version.GitCommit=${GIT_COMMIT}".
+var GitCommit = "UNKNOWN"


### PR DESCRIPTION
This will make it easier for us during debugging e2e test failures. Specifically, we now do not need to cross-reference with the latest e2e image push job run to find out the commit used in the test.

/assign @nicksardo 