### PR TITLE
Slight refactor of Controller interface to eliminate Ingress type specifically

### DIFF
--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"k8s.io/ingress-gce/pkg/utils"
+
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+// gcState is used by the controller to maintain state for garbage collection routines.
+type gcState struct {
+	lbNames  []string
+	svcPorts []utils.ServicePort
+}
+
+// syncState is used by the controller to maintain state for routines that sync GCP resources of an Ingress.
+type syncState struct {
+	urlMap *utils.GCEURLMap
+	ing    *extensions.Ingress
+}

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -1,13 +1,25 @@
-package sync
+/*
+Copyright 2018 The Kubernetes Authors.
 
-import (
-	extensions "k8s.io/api/extensions/v1beta1"
-)
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
 
 // Syncer is an interface to sync GCP resources associated with an Ingress.
 type Syncer interface {
-	// Sync creates a full GCLB given an Ingress.
-	Sync(ing *extensions.Ingress) error
+	// Sync creates a full GCLB given some state related to an Ingress.
+	Sync(state interface{}) error
 	// GC cleans up GCLB resources for all Ingresses and can optionally
 	// use some arbitrary to help with the process.
 	// TODO(rramkumar): Do we need to rethink the strategy of GC'ing
@@ -18,21 +30,14 @@ type Syncer interface {
 // Controller is an interface for ingress controllers and declares methods
 // on how to sync the various portions of the GCLB for an Ingress.
 type Controller interface {
-	// PreProcess allows for doing some pre-processing on an Ingress before
-	// it is synced. Some arbitrary state can also be returned.
-	PreProcess(ing *extensions.Ingress) (interface{}, error)
-	// SyncBackends syncs the backends for a GCLB given an ingress or some
-	// existing state.
-	SyncBackends(ing *extensions.Ingress, state interface{}) error
-	// GCBackends garbage collects backends for all Ingresses.
+	// SyncBackends syncs the backends for a GCLB given some existing state.
+	SyncBackends(state interface{}) error
+	// GCBackends garbage collects backends for all Ingresses given some existing state.
 	GCBackends(state interface{}) error
-	// SyncLoadBalancer syncs the front-end load balancer resources for a GCLB given
-	// an ingress or some existing state.
-	SyncLoadBalancer(ing *extensions.Ingress, state interface{}) error
-	// GCLoadBalancers garbage collects front-end load balancer resources
-	// for all Ingresses.
+	// SyncLoadBalancer syncs the front-end load balancer resources for a GCLB given some existing state.
+	SyncLoadBalancer(state interface{}) error
+	// GCLoadBalancers garbage collects front-end load balancer resources for all Ingresses given some existing state.
 	GCLoadBalancers(state interface{}) error
-	// PostProcess allows for doing some post-processing on an Ingress before
-	// the overall sync is complete.
-	PostProcess(ing *extensions.Ingress) error
+	// PostProcess allows for doing some post-processing after an Ingress is synced to a GCLB.
+	PostProcess(state interface{}) error
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1,10 +1,24 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sync
 
 import (
 	"errors"
 	"fmt"
-
-	extensions "k8s.io/api/extensions/v1beta1"
 )
 
 // ErrSkipBackendsSync is an error that can be returned by a Controller to
@@ -23,26 +37,22 @@ func NewIngressSyncer(controller Controller) Syncer {
 }
 
 // Sync implements Syncer.
-func (s *IngressSyncer) Sync(ing *extensions.Ingress) error {
-	state, err := s.controller.PreProcess(ing)
-	if err != nil {
-		return fmt.Errorf("Error running pre-process routine: %v", err)
-	}
-
-	if err := s.controller.SyncBackends(ing, state); err != nil {
+func (s *IngressSyncer) Sync(state interface{}) error {
+	if err := s.controller.SyncBackends(state); err != nil {
 		if err == ErrSkipBackendsSync {
 			return nil
 		}
 		return fmt.Errorf("Error running backend syncing routine: %v", err)
 	}
 
-	if err := s.controller.SyncLoadBalancer(ing, state); err != nil {
+	if err := s.controller.SyncLoadBalancer(state); err != nil {
 		return fmt.Errorf("Error running load balancer syncing routine: %v", err)
 	}
 
-	if err := s.controller.PostProcess(ing); err != nil {
+	if err := s.controller.PostProcess(state); err != nil {
 		return fmt.Errorf("Error running post-process routine: %v", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR tries to eliminate the Ingress type from being referenced in the Controller and Syncer interfaces in pkg/sync. This ensures that implementations of the Controller interface can use any Ingress implementation.

/assign @bowei 