### PR TITLE
fake backendservices save alpha objects by default

### DIFF
--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -56,11 +56,6 @@ func (f *FakeBackendServices) GetGlobalBackendService(name string) (*compute.Bac
 	}
 
 	if name == svc.Name {
-		// Currently, getting an Alpha BackendService strips it of Protocol if HTTP2.
-		// TODO: remove this check once ProtocolHTTP2 moves into Beta or GA.
-		if svc.Protocol == string(annotations.ProtocolHTTP2) {
-			svc.Protocol = ""
-		}
 		return toV1BackendService(svc), nil
 	}
 
@@ -78,11 +73,6 @@ func (f *FakeBackendServices) GetAlphaGlobalBackendService(name string) (*comput
 	}
 
 	svc := obj.(*computealpha.BackendService)
-	// Currently, getting an Alpha BackendService strips it of Protocol if HTTP2.
-	// TODO: remove this check once ProtocolHTTP2 moves into Beta or GA.
-	if svc.Protocol == "" {
-		svc.Protocol = string(annotations.ProtocolHTTP2)
-	}
 
 	if name == svc.Name {
 		return svc, nil
@@ -196,6 +186,12 @@ func toV1BackendService(be *computealpha.BackendService) *compute.BackendService
 	bytes, _ := be.MarshalJSON()
 	res := &compute.BackendService{}
 	json.Unmarshal(bytes, res)
+
+	// Currently, getting an Alpha BackendService strips it of Protocol if HTTP2.
+	// TODO: remove this check once ProtocolHTTP2 moves into Beta or GA.
+	if res.Protocol == string(annotations.ProtocolHTTP2) {
+		res.Protocol = ""
+	}
 	return res
 }
 

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	compute "google.golang.org/api/compute/v1"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -56,7 +56,7 @@ type fakeClusterManager struct {
 func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager {
 	namer := utils.NewNamer(clusterName, firewallName)
 	fakeLbs := loadbalancers.NewFakeLoadBalancers(clusterName, namer)
-	fakeBackends := backends.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil }, false)
+	fakeBackends := backends.NewFakeBackendServices(func(op int, be *computealpha.BackendService) error { return nil })
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
 	fakeHCP := healthchecks.NewFakeHealthCheckProvider()
 	fakeNEG := neg.NewFakeNetworkEndpointGroupCloud("test-subnet", "test-network")


### PR DESCRIPTION
- Have FakeBackendServices save Alpha BackendServices by default. GA methods convert the object to alpha version. This is to avoid converting an Alpha object to GA, and potentially losing data present on fields that are only in Alpha but not GA.
- Use `alphaErrFunc` to throw error if not alpha whitelisted (currently only used for HTTP/2)