### PR TITLE
Bump Alpine base image version

### DIFF
--- a/Dockerfile.fuzzer
+++ b/Dockerfile.fuzzer
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile.glbc
+++ b/Dockerfile.glbc
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Alpine fixed a RCE vulnerability in apk in 3.8.1 (https://alpinelinux.org/posts/Alpine-3.8.1-released.html)
Update the base image used for ingress-gce.