### PR TITLE
Add plumbing for upgrade testing

### DIFF
--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -83,7 +83,7 @@ func TestBasic(t *testing.T) {
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, tc.ing)
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}

--- a/cmd/e2e-test/basic_upgrade_test.go
+++ b/cmd/e2e-test/basic_upgrade_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kr/pretty"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestBasicUpgrade(t *testing.T) {
+	t.Parallel()
+
+	port80 := intstr.FromInt(80)
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1beta1.Ingress
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "http default backend",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			_, _, err := e2e.CreateEchoService(s, "service-1", nil)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			if _, err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+			s.PutStatus(e2e.Unstable)
+
+			runs := 0
+			for {
+				options := &e2e.WaitForIngressOptions{
+					ExpectUnreachable: runs == 0,
+				}
+				ing, err := e2e.WaitForIngress(s, tc.ing, options)
+				if err != nil {
+					t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+				}
+
+				if runs == 0 {
+					t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+					s.PutStatus(e2e.Stable)
+				} else {
+					t.Logf("GCLB is stable (%s/%s)", s.Namespace, tc.ing.Name)
+				}
+
+				// Perform whitebox testing.
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+				gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+
+				// Do some cursory checks on the GCP objects.
+				if len(gclb.ForwardingRule) != tc.numForwardingRules {
+					t.Errorf("got %d fowarding rules, want %d;\n%s", len(gclb.ForwardingRule), tc.numForwardingRules, pretty.Sprint(gclb.ForwardingRule))
+				}
+				if len(gclb.BackendService) != tc.numBackendServices {
+					t.Errorf("got %d backend services, want %d;\n%s", len(gclb.BackendService), tc.numBackendServices, pretty.Sprint(gclb.BackendService))
+				}
+
+				runs++
+			}
+		})
+	}
+}

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -95,7 +95,7 @@ func TestCDN(t *testing.T) {
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing)
+			ing, err := e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -77,7 +77,7 @@ func TestIAP(t *testing.T) {
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing)
+			ing, err := e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -111,7 +111,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 
 		t.Logf("Checking on relevant backend service whether security policy is properly attached")
 
-		testIng, err = e2e.WaitForIngress(s, testIng)
+		testIng, err = e2e.WaitForIngress(s, testIng, nil)
 		if err != nil {
 			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
 		}
@@ -181,7 +181,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 		}
 		t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
 
-		ing, err := e2e.WaitForIngress(s, testIng)
+		ing, err := e2e.WaitForIngress(s, testIng, nil)
 		if err != nil {
 			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
 		}

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -38,8 +38,15 @@ const (
 	gclbDeletionTimeout  = 10 * time.Minute
 )
 
+// WaitForIngressOptions holds options dictating how we wait for an ingress to stabilize.
+type WaitForIngressOptions struct {
+	// ExpectUnreachable is true when we expect the LB to still be
+	// programming itself (i.e 404's / 502's)
+	ExpectUnreachable bool
+}
+
 // WaitForIngress to stabilize.
-func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
+func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitForIngressOptions) (*v1beta1.Ingress, error) {
 	err := wait.Poll(ingressPollInterval, ingressPollTimeout, func() (bool, error) {
 		var err error
 		ing, err = s.f.Clientset.Extensions().Ingresses(s.Namespace).Get(ing.Name, metav1.GetOptions{})
@@ -53,8 +60,12 @@ func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error) 
 		result := validator.Check(context.Background())
 		if result.Err == nil {
 			return true, nil
+		} else {
+			if options == nil || options.ExpectUnreachable {
+				return false, nil
+			}
+			return true, fmt.Errorf("Unexpected error from validation: %v", result.Err)
 		}
-		return false, nil
 	})
 	return ing, err
 }

--- a/pkg/e2e/sandbox.go
+++ b/pkg/e2e/sandbox.go
@@ -77,3 +77,7 @@ func (s *Sandbox) Destroy() {
 	}
 	s.destroyed = true
 }
+
+func (s *Sandbox) PutStatus(status IngressStability) {
+	s.f.statusManager.putStatus(s.Namespace, status)
+}

--- a/pkg/e2e/status.go
+++ b/pkg/e2e/status.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	informerv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// IngressStability denotes the stabilization status of all Ingresses in a sandbox.
+type IngressStability string
+
+var (
+	// Stable indicates an Ingress is stable (i.e consistently serving 200's)
+	Stable IngressStability = "Stable"
+	// Unstable indicates an Ingress is unstable (i.e serving 404/502's).
+	Unstable IngressStability = "Unstable"
+	// ExitKey is the key used to indicate to the status manager
+	// whether to gracefully finish the e2e test execution.
+	exitKey = "exit"
+)
+
+const (
+	configMapName = "status-cm"
+)
+
+// StatusManager manages the status of sandboxed Ingresses via a ConfigMap.
+type StatusManager struct {
+	cm *v1.ConfigMap
+	f  *Framework
+}
+
+func NewStatusManager(f *Framework) *StatusManager {
+	return &StatusManager{
+		cm: &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapName,
+			},
+		},
+		f: f,
+	}
+}
+
+func (sm *StatusManager) init() error {
+	var err error
+	sm.cm, err = sm.f.Clientset.Core().ConfigMaps("default").Create(sm.cm)
+	if err != nil {
+		return fmt.Errorf("Error creating ConfigMap: %v", err)
+	}
+
+	newIndexer := func() cache.Indexers {
+		return cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	}
+	cmInformer := informerv1.NewConfigMapInformer(sm.f.Clientset, "default", 30*time.Second, newIndexer())
+	cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, cur interface{}) {
+			curCm := cur.(*v1.ConfigMap)
+			if curCm.Data[exitKey] == "yes" {
+				glog.V(2).Infof("ConfigMap was updated with exit switch.")
+				sm.f.shutdown(0)
+			}
+		},
+	})
+
+	go func() {
+		for _ = range time.NewTicker(30 * time.Second).C {
+			sm.flush()
+		}
+	}()
+
+	return nil
+}
+
+func (sm *StatusManager) shutdown() {
+	glog.V(2).Infof("Shutting down status manager.")
+	if err := sm.f.Clientset.Core().ConfigMaps("default").Delete(configMapName, &metav1.DeleteOptions{}); err != nil {
+		glog.Errorf("Error deleting ConfigMap: %v", err)
+	}
+}
+
+func (sm *StatusManager) putStatus(key string, status IngressStability) {
+	sm.f.lock.Lock()
+	if sm.cm.Data == nil {
+		sm.cm.Data = make(map[string]string)
+	}
+	sm.cm.Data[key] = string(status)
+	sm.f.lock.Unlock()
+}
+
+func (sm *StatusManager) flush() {
+	sm.f.lock.Lock()
+	defer sm.f.lock.Unlock()
+	var err error
+	sm.cm, err = sm.f.Clientset.Core().ConfigMaps("default").Update(sm.cm)
+	if err != nil {
+		glog.Errorf("Error updating ConfigMap: %v", err)
+	}
+	glog.V(3).Infof("Flushed statuses to ConfigMap")
+}


### PR DESCRIPTION
Based on the design we discussed offline (used a ConfigMap to manage the stability statuses of Ingresses in test sandboxes).

Open to thoughts on how to structure the type which manages the ConfigMap (StatusManager)

/assign @bowei 