### PR TITLE
Align node filtering with kubernetes service controller

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -193,7 +193,7 @@ func getZone(n *api_v1.Node) string {
 // GetZoneForNode returns the zone for a given node by looking up its zone label.
 func (t *Translator) GetZoneForNode(name string) (string, error) {
 	nodeLister := t.ctx.NodeInformer.GetIndexer()
-	nodes, err := listers.NewNodeLister(nodeLister).ListWithPredicate(utils.NodeIsReady)
+	nodes, err := listers.NewNodeLister(nodeLister).ListWithPredicate(utils.GetNodeConditionPredicate())
 	if err != nil {
 		return "", err
 	}
@@ -211,7 +211,7 @@ func (t *Translator) GetZoneForNode(name string) (string, error) {
 func (t *Translator) ListZones() ([]string, error) {
 	zones := sets.String{}
 	nodeLister := t.ctx.NodeInformer.GetIndexer()
-	readyNodes, err := listers.NewNodeLister(nodeLister).ListWithPredicate(utils.NodeIsReady)
+	readyNodes, err := listers.NewNodeLister(nodeLister).ListWithPredicate(utils.GetNodeConditionPredicate())
 	if err != nil {
 		return zones.List(), err
 	}


### PR DESCRIPTION
Addresses #292 

Use the same node selection logic as the kubernetes service controller:
- filter out master nodes
- filter out non-ready node
- filter out nodes with label `alpha.service-controller.kubernetes.io/exclude-balancer`

In the kubernetes service controller, the service node exclusion is a feature gate but there is no feature gate on this controller, so I removed the feature gate test (it seems unlikely that this label would be applied to a node that doesn't require exclusion). If you think it's not a good call I can revisit this.

I have a custom build available on dockerhub for testing: `lbernail/glbc:v0.2`