### PR TITLE
Cherrypick #442 into release-1.3

### DIFF
--- a/pkg/apis/backendconfig/v1beta1/types.go
+++ b/pkg/apis/backendconfig/v1beta1/types.go
@@ -24,13 +24,12 @@ import (
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// BackendConfig is a specification for a BackendConfig resource
 // +k8s:openapi-gen=true
 type BackendConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BackendConfigSpec   `json:"spec"`
+	Spec   BackendConfigSpec   `json:"spec,omitempty"`
 	Status BackendConfigStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/backendconfig/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/backendconfig/v1beta1/zz_generated.openapi.go
@@ -32,7 +32,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.BackendConfig": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "BackendConfig is a specification for a BackendConfig resource",
 					Properties: map[string]spec.Schema{
 						"kind": {
 							SchemaProps: spec.SchemaProps{
@@ -64,7 +63,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"spec"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
Cherrypicking https://github.com/kubernetes/ingress-gce/pull/442 so it can make the next patch release.