### PR TITLE
Fix BackendConfigKey to use beta

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -47,7 +47,7 @@ const (
 	// Examples:
 	// - '{"ports":{"my-https-port":"config-https","my-http-port":"config-http"}}'
 	// - '{"default":"config-default","ports":{"my-https-port":"config-https"}}'
-	BackendConfigKey = "alpha.cloud.google.com/backend-config"
+	BackendConfigKey = "beta.cloud.google.com/backend-config"
 
 	// ProtocolHTTP protocol for a service
 	ProtocolHTTP AppProtocol = "HTTP"


### PR DESCRIPTION
Sorry I missed this in https://github.com/kubernetes/ingress-gce/pull/271.