### PR TITLE
Small addition to ClusterServiceMapper interface

### DIFF
--- a/pkg/mapper/fakes.go
+++ b/pkg/mapper/fakes.go
@@ -35,3 +35,7 @@ func NewFakeClusterServiceMapper(returnError bool) ClusterServiceMapper {
 func (f *fakeClusterServiceMapper) Services(ing *v1beta1.Ingress) (map[v1beta1.IngressBackend]v1.Service, error) {
 	return nil, fmt.Errorf("fake error")
 }
+
+func (f *fakeClusterServiceMapper) SetExpectedServices(expectedSvcs []string) {
+	return
+}

--- a/pkg/mapper/interfaces.go
+++ b/pkg/mapper/interfaces.go
@@ -23,4 +23,5 @@ import (
 // Services it defines for a specific cluster,
 type ClusterServiceMapper interface {
 	Services(ing *v1beta1.Ingress) (map[v1beta1.IngressBackend]v1.Service, error)
+	SetExpectedServices(expectedSvcs []string)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -180,3 +180,11 @@ func BackendServiceComparablePath(url string) string {
 	}
 	return fmt.Sprintf("global/%s", path_parts[1])
 }
+
+func StringsToKeyMap(strings []string) map[string]bool {
+	m := make(map[string]bool)
+	for _, s := range strings {
+		m[s] = true
+	}
+	return m
+}


### PR DESCRIPTION
This PR adds a new method to the interface. Specifically, now the list of expected services can be overwritten with a call to SetExpectedServices. 

/assign @nicksardo 