### PR TITLE
Make sure structs in OpenAPI spec are serialized with 'type: object'

### DIFF
--- a/pkg/crd/validation.go
+++ b/pkg/crd/validation.go
@@ -50,6 +50,7 @@ func condenseSchema(currentSchema spec.Schema, openapiSpec map[string]common.Ope
 		ref := propertySchema.SchemaProps.Ref.String()
 		if ref != "" {
 			referencedSchema := openapiSpec[ref].Schema
+			referencedSchema.SchemaProps.Type = spec.StringOrArray{"object"}
 			propertySchema.SchemaProps = referencedSchema.SchemaProps
 			currentSchemaProperties[property] = propertySchema
 			condenseSchema(propertySchema, openapiSpec)


### PR DESCRIPTION
This will ensure that if a user pushes a spec like below, that an error will be returned to them:

```
spec:
  iap:
```

/assign @MrHohn 