### PR TITLE
BackendPool Update() should set backend service version

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -108,6 +108,8 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 
 // Update implements Pool.
 func (b *Backends) Update(be *composite.BackendService) error {
+	// Ensure the backend service has the proper version before updating.
+	be.Version = features.VersionFromDescription(be.Description)
 	if err := composite.UpdateBackendService(be, b.cloud); err != nil {
 		return err
 	}

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -105,8 +105,7 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 			return err
 		}
 	}
-	// Set composite backend service to the version required by current service port.
-	be.Version = version
+
 	needUpdate := ensureProtocol(be, sp)
 	needUpdate = ensureHealthCheckLink(be, hcLink) || needUpdate
 	needUpdate = ensureDescription(be, &sp) || needUpdate


### PR DESCRIPTION
Makes it easier to not make a mistake of forgetting to set version when calling Update(). All logic is now encapsulated in Update() implementation itself.

/assign @bowei 