### PR TITLE
Fix the issue where Shutdown doesn't shutdown taskqueue

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -192,7 +192,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	go app.RunSIGTERMHandler(lbc, flags.F.DeleteAllOnQuit)
 
-	go fwc.Run(stopCh)
+	go fwc.Run()
 	glog.V(0).Infof("firewall controller started")
 
 	ctx.Start(stopCh)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -226,8 +226,8 @@ func (lbc *LoadBalancerController) Init() {
 // Run starts the loadbalancer controller.
 func (lbc *LoadBalancerController) Run() {
 	glog.Infof("Starting loadbalancer controller")
-	go lbc.ingQueue.Run(time.Second, lbc.stopCh)
-	lbc.nodes.Run(lbc.stopCh)
+	go lbc.ingQueue.Run()
+	go lbc.nodes.Run()
 
 	<-lbc.stopCh
 	glog.Infof("Shutting down Loadbalancer Controller")

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -17,18 +17,12 @@ limitations under the License.
 package controller
 
 import (
-	"time"
-
 	apiv1 "k8s.io/api/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/utils"
-)
-
-const (
-	nodeUpdatePeriod = 1 * time.Second
 )
 
 // NodeController synchronizes the state of the nodes to the unmanaged instance
@@ -66,12 +60,12 @@ func NewNodeController(ctx *context.ControllerContext, instancePool instances.No
 	return c
 }
 
-// Run a go routine to process updates for the controller.
-func (c *NodeController) Run(stopCh chan struct{}) {
-	go c.queue.Run(nodeUpdatePeriod, stopCh)
+// Run a goroutine to process updates for the controller.
+func (c *NodeController) Run() {
+	c.queue.Run()
 }
 
-// Run a go routine to process updates for the controller.
+// Shutdown shuts down the goroutine that processes node updates.
 func (c *NodeController) Shutdown() {
 	c.queue.Shutdown()
 }

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -129,9 +129,9 @@ func (fwc *FirewallController) ToSvcPorts(ings *extensions.IngressList) []utils.
 	return knownPorts
 }
 
-func (fwc *FirewallController) Run(stopCh chan struct{}) {
+func (fwc *FirewallController) Run() {
 	defer fwc.shutdown()
-	fwc.queue.Run(time.Second, stopCh)
+	fwc.queue.Run()
 }
 
 // This should only be called when the process is being terminated.


### PR DESCRIPTION
Originally, PeriodicTaskQueue has 2 loops:
- wait.Until managed by stopCh
- for loop in worker() managed by workqueue

Shutdown only exits the second loop. Failing to close stopCh before
calling Shutdown will cause panic because of double close workDone
channel.