### PR TITLE
NEG Metrics

### DIFF
--- a/pkg/metrics/util.go
+++ b/pkg/metrics/util.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+const GLBC_NAMESPACE = "glbc"

--- a/pkg/neg/metrics.go
+++ b/pkg/neg/metrics.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neg
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/ingress-gce/pkg/metrics"
+)
+
+const (
+	negControllerSubsystem = "neg_controller"
+	syncLatencyKey         = "neg_sync_duration_seconds"
+	lastSyncTimestampKey   = "sync_timestamp"
+
+	resultSuccess = "success"
+	resultError   = "error"
+
+	attachSync = syncType("attach")
+	detachSync = syncType("detach")
+)
+
+type syncType string
+
+var (
+	syncMetricsLabels = []string{
+		"key",    // The key to uniquely identify the NEG syncer.
+		"type",   // Type of the NEG sync
+		"result", // Result of the sync.
+	}
+
+	syncLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.GLBC_NAMESPACE,
+			Subsystem: negControllerSubsystem,
+			Name:      syncLatencyKey,
+			Help:      "Sync latency of a NEG syncer",
+		},
+		syncMetricsLabels,
+	)
+
+	lastSyncTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.GLBC_NAMESPACE,
+			Subsystem: negControllerSubsystem,
+			Name:      lastSyncTimestampKey,
+			Help:      "The timestamp of the last execution of NEG controller sync loop.",
+		},
+		[]string{},
+	)
+)
+
+var register sync.Once
+
+func registerMetrics() {
+	register.Do(func() {
+		prometheus.MustRegister(syncLatency)
+		prometheus.MustRegister(lastSyncTimestamp)
+	})
+}
+
+// observeNegSync publish collected metrics for the sync of NEG
+func observeNegSync(negName string, syncType syncType, err error, start time.Time) {
+	result := resultSuccess
+	if err != nil {
+		result = resultError
+	}
+	syncLatency.WithLabelValues(negName, string(syncType), result).Observe(time.Since(start).Seconds())
+}

--- a/pkg/neg/syncer.go
+++ b/pkg/neg/syncer.go
@@ -184,13 +184,14 @@ func (s *syncer) IsShuttingDown() bool {
 	return s.shuttingDown
 }
 
-func (s *syncer) sync() error {
+func (s *syncer) sync() (err error) {
 	if s.IsStopped() || s.IsShuttingDown() {
 		glog.V(4).Infof("Skip syncing NEG %q for %s/%s-%s.", s.negName, s.namespace, s.name, s.targetPort)
 		return nil
 	}
-
 	glog.V(2).Infof("Sync NEG %q for %s/%s-%s", s.negName, s.namespace, s.name, s.targetPort)
+	start := time.Now()
+	defer observeNegSync(s.negName, attachSync, err, start)
 	ep, exists, err := s.endpointLister.Get(
 		&apiv1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
promethues dump:
```
# HELP neg_controller_neg_sync_count Number of execution for a NEG syncer.
# TYPE neg_controller_neg_sync_count counter
neg_controller_neg_sync_count{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach"} 3
# HELP neg_controller_neg_sync_duration_seconds Sync latency of a NEG syncer
# TYPE neg_controller_neg_sync_duration_seconds histogram
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.005"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.01"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.025"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.05"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.1"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.25"} 0
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="0.5"} 2
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="1"} 2
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="2.5"} 3
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="5"} 3
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="10"} 3
neg_controller_neg_sync_duration_seconds_bucket{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach",le="+Inf"} 3
neg_controller_neg_sync_duration_seconds_sum{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach"} 3.252480561
neg_controller_neg_sync_duration_seconds_count{key="k8s1-84a1883c1680fcf8-default-hostname-9376-d05afea4",result="success",type="attach"} 3
# HELP neg_controller_sync_timestamp The timestamp of the last execution of NEG controller sync loop.
# TYPE neg_controller_sync_timestamp gauge
neg_controller_sync_timestamp 1.5288422052249308e+18

```