### PR TITLE
Refactor LoadBalancerPool to use cloud listing snapshotter

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -193,8 +193,8 @@ func (b *Backends) List() ([]interface{}, error) {
 		return nil, err
 	}
 	var ret []interface{}
-	for _, _ = range backends {
-		ret = append(ret, true)
+	for _, x := range backends {
+		ret = append(ret, x)
 	}
 	return ret, nil
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -64,7 +64,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
 	lbc.instancePool = instances.NewNodePool(instances.NewFakeInstanceGroups(sets.NewString(), namer), namer)
-	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(loadbalancers.NewFakeLoadBalancers(clusterUID, namer), namer)
+	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(loadbalancers.NewFakeLoadBalancers(clusterUID, namer), namer, false)
 	lbc.instancePool.Init(&instances.FakeZoneLister{Zones: []string{"zone-a"}})
 
 	lbc.hasSynced = func() bool { return true }

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/utils"
 
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -31,5 +32,6 @@ type gcState struct {
 // syncState is used by the controller to maintain state for routines that sync GCP resources of an Ingress.
 type syncState struct {
 	urlMap *utils.GCEURLMap
+	l7     *loadbalancers.L7
 	ing    *extensions.Ingress
 }

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -68,10 +68,12 @@ type LoadBalancers interface {
 
 // LoadBalancerPool is an interface to manage the cloud resources associated
 // with a gce loadbalancer.
+// TODO(rramkumar): Break up this interface into 2: Pool & Syncer.
 type LoadBalancerPool interface {
-	Get(name string) (*L7, error)
+	// Note: Get is currrently only used for testing.
+	Get(name string) bool
 	Delete(name string) error
-	Sync(ri *L7RuntimeInfo) error
+	Sync(ri *L7RuntimeInfo) (*L7, error)
 	GC(names []string) error
 	Shutdown() error
 }

--- a/pkg/utils/namer.go
+++ b/pkg/utils/namer.go
@@ -363,6 +363,16 @@ func (n *Namer) UrlMap(lbName string) string {
 	return truncate(fmt.Sprintf("%v-%v-%v", n.prefix, urlMapPrefix, lbName))
 }
 
+// ScrubUrlMapPrefix removes the "k8s-um" prefix from the UrlMap name.
+func (n *Namer) ScrubUrlMapPrefix(name string) string {
+	prefix := fmt.Sprintf("%s-%s-", n.prefix, urlMapPrefix)
+	parts := strings.Split(name, prefix)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
 // NamedPort returns the name for a named port.
 func (n *Namer) NamedPort(port int64) string {
 	return fmt.Sprintf("port%v", port)

--- a/pkg/utils/namer_test.go
+++ b/pkg/utils/namer_test.go
@@ -337,6 +337,33 @@ func TestNamerLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestNamerScrubUrlMapPrefix(t *testing.T) {
+	namer := NewNamer("uid1", "fw1")
+	cases := []struct {
+		urlMapName   string
+		scrubbedName string
+	}{
+		{
+			urlMapName:   "k8s-um-foo",
+			scrubbedName: "foo",
+		},
+		{
+			urlMapName:   "k8s-um-default-foo--clusterid",
+			scrubbedName: "default-foo--clusterid",
+		},
+		{
+			urlMapName: "k8s-default-foo--clusterid",
+		},
+	}
+
+	for _, tc := range cases {
+		res := namer.ScrubUrlMapPrefix(tc.urlMapName)
+		if res != tc.scrubbedName {
+			t.Fatalf("namer.ScrubUrlMapPrefix() = %s, want %s", res, tc.scrubbedName)
+		}
+	}
+}
+
 // Ensure that a valid cert name is created if clusterName is empty.
 func TestNamerSSLCertName(t *testing.T) {
 	secretHash := fmt.Sprintf("%x", sha256.Sum256([]byte("test123")))[:16]


### PR DESCRIPTION
Currently the L7 pool uses an in memory snapshotter. This is problematic because if the controller crashes, the in memory state is lost and load balancer resources could potentially become orphaned. 

This PR refactors the L7 pool to use the cloud listing snapshotter (similar to pkg/backends). By using the cloud lister, we can fetch all LB names from GCP and perform our GC against those names.

/assign @bowei 