### PR TITLE
TranslateIngress changes

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,141 +17,78 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
-	"math/rand"
+	"strings"
 	"testing"
 	"time"
-
-	compute "google.golang.org/api/compute/v1"
 
 	api_v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/fake"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned/fake"
-
-	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/firewalls"
-	"k8s.io/ingress-gce/pkg/flags"
-	"k8s.io/ingress-gce/pkg/loadbalancers"
-	"k8s.io/ingress-gce/pkg/tls"
+	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
-)
 
-const testClusterName = "testcluster"
+	"k8s.io/ingress-gce/pkg/context"
+)
 
 var (
-	testIPManager = testIP{}
+	nodePortCounter = 30000
+	clusterUID      = "aaaaa"
 )
-
-func defaultBackendName(clusterName string) string {
-	return fmt.Sprintf("%v-%v", "k8s-be", clusterName)
-}
 
 // newLoadBalancerController create a loadbalancer controller.
 func newLoadBalancerController(t *testing.T, cm *fakeClusterManager) *LoadBalancerController {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
+
 	stopCh := make(chan struct{})
-	ctx := context.NewControllerContext(kubeClient, backendConfigClient, api_v1.NamespaceAll, 1*time.Second, true)
-	lb, err := NewLoadBalancerController(kubeClient, stopCh, ctx, cm.ClusterManager, true, true)
+	ctx := context.NewControllerContext(kubeClient, backendConfigClient, api_v1.NamespaceAll, 1*time.Minute, true)
+	lbc, err := NewLoadBalancerController(kubeClient, stopCh, ctx, cm.ClusterManager, true, true)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	lb.hasSynced = func() bool { return true }
+	lbc.hasSynced = func() bool { return true }
 
 	// Create the default-backend service.
-	svc := &api_v1.Service{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      testDefaultBeSvcPort.ID.Service.Name,
-			Namespace: testDefaultBeSvcPort.ID.Service.Namespace,
-		},
-	}
-	var svcPort api_v1.ServicePort
-	switch testBackendPort.Type {
-	case intstr.Int:
-		svcPort = api_v1.ServicePort{Port: testBackendPort.IntVal}
-	default:
-		svcPort = api_v1.ServicePort{Name: testBackendPort.StrVal}
-	}
-	svcPort.NodePort = int32(testDefaultBeSvcPort.NodePort)
-	svc.Spec.Ports = []api_v1.ServicePort{svcPort}
-
-	ctx.ServiceInformer.GetIndexer().Add(svc)
-	return lb
-}
-
-// toHTTPIngressPaths converts the given pathMap to a list of HTTPIngressPaths.
-func toHTTPIngressPaths(pathMap map[string]string) []extensions.HTTPIngressPath {
-	httpPaths := []extensions.HTTPIngressPath{}
-	for path, backend := range pathMap {
-		httpPaths = append(httpPaths, extensions.HTTPIngressPath{
-			Path: path,
-			Backend: extensions.IngressBackend{
-				ServiceName: backend,
-				ServicePort: testBackendPort,
+	defaultSvc := test.NewService(testDefaultBeSvcPort.ID.Service, api_v1.ServiceSpec{
+		Type: api_v1.ServiceTypeNodePort,
+		Ports: []api_v1.ServicePort{
+			{
+				Name: "http",
+				Port: 80,
 			},
-		})
-	}
-	return httpPaths
-}
-
-// toIngressRules converts the given path map to a list of IngressRules.
-func toIngressRules(paths utils.PrimitivePathMap) []extensions.IngressRule {
-	rules := []extensions.IngressRule{}
-	for host, pathMap := range paths {
-		rules = append(rules, extensions.IngressRule{
-			Host: host,
-			IngressRuleValue: extensions.IngressRuleValue{
-				HTTP: &extensions.HTTPIngressRuleValue{
-					Paths: toHTTPIngressPaths(pathMap),
-				},
-			},
-		})
-	}
-	return rules
-}
-
-// newIngress returns a new Ingress with the given path map.
-func newIngress(paths utils.PrimitivePathMap) *extensions.Ingress {
-	ret := &extensions.Ingress{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "Ingress",
-			APIVersion: "extensions/v1beta1",
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      fmt.Sprintf("%v", uuid.NewUUID()),
-			Namespace: "default",
-		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
-				ServiceName: defaultBackendName(testClusterName),
-				ServicePort: testBackendPort,
-			},
-			Rules: toIngressRules(paths),
-		},
-		Status: extensions.IngressStatus{
-			LoadBalancer: api_v1.LoadBalancerStatus{
-				Ingress: []api_v1.LoadBalancerIngress{
-					{IP: testIPManager.ip()},
-				},
-			},
-		},
-	}
-	ret.SelfLink = fmt.Sprintf("%s/%s", ret.Namespace, ret.Name)
-	return ret
-}
-
-// validIngress returns a valid Ingress.
-func validIngress() *extensions.Ingress {
-	return newIngress(utils.PrimitivePathMap{
-		"foo.bar.com": {
-			"/foo": defaultBackendName(testClusterName),
 		},
 	})
+	addService(lbc, defaultSvc)
+
+	return lbc
+}
+
+func addService(lbc *LoadBalancerController, svc *api_v1.Service) {
+	if svc.Spec.Type == api_v1.ServiceTypeNodePort {
+		for x, p := range svc.Spec.Ports {
+			if p.NodePort == 0 {
+				svc.Spec.Ports[x].NodePort = int32(nodePortCounter)
+				nodePortCounter++
+			}
+		}
+	}
+
+	lbc.client.CoreV1().Services(svc.Namespace).Create(svc)
+	lbc.ctx.ServiceInformer.GetIndexer().Add(svc)
+}
+
+func addIngress(lbc *LoadBalancerController, ing *extensions.Ingress) {
+	lbc.client.Extensions().Ingresses(ing.Namespace).Create(ing)
+	lbc.ctx.IngressInformer.GetIndexer().Add(ing)
+}
+
+func deleteIngress(lbc *LoadBalancerController, ing *extensions.Ingress) {
+	lbc.client.Extensions().Ingresses(ing.Namespace).Delete(ing.Name, &meta_v1.DeleteOptions{})
+	lbc.ctx.IngressInformer.GetIndexer().Delete(ing)
 }
 
 // getKey returns the key for an ingress.
@@ -163,345 +100,104 @@ func getKey(ing *extensions.Ingress, t *testing.T) string {
 	return key
 }
 
-// gceURLMapFromPrimitive returns a GCEURLMap that is populated from a primitive representation.
-// It uses the passed in nodePortManager to construct a stubbed ServicePort based on service names.
-func gceURLMapFromPrimitive(primitiveMap utils.PrimitivePathMap, pm *nodePortManager) *utils.GCEURLMap {
-	urlMap := utils.NewGCEURLMap()
-	for hostname, rules := range primitiveMap {
-		pathRules := make([]utils.PathRule, 0)
-		for path, backend := range rules {
-			nodePort := pm.getNodePort(backend)
-			stubSvcPort := utils.ServicePort{NodePort: int64(nodePort)}
-			pathRules = append(pathRules, utils.PathRule{Path: path, Backend: stubSvcPort})
-		}
-		urlMap.PutPathRulesForHost(hostname, pathRules)
+func backend(name string, port intstr.IntOrString) extensions.IngressBackend {
+	return extensions.IngressBackend{
+		ServiceName: name,
+		ServicePort: port,
 	}
-	urlMap.DefaultBackend = testDefaultBeSvcPort
-	return urlMap
 }
 
-// nodePortManager is a helper to allocate ports to services and
-// remember the allocations.
-type nodePortManager struct {
-	portMap map[string]int
-	start   int
-	end     int
-	namer   *utils.Namer
-}
-
-// randPort generated pseudo random port numbers.
-func (p *nodePortManager) getNodePort(svcName string) int {
-	if port, ok := p.portMap[svcName]; ok {
-		return port
-	}
-	p.portMap[svcName] = rand.Intn(p.end-p.start) + p.start
-	return p.portMap[svcName]
-}
-
-func newPortManager(st, end int, namer *utils.Namer) *nodePortManager {
-	return &nodePortManager{map[string]int{}, st, end, namer}
-}
-
-// addIngress adds an ingress to the loadbalancer controllers ingress store. If
-// a nodePortManager is supplied, it also adds all backends to the service store
-// with a nodePort acquired through it.
-func addIngress(lbc *LoadBalancerController, ing *extensions.Ingress, pm *nodePortManager) {
-	for _, rule := range ing.Spec.Rules {
-		for _, path := range rule.HTTP.Paths {
-			svc := &api_v1.Service{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      path.Backend.ServiceName,
-					Namespace: ing.Namespace,
-				},
-			}
-			var svcPort api_v1.ServicePort
-			switch path.Backend.ServicePort.Type {
-			case intstr.Int:
-				svcPort = api_v1.ServicePort{Port: path.Backend.ServicePort.IntVal}
-			default:
-				svcPort = api_v1.ServicePort{Name: path.Backend.ServicePort.StrVal}
-			}
-			svcPort.NodePort = int32(pm.getNodePort(path.Backend.ServiceName))
-			svc.Spec.Ports = []api_v1.ServicePort{svcPort}
-			lbc.ctx.ServiceInformer.GetIndexer().Add(svc)
-		}
-	}
-	lbc.client.Extensions().Ingresses(ing.Namespace).Create(ing)
-	lbc.ctx.IngressInformer.GetIndexer().Add(ing)
-}
-
-func TestLbCreateDelete(t *testing.T) {
-	testFirewallName := "quux"
-	cm := NewFakeClusterManager(flags.DefaultClusterUID, testFirewallName)
+// TestIngressSyncError asserts that `sync` will bubble an error when an ingress cannot be synced
+// due to configuration problems.
+func TestIngressSyncError(t *testing.T) {
+	cm := NewFakeClusterManager(clusterUID, "")
 	lbc := newLoadBalancerController(t, cm)
-	pm := newPortManager(1, 65536, cm.Namer)
-	inputMap1 := utils.PrimitivePathMap{
-		"foo.example.com": {
-			"/foo1": "foo1svc",
-			"/foo2": "foo2svc",
-		},
-		"bar.example.com": {
-			"/bar1": "bar1svc",
-			"/bar2": "bar2svc",
-		},
-	}
-	inputMap2 := utils.PrimitivePathMap{
-		"baz.foobar.com": {
-			"/foo": "foo1svc",
-			"/bar": "bar1svc",
-		},
-	}
-	ings := []*extensions.Ingress{}
-	for _, m := range []utils.PrimitivePathMap{inputMap1, inputMap2} {
-		newIng := newIngress(m)
-		addIngress(lbc, newIng, pm)
-		ingStoreKey := getKey(newIng, t)
-		if err := lbc.sync(ingStoreKey); err != nil {
-			t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
-		}
-		l7, err := cm.l7Pool.Get(ingStoreKey)
-		if err != nil {
-			t.Fatalf("cm.l7Pool.Get(%q) = _, %v; want nil", ingStoreKey, err)
-		}
-		expectedUrlMap := gceURLMapFromPrimitive(m, pm)
-		if err := cm.fakeLbs.CheckURLMap(l7, expectedUrlMap); err != nil {
-			t.Fatalf("cm.fakeLbs.CheckURLMap(l7, expectedUrlMap) = %v, want nil", err)
-		}
-		ings = append(ings, newIng)
-	}
-	lbc.ingLister.Store.Delete(ings[0])
-	if err := lbc.sync(getKey(ings[0], t)); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
 
-	// BackendServices associated with ports of deleted Ingress' should get gc'd
-	// when the Ingress is deleted, regardless of the service. At the same time
-	// we shouldn't pull shared backends out from existing loadbalancers.
-	unexpected := []int{pm.portMap["foo2svc"], pm.portMap["bar2svc"]}
-	expected := []int{pm.portMap["foo1svc"], pm.portMap["bar1svc"]}
-	pm.namer.SetFirewall(testFirewallName)
-	firewallName := pm.namer.FirewallRule()
+	someBackend := backend("my-service", intstr.FromInt(80))
+	ing := test.NewIngress(types.NamespacedName{Name: "my-ingress", Namespace: "default"},
+		extensions.IngressSpec{
+			Backend: &someBackend,
+		})
+	addIngress(lbc, ing)
 
-	// Check existence of firewall rule
-	_, err := cm.firewallPool.(*firewalls.FirewallRules).GetFirewall(firewallName)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	for _, port := range unexpected {
-		beName := pm.namer.IGBackend(int64(port))
-		if be, err := cm.backendPool.Get(beName, false); err == nil {
-			t.Fatalf("Found backend %+v for port %v", be, port)
-		}
-	}
-
-	lbc.ingLister.Store.Delete(ings[1])
-	if err := lbc.sync(getKey(ings[1], t)); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-
-	// No cluster resources (except the defaults used by the cluster manager)
-	// should exist at this point.
-	for _, port := range expected {
-		beName := pm.namer.IGBackend(int64(port))
-		if be, err := cm.backendPool.Get(beName, false); err == nil {
-			t.Fatalf("Found backend %+v for port %v", be, port)
-		}
-	}
-	if len(cm.fakeLbs.Fw) != 0 || len(cm.fakeLbs.Um) != 0 || len(cm.fakeLbs.Tp) != 0 {
-		t.Errorf("Loadbalancer leaked resources")
-	}
-	for _, lbName := range []string{getKey(ings[0], t), getKey(ings[1], t)} {
-		if l7, err := cm.l7Pool.Get(lbName); err == nil {
-			t.Fatalf("Got loadbalancer %+v: %v, want none", l7, err)
-		}
-	}
-	if firewallRule, err := cm.firewallPool.(*firewalls.FirewallRules).GetFirewall(firewallName); err == nil {
-		t.Errorf("Got firewall rule %+v, want none", firewallRule)
-	}
-}
-
-func TestLbFaultyUpdate(t *testing.T) {
-	cm := NewFakeClusterManager(flags.DefaultClusterUID, DefaultFirewallName)
-	lbc := newLoadBalancerController(t, cm)
-	pm := newPortManager(1, 65536, cm.Namer)
-	inputMap := utils.PrimitivePathMap{
-		"foo.example.com": {
-			"/foo1": "foo1svc",
-			"/foo2": "foo2svc",
-		},
-		"bar.example.com": {
-			"/bar1": "bar1svc",
-			"/bar2": "bar2svc",
-		},
-	}
-	ing := newIngress(inputMap)
-	addIngress(lbc, ing, pm)
 	ingStoreKey := getKey(ing, t)
-	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-	l7, err := cm.l7Pool.Get(ingStoreKey)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	expectedUrlMap := gceURLMapFromPrimitive(inputMap, pm)
-	if err := cm.fakeLbs.CheckURLMap(l7, expectedUrlMap); err != nil {
-		t.Fatalf("cm.fakeLbs.CheckURLMap(...) = %v, want nil", err)
+	err := lbc.sync(ingStoreKey)
+	if err == nil {
+		t.Fatalf("lbc.sync(%v) = nil, want error", ingStoreKey)
 	}
 
-	// Change the urlmap directly, resync, and
-	// make sure the controller corrects it.
-	l7.RuntimeInfo().UrlMap = gceURLMapFromPrimitive(utils.PrimitivePathMap{
-		"foo.example.com": {
-			"/foo1": "foo2svc",
-		},
-	}, pm)
-	l7.UpdateUrlMap()
-
-	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-	if err := cm.fakeLbs.CheckURLMap(l7, expectedUrlMap); err != nil {
-		t.Fatalf("cm.fakeLbs.CheckURLMap(...) = %v, want nil", err)
+	if !strings.Contains(err.Error(), someBackend.ServiceName) {
+		t.Errorf("lbc.sync(%v) = %v, want error containing %q", ingStoreKey, err, someBackend.ServiceName)
 	}
 }
 
-func TestLbDefaulting(t *testing.T) {
-	cm := NewFakeClusterManager(flags.DefaultClusterUID, DefaultFirewallName)
+// TestIngressCreateDelete asserts that `sync` will not return an error for a good ingress config
+// and will not return an error when the ingress is deleted.
+func TestIngressCreateDelete(t *testing.T) {
+	cm := NewFakeClusterManager(clusterUID, "")
 	lbc := newLoadBalancerController(t, cm)
-	pm := newPortManager(1, 65536, cm.Namer)
-	// Make sure the controller plugs in the default values accepted by GCE.
-	ing := newIngress(utils.PrimitivePathMap{"": {"": "foo1svc"}})
 
-	addIngress(lbc, ing, pm)
+	svc := test.NewService(types.NamespacedName{Name: "my-service", Namespace: "default"}, api_v1.ServiceSpec{
+		Type:  api_v1.ServiceTypeNodePort,
+		Ports: []api_v1.ServicePort{{Port: 80}},
+	})
+	addService(lbc, svc)
+
+	defaultBackend := backend("my-service", intstr.FromInt(80))
+	ing := test.NewIngress(types.NamespacedName{Name: "my-ingress", Namespace: "default"},
+		extensions.IngressSpec{
+			Backend: &defaultBackend,
+		})
+	addIngress(lbc, ing)
 
 	ingStoreKey := getKey(ing, t)
 	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
+		t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
 	}
-	l7, err := cm.l7Pool.Get(ingStoreKey)
-	if err != nil {
-		t.Fatalf("%v", err)
+
+	// Check Ingress status has IP.
+	updatedIng, _ := lbc.client.Extensions().Ingresses(ing.Namespace).Get(ing.Name, meta_v1.GetOptions{})
+	if len(updatedIng.Status.LoadBalancer.Ingress) != 1 || updatedIng.Status.LoadBalancer.Ingress[0].IP == "" {
+		t.Errorf("Get(%q) = status %+v, want non-empty", updatedIng.Name, updatedIng.Status.LoadBalancer.Ingress)
 	}
-	expected := utils.PrimitivePathMap{
-		loadbalancers.DefaultHost: {
-			loadbalancers.DefaultPath: "foo1svc",
-		},
-	}
-	expectedUrlMap := gceURLMapFromPrimitive(expected, pm)
-	if err := cm.fakeLbs.CheckURLMap(l7, expectedUrlMap); err != nil {
-		t.Fatalf("cm.fakeLbs.CheckURLMap(...) = %v, want nil", err)
+
+	deleteIngress(lbc, ing)
+	if err := lbc.sync(ingStoreKey); err != nil {
+		t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
 	}
 }
 
-func TestLbNoService(t *testing.T) {
-	cm := NewFakeClusterManager(flags.DefaultClusterUID, DefaultFirewallName)
-	pm := newPortManager(1, 65536, cm.Namer)
+// TestEnsureMCIngress asserts a multi-cluster ingress will result with correct status annotations.
+func TestEnsureMCIngress(t *testing.T) {
+	cm := NewFakeClusterManager(clusterUID, "")
 	lbc := newLoadBalancerController(t, cm)
-	inputMap := utils.PrimitivePathMap{
-		"foo.example.com": {
-			"/foo1": "foo1svc",
-		},
-	}
-	ing := newIngress(inputMap)
-	ing.Namespace = "ns1"
+
+	svc := test.NewService(types.NamespacedName{Name: "my-service", Namespace: "default"}, api_v1.ServiceSpec{
+		Type:  api_v1.ServiceTypeNodePort,
+		Ports: []api_v1.ServicePort{{Port: 80}},
+	})
+	addService(lbc, svc)
+
+	defaultBackend := backend("my-service", intstr.FromInt(80))
+	ing := test.NewIngress(types.NamespacedName{Name: "my-ingress", Namespace: "default"},
+		extensions.IngressSpec{
+			Backend: &defaultBackend,
+		})
+	ing.ObjectMeta.Annotations = map[string]string{"kubernetes.io/ingress.class": "gce-multi-cluster"}
+	addIngress(lbc, ing)
+
 	ingStoreKey := getKey(ing, t)
-
-	// Adds ingress to store, but doesn't create an associated service.
-	// This will still create the associated loadbalancer, it will just
-	// have empty rules. The rules will get corrected when the service
-	// pops up.
-	addIngress(lbc, ing, pm)
-	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
+	if err := lbc.ensureIngress(ing, []string{"node-a", "node-b"}, []utils.ServicePort{}); err != nil {
+		t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
 	}
 
-	l7, err := cm.l7Pool.Get(ingStoreKey)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Creates the service, next sync should have complete url map.
-	addIngress(lbc, ing, pm)
-	svc := &api_v1.Service{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "foo1svc",
-			Namespace: ing.Namespace,
-		},
-	}
-
-	lbc.enqueueIngressForService(svc)
-	if err := lbc.sync(fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-
-	expectedUrlMap := gceURLMapFromPrimitive(inputMap, pm)
-	if err := cm.fakeLbs.CheckURLMap(l7, expectedUrlMap); err != nil {
-		t.Fatalf("cm.fakeLbs.CheckURLMap(...) = %v, want nil", err)
+	// Check Ingress has annotations noting the instance group name.
+	updatedIng, _ := lbc.client.Extensions().Ingresses(ing.Namespace).Get(ing.Name, meta_v1.GetOptions{})
+	igAnnotationKey := "ingress.gcp.kubernetes.io/instance-groups"
+	wantVal := `[{"Name":"k8s-ig--aaaaa","Zone":"zone-a"}]`
+	if val, ok := updatedIng.GetAnnotations()[igAnnotationKey]; !ok {
+		t.Errorf("Ingress.Annotations does not contain key %q", igAnnotationKey)
+	} else if val != wantVal {
+		t.Errorf("Ingress.Annotation %q = %q, want %q", igAnnotationKey, val, wantVal)
 	}
 }
-
-func TestLbChangeStaticIP(t *testing.T) {
-	cm := NewFakeClusterManager(flags.DefaultClusterUID, DefaultFirewallName)
-	lbc := newLoadBalancerController(t, cm)
-	inputMap := utils.PrimitivePathMap{
-		"foo.example.com": {
-			"/foo1": "foo1svc",
-		},
-	}
-	ing := newIngress(inputMap)
-	ing.Spec.Backend.ServiceName = "foo1svc"
-	cert := extensions.IngressTLS{SecretName: "foo"}
-	ing.Spec.TLS = []extensions.IngressTLS{cert}
-
-	// Add some certs so we get 2 forwarding rules, the changed static IP
-	// should be assigned to both the HTTP and HTTPS forwarding rules.
-	lbc.tlsLoader = &tls.FakeTLSSecretLoader{
-		FakeCerts: map[string]*loadbalancers.TLSCerts{
-			cert.SecretName: {Key: "foo", Cert: "bar"},
-		},
-	}
-
-	pm := newPortManager(1, 65536, cm.Namer)
-	addIngress(lbc, ing, pm)
-	ingStoreKey := getKey(ing, t)
-
-	// First sync creates forwarding rules and allocates an IP.
-	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-
-	// First allocate a static ip, then specify a userip in annotations.
-	// The forwarding rules should contain the user ip.
-	// The static ip should get cleaned up on lb tear down.
-	oldIP := ing.Status.LoadBalancer.Ingress[0].IP
-	oldRules := cm.fakeLbs.GetForwardingRulesWithIPs([]string{oldIP})
-	if len(oldRules) != 2 || oldRules[0].IPAddress != oldRules[1].IPAddress {
-		t.Fatalf("Expected 2 forwarding rules with the same IP.")
-	}
-
-	ing.Annotations = map[string]string{annotations.StaticIPNameKey: "testip"}
-	cm.fakeLbs.ReserveGlobalAddress(&compute.Address{Name: "testip", Address: "1.2.3.4"})
-
-	// Second sync reassigns 1.2.3.4 to existing forwarding rule (by recreating it)
-	if err := lbc.sync(ingStoreKey); err != nil {
-		t.Fatalf("lbc.sync() = err %v", err)
-	}
-
-	newRules := cm.fakeLbs.GetForwardingRulesWithIPs([]string{"1.2.3.4"})
-	if len(newRules) != 2 || newRules[0].IPAddress != newRules[1].IPAddress || newRules[1].IPAddress != "1.2.3.4" {
-		t.Fatalf("Found unexpected forwaring rules after changing static IP annotation.")
-	}
-}
-
-type testIP struct {
-	start int
-}
-
-func (t *testIP) ip() string {
-	t.start++
-	return fmt.Sprintf("0.0.0.%v", t.start)
-}
-
-// TODO: Test lb status update when annotation stabilize

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -20,19 +20,37 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
-// ErrNodePortNotFound is returned when a port was not found.
-type ErrNodePortNotFound struct {
-	Backend v1beta1.IngressBackend
-	Err     error
+// ErrSvcNotNodePort is returned when the service is not a nodeport.
+type ErrSvcNotNodePort struct {
+	Service types.NamespacedName
 }
 
-func (e ErrNodePortNotFound) Error() string {
-	return fmt.Sprintf("Could not find nodeport for backend %+v: %v", e.Backend, e.Err)
+func (e ErrSvcNotNodePort) Error() string {
+	return fmt.Sprintf("service %q is not type 'NodePort'", e.Service)
+}
+
+// ErrSvcNotFound is returned when a service is not found.
+type ErrSvcNotFound struct {
+	Service types.NamespacedName
+}
+
+func (e ErrSvcNotFound) Error() string {
+	return fmt.Sprintf("could not find service %q", e.Service)
+}
+
+// ErrSvcPortNotFound is returned when a service's port is not found.
+type ErrSvcPortNotFound struct {
+	utils.ServicePortID
+}
+
+func (e ErrSvcPortNotFound) Error() string {
+	return fmt.Sprintf("could not find port %q in service %q", e.ServicePortID.Port, e.ServicePortID.Service)
 }
 
 // ErrSvcAppProtosParsing is returned when the service is malformed.

--- a/pkg/controller/translator/testdata/ingress-missing-multi-svc.json
+++ b/pkg/controller/translator/testdata/ingress-missing-multi-svc.json
@@ -1,0 +1,15 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"abc.com": [],
+		"foo.bar.com": []
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-missing-multi-svc.yaml
+++ b/pkg/controller/translator/testdata/ingress-missing-multi-svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: some-service
+          servicePort: 80
+  - host: abc.com
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: other-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-missing-rule-svc.json
+++ b/pkg/controller/translator/testdata/ingress-missing-rule-svc.json
@@ -1,0 +1,28 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"abc.com": [],
+		"foo.bar.com": [
+			{
+				"Path": "/testpath",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "first-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-missing-rule-svc.yaml
+++ b/pkg/controller/translator/testdata/ingress-missing-rule-svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: first-service
+          servicePort: 80
+  - host: abc.com
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: other-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-multi-empty.json
+++ b/pkg/controller/translator/testdata/ingress-multi-empty.json
@@ -1,0 +1,27 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"foo.bar.com": [
+			{
+				"Path": "/*",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "second-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-multi-empty.yaml
+++ b/pkg/controller/translator/testdata/ingress-multi-empty.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path:
+        backend:
+          serviceName: first-service
+          servicePort: 80
+      - path:
+        backend:
+          serviceName: second-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-multi-paths.json
+++ b/pkg/controller/translator/testdata/ingress-multi-paths.json
@@ -1,0 +1,39 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"foo.bar.com": [
+			{
+				"Path": "/testpath",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "first-service"
+						},
+						"Port": 80
+					}
+				}
+			},
+			{
+				"Path": "/otherpath",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "second-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-multi-paths.yaml
+++ b/pkg/controller/translator/testdata/ingress-multi-paths.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: first-service
+          servicePort: 80
+      - path: /otherpath
+        backend:
+          serviceName: second-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-no-host.json
+++ b/pkg/controller/translator/testdata/ingress-no-host.json
@@ -1,0 +1,27 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"*": [
+			{
+				"Path": "/testpath",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "first-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-no-host.yaml
+++ b/pkg/controller/translator/testdata/ingress-no-host.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: first-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-single-host.json
+++ b/pkg/controller/translator/testdata/ingress-single-host.json
@@ -1,0 +1,27 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"foo.bar.com": [
+			{
+				"Path": "/testpath",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "first-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-single-host.yaml
+++ b/pkg/controller/translator/testdata/ingress-single-host.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: first-service
+          servicePort: 80

--- a/pkg/controller/translator/testdata/ingress-two-hosts.json
+++ b/pkg/controller/translator/testdata/ingress-two-hosts.json
@@ -1,0 +1,41 @@
+{
+	"DefaultBackend": {
+		"ID": {
+			"Service": {
+				"Namespace": "kube-system",
+				"Name": "default-http-backend"
+			},
+			"Port": "http"
+		}
+	},
+	"HostRules": {
+		"abc.com": [
+			{
+				"Path": "/*",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "second-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		],
+		"foo.bar.com": [
+			{
+				"Path": "/*",
+				"Backend": {
+					"ID": {
+						"Service": {
+							"Namespace": "default",
+							"Name": "first-service"
+						},
+						"Port": 80
+					}
+				}
+			}
+		]
+	}
+}

--- a/pkg/controller/translator/testdata/ingress-two-hosts.yaml
+++ b/pkg/controller/translator/testdata/ingress-two-hosts.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  namespace: default
+spec:
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: first-service
+          servicePort: 80
+  - host: abc.com
+    http:
+      paths:
+      - backend:
+          serviceName: second-service
+          servicePort: 80

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -18,8 +18,10 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -35,6 +37,14 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils"
 )
+
+func joinErrs(errs []error) error {
+	var errStrs []string
+	for _, e := range errs {
+		errStrs = append(errStrs, e.Error())
+	}
+	return errors.New(strings.Join(errStrs, "; "))
+}
 
 // isGCEIngress returns true if the Ingress matches the class managed by this
 // controller.

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -729,7 +729,7 @@ func (l *L7) UpdateUrlMap() error {
 	l.um.HostRules = []*compute.HostRule{}
 	l.um.PathMatchers = []*compute.PathMatcher{}
 
-	for hostname, rules := range urlMap.AllRules() {
+	for hostname, rules := range urlMap.HostRules {
 		// Create a host rule
 		// Create a path matcher
 		// Add all given endpoint:backends to pathRules in path matcher

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -51,6 +51,7 @@ func TestCreateHTTPLoadBalancer(t *testing.T) {
 	// This should NOT create the forwarding rule and target proxy
 	// associated with the HTTPS branch of this loadbalancer.
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{
@@ -93,6 +94,7 @@ func TestCreateHTTPSLoadBalancer(t *testing.T) {
 	// This should NOT create the forwarding rule and target proxy
 	// associated with the HTTP branch of this loadbalancer.
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{
@@ -127,6 +129,7 @@ func TestCreateHTTPSLoadBalancer(t *testing.T) {
 // and the proxy is updated to another cert when the provided cert changes
 func TestCertUpdate(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbName := namer.LoadBalancer("test")
@@ -165,6 +168,7 @@ func TestCertUpdate(t *testing.T) {
 // Test that multiple secrets with the same certificate value don't cause a sync error.
 func TestMultipleSecretsWithSameCert(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbName := namer.LoadBalancer("test")
@@ -193,6 +197,7 @@ func TestMultipleSecretsWithSameCert(t *testing.T) {
 // Tests that controller can overwrite existing, unused certificates
 func TestCertCreationWithCollision(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbName := namer.LoadBalancer("test")
@@ -245,6 +250,7 @@ func TestCertCreationWithCollision(t *testing.T) {
 
 func TestMultipleCertRetentionAfterRestart(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	cert1 := createCert("key", "cert", "name")
@@ -295,6 +301,7 @@ func TestMultipleCertRetentionAfterRestart(t *testing.T) {
 // are picked up and deleted when upgrading to the new scheme.
 func TestUpgradeToNewCertNames(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbName := namer.LoadBalancer("test")
@@ -342,6 +349,7 @@ func TestUpgradeToNewCertNames(t *testing.T) {
 // Tests uploading 10 certs which is the global limit today. Ensures that creation of the 11th cert fails.
 func TestMaxCertsUpload(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	var tlsCerts []*TLSCerts
 	expectCerts := make(map[string]string)
@@ -379,6 +387,7 @@ func TestMaxCertsUpload(t *testing.T) {
 // This test verifies this behavior.
 func TestIdenticalHostnameCerts(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	var tlsCerts []*TLSCerts
 	expectCerts := make(map[string]string)
@@ -415,6 +424,7 @@ func TestIdenticalHostnameCerts(t *testing.T) {
 
 func TestIdenticalHostnameCertsPreShared(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{
@@ -460,6 +470,7 @@ func TestIdenticalHostnameCertsPreShared(t *testing.T) {
 // to secret based cert and verifies the pre-shared cert is retained.
 func TestPreSharedToSecretBasedCertUpdate(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbName := namer.LoadBalancer("test")
@@ -603,6 +614,7 @@ func TestCreateHTTPSLoadBalancerAnnotationCert(t *testing.T) {
 	// This should NOT create the forwarding rule and target proxy
 	// associated with the HTTP branch of this loadbalancer.
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	tlsName := "external-cert-name"
 	namer := utils.NewNamer("uid1", "fw1")
@@ -641,6 +653,7 @@ func TestCreateBothLoadBalancers(t *testing.T) {
 	// but they should use the same urlmap, and have the same
 	// static ip.
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{
@@ -687,13 +700,14 @@ func TestUpdateUrlMap(t *testing.T) {
 	um2 := utils.NewGCEURLMap()
 
 	um1.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar2", Backend: utils.ServicePort{NodePort: 30000}}})
+	um1.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 
 	um2.PutPathRulesForHost("foo.example.com", []utils.PathRule{
 		utils.PathRule{Path: "/foo1", Backend: utils.ServicePort{NodePort: 30001}},
 		utils.PathRule{Path: "/foo2", Backend: utils.ServicePort{NodePort: 30002}},
 	})
 	um2.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar1", Backend: utils.ServicePort{NodePort: 30003}}})
-	um2.DefaultBackend = utils.ServicePort{NodePort: 30004}
+	um2.DefaultBackend = &utils.ServicePort{NodePort: 30004}
 
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{Name: namer.LoadBalancer("test"), AllowHTTP: true, UrlMap: um1}
@@ -727,14 +741,14 @@ func TestUpdateUrlMapNoChanges(t *testing.T) {
 		utils.PathRule{Path: "/foo2", Backend: utils.ServicePort{NodePort: 30001}},
 	})
 	um1.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar1", Backend: utils.ServicePort{NodePort: 30002}}})
-	um1.DefaultBackend = utils.ServicePort{NodePort: 30003}
+	um1.DefaultBackend = &utils.ServicePort{NodePort: 30003}
 
 	um2.PutPathRulesForHost("foo.example.com", []utils.PathRule{
 		utils.PathRule{Path: "/foo1", Backend: utils.ServicePort{NodePort: 30000}},
 		utils.PathRule{Path: "/foo2", Backend: utils.ServicePort{NodePort: 30001}},
 	})
 	um2.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar1", Backend: utils.ServicePort{NodePort: 30002}}})
-	um2.DefaultBackend = utils.ServicePort{NodePort: 30003}
+	um2.DefaultBackend = &utils.ServicePort{NodePort: 30003}
 
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{Name: namer.LoadBalancer("test"), AllowHTTP: true, UrlMap: um1}
@@ -782,6 +796,7 @@ func TestNameParsing(t *testing.T) {
 
 func TestClusterNameChange(t *testing.T) {
 	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234}
 	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{utils.PathRule{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000}}})
 	namer := utils.NewNamer("uid1", "fw1")
 	lbInfo := &L7RuntimeInfo{

--- a/pkg/neg/fakes.go
+++ b/pkg/neg/fakes.go
@@ -18,10 +18,11 @@ package neg
 
 import (
 	"fmt"
-	computealpha "google.golang.org/api/compute/v0.alpha"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"reflect"
 	"sync"
+
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	api_v1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// NewIngress returns an Ingress with the given spec.
+func NewIngress(name types.NamespacedName, spec extensions.IngressSpec) *extensions.Ingress {
+	return &extensions.Ingress{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "extensions/v1beta1",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Spec: spec,
+	}
+}
+
+// NewService returns a Service with the given spec.
+func NewService(name types.NamespacedName, spec api_v1.ServiceSpec) *api_v1.Service {
+	return &api_v1.Service{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Spec: spec,
+	}
+}
+
+// Backend returns an IngressBackend with the given service name/port.
+func Backend(name string, port intstr.IntOrString) *extensions.IngressBackend {
+	return &extensions.IngressBackend{
+		ServiceName: name,
+		ServicePort: port,
+	}
+}
+
+// DecodeIngress deserializes an Ingress object.
+func DecodeIngress(data []byte) (*extensions.Ingress, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.Ingress), nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -148,6 +150,19 @@ func trimFieldsEvenly(max int, fields ...string) []string {
 	}
 
 	return ret
+}
+
+// PrettyJson marshals an object in a human-friendly format.
+func PrettyJson(data interface{}) (string, error) {
+	buffer := new(bytes.Buffer)
+	encoder := json.NewEncoder(buffer)
+	encoder.SetIndent("", "\t")
+
+	err := encoder.Encode(data)
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
 }
 
 // BackendServiceRelativeResourcePath returns a relative path of the link for a


### PR DESCRIPTION
**Changes**
 - Stop gracefully falling back on system default backend if specified backend is not found - no longer need EventRecorder in translater
 - Return list of errors from TranslateIngress
 - ensureIngress will error if TranslateIngress hits any errors. `ToSvcPorts` iterates all ingresses (for now) and will continue to collect all known service ports
 - Deleted a lot of tests in controller_test.go. Some of them should be re-created in different packages (tests that check GCE resource config), and new tests should be made for the controller that assert controller logic such as garbage collection, k8s object lifecycle edge cases.
 - Re-wrote tests for controller and created tests for TranslateIngress.
