### PR TITLE
 Merge the logic of ToUrlMap() and IngressToNodePorts() [WIP]

### DIFF
--- a/cmd/glbc/app/init.go
+++ b/cmd/glbc/app/init.go
@@ -30,11 +30,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
-func DefaultBackendServicePort(kubeClient kubernetes.Interface) *backends.ServicePort {
+func DefaultBackendServicePort(kubeClient kubernetes.Interface) *utils.ServicePort {
 	// TODO: make this not fatal
 	if flags.F.DefaultSvc == "" {
 		glog.Fatalf("Please specify --default-backend")
@@ -52,7 +52,7 @@ func DefaultBackendServicePort(kubeClient kubernetes.Interface) *backends.Servic
 			flags.F.DefaultSvc, err)
 	}
 
-	return &backends.ServicePort{
+	return &utils.ServicePort{
 		NodePort: int64(nodePort),
 		Protocol: annotations.ProtocolHTTP, // The default backend is HTTP.
 		SvcName:  types.NamespacedName{Namespace: parts[0], Name: parts[1]},

--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -181,16 +181,16 @@ func (f *FakeBackendServices) GetGlobalBackendServiceHealth(name, instanceGroupL
 
 // FakeProbeProvider implements the probeProvider interface for tests.
 type FakeProbeProvider struct {
-	probes map[ServicePort]*api_v1.Probe
+	probes map[utils.ServicePort]*api_v1.Probe
 }
 
 // NewFakeProbeProvider returns a struct which satisfies probeProvider interface
-func NewFakeProbeProvider(probes map[ServicePort]*api_v1.Probe) *FakeProbeProvider {
+func NewFakeProbeProvider(probes map[utils.ServicePort]*api_v1.Probe) *FakeProbeProvider {
 	return &FakeProbeProvider{probes}
 }
 
 // GetProbe returns the probe for a given nodePort
-func (pp *FakeProbeProvider) GetProbe(port ServicePort) (*api_v1.Probe, error) {
+func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*api_v1.Probe, error) {
 	if probe, exists := pp.probes[port]; exists && probe.HTTPGet != nil {
 		return probe, nil
 	}

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -20,25 +20,26 @@ import (
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	compute "google.golang.org/api/compute/v1"
 	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // ProbeProvider retrieves a probe struct given a nodePort
 type ProbeProvider interface {
-	GetProbe(sp ServicePort) (*api_v1.Probe, error)
+	GetProbe(sp utils.ServicePort) (*api_v1.Probe, error)
 }
 
 // BackendPool is an interface to manage a pool of kubernetes nodePort services
 // as gce backendServices, and sync them through the BackendServices interface.
 type BackendPool interface {
 	Init(p ProbeProvider)
-	Ensure(ports []ServicePort, igs []*compute.InstanceGroup) error
+	Ensure(ports []utils.ServicePort, igs []*compute.InstanceGroup) error
 	Get(port int64, isAlpha bool) (*BackendService, error)
 	Delete(port int64) error
-	GC(ports []ServicePort) error
+	GC(ports []utils.ServicePort) error
 	Shutdown() error
 	Status(name string) string
 	List() ([]interface{}, error)
-	Link(port ServicePort, zones []string) error
+	Link(port utils.ServicePort, zones []string) error
 }
 
 // BackendServices is an interface for managing gce backend services.

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -41,7 +41,7 @@ const (
 // ClusterManager manages cluster resource pools.
 type ClusterManager struct {
 	ClusterNamer           *utils.Namer
-	defaultBackendNodePort backends.ServicePort
+	defaultBackendNodePort utils.ServicePort
 	instancePool           instances.NodePool
 	backendPool            backends.BackendPool
 	l7Pool                 loadbalancers.LoadBalancerPool
@@ -100,7 +100,7 @@ func (c *ClusterManager) shutdown() error {
 // - lbServicePorts are the ports for which we require Backend Services.
 // - instanceGroups are the groups to be referenced by the Backend Services..
 // If GCE runs out of quota, a googleapi 403 is returned.
-func (c *ClusterManager) EnsureLoadBalancer(lb *loadbalancers.L7RuntimeInfo, lbServicePorts []backends.ServicePort, instanceGroups []*compute.InstanceGroup) error {
+func (c *ClusterManager) EnsureLoadBalancer(lb *loadbalancers.L7RuntimeInfo, lbServicePorts []utils.ServicePort, instanceGroups []*compute.InstanceGroup) error {
 	glog.V(4).Infof("EnsureLoadBalancer(%q lb, %v lbServicePorts, %v instanceGroups)", lb.String(), len(lbServicePorts), len(instanceGroups))
 	if err := c.backendPool.Ensure(uniq(lbServicePorts), instanceGroups); err != nil {
 		return err
@@ -109,7 +109,7 @@ func (c *ClusterManager) EnsureLoadBalancer(lb *loadbalancers.L7RuntimeInfo, lbS
 	return c.l7Pool.Sync([]*loadbalancers.L7RuntimeInfo{lb})
 }
 
-func (c *ClusterManager) EnsureInstanceGroupsAndPorts(nodeNames []string, servicePorts []backends.ServicePort) ([]*compute.InstanceGroup, error) {
+func (c *ClusterManager) EnsureInstanceGroupsAndPorts(nodeNames []string, servicePorts []utils.ServicePort) ([]*compute.InstanceGroup, error) {
 	if len(servicePorts) != 0 {
 		// Add the default backend node port to the list of named ports for instance groups.
 		servicePorts = append(servicePorts, c.defaultBackendNodePort)
@@ -145,7 +145,7 @@ func (c *ClusterManager) EnsureFirewall(nodeNames []string, endpointPorts []stri
 // - nodePorts are the ports for which we want BackendServies. BackendServices
 //   for ports not in this list are deleted.
 // This method ignores googleapi 404 errors (StatusNotFound).
-func (c *ClusterManager) GC(lbNames []string, nodePorts []backends.ServicePort) error {
+func (c *ClusterManager) GC(lbNames []string, nodePorts []utils.ServicePort) error {
 	// On GC:
 	// * Loadbalancers need to get deleted before backends.
 	// * Backends are refcounted in a shared pool.
@@ -187,7 +187,7 @@ func (c *ClusterManager) GC(lbNames []string, nodePorts []backends.ServicePort) 
 func NewClusterManager(
 	cloud *gce.GCECloud,
 	namer *utils.Namer,
-	defaultBackendNodePort backends.ServicePort,
+	defaultBackendNodePort utils.ServicePort,
 	defaultHealthCheckPath string) (*ClusterManager, error) {
 
 	// Names are fundamental to the cluster, the uid allocator makes sure names don't collide.

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	testDefaultBeNodePort = backends.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP}
+	testDefaultBeNodePort = utils.ServicePort{NodePort: 30000, Protocol: annotations.ProtocolHTTP}
 	testBackendPort       = intstr.IntOrString{Type: intstr.Int, IntVal: 80}
 	testSrcRanges         = []string{"1.1.1.1/20"}
 	testNodePortRanges    = []string{"30000-32767"}

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -69,7 +68,7 @@ func gceForTest(negEnabled bool) *GCE {
 
 func TestGetProbe(t *testing.T) {
 	translator := gceForTest(false)
-	nodePortToHealthCheck := map[backends.ServicePort]string{
+	nodePortToHealthCheck := map[utils.ServicePort]string{
 		{NodePort: 3001, Protocol: annotations.ProtocolHTTP}:  "/healthz",
 		{NodePort: 3002, Protocol: annotations.ProtocolHTTPS}: "/foo",
 	}
@@ -92,7 +91,7 @@ func TestGetProbe(t *testing.T) {
 
 func TestGetProbeNamedPort(t *testing.T) {
 	translator := gceForTest(false)
-	nodePortToHealthCheck := map[backends.ServicePort]string{
+	nodePortToHealthCheck := map[utils.ServicePort]string{
 		{NodePort: 3001, Protocol: annotations.ProtocolHTTP}: "/healthz",
 	}
 	for _, svc := range makeServices(nodePortToHealthCheck, apiv1.NamespaceDefault) {
@@ -147,7 +146,7 @@ func TestGetProbeCrossNamespace(t *testing.T) {
 		},
 	}
 	translator.podLister.Add(firstPod)
-	nodePortToHealthCheck := map[backends.ServicePort]string{
+	nodePortToHealthCheck := map[utils.ServicePort]string{
 		{NodePort: 3001, Protocol: annotations.ProtocolHTTP}: "/healthz",
 	}
 	for _, svc := range makeServices(nodePortToHealthCheck, apiv1.NamespaceDefault) {
@@ -169,7 +168,7 @@ func TestGetProbeCrossNamespace(t *testing.T) {
 	}
 }
 
-func makePods(nodePortToHealthCheck map[backends.ServicePort]string, ns string) []*apiv1.Pod {
+func makePods(nodePortToHealthCheck map[utils.ServicePort]string, ns string) []*apiv1.Pod {
 	delay := 1 * time.Minute
 
 	var pods []*apiv1.Pod
@@ -207,7 +206,7 @@ func makePods(nodePortToHealthCheck map[backends.ServicePort]string, ns string) 
 	return pods
 }
 
-func makeServices(nodePortToHealthCheck map[backends.ServicePort]string, ns string) []*apiv1.Service {
+func makeServices(nodePortToHealthCheck map[utils.ServicePort]string, ns string) []*apiv1.Service {
 	var services []*apiv1.Service
 	for np := range nodePortToHealthCheck {
 		svc := &apiv1.Service{
@@ -243,7 +242,7 @@ func TestGatherEndpointPorts(t *testing.T) {
 	ep1 := "ep1"
 	ep2 := "ep2"
 
-	svcPorts := []backends.ServicePort{
+	svcPorts := []utils.ServicePort{
 		{NodePort: int64(30001)},
 		{NodePort: int64(30002)},
 		{

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -177,12 +176,12 @@ func setInstanceGroupsAnnotation(existing map[string]string, igs []*compute.Inst
 }
 
 // uniq returns an array of unique service ports from the given array.
-func uniq(nodePorts []backends.ServicePort) []backends.ServicePort {
-	portMap := map[int64]backends.ServicePort{}
+func uniq(nodePorts []utils.ServicePort) []utils.ServicePort {
+	portMap := map[int64]utils.ServicePort{}
 	for _, p := range nodePorts {
 		portMap[p.NodePort] = p
 	}
-	nodePorts = make([]backends.ServicePort, 0, len(portMap))
+	nodePorts = make([]utils.ServicePort, 0, len(portMap))
 	for _, sp := range portMap {
 		nodePorts = append(nodePorts, sp)
 	}

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -366,8 +366,8 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 	if err != nil || um == nil {
 		return fmt.Errorf("f.GetUrlMap(%q) = %v, %v; want _, nil", l7.UrlMap().Name, um, err)
 	}
-	defaultBackendName := expectedUrlMap.DefaultBackendName
-	defaultBackendLink := utils.BackendServiceRelativeResourcePath(expectedUrlMap.DefaultBackendName)
+	defaultBackendName := f.namer.Backend(expectedUrlMap.DefaultBackend.NodePort)
+	defaultBackendLink := utils.BackendServiceRelativeResourcePath(defaultBackendName)
 	// The urlmap should have a default backend, and each path matcher.
 	if defaultBackendName != "" && l7.UrlMap().DefaultService != defaultBackendLink {
 		return fmt.Errorf("default backend = %v, want %v", l7.UrlMap().DefaultService, defaultBackendLink)
@@ -398,7 +398,7 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 				return fmt.Errorf("Expected path rules for host %v", hostname)
 			} else if ok, svc := expectedUrlMap.PathExists(hostname, pathRule); !ok {
 				return fmt.Errorf("Expected rule %v for host %v", pathRule, hostname)
-			} else if utils.BackendServiceRelativeResourcePath(svc) != rule.Service {
+			} else if utils.BackendServiceRelativeResourcePath(f.namer.Backend(svc.NodePort)) != rule.Service {
 				return fmt.Errorf("Expected service %v found %v", svc, rule.Service)
 			}
 		}

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -712,7 +712,7 @@ func (l *L7) UpdateUrlMap(ingressRules *utils.GCEURLMap) error {
 	// backend, it applies to all host rules as well as to the urlmap itself.
 	// If it doesn't the urlmap might have a stale default, so replace it with
 	// glbc's default backend.
-	defaultBackendName := ingressRules.DefaultBackendName
+	defaultBackendName := l.namer.Backend(ingressRules.DefaultBackend.NodePort)
 	if defaultBackendName != "" {
 		l.um.DefaultService = utils.BackendServiceRelativeResourcePath(defaultBackendName)
 	} else {
@@ -745,7 +745,8 @@ func (l *L7) UpdateUrlMap(ingressRules *utils.GCEURLMap) error {
 
 		// GCE ensures that matched rule with longest prefix wins.
 		for _, rule := range rules {
-			beLink := utils.BackendServiceRelativeResourcePath(rule.BackendName)
+			beName := l.namer.Backend(rule.Backend.NodePort)
+			beLink := utils.BackendServiceRelativeResourcePath(beName)
 			pathMatcher.PathRules = append(
 				pathMatcher.PathRules, &compute.PathRule{Paths: []string{rule.Path}, Service: beLink})
 		}

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -37,7 +37,7 @@ type L7s struct {
 	// TODO: Remove this field and always ask the BackendPool using the NodePort.
 	glbcDefaultBackend     *compute.BackendService
 	defaultBackendPool     backends.BackendPool
-	defaultBackendNodePort backends.ServicePort
+	defaultBackendNodePort utils.ServicePort
 	namer                  *utils.Namer
 }
 
@@ -62,7 +62,7 @@ func (l *L7s) Namer() *utils.Namer {
 func NewLoadBalancerPool(
 	cloud LoadBalancers,
 	defaultBackendPool backends.BackendPool,
-	defaultBackendNodePort backends.ServicePort, namer *utils.Namer) LoadBalancerPool {
+	defaultBackendNodePort utils.ServicePort, namer *utils.Namer) LoadBalancerPool {
 	return &L7s{cloud, storage.NewInMemoryPool(), nil, defaultBackendPool, defaultBackendNodePort, namer}
 }
 
@@ -146,7 +146,7 @@ func (l *L7s) Sync(lbs []*L7RuntimeInfo) error {
 		// Lazily create a default backend so we don't tax users who don't care
 		// about Ingress by consuming 1 of their 3 GCE BackendServices. This
 		// BackendService is GC'd when there are no more Ingresses.
-		if err := l.defaultBackendPool.Ensure([]backends.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
+		if err := l.defaultBackendPool.Ensure([]utils.ServicePort{l.defaultBackendNodePort}, nil); err != nil {
 			return err
 		}
 		defaultBackend, err := l.defaultBackendPool.Get(l.defaultBackendNodePort.NodePort, false)

--- a/pkg/utils/gceurlmap_test.go
+++ b/pkg/utils/gceurlmap_test.go
@@ -25,8 +25,8 @@ func TestGCEURLMap(t *testing.T) {
 
 	// Add some path rules for a host.
 	rules := []PathRule{
-		PathRule{Path: "/test1", BackendName: "test1"},
-		PathRule{Path: "/test2", BackendName: "test2"},
+		PathRule{Path: "/test1", Backend: ServicePort{NodePort: 30000}},
+		PathRule{Path: "/test2", Backend: ServicePort{NodePort: 30001}},
 	}
 	urlMap.PutPathRulesForHost("example.com", rules)
 	if !urlMap.HostExists("example.com") {
@@ -41,7 +41,7 @@ func TestGCEURLMap(t *testing.T) {
 
 	// Add some path rules for the same host. Ensure this results in an overwrite.
 	rules = []PathRule{
-		PathRule{Path: "/test3", BackendName: "test3"},
+		PathRule{Path: "/test3", Backend: ServicePort{NodePort: 30002}},
 	}
 	urlMap.PutPathRulesForHost("example.com", rules)
 	if ok, _ := urlMap.PathExists("example.com", "/test1"); ok {
@@ -56,13 +56,13 @@ func TestGCEURLMap(t *testing.T) {
 
 	// Add some path rules with equal paths. Ensure the last one is taken.
 	rules = []PathRule{
-		PathRule{Path: "/test4", BackendName: "test4"},
-		PathRule{Path: "/test5", BackendName: "test5"},
-		PathRule{Path: "/test4", BackendName: "test4-a"},
+		PathRule{Path: "/test4", Backend: ServicePort{NodePort: 30003}},
+		PathRule{Path: "/test5", Backend: ServicePort{NodePort: 30004}},
+		PathRule{Path: "/test4", Backend: ServicePort{NodePort: 30005}},
 	}
 	urlMap.PutPathRulesForHost("example.com", rules)
 	_, backend := urlMap.PathExists("example.com", "/test4")
-	if backend != "test4-a" {
-		t.Errorf("Expected path /test4 for hostname example.com to point to backend test4-a in %+v", urlMap)
+	if backend.NodePort != 30005 {
+		t.Errorf("Expected path /test4 for hostname example.com to point to backend with NodePort 30005 in %+v", urlMap)
 	}
 }

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
+)
+
+// ServicePort maintains configuration for a single backend.
+type ServicePort struct {
+	SvcName       types.NamespacedName
+	SvcPort       intstr.IntOrString
+	NodePort      int64
+	Protocol      annotations.AppProtocol
+	SvcTargetPort string
+	NEGEnabled    bool
+}
+
+// Description returns a string describing the ServicePort.
+func (sp ServicePort) Description() string {
+	if sp.SvcName.String() == "" || sp.SvcPort.String() == "" {
+		return ""
+	}
+	return fmt.Sprintf(`{"kubernetes.io/service-name":"%s","kubernetes.io/service-port":"%s"}`, sp.SvcName.String(), sp.SvcPort.String())
+}
+
+// IsAlpha returns true if the ServicePort is using ProtocolHTTP2 - which means
+// we need to use the Alpha API.
+func (sp ServicePort) IsAlpha() bool {
+	return sp.Protocol == annotations.ProtocolHTTP2
+}


### PR DESCRIPTION
This PR attempts to merge the logic of two function in the translator. Right now, ToUrlMap() and IngressToNodePorts() both iterate over an Ingress spec in very similar ways. In order to reduce complexity of having two similar code paths being executed at different times, we can merge these two functions together to ensure easier testing and maintainability. 

This also gives us the opportunity to store all config in one place (GCEURLMap). Now, this struct uses a ServicePort to denote a backend rather than the backend's name. (credit to @nicksardo  for this idea)

If this approach looks reasonable, I will add tests for it (there are no tests for any of this currently). 

This PR is a prerequisite for condensing backend pool's (#242).

/assign @nicksardo 