### PR TITLE
Add gke.io/suppress-firewall-xpn-error annotation to suppress XPN firewall events

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -70,6 +70,10 @@ const (
 	// manage ManagedCertificate resources, it is the user's responsibility to
 	// create/delete them.
 	ManagedCertificates = "gke.googleapis.com/managed-certificates"
+
+	// SuppressFirewallXPNErrorKey is the annotation key used by firewall
+	// controller whether to supress firewallXPNError.
+	SuppressFirewallXPNErrorKey = "networking.gke.io/suppress-firewall-xpn-error"
 )
 
 // Ingress represents ingress annotations.
@@ -127,4 +131,18 @@ func (ing *Ingress) ManagedCertificates() string {
 		return ""
 	}
 	return val
+}
+
+// SuppressFirewallXPNError returns the SuppressFirewallXPNErrorKey flag.
+// False by default.
+func (ing *Ingress) SuppressFirewallXPNError() bool {
+	val, ok := ing.v[SuppressFirewallXPNErrorKey]
+	if !ok {
+		return false
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return v
 }

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -170,6 +171,9 @@ func (fwc *FirewallController) sync(key string) error {
 		if fwErr, ok := err.(*FirewallXPNError); ok {
 			// XPN: Raise an event on each ingress
 			for _, ing := range gceIngresses.Items {
+				if annotations.FromIngress(&ing).SuppressFirewallXPNError() {
+					continue
+				}
 				fwc.ctx.Recorder(ing.Namespace).Eventf(&ing, apiv1.EventTypeNormal, "XPN", fwErr.Message)
 			}
 		} else {


### PR DESCRIPTION
Cherrypick https://github.com/kubernetes/ingress-gce/pull/506 into release-1.4

Add annotation to suppress XPN firewall events when failed to manipulate firewall due to XPN and permission error.