### PR TITLE
IAP + CDN e2e testing implementation

### DIFF
--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -61,7 +61,6 @@ func (e *DefaultValidatorEnv) BackendConfigs() (map[string]*backendconfig.Backen
 		ret[bc.Name] = bc.DeepCopy()
 	}
 	return ret, nil
-
 }
 
 // Services implements ValidatorEnv.

--- a/pkg/fuzz/features/cdn.go
+++ b/pkg/fuzz/features/cdn.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/fuzz"
+)
+
+// CDN is a feature in BackendConfig that supports using GCP CDN.
+var CDN = &CDNFeature{}
+
+// CDNFeature implements the associated feature.
+type CDNFeature struct{}
+
+// NewValidator implements fuzz.Feature.
+func (CDNFeature) NewValidator() fuzz.FeatureValidator {
+	return &cdnValidator{}
+}
+
+// Name implements fuzz.Feature.
+func (*CDNFeature) Name() string {
+	return "CDN"
+}
+
+// cdnValidator is a validator for CDNFeature.
+type cdnValidator struct {
+	fuzz.NullValidator
+
+	env fuzz.ValidatorEnv
+	ing *v1beta1.Ingress
+}
+
+// Name implements fuzz.FeatureValidator.
+func (*cdnValidator) Name() string {
+	return "CDN"
+}
+
+// ConfigureAttributes implements fuzz.FeatureValidator.
+func (v *cdnValidator) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1.Ingress, a *fuzz.IngressValidatorAttributes) error {
+	// Capture the env for use later in CheckResponse.
+	v.ing = ing
+	v.env = env
+	return nil
+}
+
+// ModifyRequest implements fuzz.FeatureValidator.
+func (v *cdnValidator) ModifyRequest(host, path string, req *http.Request) {
+	// Warm up the cache, regardless of whether this host + path has CDN enabled.
+	values := req.URL.Query()
+	// Note: cache=true tells the echo server to add caching headers.
+	values.Add("cache", "true")
+	req.URL.RawQuery = values.Encode()
+}
+
+// CheckResponse implements fuzz.FeatureValidator.
+func (v *cdnValidator) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
+	backendConfig, err := fuzz.BackendConfigForPath(host, path, v.ing, v.env)
+	if err != nil {
+		if err == annotations.ErrBackendConfigAnnotationMissing {
+			// Don't fail this test if the service associated
+			// with the host + path has no BackendConfig annotation.
+			return fuzz.CheckResponseContinue, nil
+		}
+		return fuzz.CheckResponseContinue, err
+	}
+	var cdnEnabled bool
+	if backendConfig.Spec.Cdn != nil && backendConfig.Spec.Cdn.Enabled == true {
+		cdnEnabled = true
+	}
+	// If CDN is turned on, verify response header has "Age" key, which indicates
+	// it was served from the cache.
+	if cdnEnabled && resp.Header.Get("Age") == "" {
+		return fuzz.CheckResponseContinue, fmt.Errorf("CDN is turned on but response w/ header %v was not served from cache", resp.Header)
+	}
+	// If CDN is turned off, verify response does not have "Age" key, which indicates
+	// it was not served from the cache.
+	if !cdnEnabled && resp.Header.Get("Age") != "" {
+		return fuzz.CheckResponseContinue, fmt.Errorf("CDN is turned off but response w/ header %v was served from cache", resp.Header)
+	}
+	return fuzz.CheckResponseContinue, nil
+}

--- a/pkg/fuzz/features/features.go
+++ b/pkg/fuzz/features/features.go
@@ -25,4 +25,6 @@ import "k8s.io/ingress-gce/pkg/fuzz"
 var All = []fuzz.Feature{
 	AllowHTTP,
 	PresharedCert,
+	CDN,
+	IAP,
 }

--- a/pkg/fuzz/features/iap.go
+++ b/pkg/fuzz/features/iap.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/fuzz"
+)
+
+// IAP is a feature in BackendConfig that supports using GCP Identity-Aware Proxy (IAP).
+var IAP = &IAPFeature{}
+
+// IAPFeature implements the associated feature.
+type IAPFeature struct{}
+
+// NewValidator implements fuzz.Feature.
+func (IAPFeature) NewValidator() fuzz.FeatureValidator {
+	return &iapValidator{}
+}
+
+// Name implements fuzz.Feature.
+func (*IAPFeature) Name() string {
+	return "IAP"
+}
+
+// iapValidator is a validator the CDN feature.
+type iapValidator struct {
+	fuzz.NullValidator
+
+	env fuzz.ValidatorEnv
+	ing *v1beta1.Ingress
+}
+
+// Name implements fuzz.FeatureValidator.
+func (*iapValidator) Name() string {
+	return "IAP"
+}
+
+// ConfigureAttributes implements fuzz.FeatureValidator.
+func (v *iapValidator) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1.Ingress, a *fuzz.IngressValidatorAttributes) error {
+	// Capture the env for use later in CheckResponse.
+	v.ing = ing
+	v.env = env
+	return nil
+}
+
+// CheckResponse implements fuzz.FeatureValidator.
+func (v *iapValidator) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
+	backendConfig, err := fuzz.BackendConfigForPath(host, path, v.ing, v.env)
+	if err != nil {
+		if err == annotations.ErrBackendConfigAnnotationMissing {
+			// Don't fail this test if the service associated
+			// with the host + path has no BackendConfig annotation.
+			return fuzz.CheckResponseContinue, nil
+		}
+		return fuzz.CheckResponseContinue, err
+	}
+	var iapEnabled bool
+	if backendConfig.Spec.Iap != nil && backendConfig.Spec.Iap.Enabled == true {
+		iapEnabled = true
+	}
+	// If IAP is turned on, verify response header contains "x-goog-iap-generated-response" key
+	// and that the response code was a 302.
+	if iapEnabled {
+		if resp.StatusCode != http.StatusFound {
+			glog.V(2).Infof("The response was %v", resp)
+			return fuzz.CheckResponseContinue, fmt.Errorf("IAP is turned on but response %v did not return a 302", resp)
+		}
+		if resp.Header.Get("x-goog-iap-generated-response") == "" {
+			return fuzz.CheckResponseContinue, fmt.Errorf("IAP is turned on but response w/ header %v did not contain IAP header", resp.Header)
+		}
+		return fuzz.CheckResponseSkip, nil
+	}
+	// If IAP is turned off, verify that the response code was not 302.
+	if !iapEnabled && resp.StatusCode == http.StatusFound {
+		return fuzz.CheckResponseContinue, fmt.Errorf("IAP is turned off but response w/ header %v returned a 302", resp.Header)
+	}
+	return fuzz.CheckResponseContinue, nil
+}

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -17,11 +17,58 @@ limitations under the License.
 package fuzz
 
 import (
+	"fmt"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfigutil "k8s.io/ingress-gce/pkg/backendconfig"
+	translatorutil "k8s.io/ingress-gce/pkg/controller/translator"
 )
+
+// BackendConfigForPath returns the BackendConfig associated with the given path.
+// Note: This function returns an empty object (not nil pointer) if a BackendConfig
+// did not exist in the given environment.
+func BackendConfigForPath(host, path string, ing *v1beta1.Ingress, env ValidatorEnv) (*backendconfig.BackendConfig, error) {
+	sm := ServiceMapFromIngress(ing)
+	if path == pathForDefaultBackend {
+		path = ""
+	}
+	hp := HostPath{Host: host, Path: path}
+	b, ok := sm[hp]
+	if !ok {
+		return nil, fmt.Errorf("HostPath %v not found in Ingress", hp)
+	}
+	serviceMap, err := env.Services()
+	if err != nil {
+		return nil, err
+	}
+	service, ok := serviceMap[b.ServiceName]
+	if !ok {
+		return nil, fmt.Errorf("Service %q not found in environment", b.ServiceName)
+	}
+	servicePort := translatorutil.ServicePort(*service, b.ServicePort)
+	if servicePort == nil {
+		return nil, fmt.Errorf("Port %+v in Service %q not found", b.ServicePort, b.ServiceName)
+	}
+	bc, err := annotations.FromService(service).GetBackendConfigs()
+	if err != nil {
+		return nil, err
+	}
+	configName := backendconfigutil.BackendConfigName(*bc, *servicePort)
+	backendConfigMap, err := env.BackendConfigs()
+	if err != nil {
+		return nil, err
+	}
+	backendConfig, ok := backendConfigMap[configName]
+	if !ok {
+		return &backendconfig.BackendConfig{}, nil
+	}
+	return backendConfig, nil
+}
 
 // NewService is a helper function for creating a simple Service spec.
 func NewService(name, ns string, port int) *v1.Service {


### PR DESCRIPTION
Note that this PR also contains some small changes to the validator:
    1.  In order to prevent the http client in the validator from following redirects, I implemented the 
         CheckRedirect hook. 
    2.  Move the pathToDefaultBackend variable up higher so that other files can use it.

Ref: #301
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/319)
<!-- Reviewable:end -->
