### PR TITLE
Introduce ControllerContextConfig and move some command-line tunable stuff there

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -201,7 +201,7 @@ func (lbc *LoadBalancerController) enqueueIngressForObject(obj interface{}) {
 
 // enqueueIngressForService enqueues all the Ingresses for a Service.
 func (lbc *LoadBalancerController) enqueueIngressForService(svc *apiv1.Service) {
-	ings, err := lbc.ingLister.GetServiceIngress(svc, lbc.CloudClusterManager.defaultBackendSvcPortID)
+	ings, err := lbc.ingLister.GetServiceIngress(svc, lbc.ctx.DefaultBackendSvcPortID)
 	if err != nil {
 		glog.V(5).Infof("ignoring service %v: %v", svc.Name, err)
 		return
@@ -312,7 +312,7 @@ func (lbc *LoadBalancerController) sync(key string) (retErr error) {
 }
 
 func (lbc *LoadBalancerController) ensureIngress(ing *extensions.Ingress, nodeNames []string, gceSvcPorts []utils.ServicePort) error {
-	urlMap, errs := lbc.Translator.TranslateIngress(ing, lbc.CloudClusterManager.defaultBackendSvcPortID)
+	urlMap, errs := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPortID)
 	if errs != nil {
 		return fmt.Errorf("error while evaluating the ingress spec: %v", joinErrs(errs))
 	}
@@ -479,7 +479,7 @@ func updateAnnotations(client kubernetes.Interface, name, namespace string, anno
 func (lbc *LoadBalancerController) ToSvcPorts(ings *extensions.IngressList) []utils.ServicePort {
 	var knownPorts []utils.ServicePort
 	for _, ing := range ings.Items {
-		urlMap, _ := lbc.Translator.TranslateIngress(&ing, lbc.CloudClusterManager.defaultBackendSvcPortID)
+		urlMap, _ := lbc.Translator.TranslateIngress(&ing, lbc.ctx.DefaultBackendSvcPortID)
 		knownPorts = append(knownPorts, urlMap.AllServicePorts()...)
 	}
 	return knownPorts

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -45,7 +45,14 @@ func newLoadBalancerController(t *testing.T, cm *fakeClusterManager) *LoadBalanc
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 
 	stopCh := make(chan struct{})
-	ctx := context.NewControllerContext(kubeClient, backendConfigClient, cm.fakeBackends, api_v1.NamespaceAll, 1*time.Minute, true, false)
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              true,
+		BackendConfigEnabled:    false,
+		Namespace:               api_v1.NamespaceAll,
+		ResyncPeriod:            1 * time.Minute,
+		DefaultBackendSvcPortID: testDefaultBeSvcPort.ID,
+	}
+	ctx := context.NewControllerContext(kubeClient, backendConfigClient, cm.fakeBackends, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, cm.ClusterManager, stopCh)
 
 	lbc.hasSynced = func() bool { return true }

--- a/pkg/controller/fakes.go
+++ b/pkg/controller/fakes.go
@@ -73,12 +73,11 @@ func NewFakeClusterManager(clusterName, firewallName string) *fakeClusterManager
 	l7Pool := loadbalancers.NewLoadBalancerPool(fakeLbs, namer)
 	frPool := firewalls.NewFirewallPool(firewalls.NewFakeFirewallsProvider(false, false), namer, testSrcRanges, testNodePortRanges)
 	cm := &ClusterManager{
-		ClusterNamer:            namer,
-		instancePool:            nodePool,
-		backendPool:             backendPool,
-		l7Pool:                  l7Pool,
-		firewallPool:            frPool,
-		defaultBackendSvcPortID: testDefaultBeSvcPort.ID,
+		ClusterNamer: namer,
+		instancePool: nodePool,
+		backendPool:  backendPool,
+		l7Pool:       l7Pool,
+		firewallPool: frPool,
 	}
 	return &fakeClusterManager{cm, fakeLbs, fakeBackends, fakeIGs, namer}
 }

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -50,7 +50,14 @@ func fakeTranslator(negEnabled, backendConfigEnabled bool) *Translator {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 
 	namer := utils.NewNamer("uid1", "")
-	ctx := context.NewControllerContext(client, backendConfigClient, nil, apiv1.NamespaceAll, 1*time.Second, negEnabled, backendConfigEnabled)
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              negEnabled,
+		BackendConfigEnabled:    backendConfigEnabled,
+		Namespace:               apiv1.NamespaceAll,
+		ResyncPeriod:            1 * time.Second,
+		DefaultBackendSvcPortID: defaultBackend,
+	}
+	ctx := context.NewControllerContext(client, backendConfigClient, nil, ctxConfig)
 	gce := &Translator{
 		namer: namer,
 		ctx:   ctx,

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -26,6 +26,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -37,9 +38,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+var (
+	defaultBackend = utils.ServicePortID{Service: types.NamespacedName{Name: "default-http-backend", Namespace: "kube-system"}, Port: intstr.FromString("http")}
+)
+
 func newTestController(kubeClient kubernetes.Interface) *Controller {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, apiv1.NamespaceAll, 1*time.Second, true, false)
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              true,
+		BackendConfigEnabled:    false,
+		Namespace:               apiv1.NamespaceAll,
+		ResyncPeriod:            1 * time.Second,
+		DefaultBackendSvcPortID: defaultBackend,
+	}
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, ctxConfig)
 	controller := NewController(
 		NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network"),
 		context,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -37,7 +37,14 @@ const (
 
 func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, apiv1.NamespaceAll, 1*time.Second, true, false)
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              true,
+		BackendConfigEnabled:    false,
+		Namespace:               apiv1.NamespaceAll,
+		ResyncPeriod:            1 * time.Second,
+		DefaultBackendSvcPortID: defaultBackend,
+	}
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, ctxConfig)
 	manager := newSyncerManager(
 		utils.NewNamer(CluseterID, ""),
 		record.NewFakeRecorder(100),

--- a/pkg/neg/syncer_test.go
+++ b/pkg/neg/syncer_test.go
@@ -25,7 +25,14 @@ const (
 func NewTestSyncer() *syncer {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
-	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, apiv1.NamespaceAll, 1*time.Second, true, false)
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              true,
+		BackendConfigEnabled:    false,
+		Namespace:               apiv1.NamespaceAll,
+		ResyncPeriod:            1 * time.Second,
+		DefaultBackendSvcPortID: defaultBackend,
+	}
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, ctxConfig)
 	svcPort := servicePort{
 		namespace:  testServiceNamespace,
 		name:       testServiceName,


### PR DESCRIPTION
 This PR is one of many that aim to eliminate the need for ClusterManager. In this PR, I introduce ControllerContextConfig which simply encapsulates the values for some command line flags, most notably the default backend service port ID. This eliminates the need for ClusterManager to keep track of it.

/assign @nicksardo 