### PR TITLE
Revert "Refactor some uses of snapshotter.Add() to use bool rather than real object"

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -99,7 +99,7 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 	if err := composite.CreateBackendService(be, b.cloud); err != nil {
 		return nil, err
 	}
-	b.snapshotter.Add(name, true)
+	b.snapshotter.Add(name, be)
 	// Note: We need to perform a GCE call to re-fetch the object we just created
 	// so that the "Fingerprint" field is filled in. This is needed to update the
 	// object without error.
@@ -113,7 +113,7 @@ func (b *Backends) Update(be *composite.BackendService) error {
 	if err := composite.UpdateBackendService(be, b.cloud); err != nil {
 		return err
 	}
-	b.snapshotter.Add(be.Name, true)
+	b.snapshotter.Add(be.Name, be)
 	return nil
 }
 
@@ -133,7 +133,7 @@ func (b *Backends) Get(name string, version meta.Version) (*composite.BackendSer
 			return nil, err
 		}
 	}
-	b.snapshotter.Add(name, true)
+	b.snapshotter.Add(name, be)
 	return be, nil
 }
 
@@ -193,8 +193,8 @@ func (b *Backends) List() ([]interface{}, error) {
 		return nil, err
 	}
 	var ret []interface{}
-	for _, _ = range backends {
-		ret = append(ret, true)
+	for _, x := range backends {
+		ret = append(ret, x)
 	}
 	return ret, nil
 }

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -71,7 +71,7 @@ func (i *Instances) EnsureInstanceGroupsAndPorts(name string, ports []int64) (ig
 		return nil, err
 	}
 
-	defer i.snapshotter.Add(name, true)
+	defer i.snapshotter.Add(name, struct{}{})
 	for _, zone := range zones {
 		ig, err := i.ensureInstanceGroupAndPorts(name, zone, ports)
 		if err != nil {
@@ -200,7 +200,7 @@ func (i *Instances) Get(name, zone string) (*compute.InstanceGroup, error) {
 	if err != nil {
 		return nil, err
 	}
-	i.snapshotter.Add(name, true)
+	i.snapshotter.Add(name, struct{}{})
 	return ig, nil
 }
 


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#458

This is causing e2e tests to fail because it depends on #460. Will submit this later.

/assign @MrHohn 