### PR TITLE
Modify security policy e2e test to create unique GCP resources.

### DIFF
--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -72,7 +72,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 
 	Framework.RunWithSandbox("Security Policy Enable", t, func(t *testing.T, s *e2e.Sandbox) {
 		policies := []*computebeta.SecurityPolicy{
-			buildPolicyAllowAll("enable-test-allow-all"),
+			buildPolicyAllowAll(fmt.Sprintf("enable-test-allow-all-%s", s.Namespace)),
 		}
 		defer func() {
 			if err := cleanupSecurityPolicies(t, ctx, Framework.Cloud, policies); err != nil {
@@ -143,8 +143,8 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 	Framework.RunWithSandbox("Security Policy Transition", t, func(t *testing.T, s *e2e.Sandbox) {
 		policies := []*computebeta.SecurityPolicy{
-			buildPolicyAllowAll("transition-test-allow-all"),
-			buildPolicyDisallowAll("transition-test-disallow-all"),
+			buildPolicyAllowAll(fmt.Sprintf("transition-test-allow-all-%s", s.Namespace))
+			buildPolicyDisallowAll(fmt.Sprintf("transition-test-disallow-all-%s", s.Namespace))
 		}
 		defer func() {
 			if err := cleanupSecurityPolicies(t, ctx, Framework.Cloud, policies); err != nil {

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -143,8 +143,8 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 	Framework.RunWithSandbox("Security Policy Transition", t, func(t *testing.T, s *e2e.Sandbox) {
 		policies := []*computebeta.SecurityPolicy{
-			buildPolicyAllowAll(fmt.Sprintf("transition-test-allow-all-%s", s.Namespace))
-			buildPolicyDisallowAll(fmt.Sprintf("transition-test-disallow-all-%s", s.Namespace))
+			buildPolicyAllowAll(fmt.Sprintf("transition-test-allow-all-%s", s.Namespace)),
+			buildPolicyDisallowAll(fmt.Sprintf("transition-test-disallow-all-%s", s.Namespace)),
 		}
 		defer func() {
 			if err := cleanupSecurityPolicies(t, ctx, Framework.Cloud, policies); err != nil {


### PR DESCRIPTION
If this test runs in multiple clusters, then we will see failures since the security policy created will not be unique to that clusters. Adding the sandbox namespace to the end of the name ensures we don't see these errors.

/assign @bowei 
/cc @MrHohn 