### PR TITLE
Fire warning event instead of hard failing if TLS certificate is not present

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -26,6 +26,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	unversionedcore "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -445,7 +446,14 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *extensions.Ingress) (*load
 	if annotations.UseNamedTLS() == "" {
 		tls, err = lbc.tlsLoader.Load(ing)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get certs for Ingress %v/%v: %v", ing.Namespace, ing.Name, err)
+			if apierrors.IsNotFound(err) {
+				// TODO: this path should be removed when external certificate managers migrate to a better solution.
+				const msg = "Could not find TLS certificates. Continuing setup for the load balancer to serve HTTP. Note: this behavior is deprecated and will be removed in a future version of ingress-gce"
+				lbc.ctx.Recorder(ing.Namespace).Eventf(ing, apiv1.EventTypeWarning, "Sync", msg)
+			} else {
+				glog.Errorf("Could not get certificates for ingress %s/%s: %v", ing.Namespace, ing.Name, err)
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a follow up/in relation to my comment made here: https://github.com/kubernetes/ingress-gce/pull/112#issuecomment-394784727

This switches ingress-gce back to the previous behaviour of 'soft failing' if the specified TLS secret exists. Without this change, we've had many users complain that auto-TLS using cert-manager (and also kube-lego) is broken.

Please see the discussion in #112 and https://github.com/jetstack/cert-manager/issues/606 for more detail.

The one notable difference, is instead of simply logging a warning using `glog` (which on GKE is not visible to end users), we now fire a Warning event, but importantly **still continue afterwards**. This is essential for something like cert-manager, as without it users would need to create some kind of self-signed placeholder certificate.

For reference, ingress-nginx will actually generate its own self signed certificate, and if the specified Secret cannot be found, it will serve using this. This would also be acceptable for ingress-gce, however is a more considerable change.

I really hope we can get this patch accepted in some form, as users are currently unable to automatically obtain TLS certificates from Let's Encrypt without extra workarounds (i.e. manually specifying Certificate resources).

Most importantly however, #112 was a *breaking change* that was not communicated, and as a result has caused issues downstream for end-users.

Thanks for taking a look!