### PR TITLE
Introduce a new interface to encapsulate Ingress sync and controller implementation of the sync

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -201,7 +201,7 @@ func TestEnsureMCIngress(t *testing.T) {
 	addIngress(lbc, ing)
 
 	ingStoreKey := getKey(ing, t)
-	if err := lbc.ensureIngress(ing, []string{"node-a", "node-b"}); err != nil {
+	if err := lbc.sync(ingStoreKey); err != nil {
 		t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
 	}
 

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -1,0 +1,36 @@
+package sync
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+// Syncer is an interface to sync GCP resources associated with an Ingress.
+type Syncer interface {
+	// Sync creates a full GCLB given an Ingress.
+	Sync(ing *extensions.Ingress) error
+	// GC cleans up GCLB resources for all Ingresses and can optionally
+	// use some arbitrary state to help with the process.
+	GC(state interface{}) error
+}
+
+// Controller is an interface for ingress controllers and declares methods
+// on how to sync the various portions of the GCLB for an Ingress.
+type Controller interface {
+	// PreProcess allows for doing some pre-processing on an Ingress before
+	// it is synced. Some arbitrary state can also be returned.
+	PreProcess(ing *extensions.Ingress) (interface{}, error)
+	// SyncBackends syncs the backends for a GCLB given an ingress or some
+	// existing state.
+	SyncBackends(ing *extensions.Ingress, state interface{}) error
+	// GCBackends garbage collects backends for all Ingresses.
+	GCBackends(state interface{}) error
+	// SyncLoadBalancer syncs the front-end load balancer resources for a GCLB given
+	// an ingress or some existing state.
+	SyncLoadBalancer(ing *extensions.Ingress, state interface{}) error
+	// GCLoadBalancers garbage collects front-end load balancer resources
+	// for all Ingresses.
+	GCLoadBalancers(state interface{}) error
+	// PostProcess allows for doing some post-processing on an Ingress before
+	// the overall sync is complete.
+	PostProcess(ing *extensions.Ingress) error
+}

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -9,7 +9,9 @@ type Syncer interface {
 	// Sync creates a full GCLB given an Ingress.
 	Sync(ing *extensions.Ingress) error
 	// GC cleans up GCLB resources for all Ingresses and can optionally
-	// use some arbitrary state to help with the process.
+	// use some arbitrary to help with the process.
+	// TODO(rramkumar): Do we need to rethink the strategy of GC'ing
+	// all Ingresses at once?
 	GC(state interface{}) error
 }
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1,0 +1,47 @@
+package sync
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+// IngressSyncer processes an Ingress spec and produces a load balancer given
+// an implementation of Controller.
+type IngressSyncer struct {
+	controller Controller
+}
+
+func NewIngressSyncer(controller Controller) Syncer {
+	return &IngressSyncer{controller}
+}
+
+// Implements Syncer
+func (s *IngressSyncer) Sync(ing *extensions.Ingress) error {
+	state, err := s.controller.PreProcess(ing)
+	if err != nil {
+		return err
+	}
+
+	if err := s.controller.SyncBackends(ing, state); err != nil {
+		return err
+	}
+
+	if err := s.controller.SyncLoadBalancer(ing, state); err != nil {
+		return err
+	}
+
+	if err := s.controller.PostProcess(ing); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Implements Syncer
+func (s *IngressSyncer) GC(state interface{}) error {
+	if err := s.controller.GCBackends(state); err != nil {
+		return err
+	}
+	if err := s.controller.GCLoadBalancers(state); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces one high level sync interface and an interface for controllers to implement the sync. 
The benefit of this PR is that it enforces a simple contract for controllers to follow and makes creating controller mocks much easier. For example, the existing controller in pkg/controller/controller.go would be modified to implement the Controller interface. 

Note that this PR works at a layer above #424. A controller would potentially implement SyncBackends using the new interfaces defined in pkg/backends.

Also note that this abstraction will make it easier to parallelize syncs although the current implementation would need to be rewired a bit.

The second commit attempts to use the new interfaces in pkg/controller the way the code is currently structured.

/assign @bowei 