### PR TITLE
Support short names in CRD Meta. Allows for abbreviating CRD's in kubectl

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -102,10 +102,11 @@ func crd(meta *CRDMeta) *apiextensionsv1beta1.CustomResourceDefinition {
 			Version: meta.version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Kind:     meta.kind,
-				ListKind: meta.listKind,
-				Plural:   meta.plural,
-				Singular: meta.singular,
+				Kind:       meta.kind,
+				ListKind:   meta.listKind,
+				Plural:     meta.plural,
+				Singular:   meta.singular,
+				ShortNames: meta.shortNames,
 			},
 		},
 	}

--- a/pkg/crd/meta.go
+++ b/pkg/crd/meta.go
@@ -28,20 +28,22 @@ type CRDMeta struct {
 	listKind   string
 	singular   string
 	plural     string
+	shortNames []string
 	typeSource string
 	fn         common.GetOpenAPIDefinitions
 }
 
 // NewCRDMeta creates a CRDMeta type which can be passed to a CRDHandler in
 // order to create/ensure a CRD.
-func NewCRDMeta(groupName, version, kind, listKind, singular, plural string) *CRDMeta {
+func NewCRDMeta(groupName, version, kind, listKind, singular, plural string, shortNames ...string) *CRDMeta {
 	return &CRDMeta{
-		groupName: groupName,
-		version:   version,
-		kind:      kind,
-		listKind:  listKind,
-		singular:  singular,
-		plural:    plural,
+		groupName:  groupName,
+		version:    version,
+		kind:       kind,
+		listKind:   listKind,
+		singular:   singular,
+		plural:     plural,
+		shortNames: shortNames,
 	}
 }
 


### PR DESCRIPTION
For example, "kubectl get backendconfig" could be "kubectl get bcfg"

/assign @MrHohn 