### PR TITLE
BackendService naming for NEG backend services & healthchecks

### DIFF
--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -128,6 +128,12 @@ func (f *FakeBackendServices) DeleteGlobalBackendService(name string) error {
 	if err != nil {
 		return err
 	}
+
+	if f.errFunc != nil {
+		if err := f.errFunc(utils.Delete, svc.(*compute.BackendService)); err != nil {
+			return err
+		}
+	}
 	return f.backendServices.Delete(svc)
 }
 

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -33,8 +33,8 @@ type ProbeProvider interface {
 type BackendPool interface {
 	Init(p ProbeProvider)
 	Ensure(ports []utils.ServicePort, igs []*compute.InstanceGroup) error
-	Get(port int64, isAlpha bool) (*BackendService, error)
-	Delete(port int64) error
+	Get(name string, isAlpha bool) (*BackendService, error)
+	Delete(name string) error
 	GC(ports []utils.ServicePort) error
 	Shutdown() error
 	Status(name string) string

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -195,8 +195,6 @@ func NewClusterManager(
 	defaultBackendHealthChecker := healthchecks.NewHealthChecker(cloud, "/healthz", cluster.ClusterNamer)
 
 	cluster.healthCheckers = []healthchecks.HealthChecker{healthChecker, defaultBackendHealthChecker}
-
-	// TODO: This needs to change to a consolidated management of the default backend.
 	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, true)
 
 	// L7 pool creates targetHTTPProxy, ForwardingRules, UrlMaps, StaticIPs.

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -112,7 +112,9 @@ func (c *ClusterManager) EnsureInstanceGroupsAndPorts(nodeNames []string, servic
 	// Convert to slice of NodePort int64s.
 	ports := []int64{}
 	for _, p := range uniq(servicePorts) {
-		ports = append(ports, p.NodePort)
+		if !p.NEGEnabled {
+			ports = append(ports, p.NodePort)
+		}
 	}
 
 	// Create instance groups and set named ports.
@@ -196,7 +198,6 @@ func NewClusterManager(
 
 	cluster.healthCheckers = []healthchecks.HealthChecker{healthChecker, defaultBackendHealthChecker}
 	cluster.backendPool = backends.NewBackendPool(cloud, cloud, healthChecker, cluster.instancePool, cluster.ClusterNamer, true)
-
 	// L7 pool creates targetHTTPProxy, ForwardingRules, UrlMaps, StaticIPs.
 	cluster.l7Pool = loadbalancers.NewLoadBalancerPool(cloud, cluster.ClusterNamer)
 	cluster.firewallPool = firewalls.NewFirewallPool(cloud, cluster.ClusterNamer, gce.LoadBalancerSrcRanges(), flags.F.NodePortRanges.Values())

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -245,7 +245,6 @@ func (lbc *LoadBalancerController) sync(key string) (retErr error) {
 	if err != nil {
 		return err
 	}
-
 	// gceSvcPorts contains the ServicePorts used by only single-cluster ingress.
 	gceSvcPorts := lbc.ToSvcPorts(&gceIngresses)
 	nodeNames, err := getReadyNodeNames(listers.NewNodeLister(lbc.nodeLister))

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -268,7 +268,8 @@ func TestLbCreateDelete(t *testing.T) {
 	}
 
 	for _, port := range unexpected {
-		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
+		beName := pm.namer.Backend(int64(port))
+		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}
@@ -281,7 +282,8 @@ func TestLbCreateDelete(t *testing.T) {
 	// No cluster resources (except the defaults used by the cluster manager)
 	// should exist at this point.
 	for _, port := range expected {
-		if be, err := cm.backendPool.Get(int64(port), false); err == nil {
+		beName := pm.namer.Backend(int64(port))
+		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -268,7 +268,7 @@ func TestLbCreateDelete(t *testing.T) {
 	}
 
 	for _, port := range unexpected {
-		beName := pm.namer.Backend(int64(port))
+		beName := pm.namer.IGBackend(int64(port))
 		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}
@@ -282,7 +282,7 @@ func TestLbCreateDelete(t *testing.T) {
 	// No cluster resources (except the defaults used by the cluster manager)
 	// should exist at this point.
 	for _, port := range expected {
-		beName := pm.namer.Backend(int64(port))
+		beName := pm.namer.IGBackend(int64(port))
 		if be, err := cm.backendPool.Get(beName, false); err == nil {
 			t.Fatalf("Found backend %+v for port %v", be, port)
 		}

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -210,13 +210,13 @@ func (h *HealthChecks) Get(name string, alpha bool) (*HealthCheck, error) {
 
 // GetLegacy deletes legacy HTTP health checks
 func (h *HealthChecks) GetLegacy(port int64) (*compute.HttpHealthCheck, error) {
-	name := h.namer.Backend(port)
+	name := h.namer.IGBackend(port)
 	return h.cloud.GetHttpHealthCheck(name)
 }
 
 // DeleteLegacy deletes legacy HTTP health checks
 func (h *HealthChecks) DeleteLegacy(port int64) error {
-	name := h.namer.Backend(port)
+	name := h.namer.IGBackend(port)
 	glog.V(2).Infof("Deleting legacy HTTP health check %v", name)
 	return h.cloud.DeleteHttpHealthCheck(name)
 }

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -77,17 +77,15 @@ func NewHealthChecker(cloud HealthCheckProvider, defaultHealthCheckPath string, 
 }
 
 // New returns a *HealthCheck with default settings and specified port/protocol
-func (h *HealthChecks) New(port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck {
+func (h *HealthChecks) New(name string, port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck {
 	var hc *HealthCheck
 	if enableNEG {
 		hc = DefaultNEGHealthCheck(protocol)
 	} else {
 		hc = DefaultHealthCheck(port, protocol)
 	}
-	// port is the key for retriving existing health-check
-	// TODO: rename backend-service and health-check to not use port as key
-	hc.Name = h.namer.Backend(port)
-	hc.Port = port
+
+	hc.Name = name
 	return hc
 }
 
@@ -99,10 +97,9 @@ func (h *HealthChecks) Sync(hc *HealthCheck) (string, error) {
 		hc.RequestPath = h.defaultPath
 	}
 
-	nodePort := hc.Port
 	// Use alpha API when PORT_SPECIFICATION field is specified or when Type
 	// is HTTP2
-	existingHC, err := h.Get(nodePort, hc.isHttp2() || hc.ForNEG)
+	existingHC, err := h.Get(hc.Name, hc.isHttp2() || hc.ForNEG)
 	if err != nil {
 		if !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 			return "", err
@@ -112,7 +109,7 @@ func (h *HealthChecks) Sync(hc *HealthCheck) (string, error) {
 			return "", err
 		}
 
-		return h.getHealthCheckLink(nodePort, hc.isHttp2())
+		return h.getHealthCheckLink(hc.Name, hc.isHttp2())
 	}
 
 	if needToUpdate(existingHC, hc) {
@@ -180,8 +177,8 @@ func mergeHealthcheck(oldHC, newHC *HealthCheck) *HealthCheck {
 	return newHC
 }
 
-func (h *HealthChecks) getHealthCheckLink(port int64, alpha bool) (string, error) {
-	hc, err := h.Get(port, alpha)
+func (h *HealthChecks) getHealthCheckLink(name string, alpha bool) (string, error) {
+	hc, err := h.Get(name, alpha)
 	if err != nil {
 		return "", err
 	}
@@ -189,17 +186,15 @@ func (h *HealthChecks) getHealthCheckLink(port int64, alpha bool) (string, error
 }
 
 // Delete deletes the health check by port.
-func (h *HealthChecks) Delete(port int64) error {
-	name := h.namer.Backend(port)
+func (h *HealthChecks) Delete(name string) error {
 	glog.V(2).Infof("Deleting health check %v", name)
 	return h.cloud.DeleteHealthCheck(name)
 }
 
 // Get returns the health check by port
-func (h *HealthChecks) Get(port int64, alpha bool) (*HealthCheck, error) {
+func (h *HealthChecks) Get(name string, alpha bool) (*HealthCheck, error) {
 	var hc *computealpha.HealthCheck
 	var err error
-	name := h.namer.Backend(port)
 	if alpha {
 		hc, err = h.cloud.GetAlphaHealthCheck(name)
 	} else {

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -32,35 +32,35 @@ func TestHealthCheckAdd(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
 
-	hc := healthChecks.New(namer.Backend(80), 80, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.IGBackend(80), 80, annotations.ProtocolHTTP, false)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Verify the health check exists
-	_, err = hcp.GetHealthCheck(namer.Backend(80))
+	_, err = hcp.GetHealthCheck(namer.IGBackend(80))
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(namer.Backend(443), 443, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.IGBackend(443), 443, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Verify the health check exists
-	_, err = hcp.GetHealthCheck(namer.Backend(443))
+	_, err = hcp.GetHealthCheck(namer.IGBackend(443))
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP2, false)
+	hc = healthChecks.New(namer.IGBackend(3000), 3000, annotations.ProtocolHTTP2, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Verify the health check exists
-	_, err = hcp.GetHealthCheck(namer.Backend(3000))
+	_, err = hcp.GetHealthCheck(namer.IGBackend(3000))
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	// HTTP
 	// Manually insert a health check
 	httpHC := DefaultHealthCheck(3000, annotations.ProtocolHTTP)
-	httpHC.Name = namer.Backend(3000)
+	httpHC.Name = namer.IGBackend(3000)
 	httpHC.RequestPath = "/my-probes-health"
 	v1hc, err := httpHC.ToComputeHealthCheck()
 	if err != nil {
@@ -82,7 +82,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Should not fail adding the same type of health check
-	hc := healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.IGBackend(3000), 3000, annotations.ProtocolHTTP, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -96,7 +96,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	// HTTPS
 	// Manually insert a health check
 	httpsHC := DefaultHealthCheck(4000, annotations.ProtocolHTTPS)
-	httpsHC.Name = namer.Backend(4000)
+	httpsHC.Name = namer.IGBackend(4000)
 	httpsHC.RequestPath = "/my-probes-health"
 	v1hc, err = httpHC.ToComputeHealthCheck()
 	if err != nil {
@@ -104,7 +104,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(namer.Backend(4000), 4000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.IGBackend(4000), 4000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -118,7 +118,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	// HTTP2
 	// Manually insert a health check
 	http2 := DefaultHealthCheck(5000, annotations.ProtocolHTTP2)
-	http2.Name = namer.Backend(5000)
+	http2.Name = namer.IGBackend(5000)
 	http2.RequestPath = "/my-probes-health"
 	v1hc, err = httpHC.ToComputeHealthCheck()
 	if err != nil {
@@ -126,7 +126,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(namer.Backend(5000), 5000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.IGBackend(5000), 5000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -144,7 +144,7 @@ func TestHealthCheckDelete(t *testing.T) {
 
 	// Create HTTP HC for 1234
 	hc := DefaultHealthCheck(1234, annotations.ProtocolHTTP)
-	hc.Name = namer.Backend(1234)
+	hc.Name = namer.IGBackend(1234)
 	v1hc, err := hc.ToComputeHealthCheck()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -156,7 +156,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(namer.Backend(1234))
+	err = healthChecks.Delete(namer.IGBackend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	}
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(namer.Backend(1234))
+	err = healthChecks.Delete(namer.IGBackend(1234))
 	if err == nil {
 		t.Errorf("expected not-found error when deleting health check, err: %v", err)
 	}
@@ -180,13 +180,13 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 
 	// Create HTTP2 HC for 1234
 	hc := DefaultHealthCheck(1234, annotations.ProtocolHTTP2)
-	hc.Name = namer.Backend(1234)
+	hc.Name = namer.IGBackend(1234)
 
 	alphahc := hc.ToAlphaComputeHealthCheck()
 	hcp.CreateAlphaHealthCheck(alphahc)
 
 	// Delete only HTTP2 1234
-	err := healthChecks.Delete(namer.Backend(1234))
+	err := healthChecks.Delete(namer.IGBackend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	// HTTP
 	// Manually insert a health check
 	hc := DefaultHealthCheck(3000, annotations.ProtocolHTTP)
-	hc.Name = namer.Backend(3000)
+	hc.Name = namer.IGBackend(3000)
 	hc.RequestPath = "/my-probes-health"
 	v1hc, err := hc.ToComputeHealthCheck()
 	if err != nil {
@@ -304,7 +304,7 @@ func TestHealthCheckDeleteLegacy(t *testing.T) {
 	healthChecks := NewHealthChecker(hcp, "/", namer)
 
 	err := hcp.CreateHttpHealthCheck(&compute.HttpHealthCheck{
-		Name: namer.Backend(80),
+		Name: namer.IGBackend(80),
 	})
 	if err != nil {
 		t.Fatalf("expected health check to be created, err: %v", err)
@@ -320,7 +320,7 @@ func TestHealthCheckDeleteLegacy(t *testing.T) {
 func TestAlphaHealthCheck(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
-	hc := healthChecks.New(namer.Backend(8000), 8000, annotations.ProtocolHTTP, true)
+	hc := healthChecks.New(namer.IGBackend(8000), 8000, annotations.ProtocolHTTP, true)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -32,7 +32,7 @@ func TestHealthCheckAdd(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
 
-	hc := healthChecks.New(80, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.Backend(80), 80, annotations.ProtocolHTTP, false)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -43,7 +43,7 @@ func TestHealthCheckAdd(t *testing.T) {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(443, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(443), 443, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -54,7 +54,7 @@ func TestHealthCheckAdd(t *testing.T) {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
 
-	hc = healthChecks.New(3000, annotations.ProtocolHTTP2, false)
+	hc = healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP2, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -82,7 +82,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Should not fail adding the same type of health check
-	hc := healthChecks.New(3000, annotations.ProtocolHTTP, false)
+	hc := healthChecks.New(namer.Backend(3000), 3000, annotations.ProtocolHTTP, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -104,7 +104,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(4000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(4000), 4000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -126,7 +126,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 	}
 	hcp.CreateHealthCheck(v1hc)
 
-	hc = healthChecks.New(5000, annotations.ProtocolHTTPS, false)
+	hc = healthChecks.New(namer.Backend(5000), 5000, annotations.ProtocolHTTPS, false)
 	_, err = healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -156,7 +156,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(1234)
+	err = healthChecks.Delete(namer.Backend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	}
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(1234)
+	err = healthChecks.Delete(namer.Backend(1234))
 	if err == nil {
 		t.Errorf("expected not-found error when deleting health check, err: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 	hcp.CreateAlphaHealthCheck(alphahc)
 
 	// Delete only HTTP2 1234
-	err := healthChecks.Delete(1234)
+	err := healthChecks.Delete(namer.Backend(1234))
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(3000, false)
+	_, err = healthChecks.Get(hc.Name, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(3000, false)
+	_, err = healthChecks.Get(hc.Name, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists. HTTP2 is alpha-only.
-	_, err = healthChecks.Get(3000, true)
+	_, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(3000, true)
+	hc, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(3000, true)
+	hc, err = healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -320,13 +320,13 @@ func TestHealthCheckDeleteLegacy(t *testing.T) {
 func TestAlphaHealthCheck(t *testing.T) {
 	hcp := NewFakeHealthCheckProvider()
 	healthChecks := NewHealthChecker(hcp, "/", namer)
-	hc := healthChecks.New(8000, annotations.ProtocolHTTP, true)
+	hc := healthChecks.New(namer.Backend(8000), 8000, annotations.ProtocolHTTP, true)
 	_, err := healthChecks.Sync(hc)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}
 
-	ret, err := healthChecks.Get(8000, true)
+	ret, err := healthChecks.Get(hc.Name, true)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -41,10 +41,10 @@ type HealthCheckProvider interface {
 
 // HealthChecker is an interface to manage cloud HTTPHealthChecks.
 type HealthChecker interface {
-	New(port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck
+	New(name string, port int64, protocol annotations.AppProtocol, enableNEG bool) *HealthCheck
 	Sync(hc *HealthCheck) (string, error)
-	Delete(port int64) error
-	Get(port int64, alpha bool) (*HealthCheck, error)
+	Delete(name string) error
+	Get(name string, alpha bool) (*HealthCheck, error)
 	GetLegacy(port int64) (*compute.HttpHealthCheck, error)
 	DeleteLegacy(port int64) error
 }

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -366,7 +366,7 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 	if err != nil || um == nil {
 		return fmt.Errorf("f.GetUrlMap(%q) = %v, %v; want _, nil", l7.UrlMap().Name, um, err)
 	}
-	defaultBackendName := f.namer.Backend(expectedUrlMap.DefaultBackend.NodePort)
+	defaultBackendName := expectedUrlMap.DefaultBackend.BackendName(f.namer)
 	defaultBackendLink := utils.BackendServiceRelativeResourcePath(defaultBackendName)
 	// The urlmap should have a default backend, and each path matcher.
 	if defaultBackendName != "" && l7.UrlMap().DefaultService != defaultBackendLink {
@@ -398,7 +398,7 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 				return fmt.Errorf("Expected path rules for host %v", hostname)
 			} else if ok, svc := expectedUrlMap.PathExists(hostname, pathRule); !ok {
 				return fmt.Errorf("Expected rule %v for host %v", pathRule, hostname)
-			} else if utils.BackendServiceRelativeResourcePath(f.namer.Backend(svc.NodePort)) != rule.Service {
+			} else if utils.BackendServiceRelativeResourcePath(svc.BackendName(f.namer)) != rule.Service {
 				return fmt.Errorf("Expected service %v found %v", svc, rule.Service)
 			}
 		}

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -148,6 +148,7 @@ func (l *L7s) GC(names []string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/utils/namer.go
+++ b/pkg/utils/namer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"crypto/md5"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -72,8 +71,8 @@ const (
 
 	// maxNEGDescriptiveLabel is the max length for namespace, name and
 	// port for neg name.  63 - 5 (k8s and naming schema version prefix)
-	// - 16 (cluster id) - 8 (suffix hash) - 4 (hyphen connector) = 30
-	maxNEGDescriptiveLabel = 30
+	// - 8 (truncated cluster id) - 8 (suffix hash) - 4 (hyphen connector) = 38
+	maxNEGDescriptiveLabel = 38
 
 	// schemaVersionV1 is the version 1 naming scheme for NEG
 	schemaVersionV1 = "1"
@@ -216,6 +215,19 @@ func (n *Namer) ParseName(name string) *NameComponents {
 	}
 }
 
+// negBelongsToCluster checks that the uid is present and a substring of the
+// cluster uid, since the NEG naming schema truncates it to 8 characters.
+// This is only valid for NEGs and Backends on NEG.
+func (n *Namer) negBelongsToCluster(name string) bool {
+	l := strings.Split(name, "-")
+	var uid string
+	if len(l) > 1 {
+		uid = l[1]
+	}
+
+	return len(uid) > 0 && strings.Contains(n.UID(), uid)
+}
+
 // NameBelongsToCluster checks if a given name is tagged with this
 // cluster's UID.
 func (n *Namer) NameBelongsToCluster(name string) bool {
@@ -224,7 +236,7 @@ func (n *Namer) NameBelongsToCluster(name string) bool {
 	}
 	clusterName := n.UID()
 	components := n.ParseName(name)
-	return components.ClusterName == clusterName
+	return components.ClusterName == clusterName || n.negBelongsToCluster(name)
 }
 
 // BeName constructs the name for a backend.
@@ -363,7 +375,17 @@ func (n *Namer) NEG(namespace, name, port string) string {
 	trimedNamespace := trimmedFields[0]
 	trimedName := trimmedFields[1]
 	trimedPort := trimmedFields[2]
-	return fmt.Sprintf("%s-%s-%s-%s-%s", n.negPrefix(), trimedNamespace, trimedName, trimedPort, negSuffix(namespace, name, port))
+	return fmt.Sprintf("%s-%s-%s-%s-%s", n.negPrefix(), trimedNamespace, trimedName, trimedPort, negSuffix(n.UID(), namespace, name, port))
+}
+
+// BackendNEG names the BackendServices which are using NEG, using the same
+// naming convention as NEG.
+func (n *Namer) BackendNEG(namespace, name, port string) string {
+	trimmedFields := trimFieldsEvenly(maxNEGDescriptiveLabel, namespace, name, port)
+	trimedNamespace := trimmedFields[0]
+	trimedName := trimmedFields[1]
+	trimedPort := trimmedFields[2]
+	return fmt.Sprintf("%s-%s-%s-%s-%s", n.negPrefix(), trimedNamespace, trimedName, trimedPort, negSuffix(n.UID(), namespace, name, port))
 }
 
 // IsNEG returns true if the name is a NEG owned by this cluster.
@@ -372,10 +394,16 @@ func (n *Namer) IsNEG(name string) bool {
 }
 
 func (n *Namer) negPrefix() string {
-	return fmt.Sprintf("%s%s-%s", n.prefix, schemaVersionV1, n.UID())
+	uid := n.UID()
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+	return fmt.Sprintf("%s%s-%s", n.prefix, schemaVersionV1, uid)
 }
 
 // negSuffix returns hash code with 8 characters
-func negSuffix(namespace, name, port string) string {
-	return fmt.Sprintf("%x", md5.Sum([]byte(namespace+name+port)))[:8]
+func negSuffix(uid, namespace, name, port string) string {
+	negString := uid + namespace + name + port
+	negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))
+	return negHash[:8]
 }

--- a/pkg/utils/namer_test.go
+++ b/pkg/utils/namer_test.go
@@ -100,7 +100,7 @@ func TestNamerParseName(t *testing.T) {
 		want *NameComponents
 	}{
 		{"", &NameComponents{}}, // TODO: this should really be a parse error.
-		{namer.Backend(80), &NameComponents{uid, "be", ""}},
+		{namer.IGBackend(80), &NameComponents{uid, "be", ""}},
 		{namer.InstanceGroup(), &NameComponents{uid, "ig", ""}},
 		{namer.TargetProxy(lbName, HTTPProtocol), &NameComponents{uid, "tp", ""}},
 		{namer.TargetProxy(lbName, HTTPSProtocol), &NameComponents{uid, "tps", ""}},
@@ -126,7 +126,7 @@ func TestNameBelongsToCluster(t *testing.T) {
 		lbName := namer.LoadBalancer("key1")
 		// Positive cases.
 		for _, tc := range []string{
-			namer.Backend(80),
+			namer.IGBackend(80),
 			namer.InstanceGroup(),
 			namer.TargetProxy(lbName, HTTPProtocol),
 			namer.TargetProxy(lbName, HTTPSProtocol),
@@ -172,14 +172,14 @@ func TestNamerBackend(t *testing.T) {
 		if tc.uid != "" {
 			namer.SetUID(tc.uid)
 		}
-		name := namer.Backend(tc.port)
+		name := namer.IGBackend(tc.port)
 		if name != tc.want {
 			t.Errorf("%s: namer.Backend() = %q, want %q", tc.desc, name, tc.want)
 		}
 	}
 	// Prefix.
 	namer := NewNamerWithPrefix("mci", "uid1", "fw1")
-	name := namer.Backend(80)
+	name := namer.IGBackend(80)
 	const want = "mci-be-80--uid1"
 	if name != want {
 		t.Errorf("with prefix = %q, namer.Backend(80) = %q, want %q", "mci", name, want)
@@ -198,7 +198,7 @@ func TestBackendPort(t *testing.T) {
 		{"k8s-be-8080--uid1", "8080", true},
 		{"k8s-be-port1--uid1", "8080", false},
 	} {
-		port, err := namer.BackendPort(tc.in)
+		port, err := namer.IGBackendPort(tc.in)
 		if err != nil {
 			if tc.valid {
 				t.Errorf("namer.BackendPort(%q) = _, %v, want _, nil", tc.in, err)
@@ -386,21 +386,21 @@ func TestNamerNEG(t *testing.T) {
 			"namespace",
 			"name",
 			"80",
-			"k8s1-01234567-namespace-name-80-1bcdfee6",
+			"k8s1-01234567-namespace-name-80-5104b449",
 		},
 		{
 			"63 characters",
 			longstring[:10],
 			longstring[:10],
 			longstring[:10],
-			"k8s1-01234567-0123456789-0123456789-0123456789-0db7111e",
+			"k8s1-01234567-0123456789-0123456789-0123456789-6d4e657b",
 		},
 		{
 			"long namespace",
 			longstring,
 			"0",
 			"0",
-			"k8s1-01234567-0123456789012345678901234567890123456-0--9faea975",
+			"k8s1-01234567-0123456789012345678901234567890123456-0--72142e04",
 		},
 
 		{
@@ -408,14 +408,14 @@ func TestNamerNEG(t *testing.T) {
 			longstring,
 			longstring,
 			"0",
-			"k8s1-01234567-0123456789012345678-0123456789012345678--59770beb",
+			"k8s1-01234567-0123456789012345678-0123456789012345678--9129e3d2",
 		},
 		{
 			" long name, namespace and port",
 			longstring,
 			longstring[:40],
 			longstring[:30],
-			"k8s1-01234567-0123456789012345-0123456789012-012345678-623f075f",
+			"k8s1-01234567-0123456789012345-0123456789012-012345678-a7dff5e0",
 		},
 	}
 
@@ -433,7 +433,7 @@ func TestNamerNEG(t *testing.T) {
 	// Different prefix.
 	namer = NewNamerWithPrefix("mci", clusterId, "fw")
 	name := namer.NEG("ns", "svc", "port")
-	const want = "mci1-01234567-ns-svc-port-73fad9b3"
+	const want = "mci1-01234567-ns-svc-port-fe7dd054"
 	if name != want {
 		t.Errorf(`with prefix %q, namer.NEG("ns", "svc", 80) = %q, want %q`, "mci", name, want)
 	}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -47,3 +47,12 @@ func (sp ServicePort) Description() string {
 func (sp ServicePort) IsAlpha() bool {
 	return sp.Protocol == annotations.ProtocolHTTP2
 }
+
+// BackendName returns the name of the backend which would be used for this ServicePort.
+func (sp ServicePort) BackendName(namer *Namer) string {
+	if !sp.NEGEnabled {
+		return namer.Backend(sp.NodePort)
+	}
+
+	return namer.BackendNEG(sp.SvcName.Namespace, sp.SvcName.Name, sp.SvcTargetPort)
+}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -51,8 +51,8 @@ func (sp ServicePort) IsAlpha() bool {
 // BackendName returns the name of the backend which would be used for this ServicePort.
 func (sp ServicePort) BackendName(namer *Namer) string {
 	if !sp.NEGEnabled {
-		return namer.Backend(sp.NodePort)
+		return namer.IGBackend(sp.NodePort)
 	}
 
-	return namer.BackendNEG(sp.SvcName.Namespace, sp.SvcName.Name, sp.SvcTargetPort)
+	return namer.NEG(sp.SvcName.Namespace, sp.SvcName.Name, sp.SvcTargetPort)
 }


### PR DESCRIPTION
Continuation of https://github.com/kubernetes/ingress-gce/pull/239

More changes:
 - Neg suffix hash uses the UID truncated to 8 chars.
 - Neg suffix hash input fields are separated by a delimiter
 - ServicePort now has an extension function to return the correct name. 
 - `namer.Backend` is renamed to `namer.IGBackend` to prevent confusion between IG/NEG.

TODO in another PR:
Rewrite unit tests to not care what kind of serviceport their given. 