### PR TITLE
Fix null-pointer exception in url map ensure logic

### DIFF
--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -63,7 +63,7 @@ func (l *L7) ensureComputeURLMap() error {
 		return nil
 	}
 
-	glog.V(3).Infof("Updating URLMap: %q", l.um.Name)
+	glog.V(3).Infof("Updating URLMap for %q", l.Name)
 	expectedMap.Fingerprint = currentMap.Fingerprint
 	if err := l.cloud.UpdateUrlMap(expectedMap); err != nil {
 		return fmt.Errorf("UpdateURLMap: %v", err)


### PR DESCRIPTION
The previous code could potentially have a NPE if l.um = nil.  Modified the code to use the Name field of the L7 struct instead, which we know will always be non-nil.

Example error log:

```I0814 11:19:06.891594       1 l7s.go:66] Creating l7 e2e-tests-ingress-ckx44-hostname--bd7d411a662def7f
E0814 11:19:07.199597       1 runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/asm_amd64.s:573
/usr/local/go/src/runtime/panic.go:502
/usr/local/go/src/runtime/panic.go:63
/usr/local/go/src/runtime/signal_unix.go:388
/go/src/k8s.io/ingress-gce/pkg/loadbalancers/url_maps.go:66
/go/src/k8s.io/ingress-gce/pkg/loadbalancers/l7.go:122
/go/src/k8s.io/ingress-gce/pkg/loadbalancers/l7s.go:88
/go/src/k8s.io/ingress-gce/pkg/controller/controller.go:370
/go/src/k8s.io/ingress-gce/pkg/controller/controller.go:297
/go/src/k8s.io/ingress-gce/pkg/controller/controller.go:115
/go/src/k8s.io/ingress-gce/pkg/utils/taskqueue.go:90
/go/src/k8s.io/ingress-gce/pkg/utils/taskqueue.go:58
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/k8s.io/ingress-gce/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/go/src/k8s.io/ingress-gce/pkg/utils/taskqueue.go:58
/usr/local/go/src/runtime/asm_amd64.s:2361
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1693311]
```

/assign @MrHohn 