### PR TITLE
name NEGs with ServicePort instead of TargetPort

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -508,7 +508,7 @@ func (b *Backends) Link(sp utils.ServicePort, zones []string) error {
 	if !sp.NEGEnabled {
 		return nil
 	}
-	negName := b.namer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.SvcTargetPort)
+	negName := sp.BackendName(b.namer)
 	var negs []*computealpha.NetworkEndpointGroup
 	var err error
 	for _, zone := range zones {

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -555,34 +555,34 @@ func TestBackendPoolSyncQuota(t *testing.T) {
 		{
 			[]utils.ServicePort{{NodePort: 8080}, {NodePort: 443}},
 			[]utils.ServicePort{
-				{NodePort: 8080, SvcTargetPort: "testport8080", NEGEnabled: true},
-				{NodePort: 443, SvcTargetPort: "testport443", NEGEnabled: true},
+				{SvcPort: 8080, NodePort: 8080, NEGEnabled: true},
+				{SvcPort: 443, NodePort: 443, NEGEnabled: true},
 			},
 			true,
 			"Same port converted to NEG, plus one new NEG port",
 		},
 		{
 			[]utils.ServicePort{
-				{NodePort: 80, SvcTargetPort: "testport80", NEGEnabled: true},
-				{NodePort: 90, SvcTargetPort: "testport90"},
+				{SvcPort: 80, NodePort: 80, NEGEnabled: true},
+				{SvcPort: 90, NodePort: 90},
 			},
 			[]utils.ServicePort{
-				{NodePort: 80, SvcTargetPort: "testport80"},
-				{NodePort: 90, SvcTargetPort: "testport90", NEGEnabled: true},
+				{SvcPort: 80},
+				{SvcPort: 90, NEGEnabled: true},
 			},
 			true,
 			"Mixed NEG and non-NEG ports",
 		},
 		{
 			[]utils.ServicePort{
-				{NodePort: 100, SvcTargetPort: "testport100", NEGEnabled: true},
-				{NodePort: 110, SvcTargetPort: "testport110", NEGEnabled: true},
-				{NodePort: 120, SvcTargetPort: "testport120", NEGEnabled: true},
+				{SvcPort: 100, NodePort: 100, NEGEnabled: true},
+				{SvcPort: 110, NodePort: 110, NEGEnabled: true},
+				{SvcPort: 120, NodePort: 120, NEGEnabled: true},
 			},
 			[]utils.ServicePort{
-				{NodePort: 100, SvcTargetPort: "testport100"},
-				{NodePort: 110, SvcTargetPort: "testport110"},
-				{NodePort: 120, SvcTargetPort: "testport120"},
+				{SvcPort: 100, NodePort: 100},
+				{SvcPort: 110, NodePort: 110},
+				{SvcPort: 120, NodePort: 120},
 			},
 			true,
 			"Same ports as NEG, then non-NEG",
@@ -844,8 +844,8 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 				Namespace: namespace,
 				Name:      name,
 			},
-			Port: intstr.FromInt(80),
 		},
+		SvcPort:       80,
 		NodePort:      30001,
 		Protocol:      annotations.ProtocolHTTP,
 		SvcTargetPort: port,
@@ -857,7 +857,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 
 	for _, zone := range zones {
 		err := fakeNEG.CreateNetworkEndpointGroup(&computealpha.NetworkEndpointGroup{
-			Name: defaultNamer.NEG(namespace, name, port),
+			Name: defaultNamer.NEG(namespace, name, fmt.Sprintf("%v", svcPort.SvcPort)),
 		}, zone)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -88,6 +88,7 @@ func (t *Translator) getServicePort(id utils.ServicePortID) (*utils.ServicePort,
 	svcPort = &utils.ServicePort{
 		ID:            id,
 		NodePort:      int64(port.NodePort),
+		SvcPort:       int32(port.Port),
 		SvcTargetPort: port.TargetPort.String(),
 		NEGEnabled:    t.ctx.NEGEnabled && negEnabled,
 	}

--- a/pkg/utils/namer.go
+++ b/pkg/utils/namer.go
@@ -370,7 +370,7 @@ func (n *Namer) NamedPort(port int64) string {
 // NEG returns the gce neg name based on the service namespace, name
 // and target port. NEG naming convention:
 //
-//   {prefix}{version}-{clusterid}-{namespace}-{name}-{target port}-{hash}
+//   {prefix}{version}-{clusterid}-{namespace}-{name}-{service port}-{hash}
 //
 // Output name is at most 63 characters. NEG tries to keep as much
 // information as possible.

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -38,6 +38,7 @@ type ServicePort struct {
 	ID ServicePortID
 
 	NodePort      int64
+	SvcPort       int32
 	Protocol      annotations.AppProtocol
 	SvcTargetPort string
 	NEGEnabled    bool
@@ -74,7 +75,7 @@ func (sp ServicePort) BackendName(namer *Namer) string {
 		return namer.IGBackend(sp.NodePort)
 	}
 
-	return namer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.SvcTargetPort)
+	return namer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, fmt.Sprintf("%v", sp.SvcPort))
 }
 
 // BackendToServicePortID creates a ServicePortID from a given IngressBackend and namespace.


### PR DESCRIPTION
Refactor that makes https://github.com/kubernetes/ingress-gce/pull/284 easier