### PR TITLE
Condense backendPool and defaultBackendPool 

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	cloud := app.NewGCEClient()
 	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)
-	clusterManager, err := controller.NewClusterManager(cloud, namer, *defaultBackendServicePort, flags.F.HealthCheckPath)
+	clusterManager, err := controller.NewClusterManager(cloud, namer, flags.F.HealthCheckPath)
 	if err != nil {
 		glog.Fatalf("Error creating cluster manager: %v", err)
 	}
@@ -98,7 +98,7 @@ func main() {
 	enableNEG := cloud.AlphaFeatureGate.Enabled(gce.AlphaFeatureNetworkEndpointGroup)
 	stopCh := make(chan struct{})
 	ctx := context.NewControllerContext(kubeClient, flags.F.WatchNamespace, flags.F.ResyncPeriod, enableNEG)
-	lbc, err := controller.NewLoadBalancerController(kubeClient, stopCh, ctx, clusterManager, enableNEG)
+	lbc, err := controller.NewLoadBalancerController(kubeClient, stopCh, ctx, clusterManager, enableNEG, *defaultBackendServicePort)
 	if err != nil {
 		glog.Fatalf("Error creating load balancer controller: %v", err)
 	}

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -64,14 +64,8 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	backendPool := backends.NewBackendPool(
 		fakeBackends,
 		fakeNEG,
-		healthChecker, nodePool, namer, []int64{}, false)
-	l7Pool := loadbalancers.NewLoadBalancerPool(
-		fakeLbs,
-		// TODO: change this
-		backendPool,
-		testDefaultBeNodePort,
-		namer,
-	)
+		healthChecker, nodePool, namer, false)
+	l7Pool := loadbalancers.NewLoadBalancerPool(fakeLbs, namer)
 	frPool := firewalls.NewFirewallPool(firewalls.NewFakeFirewallsProvider(false, false), namer, testSrcRanges, testNodePortRanges)
 	cm := &ClusterManager{
 		ClusterNamer: namer,


### PR DESCRIPTION
This PR attempts to condense management of all backends into one backend pool. Users of the condensed backend pool can now access the default backend's NodePort through a method in the BackendPool interface. 

/assign @nicksardo 

Should fix #184 & #127