### PR TITLE
Do not truncate tls certs based on target proxy limit

### DIFF
--- a/pkg/loadbalancers/certificates.go
+++ b/pkg/loadbalancers/certificates.go
@@ -99,12 +99,6 @@ func (l *L7) usePreSharedCert() (bool, error) {
 		return false, nil
 	}
 	preSharedCerts := strings.Split(preSharedCertName, ",")
-	if len(preSharedCerts) > TargetProxyCertLimit {
-		glog.Warningf("Specified %d preshared certs, limit is %d, rest will be ignored",
-			len(preSharedCerts), TargetProxyCertLimit)
-		preSharedCerts = preSharedCerts[:TargetProxyCertLimit]
-	}
-
 	l.sslCerts = make([]*compute.SslCertificate, 0, len(preSharedCerts))
 	var failedCerts []string
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -58,11 +58,6 @@ func (t *TLSCertsFromSecretsLoader) Load(ing *extensions.Ingress) ([]*loadbalanc
 	}
 	var certs []*loadbalancers.TLSCerts
 
-	if len(ing.Spec.TLS) > loadbalancers.TargetProxyCertLimit {
-		glog.Warningf("Specified %d tls secrets, limit is %d, rest will be ignored",
-			len(ing.Spec.TLS), loadbalancers.TargetProxyCertLimit)
-	}
-
 	for _, tlsSecret := range ing.Spec.TLS {
 		// TODO: Replace this for a secret watcher.
 		glog.V(3).Infof("Retrieving secret for ing %v with name %v", ing.Name, tlsSecret.SecretName)
@@ -84,9 +79,6 @@ func (t *TLSCertsFromSecretsLoader) Load(ing *extensions.Ingress) ([]*loadbalanc
 			return nil, err
 		}
 		certs = append(certs, newCert)
-		if len(certs) == loadbalancers.TargetProxyCertLimit {
-			break
-		}
 	}
 	return certs, nil
 }


### PR DESCRIPTION
Hardcoding limit means more changes in ingress when targetproxy limit is increased.