### PR TITLE
Slight refactor of controller context to include both NEG & BackendConfig switches

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -107,8 +107,8 @@ func main() {
 
 	enableNEG := cloud.AlphaFeatureGate.Enabled(gce.AlphaFeatureNetworkEndpointGroup)
 	stopCh := make(chan struct{})
-	ctx := context.NewControllerContext(kubeClient, backendConfigClient, flags.F.WatchNamespace, flags.F.ResyncPeriod, enableNEG)
-	lbc, err := controller.NewLoadBalancerController(kubeClient, stopCh, ctx, clusterManager, enableNEG, flags.F.EnableBackendConfig)
+	ctx := context.NewControllerContext(kubeClient, backendConfigClient, flags.F.WatchNamespace, flags.F.ResyncPeriod, enableNEG, flags.F.EnableBackendConfig)
+	lbc, err := controller.NewLoadBalancerController(kubeClient, stopCh, ctx, clusterManager)
 	if err != nil {
 		glog.Fatalf("Error creating load balancer controller: %v", err)
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -45,8 +45,8 @@ func newLoadBalancerController(t *testing.T, cm *fakeClusterManager) *LoadBalanc
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 
 	stopCh := make(chan struct{})
-	ctx := context.NewControllerContext(kubeClient, backendConfigClient, api_v1.NamespaceAll, 1*time.Minute, true)
-	lbc, err := NewLoadBalancerController(kubeClient, stopCh, ctx, cm.ClusterManager, true, true)
+	ctx := context.NewControllerContext(kubeClient, backendConfigClient, api_v1.NamespaceAll, 1*time.Minute, true, false)
+	lbc, err := NewLoadBalancerController(kubeClient, stopCh, ctx, cm.ClusterManager)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -49,11 +49,10 @@ func fakeTranslator(negEnabled bool) *Translator {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 
 	namer := utils.NewNamer("uid1", "")
-	ctx := context.NewControllerContext(client, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, negEnabled)
+	ctx := context.NewControllerContext(client, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, negEnabled, false)
 	gce := &Translator{
-		namer:      namer,
-		ctx:        ctx,
-		negEnabled: negEnabled,
+		namer: namer,
+		ctx:   ctx,
 	}
 	return gce
 }

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -35,7 +35,7 @@ import (
 
 func newTestController(kubeClient kubernetes.Interface) *Controller {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true)
+	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true, false)
 	controller, _ := NewController(kubeClient,
 		NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network"),
 		context,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -38,7 +38,7 @@ const (
 
 func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true)
+	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true, false)
 	manager := newSyncerManager(
 		utils.NewNamer(CluseterID, ""),
 		record.NewFakeRecorder(100),

--- a/pkg/neg/syncer_test.go
+++ b/pkg/neg/syncer_test.go
@@ -25,7 +25,7 @@ const (
 func NewTestSyncer() *syncer {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true)
+	context := context.NewControllerContext(kubeClient, backendConfigClient, apiv1.NamespaceAll, 1*time.Second, true, false)
 	svcPort := servicePort{
 		namespace:  testServiceNamespace,
 		name:       testServiceName,


### PR DESCRIPTION
This ensures that all of our switches are maintained in the controller context. It also makes some parts of the code easier to read.

/assign @nicksardo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/299)
<!-- Reviewable:end -->
