### PR TITLE
Add annotation to suppress XPN firewall events

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -70,6 +70,10 @@ const (
 	// manage ManagedCertificate resources, it is the user's responsibility to
 	// create/delete them.
 	ManagedCertificates = "gke.googleapis.com/managed-certificates"
+
+	// SuppressFirewallXPNErrorKey is the annotation key used by firewall
+	// controller whether to supress firewallXPNError.
+	SuppressFirewallXPNErrorKey = "networking.gke.io/suppress-firewall-xpn-error"
 )
 
 // Ingress represents ingress annotations.
@@ -127,4 +131,18 @@ func (ing *Ingress) ManagedCertificates() string {
 		return ""
 	}
 	return val
+}
+
+// SuppressFirewallXPNError returns the SuppressFirewallXPNErrorKey flag.
+// False by default.
+func (ing *Ingress) SuppressFirewallXPNError() bool {
+	val, ok := ing.v[SuppressFirewallXPNErrorKey]
+	if !ok {
+		return false
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return v
 }

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -170,6 +171,9 @@ func (fwc *FirewallController) sync(key string) error {
 		if fwErr, ok := err.(*FirewallXPNError); ok {
 			// XPN: Raise an event on each ingress
 			for _, ing := range gceIngresses.Items {
+				if annotations.FromIngress(&ing).SuppressFirewallXPNError() {
+					continue
+				}
 				fwc.ctx.Recorder(ing.Namespace).Eventf(&ing, apiv1.EventTypeNormal, "XPN", fwErr.Message)
 			}
 		} else {


### PR DESCRIPTION
Tested using debug output. 

```
I1002 00:52:00.732636       1 firewalls.go:129] Could not create L7 firewall on XPN cluster. Raising event for cmd: "gcloud compute firewall-rules create k8s-fw-l7--f55c729d54843f52 --network shared-net --description \"GCE L7 firewall rule\" --allow tcp:30000-32767 --source-ranges 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 --target-tags gke-xpn-test-5a5694fa-node --project yankaiz-xpn-host"
I1002 00:52:00.732948       1 controller.go:178] >>>>>>>>>>>>> Emitting event for FirewallXPNError <<<<<<<<<<<<<<<
I1002 00:52:00.733404       1 controller.go:149] Syncing firewall
I1002 00:52:00.734304       1 event.go:221] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"ing-web", UID:"ac329930-c5da-11e8-a4db-42010af0009b", APIVersion:"extensions/v1beta1", ResourceVersion:"18952", FieldPath:""}): type: 'Normal' reason: 'XPN' Firewall change required by network admin: `gcloud compute firewall-rules create k8s-fw-l7--f55c729d54843f52 --network shared-net --description "GCE L7 firewall rule" --allow tcp:30000-32767 --source-ranges 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 --target-tags gke-xpn-test-5a5694fa-node --project yankaiz-xpn-host`
I1002 00:52:00.998370       1 firewalls.go:97] Creating firewall rule "k8s-fw-l7--f55c729d54843f52"
I1002 00:52:01.127250       1 firewalls.go:129] Could not create L7 firewall on XPN cluster. Raising event for cmd: "gcloud compute firewall-rules create k8s-fw-l7--f55c729d54843f52 --network shared-net --description \"GCE L7 firewall rule\" --allow tcp:30000-32767 --source-ranges 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 --target-tags gke-xpn-test-5a5694fa-node --project yankaiz-xpn-host"
I1002 00:52:01.127283       1 controller.go:178] >>>>>>>>>>>>> Emitting event for FirewallXPNError <<<<<<<<<<<<<<<
I1002 00:52:01.127865       1 event.go:221] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"default", Name:"ing-web", UID:"ac329930-c5da-11e8-a4db-42010af0009b", APIVersion:"extensions/v1beta1", ResourceVersion:"18952", FieldPath:""}): type: 'Normal' reason: 'XPN' Firewall change required by network admin: `gcloud compute firewall-rules create k8s-fw-l7--f55c729d54843f52 --network shared-net --description "GCE L7 firewall rule" --allow tcp:30000-32767 --source-ranges 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 --target-tags gke-xpn-test-5a5694fa-node --project yankaiz-xpn-host`
I1002 00:52:02.445783       1 syncer.go:62] Sync: backend {ID:default/web/8080 NodePort:31247 Port:8080 Protocol:HTTP TargetPort:8080 NEGEnabled:false BackendConfig:<nil>}
...
I1002 00:58:44.936370       1 firewalls.go:97] Creating firewall rule "k8s-fw-l7--f55c729d54843f52"
I1002 00:58:44.957027       1 instances.go:136] Setting named ports us-central1-c on instance group k8s-ig--f55c729d54843f52/[31247]
I1002 00:58:45.123424       1 firewalls.go:129] Could not create L7 firewall on XPN cluster. Raising event for cmd: "gcloud compute firewall-rules create k8s-fw-l7--f55c729d54843f52 --network shared-net --description \"GCE L7 firewall rule\" --allow tcp:30000-32767 --source-ranges 130.211.0.0/22,209.85.152.0/22,209.85.204.0/22,35.191.0.0/16 --target-tags gke-xpn-test-5a5694fa-node --project yankaiz-xpn-host"
I1002 00:58:45.123455       1 controller.go:175] >>>>>>>>>>>> FirewallXPNError suppressed  <<<<<<<<<<<<<<<<<<<
```

/hold adding unit tests.
/assign @bowei 