### PR TITLE
Add plumbing to support upgrade testing. 

### DIFF
--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -95,7 +95,7 @@ func TestCDN(t *testing.T) {
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing)
+			ing, err := e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -77,7 +77,7 @@ func TestIAP(t *testing.T) {
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing)
+			ing, err := e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}

--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -42,6 +42,7 @@ var (
 		seed             int64
 		destroySandboxes bool
 		handleSIGINT     bool
+		handleSIGTERM    bool
 	}
 
 	Framework *e2e.Framework
@@ -60,7 +61,7 @@ func init() {
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
-
+	flag.BoolVar(&flags.handleSIGTERM, "handleSIGTERM", true, "catch SIGTERM to perform clean")
 }
 
 // TestMain is the entrypoint for the end-to-end test suite. This is where
@@ -105,8 +106,8 @@ func TestMain(m *testing.M) {
 		Seed:             flags.seed,
 		DestroySandboxes: flags.destroySandboxes,
 	})
-	if flags.handleSIGINT {
-		Framework.CatchSIGINT()
+	if flags.handleSIGINT || flags.handleSIGTERM {
+		Framework.CatchSignals(flags.handleSIGINT, flags.handleSIGTERM)
 	}
 	if err := Framework.SanityCheck(); err != nil {
 		glog.Fatalf("Framework sanity check failed: %v", err)

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -111,7 +111,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 
 		t.Logf("Checking on relevant backend service whether security policy is properly attached")
 
-		testIng, err = e2e.WaitForIngress(s, testIng)
+		testIng, err = e2e.WaitForIngress(s, testIng, nil)
 		if err != nil {
 			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
 		}
@@ -181,7 +181,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 		}
 		t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
 
-		ing, err := e2e.WaitForIngress(s, testIng)
+		ing, err := e2e.WaitForIngress(s, testIng, nil)
 		if err != nil {
 			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
 		}


### PR DESCRIPTION
Adds the ability to run a test inside a sandbox continuously. This allows us to test functionality while the ingress is being updated.