### PR TITLE
merge Ingress NEG annotation and Expose NEG annotation

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -65,11 +65,6 @@ const (
 
 // NegAnnotation is the format of the annotation associated with the
 // NEGAnnotationKey key.
-// WARNING: The feature will NOT be effective in the following circumstances:
-// 1. Service is not referenced in any ingress.
-// 2. Adding this annotation on ingress.
-// ExposedPorts maps ServicePort to attributes of the NEG that should be
-// associated with the ServicePort. ServicePorts in this map will be NEG-enabled.
 type NegAnnotation struct {
 	// "Ingress" indicates whether to enable NEG feature for Ingress referencing
 	// the service. Each NEG correspond to a service port.
@@ -81,6 +76,8 @@ type NegAnnotation struct {
 	Ingress bool `json:"ingress,omitempty"`
 	// ExposedPorts specifies the service ports to be exposed as stand-alone NEG.
 	// The exposed NEGs will be created and managed by NEG controller.
+	// ExposedPorts maps ServicePort to attributes of the NEG that should be
+	// associated with the ServicePort.
 	ExposedPorts map[int32]NegAttributes `json:"exposed_ports,omitempty"`
 }
 

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -261,7 +261,7 @@ func (c *Controller) processService(key string) error {
 			knownPorts[sp.Port] = sp.TargetPort.String()
 		}
 
-		annotation, err := annotations.FromService(service).ExposeNegAnnotation()
+		annotation, err := annotations.FromService(service).NegAnnotation()
 		if err != nil {
 			return err
 		}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -26,8 +26,10 @@ import (
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	unversionedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -63,6 +65,7 @@ type Controller struct {
 	endpointSynced cache.InformerSynced
 	ingressLister  cache.Indexer
 	serviceLister  cache.Indexer
+	client         kubernetes.Interface
 
 	// serviceQueue takes service key as work item. Service key with format "namespace/name".
 	serviceQueue workqueue.RateLimitingInterface
@@ -97,6 +100,7 @@ func NewController(
 		ctx.EndpointInformer.GetIndexer())
 
 	negController := &Controller{
+		client:         ctx.KubeClient,
 		manager:        manager,
 		resyncPeriod:   resyncPeriod,
 		recorder:       recorder,
@@ -242,7 +246,7 @@ func (c *Controller) processService(key string) error {
 	if !enabled {
 		c.manager.StopSyncer(namespace, name)
 		// delete the annotation
-		return c.syncNegStatusAnnotation(namespace, name, service, make(PortNameMap))
+		return c.syncNegStatusAnnotation(namespace, name, make(PortNameMap))
 	}
 
 	glog.V(2).Infof("Syncing service %q", key)
@@ -274,15 +278,20 @@ func (c *Controller) processService(key string) error {
 		svcPortMap = svcPortMap.Union(negSvcPorts)
 	}
 
-	err = c.syncNegStatusAnnotation(namespace, name, service, svcPortMap)
+	err = c.syncNegStatusAnnotation(namespace, name, svcPortMap)
 	if err != nil {
 		return err
 	}
 	return c.manager.EnsureSyncers(namespace, name, svcPortMap)
 }
 
-func (c *Controller) syncNegStatusAnnotation(namespace, name string, service *apiv1.Service, portMap PortNameMap) error {
+func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap PortNameMap) error {
 	zones, err := c.zoneGetter.ListZones()
+	if err != nil {
+		return err
+	}
+	svcClient := c.client.CoreV1().Services(namespace)
+	service, err := svcClient.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -293,7 +302,8 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, service *ap
 			// TODO: use PATCH to remove annotation
 			delete(service.Annotations, annotations.NEGStatusKey)
 			glog.V(2).Infof("Removing expose NEG annotation from service: %s/%s", namespace, name)
-			return c.serviceLister.Update(service)
+			_, err = svcClient.Update(service)
+			return err
 		}
 		// service doesn't have the expose NEG annotation and doesn't need update
 		return nil
@@ -316,8 +326,8 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, service *ap
 
 	service.Annotations[annotations.NEGStatusKey] = annotation
 	glog.V(2).Infof("Updating NEG visibility annotation %q on service %s/%s.", annotation, namespace, name)
-	// TODO: use PATCH to Update Annotation
-	return c.serviceLister.Update(service)
+	_, err = svcClient.Update(service)
+	return err
 }
 
 func (c *Controller) handleErr(err error, key interface{}) {

--- a/pkg/neg/utils.go
+++ b/pkg/neg/utils.go
@@ -56,10 +56,10 @@ func (p1 PortNameMap) Difference(p2 PortNameMap) PortNameMap {
 // knownPorts represents the known Port:TargetPort attributes of servicePorts
 // that already exist on the service. This function returns an error if
 // any of the parsed ServicePorts from the annotation is not in knownPorts.
-func NEGServicePorts(exposedNegPortMap annotations.ExposeNegAnnotation, knownPorts PortNameMap) (PortNameMap, error) {
+func NEGServicePorts(ann annotations.NegAnnotation, knownPorts PortNameMap) (PortNameMap, error) {
 	portSet := make(PortNameMap)
 	var errList []error
-	for port, _ := range exposedNegPortMap {
+	for port, _ := range ann.ExposedPorts {
 		// TODO: also validate ServicePorts in the exposed NEG annotation via webhook
 		if _, ok := knownPorts[port]; !ok {
 			errList = append(errList, fmt.Errorf("ServicePort %v doesn't exist on Service", port))


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/ingress-gce/pull/284 .

- Merges the Expose NEG and Ingress NEG annotations into a single key. Example: `{"ingress": true,"exposed_ports":{"3000":{},"4000":{}}}`
- Use kubeClient to actually update the Kubernetes Service in addition to updating it in serviceLister.
- Additional cleanup of documentation.