### PR TITLE
Replace kubernetes-users mailing list link with discuss forum link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,6 @@ Whether you are a user or contributor, official support channels include:
 
 - GitHub issues: https://github.com/kubernetes/ingress/issues/new
 - Slack: kubernetes-users room in the [Kubernetes Slack](http://slack.kubernetes.io/)
-- Email: [kubernetes-users](https://groups.google.com/forum/#!forum/kubernetes-users) mailing list
+- Post: [Kubernetes Forum](https://discuss.kubernetes.io)
 
 Before opening a new issue or submitting a new pull request, it's helpful to search the project - it's likely that another user has already reported the issue you're facing, or it's a known issue that we're already aware of.


### PR DESCRIPTION
This PR updates the link that currently point to the [Google Groups Kubernetes Mailing List](https://groups.google.com/forum/#!forum/kubernetes-users) to the new [discuss.kubernetes.io](https://discuss.kubernetes.io) forum. 

The mailing list has been archived and set to read only. For more information on this, see issue https://github.com/kubernetes/community/issues/2492

/cc @castrojo 
