### PR TITLE
URLMap sync

### DIFF
--- a/pkg/controller/translator/testdata/ingress-missing-multi-svc.json
+++ b/pkg/controller/translator/testdata/ingress-missing-multi-svc.json
@@ -8,8 +8,14 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"abc.com": [],
-		"foo.bar.com": []
-	}
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": []
+		},
+		{
+			"HostName": "abc.com",
+			"Paths": []
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-missing-rule-svc.json
+++ b/pkg/controller/translator/testdata/ingress-missing-rule-svc.json
@@ -8,21 +8,27 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"abc.com": [],
-		"foo.bar.com": [
-			{
-				"Path": "/testpath",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "first-service"
-						},
-						"Port": 80
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": [
+				{
+					"Path": "/testpath",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "first-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			}
-		]
-	}
+			]
+		},
+		{
+			"HostName": "abc.com",
+			"Paths": []
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-multi-empty.json
+++ b/pkg/controller/translator/testdata/ingress-multi-empty.json
@@ -8,9 +8,10 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"foo.bar.com": [
-			{
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": [{
 				"Path": "/*",
 				"Backend": {
 					"ID": {
@@ -21,7 +22,7 @@
 						"Port": 80
 					}
 				}
-			}
-		]
-	}
+			}]
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-multi-paths.json
+++ b/pkg/controller/translator/testdata/ingress-multi-paths.json
@@ -8,32 +8,35 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"foo.bar.com": [
-			{
-				"Path": "/testpath",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "first-service"
-						},
-						"Port": 80
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": [
+				{
+					"Path": "/testpath",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "first-service"
+							},
+							"Port": 80
+						}
+					}
+				},
+				{
+					"Path": "/otherpath",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "second-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			},
-			{
-				"Path": "/otherpath",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "second-service"
-						},
-						"Port": 80
-					}
-				}
-			}
-		]
-	}
+			]
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-no-host.json
+++ b/pkg/controller/translator/testdata/ingress-no-host.json
@@ -8,20 +8,23 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"*": [
-			{
-				"Path": "/testpath",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "first-service"
-						},
-						"Port": 80
+	"HostRules": [
+		{
+			"HostName": "*",
+			"Paths": [
+				{
+					"Path": "/testpath",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "first-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			}
-		]
-	}
+			]
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-single-host.json
+++ b/pkg/controller/translator/testdata/ingress-single-host.json
@@ -8,20 +8,23 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"foo.bar.com": [
-			{
-				"Path": "/testpath",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "first-service"
-						},
-						"Port": 80
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": [
+				{
+					"Path": "/testpath",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "first-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			}
-		]
-	}
+			]
+		}
+	]
 }

--- a/pkg/controller/translator/testdata/ingress-two-hosts.json
+++ b/pkg/controller/translator/testdata/ingress-two-hosts.json
@@ -8,34 +8,40 @@
 			"Port": "http"
 		}
 	},
-	"HostRules": {
-		"abc.com": [
-			{
-				"Path": "/*",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "second-service"
-						},
-						"Port": 80
+	"HostRules": [
+		{
+			"HostName": "foo.bar.com",
+			"Paths": [
+				{
+					"Path": "/*",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "first-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			}
-		],
-		"foo.bar.com": [
-			{
-				"Path": "/*",
-				"Backend": {
-					"ID": {
-						"Service": {
-							"Namespace": "default",
-							"Name": "first-service"
-						},
-						"Port": 80
+			]
+		},
+		{
+			"HostName": "abc.com",
+			"Paths": [
+				{
+					"Path": "/*",
+					"Backend": {
+						"ID": {
+							"Service": {
+								"Namespace": "default",
+								"Name": "second-service"
+							},
+							"Port": 80
+						}
 					}
 				}
-			}
-		]
-	}
+			]
+		}
+	]
 }

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
@@ -106,45 +105,45 @@ func TestTranslateIngress(t *testing.T) {
 		},
 		{
 			desc:          "no host",
-			ing:           ingressFromFile("ingress-no-host.yaml"),
+			ing:           ingressFromFile(t, "ingress-no-host.yaml"),
 			wantErrCount:  0,
-			wantGCEURLMap: gceURLMapFromFile("ingress-no-host.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-no-host.json"),
 		},
 		{
 			desc:          "single host",
-			ing:           ingressFromFile("ingress-single-host.yaml"),
+			ing:           ingressFromFile(t, "ingress-single-host.yaml"),
 			wantErrCount:  0,
-			wantGCEURLMap: gceURLMapFromFile("ingress-single-host.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-single-host.json"),
 		},
 		{
 			desc:          "two hosts",
-			ing:           ingressFromFile("ingress-two-hosts.yaml"),
+			ing:           ingressFromFile(t, "ingress-two-hosts.yaml"),
 			wantErrCount:  0,
-			wantGCEURLMap: gceURLMapFromFile("ingress-two-hosts.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-two-hosts.json"),
 		},
 		{
 			desc:          "multiple paths",
-			ing:           ingressFromFile("ingress-multi-paths.yaml"),
+			ing:           ingressFromFile(t, "ingress-multi-paths.yaml"),
 			wantErrCount:  0,
-			wantGCEURLMap: gceURLMapFromFile("ingress-multi-paths.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-multi-paths.json"),
 		},
 		{
 			desc:          "multiple empty paths",
-			ing:           ingressFromFile("ingress-multi-empty.yaml"),
+			ing:           ingressFromFile(t, "ingress-multi-empty.yaml"),
 			wantErrCount:  0,
-			wantGCEURLMap: gceURLMapFromFile("ingress-multi-empty.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-multi-empty.json"),
 		},
 		{
 			desc:          "missing rule service",
-			ing:           ingressFromFile("ingress-missing-rule-svc.yaml"),
+			ing:           ingressFromFile(t, "ingress-missing-rule-svc.yaml"),
 			wantErrCount:  1,
-			wantGCEURLMap: gceURLMapFromFile("ingress-missing-rule-svc.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-missing-rule-svc.json"),
 		},
 		{
 			desc:          "missing multiple rule service",
-			ing:           ingressFromFile("ingress-missing-multi-svc.yaml"),
+			ing:           ingressFromFile(t, "ingress-missing-multi-svc.yaml"),
 			wantErrCount:  2,
-			wantGCEURLMap: gceURLMapFromFile("ingress-missing-multi-svc.json"),
+			wantGCEURLMap: gceURLMapFromFile(t, "ingress-missing-multi-svc.json"),
 		},
 		{
 			desc: "missing default service",
@@ -541,26 +540,28 @@ func newDefaultEndpoint(name string) *apiv1.Endpoints {
 	}
 }
 
-func ingressFromFile(filename string) *extensions.Ingress {
+func ingressFromFile(t *testing.T, filename string) *extensions.Ingress {
+	t.Helper()
+
 	data, err := ioutil.ReadFile("testdata/" + filename)
 	if err != nil {
-		log.Fatal(err)
+		t.Errorf("ioutil.ReadFile(%q) = %v", filename, err)
 	}
 	ing, err := test.DecodeIngress(data)
 	if err != nil {
-		log.Fatal(err)
+		t.Errorf("test.DecodeIngress(%q) = %v", filename, err)
 	}
 	return ing
 }
 
-func gceURLMapFromFile(filename string) *utils.GCEURLMap {
+func gceURLMapFromFile(t *testing.T, filename string) *utils.GCEURLMap {
 	data, err := ioutil.ReadFile("testdata/" + filename)
 	if err != nil {
-		log.Fatal(err)
+		t.Errorf("ioutil.ReadFile(%q) = %v", filename, err)
 	}
 	v := &utils.GCEURLMap{}
 	if err := json.Unmarshal(data, v); err != nil {
-		log.Fatal(err)
+		t.Errorf("json.Unmarshal(%q) = %v", filename, err)
 	}
 	return v
 }

--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -353,59 +353,6 @@ func (f *FakeLoadBalancers) SetSslCertificateForTargetHttpsProxy(proxy *compute.
 	return nil
 }
 
-// UrlMap fakes
-
-// CheckURLMap checks the compute.UrlMap maintained by the load balancer.
-// We check against our internal representation.
-func (f *FakeLoadBalancers) CheckURLMap(l7 *L7, expectedUrlMap *utils.GCEURLMap) error {
-	f.calls = append(f.calls, "CheckURLMap")
-	um, err := f.GetUrlMap(l7.UrlMap().Name)
-	if err != nil || um == nil {
-		return fmt.Errorf("f.GetUrlMap(%q) = %v, %v; want _, nil", l7.UrlMap().Name, um, err)
-	}
-	defaultBackendName := expectedUrlMap.DefaultBackend.BackendName(f.namer)
-	defaultBackendLink := cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath()
-	// The urlmap should have a default backend, and each path matcher.
-	if defaultBackendName != "" && !utils.EqualResourceIDs(l7.UrlMap().DefaultService, defaultBackendLink) {
-		return fmt.Errorf("default backend = %v, want %v", l7.UrlMap().DefaultService, defaultBackendLink)
-	}
-
-	for _, matcher := range l7.UrlMap().PathMatchers {
-		var hostname string
-		// There's a 1:1 mapping between pathmatchers and hosts
-		for _, hostRule := range l7.UrlMap().HostRules {
-			if matcher.Name == hostRule.PathMatcher {
-				if len(hostRule.Hosts) != 1 {
-					return fmt.Errorf("unexpected hosts in hostrules %+v", hostRule)
-				}
-				if defaultBackendLink != "" && !utils.EqualResourceIDs(matcher.DefaultService, defaultBackendLink) {
-					return fmt.Errorf("expected default backend %v found %v", defaultBackendLink, matcher.DefaultService)
-				}
-				hostname = hostRule.Hosts[0]
-				break
-			}
-		}
-		// These are all pathrules for a single host, found above
-		for _, rule := range matcher.PathRules {
-			if len(rule.Paths) != 1 {
-				return fmt.Errorf("Unexpected rule in pathrules %+v", rule)
-			}
-			pathRule := rule.Paths[0]
-			if !expectedUrlMap.HostExists(hostname) {
-				return fmt.Errorf("Expected path rules for host %v", hostname)
-			}
-			ok, svc := expectedUrlMap.PathExists(hostname, pathRule)
-			if !ok {
-				return fmt.Errorf("Expected rule %v for host %v", pathRule, hostname)
-			}
-			if beName, err := utils.KeyName(rule.Service); err != nil || beName != svc.BackendName(f.namer) {
-				return fmt.Errorf("Expected service %v found %v", svc, rule.Service)
-			}
-		}
-	}
-	return nil
-}
-
 // Static IP fakes
 
 // ReserveGlobalAddress fakes out static IP reservation.

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -57,9 +57,8 @@ func (l *L7s) Get(name string) (*L7, error) {
 	return lb.(*L7), nil
 }
 
-// addLB gets or creates a loadbalancer. If the loadbalancer already exists,
-// it checks that its edges are valid.
-func (l *L7s) addLB(ri *L7RuntimeInfo) (err error) {
+// Sync a load balancer with the given runtime info from the controller.
+func (l *L7s) Sync(ri *L7RuntimeInfo) error {
 	name := l.namer.LoadBalancer(ri.Name)
 
 	lb, _ := l.Get(name)
@@ -70,9 +69,6 @@ func (l *L7s) addLB(ri *L7RuntimeInfo) (err error) {
 			Name:        l.namer.LoadBalancer(ri.Name),
 			cloud:       l.cloud,
 			namer:       l.namer,
-		}
-		if err != nil {
-			return err
 		}
 	} else {
 		if !reflect.DeepEqual(lb.runtimeInfo, ri) {
@@ -108,16 +104,6 @@ func (l *L7s) Delete(name string) error {
 		return err
 	}
 	l.snapshotter.Delete(name)
-	return nil
-}
-
-// Sync a load balancer with the given runtime info from the controller.
-func (l *L7s) Sync(ri *L7RuntimeInfo) error {
-	glog.V(3).Infof("Syncing load balancer %v", ri)
-	// Create new load balancer and validate existing
-	if err := l.addLB(ri); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -20,7 +20,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
@@ -34,177 +33,78 @@ const (
 	hostRulePrefix = "host"
 )
 
-func (l *L7) assertUrlMapExists() (err error) {
+// ensureComputeURLMap retrieves the current URLMap and overwrites it if incorrect. If the resource
+// does not exist, the map is created.
+func (l *L7) ensureComputeURLMap() error {
 	if l.runtimeInfo.UrlMap == nil {
 		return fmt.Errorf("cannot create urlmap without internal representation")
 	}
 
-	defaultBackendName := l.runtimeInfo.UrlMap.DefaultBackend.BackendName(l.namer)
-	urlMapName := l.namer.UrlMap(l.Name)
-	urlMap, _ := l.cloud.GetUrlMap(urlMapName)
-	if urlMap != nil {
-		glog.V(3).Infof("Url map %v already exists", urlMap.Name)
-		l.um = urlMap
+	// Every update replaces the entire urlmap.
+	expectedMap := toComputeURLMap(l.Name, l.runtimeInfo.UrlMap, l.namer)
+
+	currentMap, err := l.cloud.GetUrlMap(expectedMap.Name)
+	if utils.IgnoreHTTPNotFound(err) != nil {
+		return err
+	}
+
+	if currentMap == nil {
+		glog.V(3).Infof("Creating URLMap %q", expectedMap.Name)
+		if err := l.cloud.CreateUrlMap(expectedMap); err != nil {
+			return fmt.Errorf("CreateUrlMap: %v", err)
+		}
+		l.um = expectedMap
 		return nil
 	}
 
-	glog.V(3).Infof("Creating url map %v for backend %v", urlMapName, defaultBackendName)
-	newUrlMap := &compute.UrlMap{
-		Name:           urlMapName,
-		DefaultService: cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath(),
-	}
-	if err = l.cloud.CreateUrlMap(newUrlMap); err != nil {
-		return err
-	}
-	urlMap, err = l.cloud.GetUrlMap(urlMapName)
-	if err != nil {
-		return err
-	}
-	l.um = urlMap
-	return nil
-}
-
-// getNameForPathMatcher returns a name for a pathMatcher based on the given host rule.
-// The host rule can be a regex, the path matcher name used to associate the 2 cannot.
-func getNameForPathMatcher(hostRule string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(hostRule))
-	return fmt.Sprintf("%v%v", hostRulePrefix, hex.EncodeToString(hasher.Sum(nil)))
-}
-
-// UpdateUrlMap translates the given hostname: endpoint->port mapping into a gce url map.
-//
-// HostRule: Conceptually contains all PathRules for a given host.
-// PathMatcher: Associates a path rule with a host rule. Mostly an optimization.
-// PathRule: Maps a single path regex to a backend.
-//
-// The GCE url map allows multiple hosts to share url->backend mappings without duplication, eg:
-//   Host: foo(PathMatcher1), bar(PathMatcher1,2)
-//   PathMatcher1:
-//     /a -> b1
-//     /b -> b2
-//   PathMatcher2:
-//     /c -> b1
-// This leads to a lot of complexity in the common case, where all we want is a mapping of
-// host->{/path: backend}.
-//
-// Consider some alternatives:
-// 1. Using a single backend per PathMatcher:
-//   Host: foo(PathMatcher1,3) bar(PathMatcher1,2,3)
-//   PathMatcher1:
-//     /a -> b1
-//   PathMatcher2:
-//     /c -> b1
-//   PathMatcher3:
-//     /b -> b2
-// 2. Using a single host per PathMatcher:
-//   Host: foo(PathMatcher1)
-//   PathMatcher1:
-//     /a -> b1
-//     /b -> b2
-//   Host: bar(PathMatcher2)
-//   PathMatcher2:
-//     /a -> b1
-//     /b -> b2
-//     /c -> b1
-// In the context of kubernetes services, 2 makes more sense, because we
-// rarely want to lookup backends (service:nodeport). When a service is
-// deleted, we need to find all host PathMatchers that have the backend
-// and remove the mapping. When a new path is added to a host (happens
-// more frequently than service deletion) we just need to lookup the 1
-// pathmatcher of the host.
-func (l *L7) UpdateUrlMap() error {
-	if l.um == nil {
-		return fmt.Errorf("cannot update GCE urlmap without an existing GCE urlmap.")
-	}
-	if l.runtimeInfo.UrlMap == nil {
-		return fmt.Errorf("cannot update GCE urlmap without internal representation")
-	}
-
-	urlMap := l.runtimeInfo.UrlMap
-	defaultBackendName := urlMap.DefaultBackend.BackendName(l.namer)
-	l.um.DefaultService = cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath()
-
-	// Every update replaces the entire urlmap.
-	// TODO:  when we have multiple loadbalancers point to a single gce url map
-	// this needs modification. For now, there is a 1:1 mapping of urlmaps to
-	// Ingresses, so if the given Ingress doesn't have a host rule we should
-	// delete the path to that backend.
-	l.um.HostRules = []*compute.HostRule{}
-	l.um.PathMatchers = []*compute.PathMatcher{}
-
-	for hostname, rules := range urlMap.HostRules {
-		// Create a host rule
-		// Create a path matcher
-		// Add all given endpoint:backends to pathRules in path matcher
-		pmName := getNameForPathMatcher(hostname)
-		l.um.HostRules = append(l.um.HostRules, &compute.HostRule{
-			Hosts:       []string{hostname},
-			PathMatcher: pmName,
-		})
-
-		pathMatcher := &compute.PathMatcher{
-			Name:           pmName,
-			DefaultService: l.um.DefaultService,
-			PathRules:      []*compute.PathRule{},
-		}
-
-		// GCE ensures that matched rule with longest prefix wins.
-		for _, rule := range rules {
-			beName := rule.Backend.BackendName(l.namer)
-			beLink := cloud.NewBackendServicesResourceID("", beName).ResourcePath()
-			pathMatcher.PathRules = append(
-				pathMatcher.PathRules, &compute.PathRule{Paths: []string{rule.Path}, Service: beLink})
-		}
-		l.um.PathMatchers = append(l.um.PathMatchers, pathMatcher)
-	}
-	oldMap, _ := l.cloud.GetUrlMap(l.um.Name)
-	if oldMap != nil && mapsEqual(oldMap, l.um) {
-		glog.V(4).Infof("URLMap for l7 %v is unchanged", l.Name)
+	if mapsEqual(currentMap, expectedMap) {
+		glog.V(4).Infof("URLMap for %q is unchanged", l.Name)
+		l.um = currentMap
 		return nil
 	}
 
 	glog.V(3).Infof("Updating URLMap: %q", l.um.Name)
-	if err := l.cloud.UpdateUrlMap(l.um); err != nil {
-		return err
+	expectedMap.Fingerprint = currentMap.Fingerprint
+	if err := l.cloud.UpdateUrlMap(expectedMap); err != nil {
+		return fmt.Errorf("UpdateURLMap: %v", err)
 	}
 
-	um, err := l.cloud.GetUrlMap(l.um.Name)
-	if err != nil {
-		return err
-	}
-
-	l.um = um
+	l.um = expectedMap
 	return nil
 }
 
 // getBackendNames returns the names of backends in this L7 urlmap.
-func (l *L7) getBackendNames() []string {
-	if l.um == nil {
-		return []string{}
-	}
+func getBackendNames(computeURLMap *compute.UrlMap) ([]string, error) {
 	beNames := sets.NewString()
-	for _, pathMatcher := range l.um.PathMatchers {
+	for _, pathMatcher := range computeURLMap.PathMatchers {
+		name, err := utils.KeyName(pathMatcher.DefaultService)
+		if err != nil {
+			return nil, err
+		}
+		beNames.Insert(name)
+
 		for _, pathRule := range pathMatcher.PathRules {
-			// This is gross, but the urlmap only has links to backend services.
-			parts := strings.Split(pathRule.Service, "/")
-			name := parts[len(parts)-1]
-			if name != "" {
-				beNames.Insert(name)
+			name, err = utils.KeyName(pathRule.Service)
+			if err != nil {
+				return nil, err
 			}
+			beNames.Insert(name)
 		}
 	}
 	// The default Service recorded in the urlMap is a link to the backend.
 	// Note that this can either be user specified, or the L7 controller's
 	// global default.
-	parts := strings.Split(l.um.DefaultService, "/")
-	defaultBackendName := parts[len(parts)-1]
-	if defaultBackendName != "" {
-		beNames.Insert(defaultBackendName)
+	name, err := utils.KeyName(computeURLMap.DefaultService)
+	if err != nil {
+		return nil, err
 	}
-	return beNames.List()
+	beNames.Insert(name)
+	return beNames.List(), nil
 }
 
+// mapsEqual compares the structure of two compute.UrlMaps.
+// The service strings are parsed and compared as resource paths (such as
+// "global/backendServices/my-service") to ignore variables: endpoint, version, and project.
 func mapsEqual(a, b *compute.UrlMap) bool {
 	if !utils.EqualResourcePaths(a.DefaultService, b.DefaultService) {
 		return false
@@ -259,12 +159,96 @@ func mapsEqual(a, b *compute.UrlMap) bool {
 					return false
 				}
 			}
-			// Trim down the url's for a.Service and b.Service to a comparable structure
-			// We do this because we update the UrlMap with relative links (not full) to backends.
 			if !utils.EqualResourcePaths(a.Service, b.Service) {
 				return false
 			}
 		}
 	}
 	return true
+}
+
+// toComputeURLMap translates the given hostname: endpoint->port mapping into a gce url map.
+//
+// HostRule: Conceptually contains all PathRules for a given host.
+// PathMatcher: Associates a path rule with a host rule. Mostly an optimization.
+// PathRule: Maps a single path regex to a backend.
+//
+// The GCE url map allows multiple hosts to share url->backend mappings without duplication, eg:
+//   Host: foo(PathMatcher1), bar(PathMatcher1,2)
+//   PathMatcher1:
+//     /a -> b1
+//     /b -> b2
+//   PathMatcher2:
+//     /c -> b1
+// This leads to a lot of complexity in the common case, where all we want is a mapping of
+// host->{/path: backend}.
+//
+// Consider some alternatives:
+// 1. Using a single backend per PathMatcher:
+//   Host: foo(PathMatcher1,3) bar(PathMatcher1,2,3)
+//   PathMatcher1:
+//     /a -> b1
+//   PathMatcher2:
+//     /c -> b1
+//   PathMatcher3:
+//     /b -> b2
+// 2. Using a single host per PathMatcher:
+//   Host: foo(PathMatcher1)
+//   PathMatcher1:
+//     /a -> b1
+//     /b -> b2
+//   Host: bar(PathMatcher2)
+//   PathMatcher2:
+//     /a -> b1
+//     /b -> b2
+//     /c -> b1
+// In the context of kubernetes services, 2 makes more sense, because we
+// rarely want to lookup backends (service:nodeport). When a service is
+// deleted, we need to find all host PathMatchers that have the backend
+// and remove the mapping. When a new path is added to a host (happens
+// more frequently than service deletion) we just need to lookup the 1
+// pathmatcher of the host.
+func toComputeURLMap(lbName string, g *utils.GCEURLMap, namer *utils.Namer) *compute.UrlMap {
+	defaultBackendName := g.DefaultBackend.BackendName(namer)
+	m := &compute.UrlMap{
+		Name:           namer.UrlMap(lbName),
+		DefaultService: cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath(),
+	}
+
+	for _, hostRule := range g.HostRules {
+		// Create a host rule
+		// Create a path matcher
+		// Add all given endpoint:backends to pathRules in path matcher
+		pmName := getNameForPathMatcher(hostRule.Hostname)
+		m.HostRules = append(m.HostRules, &compute.HostRule{
+			Hosts:       []string{hostRule.Hostname},
+			PathMatcher: pmName,
+		})
+
+		pathMatcher := &compute.PathMatcher{
+			Name:           pmName,
+			DefaultService: m.DefaultService,
+			PathRules:      []*compute.PathRule{},
+		}
+
+		// GCE ensures that matched rule with longest prefix wins.
+		for _, rule := range hostRule.Paths {
+			beName := rule.Backend.BackendName(namer)
+			beLink := cloud.NewBackendServicesResourceID("", beName).ResourcePath()
+			pathMatcher.PathRules = append(pathMatcher.PathRules, &compute.PathRule{
+				Paths:   []string{rule.Path},
+				Service: beLink,
+			})
+		}
+		m.PathMatchers = append(m.PathMatchers, pathMatcher)
+	}
+	return m
+}
+
+// getNameForPathMatcher returns a name for a pathMatcher based on the given host rule.
+// The host rule can be a regex, the path matcher name used to associate the 2 cannot.
+func getNameForPathMatcher(hostRule string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(hostRule))
+	return fmt.Sprintf("%v%v", hostRulePrefix, hex.EncodeToString(hasher.Sum(nil)))
 }

--- a/pkg/loadbalancers/url_maps_test.go
+++ b/pkg/loadbalancers/url_maps_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"testing"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+func TestComputeURLMapEquals(t *testing.T) {
+	t.Parallel()
+
+	m := testComputeURLMap()
+	// Test equality.
+	same := testComputeURLMap()
+	if !mapsEqual(m, same) {
+		t.Errorf("mapsEqual(%+v, %+v) = true, want false", m, same)
+	}
+
+	// Test different default backend.
+	diffDefault := testComputeURLMap()
+	diffDefault.DefaultService = "/global/backendServices/some-service"
+	if mapsEqual(m, diffDefault) {
+		t.Errorf("mapsEqual(%+v, %+v) = true, want false", m, diffDefault)
+	}
+}
+
+func TestToComputeURLMap(t *testing.T) {
+	t.Parallel()
+
+	wantComputeMap := testComputeURLMap()
+	gceURLMap := &utils.GCEURLMap{
+		DefaultBackend: &utils.ServicePort{NodePort: 30000},
+		HostRules: []utils.HostRule{
+			{
+				Hostname: "abc.com",
+				Paths: []utils.PathRule{
+					{
+						Path:    "/web",
+						Backend: utils.ServicePort{NodePort: 32000},
+					},
+					{
+						Path:    "/other",
+						Backend: utils.ServicePort{NodePort: 32500},
+					},
+				},
+			},
+			{
+				Hostname: "foo.bar.com",
+				Paths: []utils.PathRule{
+					{
+						Path:    "/",
+						Backend: utils.ServicePort{NodePort: 33000},
+					},
+					{
+						Path:    "/*",
+						Backend: utils.ServicePort{NodePort: 33500},
+					},
+				},
+			},
+		},
+	}
+
+	namer := utils.NewNamer("uid1", "fw1")
+	gotComputeURLMap := toComputeURLMap("lb-name", gceURLMap, namer)
+	if !mapsEqual(gotComputeURLMap, wantComputeMap) {
+		t.Errorf("toComputeURLMap() = \n%+v\n   want\n%+v", gotComputeURLMap, wantComputeMap)
+	}
+}
+
+func testComputeURLMap() *compute.UrlMap {
+	return &compute.UrlMap{
+		Name:           "k8s-um-lb-name",
+		DefaultService: "global/backendServices/k8s-be-30000--uid1",
+		HostRules: []*compute.HostRule{
+			{
+				Hosts:       []string{"abc.com"},
+				PathMatcher: "host929ba26f492f86d4a9d66a080849865a",
+			},
+			{
+				Hosts:       []string{"foo.bar.com"},
+				PathMatcher: "host2d50cf9711f59181be6a5e5658e42c21",
+			},
+		},
+		PathMatchers: []*compute.PathMatcher{
+			{
+				DefaultService: "global/backendServices/k8s-be-30000--uid1",
+				Name:           "host929ba26f492f86d4a9d66a080849865a",
+				PathRules: []*compute.PathRule{
+					{
+						Paths:   []string{"/web"},
+						Service: "global/backendServices/k8s-be-32000--uid1",
+					},
+					{
+						Paths:   []string{"/other"},
+						Service: "global/backendServices/k8s-be-32500--uid1",
+					},
+				},
+			},
+			{
+				DefaultService: "global/backendServices/k8s-be-30000--uid1",
+				Name:           "host2d50cf9711f59181be6a5e5658e42c21",
+				PathRules: []*compute.PathRule{
+					{
+						Paths:   []string{"/"},
+						Service: "global/backendServices/k8s-be-33000--uid1",
+					},
+					{
+						Paths:   []string{"/*"},
+						Service: "global/backendServices/k8s-be-33500--uid1",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetBackendNames(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		urlMap    *compute.UrlMap
+		wantNames []string
+		wantErr   bool
+	}{
+		"Valid UrlMap": {
+			urlMap: &compute.UrlMap{
+				DefaultService: "global/backendServices/service-A",
+				PathMatchers: []*compute.PathMatcher{
+					{
+						DefaultService: "global/backendServices/service-B",
+						PathRules: []*compute.PathRule{
+							{
+								Paths:   []string{"/"},
+								Service: "global/backendServices/service-C",
+							},
+						},
+					},
+				},
+			},
+			wantNames: []string{"service-A", "service-B", "service-C"},
+		},
+		"Invalid DefaultService": {
+			urlMap: &compute.UrlMap{
+				DefaultService: "/global/backendServices/service-A",
+			},
+			wantErr: true,
+		},
+		"Invalid PathMatcher DefaultService": {
+			urlMap: &compute.UrlMap{
+				DefaultService: "global/backendServices/service-A",
+				PathMatchers: []*compute.PathMatcher{
+					{
+						DefaultService: "/global/backendServices/service-B",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"Invalid PathRule Service": {
+			urlMap: &compute.UrlMap{
+				DefaultService: "global/backendServices/service-A",
+				PathMatchers: []*compute.PathMatcher{
+					{
+						DefaultService: "global/backendServices/service-B",
+						PathRules: []*compute.PathRule{
+							{
+								Paths:   []string{"/"},
+								Service: "/global/backendServices/service-C",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotNames, gotErr := getBackendNames(tc.urlMap)
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("getBackendNames(%v) = _, %v, want err? %v", tc.urlMap, gotErr, tc.wantErr)
+			}
+			if gotErr != nil {
+				return
+			}
+
+			if !sets.NewString(gotNames...).Equal(sets.NewString(tc.wantNames...)) {
+				t.Errorf("getBackendNames(%v) = %v, want %v", tc.urlMap, gotNames, tc.wantNames)
+			}
+		})
+	}
+}

--- a/pkg/utils/gceurlmap_test.go
+++ b/pkg/utils/gceurlmap_test.go
@@ -17,15 +17,27 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestGCEURLMap(t *testing.T) {
 	t.Parallel()
 	urlMap := NewGCEURLMap()
 
-	// Add some path rules for a host.
+	// Add an unrelated host to urlmap.
 	rules := []PathRule{
+		PathRule{Path: "/other", Backend: ServicePort{NodePort: 50000}},
+	}
+	urlMap.PutPathRulesForHost("foo.bar.com", rules)
+
+	if _, ok := urlMap.PathExists("example.com", "/test1"); ok {
+		t.Errorf("Expected path /test1 for hostname example.com not to exist in %+v", urlMap)
+	}
+
+	rules = []PathRule{
 		PathRule{Path: "/test1", Backend: ServicePort{NodePort: 30000}},
 		PathRule{Path: "/test2", Backend: ServicePort{NodePort: 30001}},
 	}
@@ -33,10 +45,10 @@ func TestGCEURLMap(t *testing.T) {
 	if !urlMap.HostExists("example.com") {
 		t.Errorf("Expected hostname example.com to exist in %+v", urlMap)
 	}
-	if ok, _ := urlMap.PathExists("example.com", "/test1"); !ok {
+	if _, ok := urlMap.PathExists("example.com", "/test1"); !ok {
 		t.Errorf("Expected path /test1 for hostname example.com to exist in %+v", urlMap)
 	}
-	if ok, _ := urlMap.PathExists("example.com", "/test2"); !ok {
+	if _, ok := urlMap.PathExists("example.com", "/test2"); !ok {
 		t.Errorf("Expected path /test2 for hostname example.com to exist in %+v", urlMap)
 	}
 
@@ -45,13 +57,13 @@ func TestGCEURLMap(t *testing.T) {
 		PathRule{Path: "/test3", Backend: ServicePort{NodePort: 30002}},
 	}
 	urlMap.PutPathRulesForHost("example.com", rules)
-	if ok, _ := urlMap.PathExists("example.com", "/test1"); ok {
+	if _, ok := urlMap.PathExists("example.com", "/test1"); ok {
 		t.Errorf("Expected path /test1 for hostname example.com not to exist in %+v", urlMap)
 	}
-	if ok, _ := urlMap.PathExists("example.com", "/test2"); ok {
+	if _, ok := urlMap.PathExists("example.com", "/test2"); ok {
 		t.Errorf("Expected path /test2 for hostname example.com not to exist in %+v", urlMap)
 	}
-	if ok, _ := urlMap.PathExists("example.com", "/test3"); !ok {
+	if _, ok := urlMap.PathExists("example.com", "/test3"); !ok {
 		t.Errorf("Expected path /test3 for hostname example.com to exist in %+v", urlMap)
 	}
 
@@ -62,8 +74,123 @@ func TestGCEURLMap(t *testing.T) {
 		PathRule{Path: "/test4", Backend: ServicePort{NodePort: 30005}},
 	}
 	urlMap.PutPathRulesForHost("example.com", rules)
-	_, backend := urlMap.PathExists("example.com", "/test4")
-	if backend.NodePort != 30005 {
+	backend, ok := urlMap.PathExists("example.com", "/test4")
+	if !ok || backend.NodePort != 30005 {
 		t.Errorf("Expected path /test4 for hostname example.com to point to backend with NodePort 30005 in %+v", urlMap)
 	}
+}
+
+func TestGCEURLMapDeleteHost(t *testing.T) {
+	t.Parallel()
+	urlMap := NewGCEURLMap()
+	rules := []PathRule{
+		PathRule{Path: "/test1", Backend: ServicePort{NodePort: 30000}},
+		PathRule{Path: "/test2", Backend: ServicePort{NodePort: 30001}},
+	}
+	urlMap.PutPathRulesForHost("example.com", rules)
+	urlMap.PutPathRulesForHost("foo.bar.com", rules)
+
+	// Delete last
+	urlMap.deleteHost("foo.bar.com")
+
+	if !urlMap.HostExists("example.com") {
+		t.Errorf("HostExists('example.com') = false, want true")
+	}
+	if urlMap.HostExists("foo.bar.com") {
+		t.Errorf("HostExists('foo.bar.com') = true, want false")
+	}
+
+	// Delete remaining host
+	urlMap.deleteHost("example.com")
+
+	if urlMap.HostExists("example.com") {
+		t.Errorf("HostExists('foo.bar.com') = true, want false")
+	}
+}
+
+func TestGCEURLMapEquals(t *testing.T) {
+	t.Parallel()
+	someMap := newTestMap()
+
+	// Test against itself.
+	equalMap := newTestMap()
+	if !EqualMapping(someMap, equalMap) {
+		t.Errorf("EqualMapping(%+v, %+v) = false, want true", someMap, equalMap)
+	}
+
+	// Test different DefaultBackend.
+	diffDefault := newTestMap()
+	b := NewServicePortWithID("svc-Y", "ns", intstr.FromInt(80))
+	diffDefault.DefaultBackend = &b
+	if EqualMapping(someMap, diffDefault) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffDefault)
+	}
+
+	// Test check of HostRules.
+	diffHostRules := newTestMap()
+	diffHostRules.PutPathRulesForHost("roger.com", nil)
+	if EqualMapping(someMap, diffHostRules) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffHostRules)
+	}
+
+	// Test check of HostName.
+	diffHostName := newTestMap()
+	diffHostName.HostRules[0].Hostname = "roger.com"
+	if EqualMapping(someMap, diffHostName) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffHostName)
+	}
+
+	// Test check of PathRules.
+	// Change PathRule's path.
+	diffPaths := newTestMap()
+	diffPaths.HostRules[0].Paths[0].Path = "/other"
+	if EqualMapping(someMap, diffPaths) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffPaths)
+	}
+	// Change a PathRule's backend.
+	diffPaths.HostRules[0].Paths[0] = PathRule{Path: "/ex1", Backend: NewServicePortWithID("svc-M", "ns", intstr.FromInt(80))}
+	if EqualMapping(someMap, diffPaths) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffPaths)
+	}
+	// Delete a PathRule.
+	diffPaths.HostRules[0].Paths = diffPaths.HostRules[0].Paths[:1]
+	if EqualMapping(someMap, diffPaths) {
+		t.Errorf("EqualMapping(%+v, %+v) = true, want false", someMap, diffPaths)
+	}
+}
+
+func TestAllServicePorts(t *testing.T) {
+	t.Parallel()
+	m := newTestMap()
+	wantPorts := []ServicePort{
+		NewServicePortWithID("svc-X", "ns", intstr.FromInt(80)),
+		NewServicePortWithID("svc-A", "ns", intstr.FromInt(80)),
+		NewServicePortWithID("svc-B", "ns", intstr.FromInt(80)),
+		NewServicePortWithID("svc-C", "ns", intstr.FromInt(80)),
+		NewServicePortWithID("svc-D", "ns", intstr.FromInt(80)),
+	}
+
+	gotPorts := m.AllServicePorts()
+	t.Logf("m = %v", m)
+	if !reflect.DeepEqual(gotPorts, wantPorts) {
+		t.Errorf("AllServicePorts(%+v) = \n%+v\nwant\n%+v", m, gotPorts, wantPorts)
+	}
+
+}
+
+func newTestMap() *GCEURLMap {
+	m := NewGCEURLMap()
+	b := NewServicePortWithID("svc-X", "ns", intstr.FromInt(80))
+	m.DefaultBackend = &b
+	rules := []PathRule{
+		PathRule{Path: "/ex1", Backend: NewServicePortWithID("svc-A", "ns", intstr.FromInt(80))},
+		PathRule{Path: "/ex2", Backend: NewServicePortWithID("svc-B", "ns", intstr.FromInt(80))},
+	}
+	m.PutPathRulesForHost("example.com", rules)
+	rules = []PathRule{
+		PathRule{Path: "/foo1", Backend: NewServicePortWithID("svc-C", "ns", intstr.FromInt(80))},
+		PathRule{Path: "/foo2", Backend: NewServicePortWithID("svc-D", "ns", intstr.FromInt(80))},
+	}
+	m.PutPathRulesForHost("foo.bar.com", rules)
+	return m
 }

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -72,3 +72,16 @@ func BackendToServicePortID(be extensions.IngressBackend, namespace string) Serv
 		Port: be.ServicePort,
 	}
 }
+
+// NewServicePortWithID returns a ServicePort with only ID.
+func NewServicePortWithID(svcName, svcNamespace string, port intstr.IntOrString) ServicePort {
+	return ServicePort{
+		ID: ServicePortID{
+			Service: types.NamespacedName{
+				Name:      svcName,
+				Namespace: svcNamespace,
+			},
+			Port: port,
+		},
+	}
+}


### PR DESCRIPTION
Changes
 - `UpdateUrlMap()` mostly turned into static func `toComputeURLMap()`. It's sync logic moved to `ensureComputeURLMap()`.
 - `L7s.Sync()` calls `ensureComputeURLMap()` to assert the URLMap's existence and correctness instead of making a separate, later call to `UpdateUrlMap()` 
 - `utils.GCEURLMap` used a map for hostname->path rules which made the generated URLMap's order non-deterministic (presumably this caused unnecessary API calls). It now uses a slice and maintains uniqueness.

Bulk of this PR is in tests or related datafiles.