### PR TITLE
Add ability for MCI controller to enqueue ingresses

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	if flags.F.MultiCluster {
-		mciController, _ := mci.NewController(ctx, flags.F.ResyncPeriod)
+		mciController, _ := mci.NewController(ctx, flags.F.ResyncPeriod, lbc)
 		go mciController.Run(stopCh)
 		glog.V(0).Infof("Multi-Cluster Ingress Controller started")
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -54,6 +54,7 @@ type ControllerContext struct {
 type MultiClusterContext struct {
 	RegistryClient  crclient.Interface
 	ClusterInformer cache.SharedIndexInformer
+	MCIEnabled      bool
 }
 
 // NewControllerContext returns a new shared set of informers.
@@ -76,6 +77,7 @@ func NewControllerContext(kubeClient kubernetes.Interface, registryClient crclie
 	}
 	if context.MC.RegistryClient != nil {
 		context.MC.ClusterInformer = crinformerv1alpha1.NewClusterInformer(registryClient, resyncPeriod, newIndexer())
+		context.MC.MCIEnabled = true
 	}
 
 	return context


### PR DESCRIPTION
Tested this locally and it worked. Stood up a cluster registry with a couple cluster inside of it and then deleted one of the clusters. Logs showed that all ingresses in the cluster registry host were enqueued.

/assign @nicksardo 