### PR TITLE
Add tests for gceurlmap and extends GetDefaultBackendName slightly

### DIFF
--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -712,7 +712,7 @@ func (l *L7) UpdateUrlMap(ingressRules utils.GCEURLMap) error {
 	// backend, it applies to all host rules as well as to the urlmap itself.
 	// If it doesn't the urlmap might have a stale default, so replace it with
 	// glbc's default backend.
-	defaultBackendName := ingressRules.GetDefaultBackendName()
+	defaultBackendName := ingressRules.GetDefaultBackendName(true)
 	if defaultBackendName != "" {
 		l.um.DefaultService = utils.BackendServiceRelativeResourcePath(defaultBackendName)
 	} else {

--- a/pkg/utils/gceurlmap.go
+++ b/pkg/utils/gceurlmap.go
@@ -21,16 +21,18 @@ import "fmt"
 // GCEURLMap is a nested map of hostname-> path regex-> backend name
 type GCEURLMap map[string]map[string]string
 
-// GetDefaultBackendName performs a destructive read and returns
-// the name of the default backend in the urlmap.
-func (g GCEURLMap) GetDefaultBackendName() string {
+// GetDefaultBackendName returns the name of the default backend in the urlmap.
+// If destructiveRead is true, the default backend name is subsequently removed.
+func (g GCEURLMap) GetDefaultBackendName(destructiveRead bool) string {
 	var name string
 	var exists bool
 	if h, ok := g[DefaultBackendKey]; ok {
-		if name, exists = h[DefaultBackendKey]; exists {
+		if name, exists = h[DefaultBackendKey]; exists && destructiveRead {
 			delete(h, DefaultBackendKey)
 		}
-		delete(g, DefaultBackendKey)
+		if destructiveRead {
+			delete(g, DefaultBackendKey)
+		}
 	}
 	return name
 }

--- a/pkg/utils/gceurlmap_test.go
+++ b/pkg/utils/gceurlmap_test.go
@@ -20,6 +20,34 @@ import (
 	"testing"
 )
 
-func TestGCEURLMap(t *testing.T) {
-	// TODO
+func TestGetDefaultBackendName(t *testing.T) {
+	urlMap := GCEURLMap{}
+	urlMap.PutDefaultBackendName("foo")
+	n := urlMap.GetDefaultBackendName(false)
+	if n != "foo" {
+		t.Fatalf("Expected default backend name foo. Got %v", n)
+	}
+}
+
+func TestGetDefaultBackendNameDestructive(t *testing.T) {
+	urlMap := GCEURLMap{}
+	urlMap.PutDefaultBackendName("foo")
+	n := urlMap.GetDefaultBackendName(true)
+	if n != "foo" {
+		t.Fatalf("Expected default backend name foo. Got %v", n)
+	}
+	n = urlMap.GetDefaultBackendName(true)
+	if n != "" {
+		t.Fatalf("Expected empty default backend name. Got %v", n)
+	}
+}
+
+func TestPutDefaultBackendName(t *testing.T) {
+	urlMap := GCEURLMap{}
+	urlMap.PutDefaultBackendName("foo")
+	urlMap.PutDefaultBackendName("bar")
+	n := urlMap.GetDefaultBackendName(true)
+	if n != "bar" {
+		t.Fatalf("Expected default backend name bar. Got %v", n)
+	}
 }


### PR DESCRIPTION
For future use cases, we will need to perform non-destructive reads on the gceurlmap. This PR adds that capability and also adds tests for all functionality. 

/assign @nicksardo 