### PR TITLE
Use cloud ResourceID for URL parsing and generation

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -154,14 +154,7 @@ func ensureDescription(be *BackendService, description string) (needsUpdate bool
 func ensureHealthCheckLink(be *BackendService, hcLink string) (needsUpdate bool) {
 	existingHCLink := getHealthCheckLink(be)
 
-	// Compare health check name instead of health check link.
-	// This is because health check link contains api version.
-	// For NEG, the api version for health check will be alpha.
-	// Hence, it will cause the health check links to be always different
-	// TODO (mixia): compare health check link directly once NEG is GA
-	existingHCName := retrieveObjectName(existingHCLink)
-	expectedHCName := retrieveObjectName(hcLink)
-	if existingHCName == expectedHCName {
+	if utils.EqualResourceID(existingHCLink, hcLink) {
 		return false
 	}
 
@@ -314,7 +307,11 @@ func (b *Backends) ensureBackendService(sp utils.ServicePort, igLinks []string) 
 // edgeHop checks the links of the given backend by executing an edge hop.
 // It fixes broken links and updates the Backend accordingly.
 func (b *Backends) edgeHop(be *BackendService, igLinks []string) error {
-	addIGs := getInstanceGroupsToAdd(be, igLinks)
+	addIGs, err := getInstanceGroupsToAdd(be, igLinks)
+	if err != nil {
+		return err
+	}
+
 	if len(addIGs) == 0 {
 		return nil
 	}
@@ -428,32 +425,32 @@ func getBackendsForNEGs(negs []*computealpha.NetworkEndpointGroup) []*computealp
 	return backends
 }
 
-func getInstanceGroupsToAdd(be *BackendService, igLinks []string) []string {
-	beName := be.Name
-	beIGs := sets.String{}
+func getInstanceGroupsToAdd(be *BackendService, igLinks []string) ([]string, error) {
+	existingIGs := sets.String{}
 	for _, existingBe := range be.Backends {
-		beIGs.Insert(comparableGroupPath(existingBe.Group))
-	}
-
-	expectedIGs := sets.String{}
-	for _, igLink := range igLinks {
-		expectedIGs.Insert(comparableGroupPath(igLink))
-	}
-
-	if beIGs.IsSuperset(expectedIGs) {
-		return nil
-	}
-	glog.V(2).Infof("Expected igs for backend service %v: %+v, current igs %+v",
-		beName, expectedIGs.List(), beIGs.List())
-
-	var addIGs []string
-	for _, igLink := range igLinks {
-		if !beIGs.Has(comparableGroupPath(igLink)) {
-			addIGs = append(addIGs, igLink)
+		path, err := utils.ResourcePath(existingBe.Group)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse instance group: %v", err)
 		}
+		existingIGs.Insert(path)
 	}
 
-	return addIGs
+	wantIGs := sets.String{}
+	for _, igLink := range igLinks {
+		path, err := utils.ResourcePath(igLink)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse instance group: %v", err)
+		}
+		wantIGs.Insert(path)
+	}
+
+	missingIGs := wantIGs.Difference(existingIGs)
+	if missingIGs.Len() > 0 {
+		glog.V(2).Infof("Backend service %q has instance groups %+v, want %+v",
+			be.Name, existingIGs.List(), wantIGs.List())
+	}
+
+	return missingIGs.List(), nil
 }
 
 // GC garbage collects services corresponding to ports in the given list.
@@ -580,17 +577,4 @@ func applyProbeSettingsToHC(p *v1.Probe, hc *healthchecks.HealthCheck) {
 		// For IG mode, short healthcheck interval may health check flooding problem.
 		hc.CheckIntervalSec = int64(p.PeriodSeconds) + int64(healthchecks.DefaultHealthCheckInterval.Seconds())
 	}
-}
-
-//retrieveObjectName takes a GCE object link and return the last part of the url as object name
-func retrieveObjectName(url string) string {
-	splited := strings.Split(url, "/")
-	return splited[len(splited)-1]
-}
-
-// comparableGroupPath trims project and compute version from the SelfLink
-// /zones/[ZONE_NAME]/instanceGroups/[IG_NAME]
-func comparableGroupPath(url string) string {
-	path_parts := strings.Split(url, "/zones/")
-	return fmt.Sprintf("/zones/%s", path_parts[1])
 }

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -355,7 +355,7 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	// Mess up the link between backend service and instance group.
 	// This simulates a user doing foolish things through the UI.
 	be.Backends = []*compute.Backend{
-		{Group: "/zones/edge-hop-test"},
+		{Group: "zones/us-central1-c/instanceGroups/edge-hop-test"},
 	}
 
 	// Add hook to keep track of how many calls are made.
@@ -384,16 +384,17 @@ func TestBackendPoolChaosMonkey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to find instance group %v", defaultNamer.InstanceGroup())
 	}
-	backendLinks := sets.NewString()
+	groupPath, err := utils.ResourcePath(gotGroup.SelfLink)
+	if err != nil {
+		t.Fatalf("Failed to get resource path from %q", gotGroup.SelfLink)
+	}
+
 	for _, be := range gotBackend.Backends {
-		backendLinks.Insert(be.Group)
+		if be.Group == groupPath {
+			return
+		}
 	}
-	if !backendLinks.Has(gotGroup.SelfLink) {
-		t.Fatalf(
-			"Broken instance group link, got: %+v expected: %v",
-			backendLinks.List(),
-			gotGroup.SelfLink)
-	}
+	t.Fatalf("Failed to find %q in backend groups %+v", groupPath, be.Backends)
 }
 
 func TestBackendPoolSync(t *testing.T) {
@@ -720,8 +721,8 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	// Simulate another controller updating the same backend service with
 	// a different instance group
 	newGroups := []*compute.Backend{
-		{Group: fmt.Sprintf("/zones/%s/instanceGroups/%s", defaultZone, "k8s-ig-bar")},
-		{Group: fmt.Sprintf("/zones/%s/instanceGroups/%s", defaultZone, "k8s-ig-foo")},
+		{Group: fmt.Sprintf("zones/%s/instanceGroups/%s", defaultZone, "k8s-ig-bar")},
+		{Group: fmt.Sprintf("zones/%s/instanceGroups/%s", defaultZone, "k8s-ig-foo")},
 	}
 	be.Backends = append(be.Backends, newGroups...)
 	if err = fakeGCE.UpdateGlobalBackendService(be); err != nil {
@@ -740,13 +741,21 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	}
 	gotGroups := sets.NewString()
 	for _, g := range be.Backends {
-		gotGroups.Insert(comparableGroupPath(g.Group))
+		igPath, err := utils.ResourcePath(g.Group)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		gotGroups.Insert(igPath)
 	}
 
 	// seed expectedGroups with the first group native to this controller
-	expectedGroups := sets.NewString(fmt.Sprintf("/zones/%s/instanceGroups/%s", defaultZone, "k8s-ig--uid1"))
+	expectedGroups := sets.NewString(fmt.Sprintf("zones/%s/instanceGroups/%s", defaultZone, "k8s-ig--uid1"))
 	for _, newGroup := range newGroups {
-		expectedGroups.Insert(comparableGroupPath(newGroup.Group))
+		igPath, err := utils.ResourcePath(newGroup.Group)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		expectedGroups.Insert(igPath)
 	}
 	if !expectedGroups.Equal(gotGroups) {
 		t.Fatalf("Expected %v Got %v", expectedGroups, gotGroups)
@@ -878,65 +887,9 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 	}
 
 	for _, be := range bs.Backends {
-		neg := "NetworkEndpointGroup"
+		neg := "networkEndpointGroups"
 		if !strings.Contains(be.Group, neg) {
-			t.Errorf("Expect backend to be a NEG, but got %q", be.Group)
-		}
-	}
-}
-
-func TestRetrieveObjectName(t *testing.T) {
-	testCases := []struct {
-		url    string
-		expect string
-	}{
-		{
-			"",
-			"",
-		},
-		{
-			"a/b/c/d/",
-			"",
-		},
-		{
-			"a/b/c/d",
-			"d",
-		},
-		{
-			"compute",
-			"compute",
-		},
-	}
-
-	for _, tc := range testCases {
-		if retrieveObjectName(tc.url) != tc.expect {
-			t.Errorf("expect %q, but got %q", tc.expect, retrieveObjectName(tc.url))
-		}
-	}
-}
-
-func TestComparableGroupPath(t *testing.T) {
-	testCases := []struct {
-		igPath   string
-		expected string
-	}{
-		{
-			"https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
-			"/zones/us-central1-a/instanceGroups/example-group",
-		},
-		{
-			"https://www.googleapis.com/compute/alpha/projects/project-id/zones/us-central1-b/instanceGroups/test-group",
-			"/zones/us-central1-b/instanceGroups/test-group",
-		},
-		{
-			"https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-c/instanceGroups/another-group",
-			"/zones/us-central1-c/instanceGroups/another-group",
-		},
-	}
-
-	for _, tc := range testCases {
-		if comparableGroupPath(tc.igPath) != tc.expected {
-			t.Errorf("expected %s, but got %s", tc.expected, comparableGroupPath(tc.igPath))
+			t.Errorf("Got backend link %q, want containing %q", be.Group, neg)
 		}
 	}
 }

--- a/pkg/healthchecks/fakes.go
+++ b/pkg/healthchecks/fakes.go
@@ -21,6 +21,8 @@ import (
 	compute "google.golang.org/api/compute/v1"
 
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 )
 
 // NewFakeHealthCheckProvider returns a new FakeHealthChecks.
@@ -40,7 +42,7 @@ type FakeHealthCheckProvider struct {
 // CreateHttpHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/httpHealthChecks/" + hc.Name
+	v.SelfLink = cloud.NewHttpHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionGA)
 	f.http[hc.Name] = v
 	return nil
 }
@@ -77,8 +79,8 @@ func (f *FakeHealthCheckProvider) UpdateHttpHealthCheck(hc *compute.HttpHealthCh
 // CreateHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateHealthCheck(hc *compute.HealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/healthChecks/" + hc.Name
-	alphaHC, _ := toAlphaHealthCheck(hc)
+	v.SelfLink = cloud.NewHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionGA)
+	alphaHC, _ := toAlphaHealthCheck(&v)
 	f.generic[hc.Name] = *alphaHC
 	return nil
 }
@@ -86,8 +88,8 @@ func (f *FakeHealthCheckProvider) CreateHealthCheck(hc *compute.HealthCheck) err
 // CreateHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/healthChecks/" + hc.Name
-	f.generic[hc.Name] = *hc
+	v.SelfLink = cloud.NewHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionAlpha)
+	f.generic[hc.Name] = v
 	return nil
 }
 

--- a/pkg/instances/fakes.go
+++ b/pkg/instances/fakes.go
@@ -22,6 +22,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -81,7 +83,7 @@ func (f *FakeInstanceGroups) GetInstanceGroup(name, zone string) (*compute.Insta
 
 // CreateInstanceGroup fakes instance group creation.
 func (f *FakeInstanceGroups) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
-	ig.SelfLink = fmt.Sprintf("/zones/%s/instanceGroups/%s", zone, ig.Name)
+	ig.SelfLink = cloud.NewInstanceGroupsResourceID("mock-project", zone, ig.Name).SelfLink(meta.VersionGA)
 	ig.Zone = zone
 	f.instanceGroups = append(f.instanceGroups, ig)
 	return nil

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -19,7 +19,6 @@ package instances
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -186,10 +185,11 @@ func (i *Instances) list(name string) (sets.String, error) {
 			return nodeNames, err
 		}
 		for _, ins := range instances {
-			// TODO: If round trips weren't so slow one would be inclided
-			// to GetInstance using this url and get the name.
-			parts := strings.Split(ins.Instance, "/")
-			nodeNames.Insert(parts[len(parts)-1])
+			name, err := utils.KeyName(ins.Instance)
+			if err != nil {
+				return nodeNames, err
+			}
+			nodeNames.Insert(name)
 		}
 	}
 	return nodeNames, nil

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -23,6 +23,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -134,7 +136,7 @@ func (f *FakeLoadBalancers) CreateGlobalForwardingRule(rule *compute.ForwardingR
 	if rule.IPAddress == "" {
 		rule.IPAddress = fmt.Sprintf(testIPManager.ip())
 	}
-	rule.SelfLink = rule.Name
+	rule.SelfLink = cloud.NewGlobalForwardingRulesResourceID("mock-project", rule.Name).SelfLink(meta.VersionGA)
 	f.Fw = append(f.Fw, rule)
 	return nil
 }
@@ -196,7 +198,7 @@ func (f *FakeLoadBalancers) GetUrlMap(name string) (*compute.UrlMap, error) {
 func (f *FakeLoadBalancers) CreateUrlMap(urlMap *compute.UrlMap) error {
 	glog.V(4).Infof("CreateUrlMap %+v", urlMap)
 	f.calls = append(f.calls, "CreateUrlMap")
-	urlMap.SelfLink = urlMap.Name
+	urlMap.SelfLink = cloud.NewUrlMapsResourceID("mock-project", urlMap.Name).SelfLink(meta.VersionGA)
 	f.Um = append(f.Um, urlMap)
 	return nil
 }
@@ -252,7 +254,7 @@ func (f *FakeLoadBalancers) GetTargetHttpProxy(name string) (*compute.TargetHttp
 // CreateTargetHttpProxy fakes creating a target http proxy.
 func (f *FakeLoadBalancers) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpProxy")
-	proxy.SelfLink = proxy.Name
+	proxy.SelfLink = cloud.NewTargetHttpProxiesResourceID("mock-project", proxy.Name).SelfLink(meta.VersionGA)
 	f.Tp = append(f.Tp, proxy)
 	return nil
 }
@@ -301,7 +303,7 @@ func (f *FakeLoadBalancers) GetTargetHttpsProxy(name string) (*compute.TargetHtt
 // CreateTargetHttpsProxy fakes creating a target http proxy.
 func (f *FakeLoadBalancers) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpsProxy")
-	proxy.SelfLink = proxy.Name
+	proxy.SelfLink = cloud.NewTargetHttpProxiesResourceID("mock-project", proxy.Name).SelfLink(meta.VersionGA)
 	f.Tps = append(f.Tps, proxy)
 	return nil
 }
@@ -459,7 +461,7 @@ func (f *FakeLoadBalancers) ListSslCertificates() ([]*compute.SslCertificate, er
 // CreateSslCertificate fakes out certificate creation.
 func (f *FakeLoadBalancers) CreateSslCertificate(cert *compute.SslCertificate) (*compute.SslCertificate, error) {
 	f.calls = append(f.calls, "CreateSslCertificate")
-	cert.SelfLink = cert.Name
+	cert.SelfLink = cloud.NewSslCertificatesResourceID("mock-project", cert.Name).SelfLink(meta.VersionGA)
 	if len(f.Certs) == TargetProxyCertLimit {
 		// Simulate cert creation failure
 		return nil, fmt.Errorf("Unable to create cert, Exceeded cert limit of %d.", TargetProxyCertLimit)

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -18,7 +18,6 @@ package loadbalancers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
@@ -70,8 +69,7 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 		fw = nil
 	}
 	if fw == nil {
-		parts := strings.Split(proxyLink, "/")
-		glog.V(3).Infof("Creating forwarding rule for proxy %v and ip %v:%v", parts[len(parts)-1:], ip, portRange)
+		glog.V(3).Infof("Creating forwarding rule for proxy %q and ip %v:%v", proxyLink, ip, portRange)
 		rule := &compute.ForwardingRule{
 			Name:       name,
 			IPAddress:  ip,
@@ -88,7 +86,7 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 		}
 	}
 	// TODO: If the port range and protocol don't match, recreate the rule
-	if utils.CompareLinks(fw.Target, proxyLink) {
+	if utils.EqualResourceID(fw.Target, proxyLink) {
 		glog.V(4).Infof("Forwarding rule %v already exists", fw.Name)
 	} else {
 		glog.V(3).Infof("Forwarding rule %v has the wrong proxy, setting %v overwriting %v",

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -118,24 +118,6 @@ func (l *L7) UrlMap() *compute.UrlMap {
 	return l.um
 }
 
-// Returns the name portion of a link - which is the last section
-func getResourceNameFromLink(link string) string {
-	s := strings.Split(link, "/")
-	if len(s) == 0 {
-		return ""
-	}
-	return s[len(s)-1]
-}
-
-func (l *L7) getSslCertLinkInUse() []string {
-	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
-	proxy, _ := l.cloud.GetTargetHttpsProxy(proxyName)
-	if proxy != nil && len(proxy.SslCertificates) > 0 {
-		return proxy.SslCertificates
-	}
-	return nil
-}
-
 func (l *L7) edgeHop() error {
 	if err := l.assertUrlMapExists(); err != nil {
 		return err

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -548,10 +548,11 @@ func verifyProxyCertsInOrder(hostname string, f *FakeLoadBalancers, t *testing.T
 	count := 0
 	tmp := ""
 
-	for _, linkName := range tps.SslCertificates {
-		cert, err := f.GetSslCertificate(getResourceNameFromLink(linkName))
+	for _, link := range tps.SslCertificates {
+		certName, _ := utils.KeyName(link)
+		cert, err := f.GetSslCertificate(certName)
 		if err != nil {
-			t.Fatalf("Failed to fetch certificate from link %s - %v", linkName, err)
+			t.Fatalf("Failed to fetch certificate from link %s - %v", link, err)
 		}
 		if strings.HasSuffix(cert.Certificate, hostname) {
 			// cert contents will be of the form "cert-<number> <hostname>", we want the certs with the smaller number
@@ -602,8 +603,9 @@ func verifyCertAndProxyLink(expectCerts map[string]string, expectCertsProxy map[
 	if len(tps.SslCertificates) != len(expectCertsProxy) {
 		t.Fatalf("Expected https proxy to have %d certs, actual %d", len(expectCertsProxy), len(tps.SslCertificates))
 	}
-	for _, linkName := range tps.SslCertificates {
-		if _, ok := expectCerts[getResourceNameFromLink(linkName)]; !ok {
+	for _, link := range tps.SslCertificates {
+		certName, _ := utils.KeyName(link)
+		if _, ok := expectCerts[certName]; !ok {
 			t.Fatalf("unexpected ssl certificate linked in target proxy; Expected : %v; Target Proxy Certs: %v",
 				expectCertsProxy, tps.SslCertificates)
 		}

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -51,7 +51,7 @@ func (l *L7) checkProxy() (err error) {
 		l.tp = proxy
 		return nil
 	}
-	if !utils.CompareLinks(proxy.UrlMap, l.um.SelfLink) {
+	if !utils.EqualResourceID(proxy.UrlMap, l.um.SelfLink) {
 		glog.V(3).Infof("Proxy %v has the wrong url map, setting %v overwriting %v",
 			proxy.Name, l.um, proxy.UrlMap)
 		if err := l.cloud.SetUrlMapForTargetHttpProxy(proxy, l.um); err != nil {
@@ -96,7 +96,7 @@ func (l *L7) checkHttpsProxy() (err error) {
 		l.tps = proxy
 		return nil
 	}
-	if !utils.CompareLinks(proxy.UrlMap, l.um.SelfLink) {
+	if !utils.EqualResourceID(proxy.UrlMap, l.um.SelfLink) {
 		glog.V(3).Infof("Https proxy %v has the wrong url map, setting %v overwriting %v",
 			proxy.Name, l.um, proxy.UrlMap)
 		if err := l.cloud.SetUrlMapForTargetHttpsProxy(proxy, l.um); err != nil {
@@ -117,5 +117,14 @@ func (l *L7) checkHttpsProxy() (err error) {
 
 	}
 	l.tps = proxy
+	return nil
+}
+
+func (l *L7) getSslCertLinkInUse() []string {
+	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
+	proxy, _ := l.cloud.GetTargetHttpsProxy(proxyName)
+	if proxy != nil && len(proxy.SslCertificates) > 0 {
+		return proxy.SslCertificates
+	}
 	return nil
 }

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -205,7 +205,7 @@ func (l *L7) getBackendNames() []string {
 }
 
 func mapsEqual(a, b *compute.UrlMap) bool {
-	if utils.BackendServiceComparablePath(a.DefaultService) != utils.BackendServiceComparablePath(b.DefaultService) {
+	if !utils.EqualResourcePaths(a.DefaultService, b.DefaultService) {
 		return false
 	}
 	if len(a.HostRules) != len(b.HostRules) {
@@ -235,7 +235,7 @@ func mapsEqual(a, b *compute.UrlMap) bool {
 	for i := range a.PathMatchers {
 		a := a.PathMatchers[i]
 		b := b.PathMatchers[i]
-		if utils.BackendServiceComparablePath(a.DefaultService) != utils.BackendServiceComparablePath(b.DefaultService) {
+		if !utils.EqualResourcePaths(a.DefaultService, b.DefaultService) {
 			return false
 		}
 		if a.Description != b.Description {
@@ -260,7 +260,7 @@ func mapsEqual(a, b *compute.UrlMap) bool {
 			}
 			// Trim down the url's for a.Service and b.Service to a comparable structure
 			// We do this because we update the UrlMap with relative links (not full) to backends.
-			if utils.BackendServiceComparablePath(a.Service) != utils.BackendServiceComparablePath(b.Service) {
+			if !utils.EqualResourcePaths(a.Service, b.Service) {
 				return false
 			}
 		}

--- a/pkg/neg/syncer.go
+++ b/pkg/neg/syncer.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
@@ -252,8 +253,8 @@ func (s *syncer) ensureNetworkEndpointGroups() error {
 		needToCreate := false
 		if neg == nil {
 			needToCreate = true
-		} else if retrieveName(neg.LoadBalancer.Network) != retrieveName(s.cloud.NetworkURL()) ||
-			retrieveName(neg.LoadBalancer.Subnetwork) != retrieveName(s.cloud.SubnetworkURL()) {
+		} else if !utils.EqualResourceID(neg.LoadBalancer.Network, s.cloud.NetworkURL()) ||
+			!utils.EqualResourceID(neg.LoadBalancer.Subnetwork, s.cloud.SubnetworkURL()) {
 			// Only compare network and subnetwork names to avoid api endpoint differences that cause deleting NEG accidentally.
 			// TODO: change to compare network/subnetwork url instead of name when NEG API reach GA.
 			needToCreate = true
@@ -506,11 +507,6 @@ func calculateDifference(targetMap, currentMap map[string]sets.String) (map[stri
 		}
 	}
 	return addSet, removeSet
-}
-
-func retrieveName(url string) string {
-	strs := strings.Split(url, "/")
-	return strs[len(strs)-1]
 }
 
 // getService retrieves service object from serviceLister based on the input namespace and name

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 )
 
 const (
@@ -106,16 +107,6 @@ func IsForbiddenError(err error) bool {
 	return IsHTTPErrorCode(err, http.StatusForbidden)
 }
 
-// CompareLinks returns true if the 2 self links are equal.
-func CompareLinks(l1, l2 string) bool {
-	// TODO: These can be partial links
-	return l1 == l2 && l1 != ""
-}
-
-// PrimitivePathMap is a convenience type used by multiple submodules
-// that share the same testing methods.
-type PrimitivePathMap map[string]map[string]string
-
 // trimFieldsEvenly trims the fields evenly and keeps the total length
 // <= max. Truncation is spread in ratio with their original length,
 // meaning smaller fields will be truncated less than longer ones.
@@ -172,15 +163,67 @@ func BackendServiceRelativeResourcePath(name string) string {
 	return fmt.Sprintf("global/backendServices/%v", name)
 }
 
-// BackendServiceComparablePath trims project and compute version from the SelfLink
-// for a global BackendService.
-// global/backendServices/[BACKEND_SERVICE_NAME]
-func BackendServiceComparablePath(url string) string {
-	path_parts := strings.Split(url, "global/")
-	if len(path_parts) != 2 {
-		return ""
+// KeyName returns the name portion from a full or partial GCP resource URL.
+// Example:
+//    https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
+// Output: my-backend
+func KeyName(url string) (string, error) {
+	id, err := cloud.ParseResourceURL(url)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("global/%s", path_parts[1])
+
+	if id.Key == nil {
+		// Resource is projects
+		return id.ProjectID, nil
+	}
+
+	return id.Key.Name, nil
+}
+
+// ResourcePath returns the location, resource and name portion from a
+// full or partial GCP resource URL. This removes the endpoint prefix, version, and project.
+// Example:
+//    https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
+// Output: global/backendServices/my-backend
+func ResourcePath(url string) (string, error) {
+	resID, err := cloud.ParseResourceURL(url)
+	if err != nil {
+		return "", err
+	}
+	return resID.ResourcePath(), nil
+}
+
+// EqualResourcePaths returns true if a and b have equal ResourcePaths. Resource paths
+// entail the location, resource type, and resource name.
+func EqualResourcePaths(a, b string) bool {
+	aPath, err := ResourcePath(a)
+	if err != nil {
+		return false
+	}
+
+	bPath, err := ResourcePath(b)
+	if err != nil {
+		return false
+	}
+
+	return aPath == bPath
+}
+
+// EqualResourceID returns true if a and b have equal ResourceNames. Relative resource names
+// entail the project, location, resource type, and resource name.
+func EqualResourceID(a, b string) bool {
+	aId, err := cloud.ParseResourceURL(a)
+	if err != nil {
+		return false
+	}
+
+	bId, err := cloud.ParseResourceURL(b)
+	if err != nil {
+		return false
+	}
+
+	return aId.Equal(bId)
 }
 
 // IGLinks returns a list of links extracted from the passed in list of

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -84,7 +84,7 @@ func TestTrimFieldsEvenly(t *testing.T) {
 		for i := range res {
 			totalLen += len(res[i])
 			if res[i] != tc.expect[i] {
-				t.Errorf("%s: the %d field is expected to be %q, but got %q", tc.desc, i, tc.expect[i], res[i])
+				t.Errorf("%s: the %d field is want to be %q, but got %q", tc.desc, i, tc.expect[i], res[i])
 			}
 		}
 
@@ -94,10 +94,10 @@ func TestTrimFieldsEvenly(t *testing.T) {
 	}
 }
 
-func TestBackendServiceComparablePath(t *testing.T) {
+func TestResourcePathOfURL(t *testing.T) {
 	testCases := []struct {
-		url      string
-		expected string
+		url  string
+		want string
 	}{
 		{
 			"global/backendServices/foo",
@@ -108,15 +108,15 @@ func TestBackendServiceComparablePath(t *testing.T) {
 			"global/backendServices/foo",
 		},
 		{
-			"https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-c/backendServices/foo",
+			"https://www.googleapis.com/compute/v1/projects/foo/BAD-INPUT/zones/us-central1-c/backendServices/foo",
 			"",
 		},
 	}
 
 	for _, tc := range testCases {
-		res := BackendServiceComparablePath(tc.url)
-		if res != tc.expected {
-			t.Errorf("Expected result after url trim to be %v, but got %v", tc.expected, res)
+		res, _ := ResourcePath(tc.url)
+		if res != tc.want {
+			t.Errorf("ResourcePath(%q) = %q, want %q", tc.url, res, tc.want)
 		}
 	}
 }
@@ -152,6 +152,120 @@ func TestToNamespacedName(t *testing.T) {
 
 			if gotOut != tc.wantOut {
 				t.Errorf("ToNamespacedName(%v) = %v, want %v", tc.input, gotOut, tc.wantOut)
+			}
+		})
+	}
+}
+
+func TestEqualResourcePaths(t *testing.T) {
+	testCases := map[string]struct {
+		a    string
+		b    string
+		want bool
+	}{
+		"partial vs full": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			b:    "zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"full vs full": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"diff projects and versions": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"diff name": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-groupA",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-a/instanceGroups/example-groupB",
+			want: false,
+		},
+		"diff location": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"diff resource": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/backendServices/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"bad input a": {
+			a:    "/project-A/zones/us-central1-a/backendServices/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"bad input b": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			b:    "/project-A/zones/us-central1-a/backendServices/example-group",
+			want: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if got := EqualResourcePaths(tc.a, tc.b); got != tc.want {
+				t.Errorf("EqualResourcePathsOfURLs(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEqualResourceID(t *testing.T) {
+	testCases := map[string]struct {
+		a    string
+		b    string
+		want bool
+	}{
+		"partial vs full": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			b:    "projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"full vs full": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-id/zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"diff versions": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-A/zones/us-central1-a/instanceGroups/example-group",
+			want: true,
+		},
+		"diff name": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-groupA",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-a/instanceGroups/example-groupB",
+			want: false,
+		},
+		"diff location": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/instanceGroups/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"diff resource": {
+			a:    "https://www.googleapis.com/compute/v1/projects/project-A/zones/us-central1-a/backendServices/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"bad input a": {
+			a:    "/project-A/zones/us-central1-a/backendServices/example-group",
+			b:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			want: false,
+		},
+		"bad input b": {
+			a:    "https://www.googleapis.com/compute/beta/projects/project-B/zones/us-central1-b/instanceGroups/example-group",
+			b:    "/project-A/zones/us-central1-a/backendServices/example-group",
+			want: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if got := EqualResourceID(tc.a, tc.b); got != tc.want {
+				t.Errorf("EqualResourcePathsOfURLs(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Removes the plethora of helper functions which all perform the same basic action:
 - `retrieveObjectName`
 - `comparableGroupPath`
 - `getResourceNameFromLink`
 - `CompareLinks`
 - `BackendServiceComparablePath`
 - `retrieveName`

Replacing them with a few utility functions which depend on on the [cloud package](https://godoc.org/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud).