### PR TITLE
BackendService Naming

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -19,7 +19,6 @@ package backends
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -181,10 +180,6 @@ func (be *BackendService) ensureDescription(description string) (needsUpdate boo
 // Backends is a BackendPool.
 var _ BackendPool = (*Backends)(nil)
 
-func portKey(port int64) string {
-	return fmt.Sprintf("%d", port)
-}
-
 // ServicePort for tupling port and protocol
 type ServicePort struct {
 	SvcName       types.NamespacedName
@@ -222,12 +217,13 @@ func NewBackendPool(
 	healthChecker healthchecks.HealthChecker,
 	nodePool instances.NodePool,
 	namer *utils.Namer,
-	ignorePorts []int64,
+	ignorePorts []ServicePort,
 	resyncWithCloud bool) *Backends {
 
 	ignored := []string{}
 	for _, p := range ignorePorts {
-		ignored = append(ignored, portKey(p))
+		portName := namer.BackendNEG(p.SvcName.Namespace, p.SvcName.Name, p.SvcTargetPort)
+		ignored = append(ignored, portName)
 	}
 	backendPool := &Backends{
 		cloud:         cloud,
@@ -246,11 +242,7 @@ func NewBackendPool(
 		if !namer.NameBelongsToCluster(bs.Name) {
 			return "", fmt.Errorf("unrecognized name %v", bs.Name)
 		}
-		port, err := namer.BackendPort(bs.Name)
-		if err != nil {
-			return "", err
-		}
-		return port, nil
+		return bs.Name, nil
 	}
 	backendPool.snapshotter = storage.NewCloudListingPool("backends", keyFunc, backendPool, 30*time.Second)
 	return backendPool
@@ -262,8 +254,8 @@ func (b *Backends) Init(pp ProbeProvider) {
 }
 
 // Get returns a single backend.
-func (b *Backends) Get(port int64, isAlpha bool) (*BackendService, error) {
-	beGa, err := b.cloud.GetGlobalBackendService(b.namer.Backend(port))
+func (b *Backends) Get(name string, isAlpha bool) (*BackendService, error) {
+	beGa, err := b.cloud.GetGlobalBackendService(name)
 	if err != nil {
 		return nil, err
 	}
@@ -275,18 +267,22 @@ func (b *Backends) Get(port int64, isAlpha bool) (*BackendService, error) {
 	// is no longer alpha whitelisted, this will always return an isForbidden err
 	// until the user can access the alpha APIs again.
 	if beGa.Protocol == "" || isAlpha {
-		beAlpha, err = b.cloud.GetAlphaGlobalBackendService(b.namer.Backend(port))
+		beAlpha, err = b.cloud.GetAlphaGlobalBackendService(beGa.Name)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	b.snapshotter.Add(portKey(port), beGa)
+	b.snapshotter.Add(name, beGa)
 	return &BackendService{Ga: beGa, Alpha: beAlpha}, nil
 }
 
 func (b *Backends) ensureHealthCheck(sp ServicePort) (string, error) {
-	hc := b.healthChecker.New(sp.NodePort, sp.Protocol, sp.NEGEnabled)
+	name := b.namer.Backend(sp.NodePort)
+	if sp.NEGEnabled {
+		name = b.namer.BackendNEG(sp.SvcName.Namespace, sp.SvcName.Name, sp.SvcTargetPort)
+	}
+	hc := b.healthChecker.New(name, sp.NodePort, sp.Protocol, sp.NEGEnabled)
 	existingLegacyHC, err := b.healthChecker.GetLegacy(sp.NodePort)
 	if err != nil && !utils.IsNotFoundError(err) {
 		return "", err
@@ -339,7 +335,7 @@ func (b *Backends) create(namedPort *compute.NamedPort, hcLink string, sp Servic
 		}
 	}
 
-	return b.Get(namedPort.Port, isAlpha)
+	return b.Get(name, isAlpha)
 }
 
 // Ensure will update or create Backends for the given ports.
@@ -376,8 +372,14 @@ func (b *Backends) ensureBackendService(p ServicePort, igs []*compute.InstanceGr
 	// We must track the ports even if creating the backends failed, because
 	// we might've created health-check for them.
 	be := &BackendService{}
-	defer func() { b.snapshotter.Add(portKey(p.NodePort), be) }()
+	beName := b.namer.Backend(p.NodePort)
+	if p.NEGEnabled {
+		beName = b.namer.BackendNEG(p.SvcName.Namespace, p.SvcName.Name, p.SvcTargetPort)
+	}
 
+	defer func() {
+		b.snapshotter.Add(beName, be)
+	}()
 	var err error
 
 	// Ensure health check for backend service exists
@@ -387,14 +389,15 @@ func (b *Backends) ensureBackendService(p ServicePort, igs []*compute.InstanceGr
 	}
 
 	// Verify existance of a backend service for the proper port, but do not specify any backends/igs
-	beName := b.namer.Backend(p.NodePort)
-	be, _ = b.Get(p.NodePort, p.isAlpha())
+	be, _ = b.Get(beName, p.isAlpha())
+
 	if be == nil {
 		namedPort := &compute.NamedPort{
 			Name: b.namer.NamedPort(p.NodePort),
 			Port: p.NodePort,
 		}
-		glog.V(2).Infof("Creating backend service for port %v named port %v", p.NodePort, namedPort)
+
+		glog.V(2).Infof("Creating backend service for port %v named %v", p.NodePort, beName)
 		be, err = b.create(namedPort, hcLink, p, beName)
 		if err != nil {
 			return err
@@ -505,23 +508,24 @@ func (b *Backends) update(be *BackendService) error {
 }
 
 // Delete deletes the Backend for the given port.
-func (b *Backends) Delete(port int64) (err error) {
-	name := b.namer.Backend(port)
-	glog.V(2).Infof("Deleting backend service %v", name)
+func (b *Backends) Delete(name string) (err error) {
 	defer func() {
 		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 			err = nil
 		}
 		if err == nil {
-			b.snapshotter.Delete(portKey(port))
+			b.snapshotter.Delete(name)
 		}
 	}()
+
+	glog.V(2).Infof("Deleting backend service %v", name)
+
 	// Try deleting health checks even if a backend is not found.
 	if err = b.cloud.DeleteGlobalBackendService(name); err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 		return err
 	}
 
-	return b.healthChecker.Delete(port)
+	return b.healthChecker.Delete(name)
 }
 
 // List lists all backends.
@@ -626,20 +630,20 @@ func getInstanceGroupsToAdd(be *BackendService, igs []*compute.InstanceGroup) []
 func (b *Backends) GC(svcNodePorts []ServicePort) error {
 	knownPorts := sets.NewString()
 	for _, p := range svcNodePorts {
-		knownPorts.Insert(portKey(p.NodePort))
+		name := b.namer.Backend(p.NodePort)
+		if p.NEGEnabled {
+			name = b.namer.BackendNEG(p.SvcName.Namespace, p.SvcName.Name, p.SvcTargetPort)
+		}
+		knownPorts.Insert(name)
 	}
 	pool := b.snapshotter.Snapshot()
 	for port := range pool {
-		p, err := strconv.ParseUint(port, 10, 16)
-		if err != nil {
-			return err
-		}
-		nodePort := int64(p)
-		if knownPorts.Has(portKey(nodePort)) || b.ignoredPorts.Has(portKey(nodePort)) {
+		if knownPorts.Has(port) || b.ignoredPorts.Has(port) {
 			continue
 		}
-		glog.V(3).Infof("GCing backend for port %v", p)
-		if err := b.Delete(nodePort); err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+
+		glog.V(3).Infof("GCing backendService for port %s", port)
+		if err := b.Delete(port); err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 			return err
 		}
 	}
@@ -687,7 +691,7 @@ func (b *Backends) Link(port ServicePort, zones []string) error {
 		negs = append(negs, neg)
 	}
 
-	backendService, err := b.cloud.GetAlphaGlobalBackendService(b.namer.Backend(port.NodePort))
+	backendService, err := b.cloud.GetAlphaGlobalBackendService(negName)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -64,7 +64,7 @@ func newTestJig(f BackendServices, fakeIGs instances.InstanceGroups, syncWithClo
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	healthCheckProvider := healthchecks.NewFakeHealthCheckProvider()
 	healthChecks := healthchecks.NewHealthChecker(healthCheckProvider, "/", defaultNamer)
-	bp := NewBackendPool(f, negGetter, healthChecks, nodePool, defaultNamer, []int64{}, syncWithCloud)
+	bp := NewBackendPool(f, negGetter, healthChecks, nodePool, defaultNamer, []ServicePort{}, syncWithCloud)
 	probes := map[ServicePort]*api_v1.Probe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS}: existingProbe}
 	bp.Init(NewFakeProbeProvider(probes))
 
@@ -117,7 +117,7 @@ func TestBackendPoolAdd(t *testing.T) {
 
 			// Check the created healthcheck is the correct protocol
 			isAlpha := sp.Protocol == annotations.ProtocolHTTP2
-			hc, err := pool.healthChecker.Get(sp.NodePort, isAlpha)
+			hc, err := pool.healthChecker.Get(beName, isAlpha)
 			if err != nil {
 				t.Fatalf("Unexpected err when querying fake healthchecker: %v", err)
 			}
@@ -168,7 +168,7 @@ func TestHealthCheckMigration(t *testing.T) {
 	pool.Ensure([]ServicePort{p}, nil)
 
 	// Assert the proper health check was created
-	hc, _ := pool.healthChecker.Get(p.NodePort, p.isAlpha())
+	hc, _ := pool.healthChecker.Get(defaultNamer.Backend(p.NodePort), p.isAlpha())
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -202,7 +202,7 @@ func TestBackendPoolUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := pool.healthChecker.Get(p.NodePort, p.isAlpha())
+	hc, _ := pool.healthChecker.Get(beName, p.isAlpha())
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -222,7 +222,7 @@ func TestBackendPoolUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = pool.healthChecker.Get(p.NodePort, p.isAlpha())
+	hc, _ = pool.healthChecker.Get(beName, p.isAlpha())
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -247,7 +247,7 @@ func TestBackendPoolUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := pool.healthChecker.Get(p.NodePort, p.isAlpha())
+	hc, _ := pool.healthChecker.Get(beName, p.isAlpha())
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -267,7 +267,7 @@ func TestBackendPoolUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = pool.healthChecker.Get(p.NodePort, true)
+	hc, _ = pool.healthChecker.Get(beName, true)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -352,31 +352,31 @@ func TestBackendPoolSync(t *testing.T) {
 	f := NewFakeBackendServices(noOpErrFunc, false)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, true)
-	pool.Ensure([]ServicePort{{NodePort: 81}}, nil)
-	pool.Ensure([]ServicePort{{NodePort: 90}}, nil)
+	pool.Ensure([]ServicePort{svcNodePorts[0]}, nil)
+	pool.Ensure([]ServicePort{svcNodePorts[1]}, nil)
 	if err := pool.Ensure(svcNodePorts, nil); err != nil {
 		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
 	if err := pool.GC(svcNodePorts); err != nil {
 		t.Errorf("Expected backend pool to GC, err: %v", err)
 	}
-	if _, err := pool.Get(90, false); err == nil {
+	if _, err := pool.Get(defaultNamer.Backend(90), false); err == nil {
 		t.Fatalf("Did not expect to find port 90")
 	}
 	for _, port := range svcNodePorts {
-		if _, err := pool.Get(port.NodePort, false); err != nil {
+		if _, err := pool.Get(defaultNamer.Backend(port.NodePort), false); err != nil {
 			t.Fatalf("Expected to find port %v", port)
 		}
 	}
 
-	svcNodePorts = []ServicePort{{NodePort: 81}}
-	deletedPorts := []ServicePort{{NodePort: 82}, {NodePort: 83}}
+	deletedPorts := []ServicePort{svcNodePorts[1], svcNodePorts[2]}
+	svcNodePorts = []ServicePort{svcNodePorts[0]}
 	if err := pool.GC(svcNodePorts); err != nil {
 		t.Fatalf("Expected backend pool to GC, err: %v", err)
 	}
 
 	for _, port := range deletedPorts {
-		if _, err := pool.Get(port.NodePort, false); err == nil {
+		if _, err := pool.Get(defaultNamer.Backend(port.NodePort), false); err == nil {
 			t.Fatalf("Pool contains %v after deletion", port)
 		}
 	}
@@ -418,6 +418,174 @@ func TestBackendPoolSync(t *testing.T) {
 	}
 }
 
+func TestBackendPoolSyncNEG(t *testing.T) {
+	// Convert a BackendPool from non-NEG to NEG.
+	// Expect the old BackendServices to be GC'ed
+	svcPort := ServicePort{NodePort: 81, Protocol: annotations.ProtocolHTTP}
+	f := NewFakeBackendServices(noOpErrFunc, true)
+	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
+	pool, _ := newTestJig(f, fakeIGs, true)
+	if err := pool.Ensure([]ServicePort{svcPort}, nil); err != nil {
+		t.Errorf("Expected backend pool to add node ports, err: %v", err)
+	}
+
+	nodePortName := defaultNamer.Backend(svcPort.NodePort)
+	_, err := f.GetGlobalBackendService(nodePortName)
+	if err != nil {
+		t.Fatalf("Failed to get backend service: %v", err)
+	}
+
+	// Convert to NEG
+	svcPort.NEGEnabled = true
+	if err := pool.Ensure([]ServicePort{svcPort}, nil); err != nil {
+		t.Errorf("Expected backend pool to add node ports, err: %v", err)
+	}
+
+	negName := defaultNamer.BackendNEG(svcPort.SvcName.Namespace, svcPort.SvcName.Name, svcPort.SvcTargetPort)
+	_, err = f.GetGlobalBackendService(negName)
+	if err != nil {
+		t.Fatalf("Failed to get backend service with name %v: %v", negName, err)
+	}
+	// GC should garbage collect the Backend on the old naming schema
+	pool.GC([]ServicePort{svcPort})
+
+	bs, err := f.GetGlobalBackendService(nodePortName)
+	if err == nil {
+		t.Fatalf("Expected not to get BackendService with name %v, got: %+v", nodePortName, bs)
+	}
+
+	// Convert back to non-NEG
+	svcPort.NEGEnabled = false
+	if err := pool.Ensure([]ServicePort{svcPort}, nil); err != nil {
+		t.Errorf("Expected backend pool to add node ports, err: %v", err)
+	}
+
+	pool.GC([]ServicePort{svcPort})
+
+	_, err = f.GetGlobalBackendService(nodePortName)
+	if err != nil {
+		t.Fatalf("Failed to get backend service with name %v: %v", nodePortName, err)
+	}
+}
+
+func TestBackendPoolSyncQuota(t *testing.T) {
+	testCases := []struct {
+		oldPorts      []ServicePort
+		newPorts      []ServicePort
+		expectSyncErr bool
+		desc          string
+	}{
+		{
+			[]ServicePort{{NodePort: 8080}},
+			[]ServicePort{{NodePort: 8080}},
+			false,
+			"Same port",
+		},
+		{
+			[]ServicePort{{NodePort: 8080}},
+			[]ServicePort{{NodePort: 9000}},
+			true,
+			"Different port",
+		},
+		{
+			[]ServicePort{{NodePort: 8080}},
+			[]ServicePort{{NodePort: 8080}, {NodePort: 443}},
+			false,
+			"Same port plus additional port",
+		},
+		{
+			[]ServicePort{{NodePort: 8080}},
+			[]ServicePort{{NodePort: 3000}, {NodePort: 4000}, {NodePort: 5000}},
+			true,
+			"New set of ports not including the same port",
+		},
+		// Need to fill the SvcTargetPort field on ServicePort to make sure
+		// NEG Backend naming is unique
+		{
+			[]ServicePort{{NodePort: 8080}, {NodePort: 443}},
+			[]ServicePort{
+				{NodePort: 8080, SvcTargetPort: "testport8080", NEGEnabled: true},
+				{NodePort: 443, SvcTargetPort: "testport443", NEGEnabled: true},
+			},
+			true,
+			"Same port converted to NEG, plus one new NEG port",
+		},
+		{
+			[]ServicePort{
+				{NodePort: 80, SvcTargetPort: "testport80", NEGEnabled: true},
+				{NodePort: 90, SvcTargetPort: "testport90"},
+			},
+			[]ServicePort{
+				{NodePort: 80, SvcTargetPort: "testport80"},
+				{NodePort: 90, SvcTargetPort: "testport90", NEGEnabled: true},
+			},
+			true,
+			"Mixed NEG and non-NEG ports",
+		},
+		{
+			[]ServicePort{
+				{NodePort: 100, SvcTargetPort: "testport100", NEGEnabled: true},
+				{NodePort: 110, SvcTargetPort: "testport110", NEGEnabled: true},
+				{NodePort: 120, SvcTargetPort: "testport120", NEGEnabled: true},
+			},
+			[]ServicePort{
+				{NodePort: 100, SvcTargetPort: "testport100"},
+				{NodePort: 110, SvcTargetPort: "testport110"},
+				{NodePort: 120, SvcTargetPort: "testport120"},
+			},
+			true,
+			"Same ports as NEG, then non-NEG",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := NewFakeBackendServices(noOpErrFunc, true)
+			fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
+			pool, _ := newTestJig(f, fakeIGs, false)
+
+			bsCreated := 0
+			quota := len(tc.newPorts)
+
+			// Throw an error if more BackendServices than quota allows have been created
+			f.errFunc = func(op int, be *compute.BackendService) error {
+				if op == utils.Create {
+					if bsCreated+1 > quota {
+						return &googleapi.Error{Code: http.StatusForbidden, Body: be.Name}
+					}
+					bsCreated += 1
+				}
+
+				if op == utils.Delete {
+					bsCreated -= 1
+				}
+
+				return nil
+			}
+
+			if err := pool.Ensure(tc.oldPorts, nil); err != nil {
+				t.Errorf("Expected backend pool to add node ports, err: %v", err)
+			}
+
+			// Ensuring these ports again without first Garbage Collecting goes over
+			// the set quota. Expect an error here, until GC is called.
+			err := pool.Ensure(tc.newPorts, nil)
+			if tc.expectSyncErr && err == nil {
+				t.Errorf("Expect initial sync to go over quota, but received no error")
+			}
+
+			pool.GC(tc.newPorts)
+			if err := pool.Ensure(tc.newPorts, nil); err != nil {
+				t.Errorf("Expected backend pool to add node ports, err: %v", err)
+			}
+
+			if bsCreated != quota {
+				t.Errorf("Expected to create %v BackendServices, got: %v", quota, bsCreated)
+			}
+		})
+	}
+}
+
 func TestBackendPoolDeleteLegacyHealthChecks(t *testing.T) {
 	f := NewFakeBackendServices(noOpErrFunc, true)
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
@@ -426,7 +594,7 @@ func TestBackendPoolDeleteLegacyHealthChecks(t *testing.T) {
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	hcp := healthchecks.NewFakeHealthCheckProvider()
 	healthChecks := healthchecks.NewHealthChecker(hcp, "/", defaultNamer)
-	bp := NewBackendPool(f, negGetter, healthChecks, nodePool, defaultNamer, []int64{}, false)
+	bp := NewBackendPool(f, negGetter, healthChecks, nodePool, defaultNamer, []ServicePort{}, false)
 	probes := map[ServicePort]*api_v1.Probe{}
 	bp.Init(NewFakeProbeProvider(probes))
 
@@ -604,7 +772,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	hcp := healthchecks.NewFakeHealthCheckProvider()
 	healthChecks := healthchecks.NewHealthChecker(hcp, "/", defaultNamer)
-	bp := NewBackendPool(f, fakeNEG, healthChecks, nodePool, defaultNamer, []int64{}, false)
+	bp := NewBackendPool(f, fakeNEG, healthChecks, nodePool, defaultNamer, []ServicePort{}, false)
 
 	svcPort := ServicePort{
 		NodePort: 30001,
@@ -623,7 +791,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 
 	for _, zone := range zones {
 		err := fakeNEG.CreateNetworkEndpointGroup(&computealpha.NetworkEndpointGroup{
-			Name: defaultNamer.NEG(namespace, name, port),
+			Name: defaultNamer.BackendNEG(namespace, name, port),
 		}, zone)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -634,7 +802,8 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 		t.Fatalf("Failed to link backend service to NEG: %v", err)
 	}
 
-	bs, err := f.GetGlobalBackendService(defaultNamer.Backend(svcPort.NodePort))
+	beName := defaultNamer.BackendNEG(svcPort.SvcName.Namespace, svcPort.SvcName.Name, svcPort.SvcTargetPort)
+	bs, err := f.GetGlobalBackendService(beName)
 	if err != nil {
 		t.Fatalf("Failed to retrieve backend service: %v", err)
 	}
@@ -723,7 +892,7 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					pool.Ensure([]ServicePort{oldPort}, nil)
-					be, err := pool.Get(oldPort.NodePort, newPort.isAlpha())
+					be, err := pool.Get(defaultNamer.Backend(oldPort.NodePort), newPort.isAlpha())
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -772,7 +941,7 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					pool.Ensure([]ServicePort{oldPort}, nil)
-					be, err := pool.Get(oldPort.NodePort, oldPort.isAlpha())
+					be, err := pool.Get(defaultNamer.Backend(oldPort.NodePort), oldPort.isAlpha())
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -801,7 +970,7 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 
 	p := ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, SvcPort: intstr.FromInt(1)}
 	pool.Ensure([]ServicePort{p}, nil)
-	be, err := pool.Get(p.NodePort, p.isAlpha())
+	be, err := pool.Get(defaultNamer.Backend(p.NodePort), p.isAlpha())
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -125,6 +125,12 @@ func (f *FakeBackendServices) DeleteGlobalBackendService(name string) error {
 	if err != nil {
 		return err
 	}
+
+	if f.errFunc != nil {
+		if err := f.errFunc(utils.Delete, svc.(*compute.BackendService)); err != nil {
+			return err
+		}
+	}
 	return f.backendServices.Delete(svc)
 }
 

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -32,8 +32,8 @@ type ProbeProvider interface {
 type BackendPool interface {
 	Init(p ProbeProvider)
 	Ensure(ports []ServicePort, igs []*compute.InstanceGroup) error
-	Get(port int64, isAlpha bool) (*BackendService, error)
-	Delete(port int64) error
+	Get(name string, isAlpha bool) (*BackendService, error)
+	Delete(name string) error
 	GC(ports []ServicePort) error
 	Shutdown() error
 	Status(name string) string

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -204,8 +204,8 @@ func NewClusterManager(
 	cluster.healthCheckers = []healthchecks.HealthChecker{healthChecker, defaultBackendHealthChecker}
 
 	// TODO: This needs to change to a consolidated management of the default backend.
-	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{defaultBackendNodePort.NodePort}, true)
-	defaultBackendPool := backends.NewBackendPool(cloud, cloud, defaultBackendHealthChecker, cluster.instancePool, cluster.ClusterNamer, []int64{}, false)
+	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, []backends.ServicePort{defaultBackendNodePort}, true)
+	defaultBackendPool := backends.NewBackendPool(cloud, cloud, defaultBackendHealthChecker, cluster.instancePool, cluster.ClusterNamer, []backends.ServicePort{}, false)
 	cluster.defaultBackendNodePort = defaultBackendNodePort
 
 	// L7 pool creates targetHTTPProxy, ForwardingRules, UrlMaps, StaticIPs.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -264,7 +264,8 @@ func TestLbCreateDelete(t *testing.T) {
 	}
 
 	for _, port := range unexpected {
-		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
+		beName := pm.namer.Backend(int64(port))
+		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}
@@ -277,7 +278,8 @@ func TestLbCreateDelete(t *testing.T) {
 	// No cluster resources (except the defaults used by the cluster manager)
 	// should exist at this point.
 	for _, port := range expected {
-		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
+		beName := pm.namer.Backend(int64(port))
+		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -64,7 +64,7 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	backendPool := backends.NewBackendPool(
 		fakeBackends,
 		fakeNEG,
-		healthChecker, nodePool, namer, []int64{}, false)
+		healthChecker, nodePool, namer, []backends.ServicePort{}, false)
 	l7Pool := loadbalancers.NewLoadBalancerPool(
 		fakeLbs,
 		// TODO: change this

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -144,6 +144,10 @@ func (t *GCE) toGCEBackendName(be *extensions.IngressBackend, ns string) (string
 		return "", err
 	}
 	backendName := t.namer.Backend(port.NodePort)
+	if port.NEGEnabled {
+		backendName = t.namer.BackendNEG(port.SvcName.Namespace, port.SvcName.Name, port.SvcTargetPort)
+	}
+
 	return backendName, nil
 }
 

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -77,17 +77,15 @@ func NewHealthChecker(cloud HealthCheckProvider, defaultHealthCheckPath string, 
 }
 
 // New returns a *HealthCheck with default settings and specified port/protocol
-func (h *HealthChecks) New(port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck {
+func (h *HealthChecks) New(name string, port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck {
 	var hc *HealthCheck
 	if enableNEG {
 		hc = DefaultNEGHealthCheck(protocol)
 	} else {
 		hc = DefaultHealthCheck(port, protocol)
 	}
-	// port is the key for retriving existing health-check
-	// TODO: rename backend-service and health-check to not use port as key
-	hc.Name = h.namer.Backend(port)
-	hc.Port = port
+
+	hc.Name = name
 	return hc
 }
 
@@ -99,10 +97,9 @@ func (h *HealthChecks) Sync(hc *HealthCheck) (string, error) {
 		hc.RequestPath = h.defaultPath
 	}
 
-	nodePort := hc.Port
 	// Use alpha API when PORT_SPECIFICATION field is specified or when Type
 	// is HTTP2
-	existingHC, err := h.Get(nodePort, hc.isHttp2() || hc.ForNEG)
+	existingHC, err := h.Get(hc.Name, hc.isHttp2() || hc.ForNEG)
 	if err != nil {
 		if !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 			return "", err
@@ -112,7 +109,7 @@ func (h *HealthChecks) Sync(hc *HealthCheck) (string, error) {
 			return "", err
 		}
 
-		return h.getHealthCheckLink(nodePort, hc.isHttp2())
+		return h.getHealthCheckLink(hc.Name, hc.isHttp2())
 	}
 
 	if needToUpdate(existingHC, hc) {
@@ -180,8 +177,8 @@ func mergeHealthcheck(oldHC, newHC *HealthCheck) *HealthCheck {
 	return newHC
 }
 
-func (h *HealthChecks) getHealthCheckLink(port int64, alpha bool) (string, error) {
-	hc, err := h.Get(port, alpha)
+func (h *HealthChecks) getHealthCheckLink(name string, alpha bool) (string, error) {
+	hc, err := h.Get(name, alpha)
 	if err != nil {
 		return "", err
 	}
@@ -189,17 +186,15 @@ func (h *HealthChecks) getHealthCheckLink(port int64, alpha bool) (string, error
 }
 
 // Delete deletes the health check by port.
-func (h *HealthChecks) Delete(port int64) error {
-	name := h.namer.Backend(port)
+func (h *HealthChecks) Delete(name string) error {
 	glog.V(2).Infof("Deleting health check %v", name)
 	return h.cloud.DeleteHealthCheck(name)
 }
 
 // Get returns the health check by port
-func (h *HealthChecks) Get(port int64, alpha bool) (*HealthCheck, error) {
+func (h *HealthChecks) Get(name string, alpha bool) (*HealthCheck, error) {
 	var hc *computealpha.HealthCheck
 	var err error
-	name := h.namer.Backend(port)
 	if alpha {
 		hc, err = h.cloud.GetAlphaHealthCheck(name)
 	} else {

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -32,7 +32,7 @@ func TestHealthCheckAdd(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
 
-	hc := healthChecks.New(80, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.Backend(80), 80, annotations.ProtocolHTTP, false)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -43,7 +43,7 @@ func TestHealthCheckAdd(t *testing.T) {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(443, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(443), 443, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -54,7 +54,7 @@ func TestHealthCheckAdd(t *testing.T) {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(3000, annotations.ProtocolHTTP2, false)
+	hc = healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP2, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -82,7 +82,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Should not fail adding the same type of health check
-	hc := healthChecks.New(3000, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -104,7 +104,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(4000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(4000), 4000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -126,7 +126,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(5000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(5000), 5000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -156,7 +156,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(1234)
+	err = healthChecks.Delete(namer.Backend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	}
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(1234)
+	err = healthChecks.Delete(namer.Backend(1234))
 	if err == nil {
 		t.Errorf("expected not-found error when deleting health check, err: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 	hcp.CreateAlphaHealthCheck(alphahc)
 
 	// Delete only HTTP2 1234
-	err := healthChecks.Delete(1234)
+	err := healthChecks.Delete(namer.Backend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(3000, false)
+	_, err = healthChecks.Get(hc.Name, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(3000, false)
+	_, err = healthChecks.Get(hc.Name, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists. HTTP2 is alpha-only.
-	_, err = healthChecks.Get(3000, true)
+	_, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(3000, true)
+	hc, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(3000, true)
+	hc, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -320,13 +320,13 @@ func TestHealthCheckDeleteLegacy(t *testing.T) {
 func TestAlphaHealthCheck(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
-	hc := healthChecks.New(8000, annotations.ProtocolHTTP, true)
+	hc := healthChecks.New(namer.Backend(8000), 8000, annotations.ProtocolHTTP, true)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}
 
-	ret, err := healthChecks.Get(8000, true)
+	ret, err := healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -41,10 +41,10 @@ type HealthCheckProvider interface {
 
 // HealthChecker is an interface to manage cloud HTTPHealthChecks.
 type HealthChecker interface {
-	New(port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck
+	New(name string, port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck
 	Sync(hc *HealthCheck) (string, error)
-	Delete(port int64) error
-	Get(port int64, alpha bool) (*HealthCheck, error)
+	Delete(name string) error
+	Get(name string, alpha bool) (*HealthCheck, error)
 	GetLegacy(port int64) (*compute.HttpHealthCheck, error)
 	DeleteLegacy(port int64) error
 }

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -149,7 +149,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
 			return err
 		}
-		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.NodePort, false)
+		defaultBackend, err := l.defaultBackendPool.Get(l.namer.Backend(l.defaultBackendNodePort.NodePort), false)
 		if err != nil {
 			return err
 		}
@@ -188,7 +188,8 @@ func (l *L7s) GC(names []string) error {
 	// This needs to happen after we've deleted all url-maps that might be
 	// using it.
 	if len(names) == 0 {
-		if err := l.defaultBackendPool.Delete(l.defaultBackendNodePort.NodePort); err != nil {
+		name := l.namer.Backend(l.defaultBackendNodePort.NodePort)
+		if err := l.defaultBackendPool.Delete(name); err != nil {
 			return err
 		}
 		l.glbcDefaultBackend = nil

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -51,7 +51,7 @@ func newFakeLoadBalancerPool(f LoadBalancers, t *testing.T, namer *utils.Namer) 
 	nodePool := instances.NewNodePool(fakeIGs, namer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 	backendPool := backends.NewBackendPool(
-		fakeBackends, fakeNEG, healthChecker, nodePool, namer, []int64{}, false)
+		fakeBackends, fakeNEG, healthChecker, nodePool, namer, []backends.ServicePort{}, false)
 
 	return NewLoadBalancerPool(f, backendPool, testDefaultBeNodePort, namer)
 }


### PR DESCRIPTION
- Use NEG naming schema for NEG Backends associated with NEG-enabled ServicePorts. Rely on garbage collection to remove Backends with the incorrect naming schema.
- Instead of md5 hash, use a sha256 hash of concatenated values for NEG name suffix
- Use BackendService name as the key in BackendPool.snapshotter