### PR TITLE
Make WaitForIngressDeletion() a util func and add a knob for omitting default backend

### DIFF
--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kr/pretty"
 	"k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
 	"k8s.io/ingress-gce/pkg/fuzz"
@@ -110,15 +109,9 @@ func TestBasic(t *testing.T) {
 				t.Errorf("got %d backend services, want %d;\n%s", len(gclb.BackendService), tc.numBackendServices, pretty.Sprint(gclb.BackendService))
 			}
 
-			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Delete(tc.ing.Name, &metav1.DeleteOptions{}); err != nil {
-				t.Errorf("Delete(%q) = %v, want nil", tc.ing.Name, err)
+			if err := e2e.WaitForIngressDeletion(ctx, Framework.Cloud, gclb, s, ing, false); err != nil {
+				t.Errorf("Failed to wait for ingress deletion: %v", err)
 			}
-			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, tc.ing.Name)
-			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb); err != nil {
-				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
-			}
-			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, tc.ing.Name)
 		})
 	}
 }

--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -28,9 +28,12 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/filter"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
+
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // ForwardingRule is a union of the API version types.
@@ -93,7 +96,7 @@ func NewGCLB(vip string) *GCLB {
 
 // CheckResourceDeletion checks the existance of the resources. Returns nil if
 // all of the associated resources no longer exist.
-func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud) error {
+func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, omitSystemDefaultBackend bool) error {
 	var resources []*meta.Key
 
 	for k := range g.ForwardingRule {
@@ -137,12 +140,18 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud) error {
 		}
 	}
 	for k := range g.BackendService {
-		_, err := c.BackendServices().Get(ctx, &k)
+		bs, err := c.BackendServices().Get(ctx, &k)
 		if err != nil {
 			if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 				return err
 			}
 		} else {
+			if omitSystemDefaultBackend {
+				desc := utils.DescriptionFromString(bs.Description)
+				if desc.ServiceName == "kube-system/default-http-backend" {
+					continue
+				}
+			}
 			resources = append(resources, &k)
 		}
 	}


### PR DESCRIPTION
Thinking a knob for omitting default backend service might be useful given it can be shared among LBs.

/assign @rramkumar1 @bowei 