### PR TITLE
Update defaultbackend image to 1.5

### DIFF
--- a/deploy/glbc/yaml/default-http-backend.yaml
+++ b/deploy/glbc/yaml/default-http-backend.yaml
@@ -23,7 +23,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.4
+        image: k8s.gcr.io/defaultbackend:1.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -192,7 +192,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: k8s.gcr.io/defaultbackend:1.5
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: kubeconfig

--- a/examples/deployment/gce-ingress-controller.yaml
+++ b/examples/deployment/gce-ingress-controller.yaml
@@ -43,7 +43,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: k8s.gcr.io/defaultbackend:1.5
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**What this PR does / why we need it**:

Update docker image for default backend service (render 404 page)

**Release note**:

```release-note
Update defaultbackend image to 1.5.
```

@bowei @timstclair 
