### PR TITLE
Use cloud ResourceID for URL parsing, generation, and comparison

### DIFF
--- a/pkg/healthchecks/fakes.go
+++ b/pkg/healthchecks/fakes.go
@@ -21,6 +21,8 @@ import (
 	compute "google.golang.org/api/compute/v1"
 
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 )
 
 // NewFakeHealthCheckProvider returns a new FakeHealthChecks.
@@ -40,7 +42,7 @@ type FakeHealthCheckProvider struct {
 // CreateHttpHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/httpHealthChecks/" + hc.Name
+	v.SelfLink = cloud.NewHttpHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionGA)
 	f.http[hc.Name] = v
 	return nil
 }
@@ -77,8 +79,8 @@ func (f *FakeHealthCheckProvider) UpdateHttpHealthCheck(hc *compute.HttpHealthCh
 // CreateHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateHealthCheck(hc *compute.HealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/healthChecks/" + hc.Name
-	alphaHC, _ := toAlphaHealthCheck(hc)
+	v.SelfLink = cloud.NewHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionGA)
+	alphaHC, _ := toAlphaHealthCheck(&v)
 	f.generic[hc.Name] = *alphaHC
 	return nil
 }
@@ -86,8 +88,8 @@ func (f *FakeHealthCheckProvider) CreateHealthCheck(hc *compute.HealthCheck) err
 // CreateHealthCheck fakes out http health check creation.
 func (f *FakeHealthCheckProvider) CreateAlphaHealthCheck(hc *computealpha.HealthCheck) error {
 	v := *hc
-	v.SelfLink = "https://fake.google.com/compute/healthChecks/" + hc.Name
-	f.generic[hc.Name] = *hc
+	v.SelfLink = cloud.NewHealthChecksResourceID("mock-project", hc.Name).SelfLink(meta.VersionAlpha)
+	f.generic[hc.Name] = v
 	return nil
 }
 

--- a/pkg/instances/fakes.go
+++ b/pkg/instances/fakes.go
@@ -22,6 +22,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -81,7 +83,7 @@ func (f *FakeInstanceGroups) GetInstanceGroup(name, zone string) (*compute.Insta
 
 // CreateInstanceGroup fakes instance group creation.
 func (f *FakeInstanceGroups) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
-	ig.SelfLink = fmt.Sprintf("/zones/%s/instanceGroups/%s", zone, ig.Name)
+	ig.SelfLink = cloud.NewInstanceGroupsResourceID("mock-project", zone, ig.Name).SelfLink(meta.VersionGA)
 	ig.Zone = zone
 	f.instanceGroups = append(f.instanceGroups, ig)
 	return nil

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -19,7 +19,6 @@ package instances
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -186,10 +185,11 @@ func (i *Instances) list(name string) (sets.String, error) {
 			return nodeNames, err
 		}
 		for _, ins := range instances {
-			// TODO: If round trips weren't so slow one would be inclided
-			// to GetInstance using this url and get the name.
-			parts := strings.Split(ins.Instance, "/")
-			nodeNames.Insert(parts[len(parts)-1])
+			name, err := utils.KeyName(ins.Instance)
+			if err != nil {
+				return nodeNames, err
+			}
+			nodeNames.Insert(name)
 		}
 	}
 	return nodeNames, nil

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -23,6 +23,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -134,7 +136,7 @@ func (f *FakeLoadBalancers) CreateGlobalForwardingRule(rule *compute.ForwardingR
 	if rule.IPAddress == "" {
 		rule.IPAddress = fmt.Sprintf(testIPManager.ip())
 	}
-	rule.SelfLink = rule.Name
+	rule.SelfLink = cloud.NewGlobalForwardingRulesResourceID("mock-project", rule.Name).SelfLink(meta.VersionGA)
 	f.Fw = append(f.Fw, rule)
 	return nil
 }
@@ -196,7 +198,7 @@ func (f *FakeLoadBalancers) GetUrlMap(name string) (*compute.UrlMap, error) {
 func (f *FakeLoadBalancers) CreateUrlMap(urlMap *compute.UrlMap) error {
 	glog.V(4).Infof("CreateUrlMap %+v", urlMap)
 	f.calls = append(f.calls, "CreateUrlMap")
-	urlMap.SelfLink = urlMap.Name
+	urlMap.SelfLink = cloud.NewUrlMapsResourceID("mock-project", urlMap.Name).SelfLink(meta.VersionGA)
 	f.Um = append(f.Um, urlMap)
 	return nil
 }
@@ -252,7 +254,7 @@ func (f *FakeLoadBalancers) GetTargetHttpProxy(name string) (*compute.TargetHttp
 // CreateTargetHttpProxy fakes creating a target http proxy.
 func (f *FakeLoadBalancers) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpProxy")
-	proxy.SelfLink = proxy.Name
+	proxy.SelfLink = cloud.NewTargetHttpProxiesResourceID("mock-project", proxy.Name).SelfLink(meta.VersionGA)
 	f.Tp = append(f.Tp, proxy)
 	return nil
 }
@@ -301,7 +303,7 @@ func (f *FakeLoadBalancers) GetTargetHttpsProxy(name string) (*compute.TargetHtt
 // CreateTargetHttpsProxy fakes creating a target http proxy.
 func (f *FakeLoadBalancers) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
 	f.calls = append(f.calls, "CreateTargetHttpsProxy")
-	proxy.SelfLink = proxy.Name
+	proxy.SelfLink = cloud.NewTargetHttpProxiesResourceID("mock-project", proxy.Name).SelfLink(meta.VersionGA)
 	f.Tps = append(f.Tps, proxy)
 	return nil
 }
@@ -362,9 +364,9 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 		return fmt.Errorf("f.GetUrlMap(%q) = %v, %v; want _, nil", l7.UrlMap().Name, um, err)
 	}
 	defaultBackendName := expectedUrlMap.DefaultBackend.BackendName(f.namer)
-	defaultBackendLink := utils.BackendServiceRelativeResourcePath(defaultBackendName)
+	defaultBackendLink := cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath()
 	// The urlmap should have a default backend, and each path matcher.
-	if defaultBackendName != "" && l7.UrlMap().DefaultService != defaultBackendLink {
+	if defaultBackendName != "" && !utils.EqualResourceIDs(l7.UrlMap().DefaultService, defaultBackendLink) {
 		return fmt.Errorf("default backend = %v, want %v", l7.UrlMap().DefaultService, defaultBackendLink)
 	}
 
@@ -376,7 +378,7 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 				if len(hostRule.Hosts) != 1 {
 					return fmt.Errorf("unexpected hosts in hostrules %+v", hostRule)
 				}
-				if defaultBackendLink != "" && matcher.DefaultService != defaultBackendLink {
+				if defaultBackendLink != "" && !utils.EqualResourceIDs(matcher.DefaultService, defaultBackendLink) {
 					return fmt.Errorf("expected default backend %v found %v", defaultBackendLink, matcher.DefaultService)
 				}
 				hostname = hostRule.Hosts[0]
@@ -391,9 +393,12 @@ func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap)
 			pathRule := rule.Paths[0]
 			if !expectedUrlMap.HostExists(hostname) {
 				return fmt.Errorf("Expected path rules for host %v", hostname)
-			} else if ok, svc := expectedUrlMap.PathExists(hostname, pathRule); !ok {
+			}
+			ok, svc := expectedUrlMap.PathExists(hostname, pathRule)
+			if !ok {
 				return fmt.Errorf("Expected rule %v for host %v", pathRule, hostname)
-			} else if utils.BackendServiceRelativeResourcePath(svc.BackendName(f.namer)) != rule.Service {
+			}
+			if beName, err := utils.KeyName(rule.Service); err != nil || beName != svc.BackendName(f.namer) {
 				return fmt.Errorf("Expected service %v found %v", svc, rule.Service)
 			}
 		}
@@ -459,7 +464,7 @@ func (f *FakeLoadBalancers) ListSslCertificates() ([]*compute.SslCertificate, er
 // CreateSslCertificate fakes out certificate creation.
 func (f *FakeLoadBalancers) CreateSslCertificate(cert *compute.SslCertificate) (*compute.SslCertificate, error) {
 	f.calls = append(f.calls, "CreateSslCertificate")
-	cert.SelfLink = cert.Name
+	cert.SelfLink = cloud.NewSslCertificatesResourceID("mock-project", cert.Name).SelfLink(meta.VersionGA)
 	if len(f.Certs) == TargetProxyCertLimit {
 		// Simulate cert creation failure
 		return nil, fmt.Errorf("Unable to create cert, Exceeded cert limit of %d.", TargetProxyCertLimit)

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -18,7 +18,6 @@ package loadbalancers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
@@ -70,8 +69,7 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 		fw = nil
 	}
 	if fw == nil {
-		parts := strings.Split(proxyLink, "/")
-		glog.V(3).Infof("Creating forwarding rule for proxy %v and ip %v:%v", parts[len(parts)-1:], ip, portRange)
+		glog.V(3).Infof("Creating forwarding rule for proxy %q and ip %v:%v", proxyLink, ip, portRange)
 		rule := &compute.ForwardingRule{
 			Name:       name,
 			IPAddress:  ip,
@@ -88,7 +86,7 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 		}
 	}
 	// TODO: If the port range and protocol don't match, recreate the rule
-	if utils.CompareLinks(fw.Target, proxyLink) {
+	if utils.EqualResourceIDs(fw.Target, proxyLink) {
 		glog.V(4).Infof("Forwarding rule %v already exists", fw.Name)
 	} else {
 		glog.V(3).Infof("Forwarding rule %v has the wrong proxy, setting %v overwriting %v",

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -118,24 +118,6 @@ func (l *L7) UrlMap() *compute.UrlMap {
 	return l.um
 }
 
-// Returns the name portion of a link - which is the last section
-func getResourceNameFromLink(link string) string {
-	s := strings.Split(link, "/")
-	if len(s) == 0 {
-		return ""
-	}
-	return s[len(s)-1]
-}
-
-func (l *L7) getSslCertLinkInUse() []string {
-	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
-	proxy, _ := l.cloud.GetTargetHttpsProxy(proxyName)
-	if proxy != nil && len(proxy.SslCertificates) > 0 {
-		return proxy.SslCertificates
-	}
-	return nil
-}
-
 func (l *L7) edgeHop() error {
 	if err := l.assertUrlMapExists(); err != nil {
 		return err

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -548,10 +548,11 @@ func verifyProxyCertsInOrder(hostname string, f *FakeLoadBalancers, t *testing.T
 	count := 0
 	tmp := ""
 
-	for _, linkName := range tps.SslCertificates {
-		cert, err := f.GetSslCertificate(getResourceNameFromLink(linkName))
+	for _, link := range tps.SslCertificates {
+		certName, _ := utils.KeyName(link)
+		cert, err := f.GetSslCertificate(certName)
 		if err != nil {
-			t.Fatalf("Failed to fetch certificate from link %s - %v", linkName, err)
+			t.Fatalf("Failed to fetch certificate from link %s - %v", link, err)
 		}
 		if strings.HasSuffix(cert.Certificate, hostname) {
 			// cert contents will be of the form "cert-<number> <hostname>", we want the certs with the smaller number
@@ -602,8 +603,9 @@ func verifyCertAndProxyLink(expectCerts map[string]string, expectCertsProxy map[
 	if len(tps.SslCertificates) != len(expectCertsProxy) {
 		t.Fatalf("Expected https proxy to have %d certs, actual %d", len(expectCertsProxy), len(tps.SslCertificates))
 	}
-	for _, linkName := range tps.SslCertificates {
-		if _, ok := expectCerts[getResourceNameFromLink(linkName)]; !ok {
+	for _, link := range tps.SslCertificates {
+		certName, _ := utils.KeyName(link)
+		if _, ok := expectCerts[certName]; !ok {
 			t.Fatalf("unexpected ssl certificate linked in target proxy; Expected : %v; Target Proxy Certs: %v",
 				expectCertsProxy, tps.SslCertificates)
 		}

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -51,7 +51,7 @@ func (l *L7) checkProxy() (err error) {
 		l.tp = proxy
 		return nil
 	}
-	if !utils.CompareLinks(proxy.UrlMap, l.um.SelfLink) {
+	if !utils.EqualResourceIDs(proxy.UrlMap, l.um.SelfLink) {
 		glog.V(3).Infof("Proxy %v has the wrong url map, setting %v overwriting %v",
 			proxy.Name, l.um, proxy.UrlMap)
 		if err := l.cloud.SetUrlMapForTargetHttpProxy(proxy, l.um); err != nil {
@@ -96,7 +96,7 @@ func (l *L7) checkHttpsProxy() (err error) {
 		l.tps = proxy
 		return nil
 	}
-	if !utils.CompareLinks(proxy.UrlMap, l.um.SelfLink) {
+	if !utils.EqualResourceIDs(proxy.UrlMap, l.um.SelfLink) {
 		glog.V(3).Infof("Https proxy %v has the wrong url map, setting %v overwriting %v",
 			proxy.Name, l.um, proxy.UrlMap)
 		if err := l.cloud.SetUrlMapForTargetHttpsProxy(proxy, l.um); err != nil {
@@ -118,4 +118,14 @@ func (l *L7) checkHttpsProxy() (err error) {
 	}
 	l.tps = proxy
 	return nil
+}
+
+func (l *L7) getSslCertLinkInUse() ([]string, error) {
+	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
+	proxy, err := l.cloud.GetTargetHttpsProxy(proxyName)
+	if err != nil {
+		return nil, err
+	}
+
+	return proxy.SslCertificates, nil
 }

--- a/pkg/neg/syncer.go
+++ b/pkg/neg/syncer.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
@@ -253,10 +254,8 @@ func (s *syncer) ensureNetworkEndpointGroups() error {
 		needToCreate := false
 		if neg == nil {
 			needToCreate = true
-		} else if retrieveName(neg.LoadBalancer.Network) != retrieveName(s.cloud.NetworkURL()) ||
-			retrieveName(neg.LoadBalancer.Subnetwork) != retrieveName(s.cloud.SubnetworkURL()) {
-			// Only compare network and subnetwork names to avoid api endpoint differences that cause deleting NEG accidentally.
-			// TODO: change to compare network/subnetwork url instead of name when NEG API reach GA.
+		} else if !utils.EqualResourceIDs(neg.LoadBalancer.Network, s.cloud.NetworkURL()) ||
+			!utils.EqualResourceIDs(neg.LoadBalancer.Subnetwork, s.cloud.SubnetworkURL()) {
 			needToCreate = true
 			glog.V(2).Infof("NEG %q in %q does not match network and subnetwork of the cluster. Deleting NEG.", s.negName, zone)
 			err = s.cloud.DeleteNetworkEndpointGroup(s.negName, zone)
@@ -507,11 +506,6 @@ func calculateDifference(targetMap, currentMap map[string]sets.String) (map[stri
 		}
 	}
 	return addSet, removeSet
-}
-
-func retrieveName(url string) string {
-	strs := strings.Split(url, "/")
-	return strs[len(strs)-1]
 }
 
 // getService retrieves service object from serviceLister based on the input namespace and name

--- a/pkg/utils/gceurlmap_test.go
+++ b/pkg/utils/gceurlmap_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestGCEURLMap(t *testing.T) {
+	t.Parallel()
 	urlMap := NewGCEURLMap()
 
 	// Add some path rules for a host.

--- a/pkg/utils/taskqueue_test.go
+++ b/pkg/utils/taskqueue_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestPeriodicTaskQueue(t *testing.T) {
+	t.Parallel()
 	synced := map[string]bool{}
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{}, 1)


### PR DESCRIPTION
Removes the plethora of helper functions which all perform the same basic action:
 - `retrieveObjectName`
 - `comparableGroupPath`
 - `getResourceNameFromLink`
 - `CompareLinks`
 - `BackendServiceComparablePath`
 - `BackendServiceRelativeResourcePath`
 - `retrieveName`

Replacing them with a few utility functions which depend on on the [cloud package](https://godoc.org/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud).