### PR TITLE
Ensure Load Balancer using IG links instead of IG compute object

### DIFF
--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -93,7 +93,7 @@ func TestBackendPoolAdd(t *testing.T) {
 			// Add a backend for a port, then re-add the same port and
 			// make sure it corrects a broken link from the backend to
 			// the instance group.
-			err = pool.Ensure([]utils.ServicePort{sp}, igs)
+			err = pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 			if err != nil {
 				t.Fatalf("Did not expect error when ensuring a ServicePort %+v: %v", sp, err)
 			}
@@ -314,8 +314,11 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP}
-	igs, _ := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
-	pool.Ensure([]utils.ServicePort{sp}, igs)
+	igs, err := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	if err != nil {
+		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
+	}
+	pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 	beName := sp.BackendName(defaultNamer)
 
 	be, _ := f.GetGlobalBackendService(beName)
@@ -328,8 +331,11 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	f.calls = []int{}
 	f.UpdateGlobalBackendService(be)
 
-	igs, _ = pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
-	pool.Ensure([]utils.ServicePort{sp}, igs)
+	igs, err = pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	if err != nil {
+		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
+	}
+	pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 	for _, call := range f.calls {
 		if call == utils.Create {
 			t.Fatalf("Unexpected create for existing backend service")
@@ -669,8 +675,11 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	pool, _ := newTestJig(f, fakeIGs, false)
 
 	sp := utils.ServicePort{NodePort: 80}
-	igs, _ := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
-	pool.Ensure([]utils.ServicePort{sp}, igs)
+	igs, err := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	if err != nil {
+		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
+	}
+	pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 
 	be, err := f.GetGlobalBackendService(defaultNamer.IGBackend(80))
 	if err != nil {
@@ -688,8 +697,11 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	}
 
 	// Make sure repeated adds don't clobber the inserted instance group
-	igs, _ = pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
-	pool.Ensure([]utils.ServicePort{sp}, igs)
+	igs, err = pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	if err != nil {
+		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
+	}
+	pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 	be, err = f.GetGlobalBackendService(defaultNamer.IGBackend(80))
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -729,8 +741,11 @@ func TestBackendCreateBalancingMode(t *testing.T) {
 			return nil
 		}
 
-		igs, _ := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
-		pool.Ensure([]utils.ServicePort{sp}, igs)
+		igs, err := pool.nodePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+		if err != nil {
+			t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
+		}
+		pool.Ensure([]utils.ServicePort{sp}, utils.IGLinks(igs))
 		be, err := f.GetGlobalBackendService(sp.BackendName(defaultNamer))
 		if err != nil {
 			t.Fatalf("%v", err)

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -32,7 +32,7 @@ type ProbeProvider interface {
 // as gce backendServices, and sync them through the BackendServices interface.
 type BackendPool interface {
 	Init(p ProbeProvider)
-	Ensure(ports []utils.ServicePort, igs []*compute.InstanceGroup) error
+	Ensure(ports []utils.ServicePort, igLinks []string) error
 	Get(name string, isAlpha bool) (*BackendService, error)
 	Delete(name string) error
 	GC(ports []utils.ServicePort) error

--- a/pkg/controller/cluster_manager.go
+++ b/pkg/controller/cluster_manager.go
@@ -92,9 +92,9 @@ func (c *ClusterManager) shutdown() error {
 // - lbServicePorts are the ports for which we require Backend Services.
 // - instanceGroups are the groups to be referenced by the Backend Services..
 // If GCE runs out of quota, a googleapi 403 is returned.
-func (c *ClusterManager) EnsureLoadBalancer(lb *loadbalancers.L7RuntimeInfo, lbServicePorts []utils.ServicePort, instanceGroups []*compute.InstanceGroup) error {
-	glog.V(4).Infof("EnsureLoadBalancer(%q lb, %v lbServicePorts, %v instanceGroups)", lb.String(), len(lbServicePorts), len(instanceGroups))
-	if err := c.backendPool.Ensure(uniq(lbServicePorts), instanceGroups); err != nil {
+func (c *ClusterManager) EnsureLoadBalancer(lb *loadbalancers.L7RuntimeInfo, lbServicePorts []utils.ServicePort, igLinks []string) error {
+	glog.V(4).Infof("EnsureLoadBalancer(%q lb, %v lbServicePorts, %v instanceGroups)", lb.String(), len(lbServicePorts), len(igLinks))
+	if err := c.backendPool.Ensure(uniq(lbServicePorts), igLinks); err != nil {
 		return err
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -364,7 +364,8 @@ func (lbc *LoadBalancerController) ensureIngress(ing *extensions.Ingress, nodeNa
 	lb.UrlMap = urlMap
 
 	// Create the backend services and higher-level LB resources.
-	if err = lbc.CloudClusterManager.EnsureLoadBalancer(lb, ingSvcPorts, igs); err != nil {
+	// Note: To ensure the load balancer, we only need the IG links.
+	if err = lbc.CloudClusterManager.EnsureLoadBalancer(lb, ingSvcPorts, utils.IGLinks(igs)); err != nil {
 		return err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strings"
 
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -180,4 +181,13 @@ func BackendServiceComparablePath(url string) string {
 		return ""
 	}
 	return fmt.Sprintf("global/%s", path_parts[1])
+}
+
+// IGLinks returns a list of links extracted from the passed in list of
+// compute.InstanceGroup's.
+func IGLinks(igs []*compute.InstanceGroup) (igLinks []string) {
+	for _, ig := range igs {
+		igLinks = append(igLinks, ig.SelfLink)
+	}
+	return
 }


### PR DESCRIPTION
Right now, BackendPool.Ensure takes in a list of compute.InstanceGroup. However, the backend pool does not use any field of the IG other than its link. Therefore, it's cleaner to just pass in a list of IG links rather than the full object.

/assign @nicksardo 