### PR TITLE
Use HTTPS readiness probe for HTTP2 services because the Kubernetes A…

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -245,7 +245,7 @@ func (t *Translator) getHTTPProbe(svc api_v1.Service, targetPort intstr.IntOrStr
 		}
 		logStr := fmt.Sprintf("Pod %v matching service selectors %v (targetport %+v)", pod.Name, l, targetPort)
 		for _, c := range pod.Spec.Containers {
-			if !isSimpleHTTPProbe(c.ReadinessProbe) || string(getProbeScheme(protocol)) != string(c.ReadinessProbe.HTTPGet.Scheme) {
+			if !isSimpleHTTPProbe(c.ReadinessProbe) || getProbeScheme(protocol) != c.ReadinessProbe.HTTPGet.Scheme {
 				continue
 			}
 

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -245,7 +245,7 @@ func (t *Translator) getHTTPProbe(svc api_v1.Service, targetPort intstr.IntOrStr
 		}
 		logStr := fmt.Sprintf("Pod %v matching service selectors %v (targetport %+v)", pod.Name, l, targetPort)
 		for _, c := range pod.Spec.Containers {
-			if !isSimpleHTTPProbe(c.ReadinessProbe) || string(protocol) != string(c.ReadinessProbe.HTTPGet.Scheme) {
+			if !isSimpleHTTPProbe(c.ReadinessProbe) || string(getProbeScheme(protocol)) != string(c.ReadinessProbe.HTTPGet.Scheme) {
 				continue
 			}
 
@@ -303,6 +303,15 @@ func isSimpleHTTPProbe(probe *api_v1.Probe) bool {
 	return (probe != nil && probe.Handler.HTTPGet != nil && probe.Handler.HTTPGet.Host == "" &&
 		(len(probe.Handler.HTTPGet.HTTPHeaders) == 0 ||
 			(len(probe.Handler.HTTPGet.HTTPHeaders) == 1 && probe.Handler.HTTPGet.HTTPHeaders[0].Name == "Host")))
+}
+
+// getProbeScheme returns the Kubernetes API URL scheme corresponding to the
+// protocol.
+func getProbeScheme(protocol annotations.AppProtocol) api_v1.URIScheme {
+	if protocol == annotations.ProtocolHTTP2 {
+		return api_v1.URISchemeHTTPS
+	}
+	return api_v1.URIScheme(string(protocol))
 }
 
 // GetProbe returns a probe that's used for the given nodeport

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -325,6 +325,7 @@ func TestGetProbe(t *testing.T) {
 	nodePortToHealthCheck := map[utils.ServicePort]string{
 		{NodePort: 3001, Protocol: annotations.ProtocolHTTP}:  "/healthz",
 		{NodePort: 3002, Protocol: annotations.ProtocolHTTPS}: "/foo",
+		{NodePort: 3003, Protocol: annotations.ProtocolHTTP2}: "/http2-check",
 	}
 	for _, svc := range makeServices(nodePortToHealthCheck, apiv1.NamespaceDefault) {
 		translator.ctx.ServiceInformer.GetIndexer().Add(svc)
@@ -441,7 +442,7 @@ func makePods(nodePortToHealthCheck map[utils.ServicePort]string, ns string) []*
 						ReadinessProbe: &apiv1.Probe{
 							Handler: apiv1.Handler{
 								HTTPGet: &apiv1.HTTPGetAction{
-									Scheme: apiv1.URIScheme(string(np.Protocol)),
+									Scheme: getProbeScheme(np.Protocol),
 									Path:   u,
 									Port: intstr.IntOrString{
 										Type:   intstr.Int,


### PR DESCRIPTION
…PI does not make a distinction between HTTPS and HTTP2 for probes.

Fixes #487 