### PR TITLE
Fix WaitForGCLBDeletion() callers

### DIFF
--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -118,7 +118,7 @@ func TestCDN(t *testing.T) {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
-			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb); err != nil {
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, nil); err != nil {
 				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
 			}
 			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -95,7 +95,7 @@ func TestIAP(t *testing.T) {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
-			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb); err != nil {
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, nil); err != nil {
 				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
 			}
 			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)


### PR DESCRIPTION
Sorry, the signature of `WaitForGCLBDeletion()` was changed by https://github.com/kubernetes/ingress-gce/pull/360 but new callers were added in https://github.com/kubernetes/ingress-gce/pull/367 so codes can't built at the moment.

/assign @rramkumar1 