### PR TITLE
Managed Certs integration: Fix code so that informers are not instantiated if managed certs is not enabled

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -122,6 +122,7 @@ func main() {
 	ctxConfig := ingctx.ControllerContextConfig{
 		NEGEnabled:                    enableNEG,
 		BackendConfigEnabled:          flags.F.EnableBackendConfig,
+		ManagedCertificateEnabled:     flags.F.Features.ManagedCertificates,
 		Namespace:                     flags.F.WatchNamespace,
 		ResyncPeriod:                  flags.F.ResyncPeriod,
 		DefaultBackendSvcPortID:       defaultBackendServicePortID,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -98,10 +98,16 @@ func NewLoadBalancerController(
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{
 		Interface: ctx.KubeClient.Core().Events(""),
 	})
+
 	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendHealthCheckPath, ctx.ClusterNamer, ctx.DefaultBackendSvcPortID.Service)
 	instancePool := instances.NewNodePool(ctx.Cloud, ctx.ClusterNamer)
 	backendPool := backends.NewPool(ctx.Cloud, ctx.ClusterNamer, true)
-	mcrtLister := mcrtv1alpha1.NewManagedCertificateLister(ctx.ManagedCertificateInformer.GetIndexer())
+
+	var mcrtLister mcrtv1alpha1.ManagedCertificateLister
+	if ctx.ManagedCertificateEnabled {
+		mcrtLister = mcrtv1alpha1.NewManagedCertificateLister(ctx.ManagedCertificateInformer.GetIndexer())
+	}
+
 	lbc := LoadBalancerController{
 		ctx:           ctx,
 		ingLister:     utils.StoreToIngressLister{Store: ctx.IngressInformer.GetStore()},


### PR DESCRIPTION
This should fix the current failures in the OSS CI:

Ref: https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-ingress-gce-e2e/3251