### PR TITLE
WIP feat: https sslpolicy support

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -22,7 +22,13 @@ configured.
 `ingress.gcp.kubernetes.io/pre-shared-cert`  
 
 Instead of storing certificates and keys in Kubernetes secrets, you can upload them to GCP and
-reference them by name through this annotation.  
+reference them by name through this annotation.
+
+#### Use GCP SSL Policy
+`ingress.gcp.kubernetes.io/ssl-policy`
+
+Use a pre-existing SSL Policy by specifying the selfLink for the SSL Policy.
+`selfLink` can be found via: `gcloud beta compute ssl-policies --project $PROJECT describe $POLICY_NAME`.
 
 #### Specify Reserved GCP address  
 `kubernetes.io/ingress.global-static-ip-name`   

--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -48,6 +48,13 @@ const (
 	// to the target proxies of the Ingress.
 	PreSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
 
+	// SSLPolicyKey represents a URL for a pre-existing Google Cloud
+	// SSLPolicy. The controller *does not* manage the SSLPolicy, it is the
+	// user's responsibility to create/delete it.
+	// In GCP, the Ingress controller assigns the SSL Policy with this name
+	// to the target proxies of the ingress.
+	SSLPolicyKey = "ingress.gcp.kubernetes.io/ssl-policy"
+
 	// IngressClassKey picks a specific "class" for the Ingress. The controller
 	// only processes Ingresses with this annotation either unset, or set
 	// to either gceIngessClass or the empty string.
@@ -92,6 +99,15 @@ func (ing *Ingress) AllowHTTP() bool {
 // UseNamedTLS returns the name of the GCE SSL certificate. Empty by default.
 func (ing *Ingress) UseNamedTLS() string {
 	val, ok := ing.v[PreSharedCertKey]
+	if !ok {
+		return ""
+	}
+
+	return val
+}
+
+func (ing *Ingress) UseSSLPolicy() string {
+	val, ok := ing.v[SSLPolicyKey]
 	if !ok {
 		return ""
 	}

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -28,6 +28,7 @@ func TestIngress(t *testing.T) {
 		ing          *extensions.Ingress
 		allowHTTP    bool
 		useNamedTLS  string
+		useSSLPolicy string
 		staticIPName string
 		ingressClass string
 	}{
@@ -43,11 +44,13 @@ func TestIngress(t *testing.T) {
 						IngressClassKey:  "gce",
 						PreSharedCertKey: "shared-cert-key",
 						StaticIPNameKey:  "1.2.3.4",
+						SSLPolicyKey:     "https://google.com/sslpolicy/selflink",
 					},
 				},
 			},
 			allowHTTP:    false,
 			useNamedTLS:  "shared-cert-key",
+			useSSLPolicy: "https://google.com/sslpolicy/selflink",
 			staticIPName: "1.2.3.4",
 			ingressClass: "gce",
 		},
@@ -64,6 +67,9 @@ func TestIngress(t *testing.T) {
 		}
 		if x := ing.IngressClass(); x != tc.ingressClass {
 			t.Errorf("ingress %+v; IngressClass() = %v, want %v", tc.ing, x, tc.ingressClass)
+		}
+		if x := ing.UseSSLPolicy(); x != tc.useSSLPolicy {
+			t.Errorf("ingress %+v; UseSSLPolicy() = %v, want %v", tc.ing, x, tc.useSSLPolicy)
 		}
 	}
 }

--- a/pkg/loadbalancers/ssl_policies.go
+++ b/pkg/loadbalancers/ssl_policies.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+func (l *L7) checkSSLPolicy() error {
+	if l.runtimeInfo.SSLPolicy != "" {
+		l.sslPolicy = l.runtimeInfo.SSLPolicy
+	}
+	return nil
+}

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -79,6 +79,10 @@ func (l *L7) checkHttpsProxy() (err error) {
 			newProxy.SslCertificates = append(newProxy.SslCertificates, c.SelfLink)
 		}
 
+		if l.sslPolicy != "" {
+			newProxy.SslPolicy = l.sslPolicy
+		}
+
 		if err = l.cloud.CreateTargetHttpsProxy(newProxy); err != nil {
 			return err
 		}


### PR DESCRIPTION
I'm trying to add support for specifying an `SSLPolicy` via an annotation: `ingress.gcp.kubernetes.io/ssl-policy`.

Would love a bit of direction if possible, but this seemed like a pretty easy change. There just seem to be a lot of different places in the code to make changes and I'm guaranteed to be missing something.

Also any pointers/tips on automation you all have written so I can build an image and deploy it in my cluster. I'm assuming just basic go build for binaries.