### PR TITLE
Make Ingress builder reusable

### DIFF
--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -31,6 +31,8 @@ import (
 func TestBasic(t *testing.T) {
 	t.Parallel()
 
+	port80 := intstr.FromInt(80)
+
 	for _, tc := range []struct {
 		desc string
 		ing  *v1beta1.Ingress
@@ -39,20 +41,27 @@ func TestBasic(t *testing.T) {
 		numBackendServices int
 	}{
 		{
-			desc:               "http default backend",
-			ing:                fuzz.NewIngressBuilder("", "ingress-1", "").DefaultBackend("service-1", intstr.FromInt(80)).I,
+			desc: "http default backend",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				Build(),
 			numForwardingRules: 1,
 			numBackendServices: 1,
 		},
 		{
-			desc:               "http one path",
-			ing:                fuzz.NewIngressBuilder("", "ingress-1", "").AddPath("test.com", "/", "service-1", intstr.FromInt(80)).I,
+			desc: "http one path",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/", "service-1", port80).
+				Build(),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 		},
 		{
-			desc:               "http multiple paths",
-			ing:                fuzz.NewIngressBuilder("", "ingress-1", "").AddPath("test.com", "/foo", "service-1", intstr.FromInt(80)).AddPath("test.com", "/bar", "service-1", intstr.FromInt(80)).I,
+			desc: "http multiple paths",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/foo", "service-1", port80).
+				AddPath("test.com", "/bar", "service-1", port80).
+				Build(),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 		},

--- a/pkg/fuzz/features/allow_http_test.go
+++ b/pkg/fuzz/features/allow_http_test.go
@@ -30,7 +30,7 @@ func TestAllowHTTPFeature(t *testing.T) {
 	a := &fuzz.IngressValidatorAttributes{CheckHTTP: true}
 	env := &fuzz.MockValidatorEnv{}
 
-	ing := fuzz.NewIngressBuilder("ns1", "ing1", "").I
+	ing := fuzz.NewIngressBuilder("ns1", "ing1", "").Build()
 	ing.Annotations = map[string]string{}
 	ing.Annotations[annotations.AllowHTTPKey] = "false"
 

--- a/pkg/fuzz/helpers_test.go
+++ b/pkg/fuzz/helpers_test.go
@@ -66,7 +66,9 @@ func TestServiceMapFromIngress(t *testing.T) {
 	}{
 		{
 			desc: "one path",
-			ing:  NewIngressBuilder("n1", "ing1", "").AddPath("test1.com", "/foo", "s", intstr.FromInt(80)).I,
+			ing: NewIngressBuilder("n1", "ing1", "").
+				AddPath("test1.com", "/foo", "s", intstr.FromInt(80)).
+				Build(),
 			want: ServiceMap{
 				HostPath{"test1.com", "/foo"}: &v1beta1.IngressBackend{
 					ServiceName: "s", ServicePort: intstr.IntOrString{IntVal: 80},
@@ -75,7 +77,10 @@ func TestServiceMapFromIngress(t *testing.T) {
 		},
 		{
 			desc: "multiple paths",
-			ing:  NewIngressBuilder("n1", "ing1", "").AddPath("test1.com", "/foo", "s", intstr.FromInt(80)).AddPath("test1.com", "/bar", "s", intstr.FromInt(80)).I,
+			ing: NewIngressBuilder("n1", "ing1", "").
+				AddPath("test1.com", "/foo", "s", intstr.FromInt(80)).
+				AddPath("test1.com", "/bar", "s", intstr.FromInt(80)).
+				Build(),
 			want: ServiceMap{
 				HostPath{"test1.com", "/foo"}: &v1beta1.IngressBackend{
 					ServiceName: "s", ServicePort: intstr.IntOrString{IntVal: 80},
@@ -87,7 +92,9 @@ func TestServiceMapFromIngress(t *testing.T) {
 		},
 		{
 			desc: "default backend",
-			ing:  NewIngressBuilder("n1", "ing1", "").DefaultBackend("s", intstr.FromInt(80)).I,
+			ing: NewIngressBuilder("n1", "ing1", "").
+				DefaultBackend("s", intstr.FromInt(80)).
+				Build(),
 			want: ServiceMap{
 				HostPath{}: &v1beta1.IngressBackend{
 					ServiceName: "s", ServicePort: intstr.IntOrString{IntVal: 80},
@@ -124,7 +131,7 @@ func TestIngressBuilder(t *testing.T) {
 			want: &v1beta1.Ingress{
 				ObjectMeta: om,
 			},
-			got: NewIngressBuilder(ns, name, "").I,
+			got: NewIngressBuilder(ns, name, "").Build(),
 		},
 		{
 			desc: "one path",
@@ -151,7 +158,9 @@ func TestIngressBuilder(t *testing.T) {
 					},
 				},
 			},
-			got: NewIngressBuilder(ns, name, "").AddPath("test.com", "/", "svc1", intstr.FromInt(80)).I,
+			got: NewIngressBuilder(ns, name, "").
+				AddPath("test.com", "/", "svc1", intstr.FromInt(80)).
+				Build(),
 		},
 		{
 			desc: "with VIP",
@@ -163,7 +172,7 @@ func TestIngressBuilder(t *testing.T) {
 					},
 				},
 			},
-			got: NewIngressBuilder(ns, name, "127.0.0.1").I,
+			got: NewIngressBuilder(ns, name, "127.0.0.1").Build(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/fuzz/validator_test.go
+++ b/pkg/fuzz/validator_test.go
@@ -102,12 +102,14 @@ func TestIngressValidatorAttributes(t *testing.T) {
 	}{
 		{
 			desc:          "default",
-			ing:           NewIngressBuilder("ns1", "name1", "").I,
+			ing:           NewIngressBuilder("ns1", "name1", "").Build(),
 			wantCheckHTTP: true,
 		},
 		{
-			desc:           "with TLS",
-			ing:            NewIngressBuilder("ns1", "name1", "").AddTLS([]string{"foo.com"}, "s1").I,
+			desc: "with TLS",
+			ing: NewIngressBuilder("ns1", "name1", "").
+				AddTLS([]string{"foo.com"}, "s1").
+				Build(),
 			wantCheckHTTP:  true,
 			wantCheckHTTPS: true,
 		},
@@ -237,39 +239,60 @@ func TestValidatorCheck(t *testing.T) {
 	}{
 		{
 			desc: "simple",
-			ing:  NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).I,
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				Build(),
 		},
 		{
-			desc:              "default backend",
-			ing:               NewIngressBuilderFromExisting(baseIngress).DefaultBackend("s", port80).I,
+			desc: "default backend",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				DefaultBackend("s", port80).
+				Build(),
 			hasDefaultBackend: true,
 		},
 		{
 			desc: "multiple paths",
-			ing:  NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).AddPath("test.com", "/path2", "s", port80).AddPath("test.com", "/path3", "s", port80).I,
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				AddPath("test.com", "/path2", "s", port80).
+				AddPath("test.com", "/path3", "s", port80).
+				Build(),
 		},
 		{
 			desc: "TLS",
-			ing:  NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).AddTLS([]string{"test.com"}, "secret1").I,
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				AddTLS([]string{"test.com"}, "secret1").
+				Build(),
 		},
 		{
-			desc:    "no VIP",
-			ing:     NewIngressBuilder("ns1", "ing1", "").AddPath("test.com", "/badpath", "s", port80).I,
+			desc: "no VIP",
+			ing: NewIngressBuilder("ns1", "ing1", "").
+				AddPath("test.com", "/badpath", "s", port80).
+				Build(),
 			wantErr: true,
 		},
 		{
-			desc:    "bad paths",
-			ing:     NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/badpath", "s", port80).I,
+			desc: "bad paths",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/badpath", "s", port80).
+				Build(),
 			wantErr: true,
 		},
 		{
-			desc:    "bad paths TLS",
-			ing:     NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/badpath", "s", port80).AddTLS([]string{"test.com"}, "secret1").I,
+			desc: "bad paths TLS",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/badpath", "s", port80).
+				AddTLS([]string{"test.com"}, "secret1").
+				Build(),
 			wantErr: true,
 		},
 		{
-			desc:            "server timeout",
-			ing:             NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/badpath", "s", port80).AddTLS([]string{"test.com"}, "secret1").I,
+			desc: "server timeout",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/badpath", "s", port80).
+				AddTLS([]string{"test.com"}, "secret1").
+				Build(),
 			dontStartServer: true,
 			wantErr:         true,
 		},
@@ -320,24 +343,32 @@ func TestValidatorCheckFeature(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			desc:    "simple",
-			ing:     NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).I,
+			desc: "simple",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				Build(),
 			feature: &mockFeature{},
 		},
 		{
-			desc:    "skip default check",
-			ing:     NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).I,
+			desc: "skip default check",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				Build(),
 			feature: &mockFeature{mode: mockValidatorSkipCheck},
 		},
 		{
-			desc:                "error in configure",
-			ing:                 NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).I,
+			desc: "error in configure",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				Build(),
 			feature:             &mockFeature{mode: mockValidatorConfigureError},
 			wantNewValidatorErr: true,
 		},
 		{
-			desc:    "error in check",
-			ing:     NewIngressBuilderFromExisting(baseIngress).AddPath("test.com", "/path1", "s", port80).I,
+			desc: "error in check",
+			ing: NewIngressBuilderFromExisting(baseIngress).
+				AddPath("test.com", "/path1", "s", port80).
+				Build(),
 			feature: &mockFeature{mode: mockValidatorCheckError},
 			wantErr: true,
 		},


### PR DESCRIPTION
- Get Ingress definition from builder with method Build() rather than
  direct access to the object.
- Fix line breaks to make invocations more readable.