### PR TITLE
Add option to specify number of consecutive runs for e2e framework [WIP]

### DIFF
--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -42,6 +42,7 @@ var (
 		seed             int64
 		destroySandboxes bool
 		handleSIGINT     bool
+		consecutiveRuns  int64
 	}
 
 	Framework *e2e.Framework
@@ -60,6 +61,7 @@ func init() {
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
+	flag.Int64Var(&flags.consecutiveRuns, "consecutiveRuns", 1, "number of times to run each e2e test before exiting.")
 
 }
 
@@ -104,6 +106,7 @@ func TestMain(m *testing.M) {
 		Project:          flags.project,
 		Seed:             flags.seed,
 		DestroySandboxes: flags.destroySandboxes,
+		ConsecutiveRuns:  flags.consecutiveRuns,
 	})
 	if flags.handleSIGINT {
 		Framework.CatchSIGINT()

--- a/cmd/e2e-test/run.sh
+++ b/cmd/e2e-test/run.sh
@@ -32,10 +32,15 @@ if [[ -z "$PROJECT" ]]; then
   exit 1
 fi
 
+
+if [[ -z "$NUM_RUNS" ]]; then 
+  NUM_RUNS=1
+fi
+
 echo
 echo ==============================================================================
 echo "PROJECT: ${PROJECT}"
-CMD="/e2e-test -test.v -test.parallel=10 -run -project ${PROJECT} -logtostderr -inCluster -v=2"
+CMD="/e2e-test -test.v -test.parallel=10 -run -consecutiveRuns ${NUM_RUNS} -project ${PROJECT} -logtostderr -inCluster -v=2"
 echo "CMD: ${CMD}" $@
 echo
 

--- a/pkg/e2e/sandbox.go
+++ b/pkg/e2e/sandbox.go
@@ -33,10 +33,22 @@ type Sandbox struct {
 	Namespace string
 	// ValidatorEnv for use with the test.
 	ValidatorEnv fuzz.ValidatorEnv
-
+	
+	totalExecutions int
 	lock      sync.Mutex
 	f         *Framework
 	destroyed bool
+}
+
+// IsNew returns true if this sandbox has never had a test executed inside of it.
+func (s *Sandbox) IsNew() bool {
+	return s.totalExecutions == 0
+}
+
+// PendingDestruction returns true if this sandbox will be destroyed at the 
+// end of the its current test run.
+func (s *Sandbox) PendingDestruction(f *Framework) {
+	return f.destroySandboxes && s.totalExecutions - 1  == f.consecutiveRuns
 }
 
 // Create the sandbox.


### PR DESCRIPTION
This will allow us to implement some upgrade testing. Specifically, we can continuously run the e2e tests while the GLBC is getting updated without destroying the sandboxes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/373)
<!-- Reviewable:end -->
