### PR TITLE
Pass service/port tuple separate from ServicePort

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -89,8 +89,8 @@ func main() {
 	}
 
 	cloud := app.NewGCEClient()
-	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)
-	clusterManager, err := controller.NewClusterManager(cloud, namer, *defaultBackendServicePort, flags.F.HealthCheckPath, flags.F.DefaultSvcHealthCheckPath)
+	defaultBackendServicePortID := app.DefaultBackendServicePortID(kubeClient)
+	clusterManager, err := controller.NewClusterManager(cloud, namer, defaultBackendServicePortID, flags.F.HealthCheckPath, flags.F.DefaultSvcHealthCheckPath)
 	if err != nil {
 		glog.Fatalf("Error creating cluster manager: %v", err)
 	}

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -612,11 +612,11 @@ func (b *Backends) Status(name string) string {
 	return hs.HealthStatus[0].HealthState
 }
 
-func (b *Backends) Link(port utils.ServicePort, zones []string) error {
-	if !port.NEGEnabled {
+func (b *Backends) Link(sp utils.ServicePort, zones []string) error {
+	if !sp.NEGEnabled {
 		return nil
 	}
-	negName := b.namer.NEG(port.SvcName.Namespace, port.SvcName.Name, port.SvcTargetPort)
+	negName := b.namer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.SvcTargetPort)
 	var negs []*computealpha.NetworkEndpointGroup
 	var err error
 	for _, zone := range zones {
@@ -627,7 +627,8 @@ func (b *Backends) Link(port utils.ServicePort, zones []string) error {
 		negs = append(negs, neg)
 	}
 
-	backendService, err := b.cloud.GetAlphaGlobalBackendService(negName)
+	beName := sp.BackendName(b.namer)
+	backendService, err := b.cloud.GetAlphaGlobalBackendService(beName)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -788,13 +788,15 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 	bp := NewBackendPool(f, fakeNEG, healthChecks, nodePool, defaultNamer, false)
 
 	svcPort := utils.ServicePort{
-		NodePort: 30001,
-		Protocol: annotations.ProtocolHTTP,
-		SvcName: types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
+		ID: utils.ServicePortID{
+			Service: types.NamespacedName{
+				Namespace: namespace,
+				Name:      name,
+			},
+			Port: intstr.FromInt(80),
 		},
-		SvcPort:       intstr.FromInt(80),
+		NodePort:      30001,
+		Protocol:      annotations.ProtocolHTTP,
 		SvcTargetPort: port,
 		NEGEnabled:    true,
 	}
@@ -894,9 +896,9 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	svcPorts := []utils.ServicePort{
-		{NodePort: 80, Protocol: annotations.ProtocolHTTP, SvcPort: intstr.FromInt(1)},
-		{NodePort: 443, Protocol: annotations.ProtocolHTTPS, SvcPort: intstr.FromInt(2)},
-		{NodePort: 3000, Protocol: annotations.ProtocolHTTP2, SvcPort: intstr.FromInt(3)},
+		{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}},
+		{NodePort: 443, Protocol: annotations.ProtocolHTTPS, ID: utils.ServicePortID{Port: intstr.FromInt(2)}},
+		{NodePort: 3000, Protocol: annotations.ProtocolHTTP2, ID: utils.ServicePortID{Port: intstr.FromInt(3)}},
 	}
 
 	for _, oldPort := range svcPorts {
@@ -943,9 +945,9 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	svcPorts := []utils.ServicePort{
-		{NodePort: 80, Protocol: annotations.ProtocolHTTP, SvcPort: intstr.FromInt(1)},
-		{NodePort: 443, Protocol: annotations.ProtocolHTTPS, SvcPort: intstr.FromInt(2)},
-		{NodePort: 3000, Protocol: annotations.ProtocolHTTP2, SvcPort: intstr.FromInt(3)},
+		{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}},
+		{NodePort: 443, Protocol: annotations.ProtocolHTTPS, ID: utils.ServicePortID{Port: intstr.FromInt(2)}},
+		{NodePort: 3000, Protocol: annotations.ProtocolHTTP2, ID: utils.ServicePortID{Port: intstr.FromInt(3)}},
 	}
 
 	for _, oldPort := range svcPorts {
@@ -981,7 +983,7 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
 	pool, _ := newTestJig(f, fakeIGs, false)
 
-	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, SvcPort: intstr.FromInt(1)}
+	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}}
 	pool.Ensure([]utils.ServicePort{p}, nil)
 	be, err := pool.Get(p.BackendName(defaultNamer), p.IsAlpha())
 	if err != nil {

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -44,8 +44,8 @@ type ClusterManager struct {
 	// TODO: Refactor so we simply init a health check pool.
 	healthChecker healthchecks.HealthChecker
 
-	// defaultBackendSvcPort is the ServicePort for the system default backend.
-	defaultBackendSvcPort utils.ServicePort
+	// defaultBackendSvcPortID is the ServicePortID for the system default backend.
+	defaultBackendSvcPortID utils.ServicePortID
 }
 
 // Init initializes the cluster manager.
@@ -177,18 +177,18 @@ func (c *ClusterManager) GC(lbNames []string, nodePorts []utils.ServicePort) err
 func NewClusterManager(
 	cloud *gce.GCECloud,
 	namer *utils.Namer,
-	defaultBackendSvcPort utils.ServicePort,
+	defaultBackendSvcPortID utils.ServicePortID,
 	healthCheckPath string,
 	defaultBackendHealthCheckPath string) (*ClusterManager, error) {
 
 	// Names are fundamental to the cluster, the uid allocator makes sure names don't collide.
-	cluster := ClusterManager{ClusterNamer: namer, defaultBackendSvcPort: defaultBackendSvcPort}
+	cluster := ClusterManager{ClusterNamer: namer, defaultBackendSvcPortID: defaultBackendSvcPortID}
 
 	// NodePool stores GCE vms that are in this Kubernetes cluster.
 	cluster.instancePool = instances.NewNodePool(cloud, namer)
 
 	// BackendPool creates GCE BackendServices and associated health checks.
-	cluster.healthChecker = healthchecks.NewHealthChecker(cloud, healthCheckPath, defaultBackendHealthCheckPath, cluster.ClusterNamer, defaultBackendSvcPort.SvcName)
+	cluster.healthChecker = healthchecks.NewHealthChecker(cloud, healthCheckPath, defaultBackendHealthCheckPath, cluster.ClusterNamer, defaultBackendSvcPortID.Service)
 	cluster.backendPool = backends.NewBackendPool(cloud, cloud, cluster.healthChecker, cluster.instancePool, cluster.ClusterNamer, true)
 
 	// L7 pool creates targetHTTPProxy, ForwardingRules, UrlMaps, StaticIPs.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -60,6 +60,25 @@ func newLoadBalancerController(t *testing.T, cm *fakeClusterManager) *LoadBalanc
 		t.Fatalf("%v", err)
 	}
 	lb.hasSynced = func() bool { return true }
+
+	// Create the default-backend service.
+	svc := &api_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      testDefaultBeSvcPort.ID.Service.Name,
+			Namespace: testDefaultBeSvcPort.ID.Service.Namespace,
+		},
+	}
+	var svcPort api_v1.ServicePort
+	switch testBackendPort.Type {
+	case intstr.Int:
+		svcPort = api_v1.ServicePort{Port: testBackendPort.IntVal}
+	default:
+		svcPort = api_v1.ServicePort{Name: testBackendPort.StrVal}
+	}
+	svcPort.NodePort = int32(testDefaultBeSvcPort.NodePort)
+	svc.Spec.Ports = []api_v1.ServicePort{svcPort}
+
+	ctx.ServiceInformer.GetIndexer().Add(svc)
 	return lb
 }
 

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -33,12 +33,12 @@ import (
 )
 
 var (
+	testBackendPort      = intstr.IntOrString{Type: intstr.Int, IntVal: 80}
 	testDefaultBeSvcPort = utils.ServicePort{
+		ID:       utils.ServicePortID{Service: types.NamespacedName{Namespace: "system", Name: "default"}, Port: testBackendPort},
 		NodePort: 30000,
 		Protocol: annotations.ProtocolHTTP,
-		SvcName:  types.NamespacedName{Namespace: "system", Name: "default"},
 	}
-	testBackendPort    = intstr.IntOrString{Type: intstr.Int, IntVal: 80}
 	testSrcRanges      = []string{"1.1.1.1/20"}
 	testNodePortRanges = []string{"30000-32767"}
 )
@@ -64,7 +64,7 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	nodePool := instances.NewNodePool(fakeIGs, namer)
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{"zone-a"}})
 
-	healthChecker := healthchecks.NewHealthChecker(fakeHCP, "/", "/healthz", namer, testDefaultBeSvcPort.SvcName)
+	healthChecker := healthchecks.NewHealthChecker(fakeHCP, "/", "/healthz", namer, testDefaultBeSvcPort.ID.Service)
 
 	backendPool := backends.NewBackendPool(
 		fakeBackends,
@@ -73,12 +73,12 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	l7Pool := loadbalancers.NewLoadBalancerPool(fakeLbs, namer)
 	frPool := firewalls.NewFirewallPool(firewalls.NewFakeFirewallsProvider(false, false), namer, testSrcRanges, testNodePortRanges)
 	cm := &ClusterManager{
-		ClusterNamer:          namer,
-		instancePool:          nodePool,
-		backendPool:           backendPool,
-		l7Pool:                l7Pool,
-		firewallPool:          frPool,
-		defaultBackendSvcPort: testDefaultBeSvcPort,
+		ClusterNamer:            namer,
+		instancePool:            nodePool,
+		backendPool:             backendPool,
+		l7Pool:                  l7Pool,
+		firewallPool:            frPool,
+		defaultBackendSvcPortID: testDefaultBeSvcPort.ID,
 	}
 	return &fakeClusterManager{cm, fakeLbs, fakeBackends, fakeIGs, namer}
 }

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -246,13 +246,13 @@ func TestGatherEndpointPorts(t *testing.T) {
 		{NodePort: int64(30001)},
 		{NodePort: int64(30002)},
 		{
-			SvcName:       types.NamespacedName{Namespace: "ns", Name: ep1},
+			ID:            utils.ServicePortID{Service: types.NamespacedName{Namespace: "ns", Name: ep1}},
 			NodePort:      int64(30003),
 			NEGEnabled:    true,
 			SvcTargetPort: "80",
 		},
 		{
-			SvcName:       types.NamespacedName{Namespace: "ns", Name: ep2},
+			ID:            utils.ServicePortID{Service: types.NamespacedName{Namespace: "ns", Name: ep2}},
 			NodePort:      int64(30004),
 			NEGEnabled:    true,
 			SvcTargetPort: "named-port",

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -43,6 +43,7 @@ var (
 		ConfigFilePath            string
 		DefaultSvcHealthCheckPath string
 		DefaultSvc                string
+		DefaultSvcPortName        string
 		DeleteAllOnQuit           bool
 		GCERateLimit              RateLimitSpecs
 		HealthCheckPath           string
@@ -99,12 +100,15 @@ resources.`)
 		`Path to a file containing the gce config. If left unspecified this
 controller only works with default zones.`)
 	flag.StringVar(&F.DefaultSvcHealthCheckPath, "default-backend-health-check-path", "/healthz",
-		`Path used to health-check a default backend service. The default backend service
-must serve a 200 page on this path.`)
+		`Path used to health-check the default backend service. This path must serve a 200 page.
+Flags default-backend-service and default-backend-service-port should never be empty - default
+values will be used if not specified.`)
 	flag.StringVar(&F.DefaultSvc, "default-backend-service", "kube-system/default-http-backend",
 		`Service used to serve a 404 page for the default backend. Takes the
-form namespace/name. The controller uses the first node port of this Service for
-the default backend.`)
+form namespace/name.`)
+	flag.StringVar(&F.DefaultSvcPortName, "default-backend-service-port", "http",
+		`Specify the default service's port used to serve a 404 page for the default backend. Takes
+only the port's name - not its number.`)
 	flag.BoolVar(&F.DeleteAllOnQuit, "delete-all-on-quit", false,
 		`If true, the controller will delete all Ingress and the associated
 external cloud resources as it's shutting down. Mostly used for testing. In

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -387,7 +387,7 @@ func toAlphaHealthCheck(hc *compute.HealthCheck) (*computealpha.HealthCheck, err
 // pathFromSvcPort returns the default path for a health check based on whether
 // the passed in ServicePort is associated with the system default backend.
 func (h *HealthChecks) pathFromSvcPort(sp utils.ServicePort) string {
-	if h.defaultBackendSvc == sp.SvcName {
+	if h.defaultBackendSvc == sp.ID.Service {
 		return h.defaultBackendPath
 	}
 	return h.path

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"google.golang.org/api/googleapi"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -60,6 +61,18 @@ func FakeGoogleAPINotFoundErr() *googleapi.Error {
 func IsHTTPErrorCode(err error, code int) bool {
 	apiErr, ok := err.(*googleapi.Error)
 	return ok && apiErr.Code == code
+}
+
+// ToNamespacedName returns a types.NamespacedName struct parsed from namespace/name.
+func ToNamespacedName(s string) (r types.NamespacedName, err error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return r, fmt.Errorf("service should take the form 'namespace/name': %q", s)
+	}
+	return types.NamespacedName{
+		Namespace: parts[0],
+		Name:      parts[1],
+	}, nil
 }
 
 // IgnoreHTTPNotFound returns the passed err if it's not a GoogleAPI error

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestTrimFieldsEvenly(t *testing.T) {
@@ -116,5 +118,41 @@ func TestBackendServiceComparablePath(t *testing.T) {
 		if res != tc.expected {
 			t.Errorf("Expected result after url trim to be %v, but got %v", tc.expected, res)
 		}
+	}
+}
+
+func TestToNamespacedName(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+		wantOut types.NamespacedName
+	}{
+		{
+			input:   "kube-system/default-http-backend",
+			wantOut: types.NamespacedName{Namespace: "kube-system", Name: "default-http-backend"},
+		},
+		{
+			input:   "abc",
+			wantErr: true,
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			gotOut, gotErr := ToNamespacedName(tc.input)
+			if tc.wantErr != (gotErr != nil) {
+				t.Errorf("ToNamespacedName(%v) = _, %v, want err? %v", tc.input, gotErr, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+
+			if gotOut != tc.wantOut {
+				t.Errorf("ToNamespacedName(%v) = %v, want %v", tc.input, gotOut, tc.wantOut)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Changes:
- Users can now configure the default backend service **port** by flag - defaults to "http".
- Controller checks that the default backend service exists and has the specified port name.
- Now only the ServicePortID is passed to the LBC - the nodeport is no longer cached.
- TranslateIngress may now return an error. This will occur if the default backend service does not exist at sync-time.