### PR TITLE
Transaction Syncer

### DIFF
--- a/pkg/neg/syncers/batch.go
+++ b/pkg/neg/syncers/batch.go
@@ -238,6 +238,7 @@ func (s *batchSyncer) ensureNetworkEndpointGroups() error {
 }
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map
+// TODO: migrate to use the util function instead
 func (s *batchSyncer) toZoneNetworkEndpointMap(endpoints *apiv1.Endpoints) (map[string]sets.String, error) {
 	zoneNetworkEndpointMap := map[string]sets.String{}
 	targetPort, _ := strconv.Atoi(s.TargetPort)
@@ -285,6 +286,7 @@ func (s *batchSyncer) toZoneNetworkEndpointMap(endpoints *apiv1.Endpoints) (map[
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map
+// TODO: migrate to use the util function instead
 func (s *batchSyncer) retrieveExistingZoneNetworkEndpointMap() (map[string]sets.String, error) {
 	zones, err := s.zoneGetter.ListZones()
 	if err != nil {

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -1,0 +1,406 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"sync"
+
+	"fmt"
+	"github.com/golang/glog"
+	"google.golang.org/api/compute/v0.beta"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+)
+
+type transactionSyncer struct {
+	// metadata
+	NegSyncerKey
+	negName string
+
+	// syncer provides syncer life cycle interfaces
+	syncer negtypes.NegSyncer
+
+	// syncLock ensures state transitions are thread safe
+	syncLock sync.Mutex
+	// needInit indicates if the NEG resources needed to be initialized.
+	// needInit will be set to true under 3 conditions:
+	// 1. transaction syncer is newly created
+	// 2. the syncInternal function returns any error
+	// 3. the operationInternal observed any error
+	needInit bool
+	// transactions stores each transaction
+	transactions transactionTable
+
+	serviceLister  cache.Indexer
+	endpointLister cache.Indexer
+	recorder       record.EventRecorder
+	cloud          negtypes.NetworkEndpointGroupCloud
+	zoneGetter     negtypes.ZoneGetter
+
+	// retry handles back off retry for NEG API operations
+	retry retryHandler
+}
+
+func NewTransactionSyncer(negSyncerKey NegSyncerKey, networkEndpointGroupName string, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, serviceLister cache.Indexer, endpointLister cache.Indexer) negtypes.NegSyncer {
+	syncer := newSyncer(negSyncerKey, networkEndpointGroupName, serviceLister, recorder)
+	ts := &transactionSyncer{
+		syncer:         syncer,
+		needInit:       true,
+		transactions:   NewTransactionTable(),
+		serviceLister:  serviceLister,
+		endpointLister: endpointLister,
+		recorder:       recorder,
+		cloud:          cloud,
+		zoneGetter:     zoneGetter,
+		retry:          NewDelayRetryHandler(func() { syncer.Sync() }, NewExponentialBackendOffHandler(maxRetries, minRetryDelay, maxRetryDelay)),
+	}
+	syncer.SetSyncFunc(ts.sync)
+	return syncer
+}
+
+func (s *transactionSyncer) sync() error {
+	err := s.syncInternal()
+	if err != nil {
+		s.syncLock.Lock()
+		s.needInit = true
+		s.syncLock.Unlock()
+	}
+	return err
+}
+
+func (s *transactionSyncer) syncInternal() error {
+	s.syncLock.Lock()
+	defer s.syncLock.Unlock()
+	if s.needInit {
+		if err := s.ensureNetworkEndpointGroups(); err != nil {
+			return err
+		}
+	}
+
+	if s.syncer.IsStopped() || s.syncer.IsShuttingDown() {
+		glog.V(4).Infof("Skip syncing NEG %q for %s.", s.negName, s.NegSyncerKey.String())
+		return nil
+	}
+	glog.V(2).Infof("Sync NEG %q for %s.", s.negName, s.NegSyncerKey.String())
+
+	ep, exists, err := s.endpointLister.Get(
+		&apiv1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      s.Name,
+				Namespace: s.Namespace,
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		glog.Warningf("Endpoint %s/%s does not exist. Skipping NEG sync", s.Namespace, s.Name)
+		return nil
+	}
+
+	targetMap, err := toZoneNetworkEndpointMap(ep.(*apiv1.Endpoints), s.zoneGetter, s.TargetPort)
+	if err != nil {
+		return err
+	}
+
+	currentMap, err := retrieveExistingZoneNetworkEndpointMap(s.negName, s.zoneGetter, s.cloud)
+	if err != nil {
+		return err
+	}
+
+	// Merge the current state from cloud with the transaction table together
+	// The combined state represents the eventual result when all transactions completed
+	mergeTransactionIntoZoneEndpointMap(currentMap, s.transactions)
+	// Find transaction entries that needs to be reconciled
+	reconcileTransactions(targetMap, s.transactions)
+	// Calculate the endpoints to add and delete to transform the current state to desire state
+	addEndpoints, removeEndpoints := calculateDifference(targetMap, currentMap)
+	// Filter out the endpoints with existing transaction
+	// This mostly happens when transaction entry require reconciliation but the transaction is still progress
+	// e.g. endpoint A is in the process of adding to NEG N, and the new desire state is not to have A in N.
+	// This ensures the endpoint that requires reconciliation to wait till the existing transaction to complete.
+	filterEndpointByTransaction(addEndpoints, s.transactions)
+	filterEndpointByTransaction(removeEndpoints, s.transactions)
+
+	if len(addEndpoints) == 0 && len(removeEndpoints) == 0 {
+		glog.V(4).Infof("No endpoint change for %s/%s, skip syncing NEG. ", s.Namespace, s.Name)
+		return nil
+	}
+
+	return s.syncNetworkEndpoints(addEndpoints, removeEndpoints)
+}
+
+// ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
+func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
+	var err error
+	zones, err := s.zoneGetter.ListZones()
+	if err != nil {
+		return err
+	}
+
+	var errList []error
+	for _, zone := range zones {
+		if err := ensureNetworkEndpointGroup(s.Namespace, s.Name, s.negName, zone, s.NegSyncerKey.String(), s.cloud, s.serviceLister, s.recorder); err != nil {
+			errList = append(errList, err)
+		}
+	}
+	return utilerrors.NewAggregate(errList)
+}
+
+// syncNetworkEndpoints spins off go routines to execute NEG operations
+func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints map[string]sets.String) error {
+	syncFunc := func(endpointMap map[string]sets.String, operation transactionOp) error {
+		for zone, endpointSet := range endpointMap {
+			if endpointSet.Len() == 0 {
+				glog.V(2).Infof("0 endpoint for %s operation for %s in NEG %s at %s. Skipping", attachOp, s.NegSyncerKey.String(), s.negName, zone)
+				continue
+			}
+
+			batch, err := makeEndpointBatch(endpointSet)
+			if err != nil {
+				return err
+			}
+
+			transEntry := transactionEntry{
+				Operation:     operation,
+				NeedReconcile: false,
+				Zone:          zone,
+			}
+
+			// Insert encodedEndpoint into transaction table
+			for encodedEndpoint := range batch {
+				s.transactions.Put(encodedEndpoint, transEntry)
+			}
+
+			if operation == attachOp {
+				s.attachNetworkEndpoints(zone, batch)
+			}
+			if operation == detachOp {
+				s.detachNetworkEndpoints(zone, batch)
+			}
+		}
+		return nil
+	}
+
+	if err := syncFunc(addEndpoints, attachOp); err != nil {
+		return err
+	}
+
+	if err := syncFunc(removeEndpoints, detachOp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// attachNetworkEndpoints creates go routine to run operations for attaching network endpoints
+func (s *transactionSyncer) attachNetworkEndpoints(zone string, networkEndpointMap map[string]*compute.NetworkEndpoint) {
+	glog.V(2).Infof("Attaching %d endpoint(s) for %s in NEG %s at %s.", len(networkEndpointMap), s.NegSyncerKey.String(), s.negName, zone)
+	go s.operationInternal(attachOp, zone, networkEndpointMap)
+}
+
+// detachNetworkEndpoints creates go routine to run operations for detaching network endpoints
+func (s *transactionSyncer) detachNetworkEndpoints(zone string, networkEndpointMap map[string]*compute.NetworkEndpoint) {
+	glog.V(2).Infof("Detaching %d endpoint(s) for %s in NEG %s at %s.", len(networkEndpointMap), s.NegSyncerKey.String(), s.negName, zone)
+	go s.operationInternal(detachOp, zone, networkEndpointMap)
+}
+
+// operationInternal executes NEG API call and commits the transactions
+// It will record events when operations are completed
+// If error occurs or any transaction entry requires reconciliation, it will trigger resync
+func (s *transactionSyncer) operationInternal(operation transactionOp, zone string, networkEndpointMap map[string]*compute.NetworkEndpoint) {
+	var err error
+	defer s.commitTransaction(err, networkEndpointMap)
+
+	networkEndpoints := []*compute.NetworkEndpoint{}
+	for _, ne := range networkEndpointMap {
+		networkEndpoints = append(networkEndpoints, ne)
+	}
+
+	if operation == attachOp {
+		err = s.cloud.AttachNetworkEndpoints(s.negName, zone, networkEndpoints)
+	}
+	if operation == detachOp {
+		err = s.cloud.DetachNetworkEndpoints(s.negName, zone, networkEndpoints)
+	}
+
+	if err == nil {
+		s.recordEvent(apiv1.EventTypeNormal, operation.String(), fmt.Sprintf("%s %d network endpoint(s) (NEG %q in zone %q)", operation.String(), len(networkEndpointMap), s.negName, zone))
+	} else {
+		s.recordEvent(apiv1.EventTypeWarning, operation.String()+"Failed", fmt.Sprintf("Failed to %s %d network endpoint(s) (NEG %q in zone %q): %v", operation.String(), len(networkEndpointMap), s.negName, zone, err))
+	}
+
+}
+
+func (s *transactionSyncer) recordEvent(eventType, reason, eventDesc string) {
+	if svc := getService(s.serviceLister, s.Namespace, s.Name); svc != nil {
+		s.recorder.Eventf(svc, eventType, reason, eventDesc)
+	}
+}
+
+// commitTransaction commits the transactions for the input endpoints.
+// It will trigger syncer retry in the following conditions:
+// 1. Any of the transaction committed needed to be reconciled
+// 2. Input error was not nil
+func (s *transactionSyncer) commitTransaction(err error, networkEndpointMap map[string]*compute.NetworkEndpoint) {
+	s.syncLock.Lock()
+	defer s.syncLock.Unlock()
+
+	// If error is not nil, trigger backoff retry
+	// If any transaction needs reconciliation, trigger resync.
+	// needRetry indicates if the transaction needs to backoff and retry
+	needRetry := false
+	// needSync indicates if the transaction needs to trigger resync immediately
+	needSync := false
+
+	if err != nil {
+		s.needInit = true
+		needRetry = true
+	}
+
+	for encodedEndpoint := range networkEndpointMap {
+		entry, ok := s.transactions.Get(encodedEndpoint)
+		if !ok {
+			glog.Errorf("Endpoint %q was not found in the transaction table.")
+			needSync = true
+			continue
+		}
+		if entry.NeedReconcile == true {
+			glog.Errorf("Endpoint %q in NEG %q need to be reconciled.", encodedEndpoint, s.NegSyncerKey.String())
+			needSync = true
+		}
+		s.transactions.Delete(encodedEndpoint)
+	}
+
+	if needSync {
+		s.syncer.Sync()
+		return
+	}
+
+	if needRetry {
+		if retryErr := s.retry.Retry(); retryErr != nil {
+			s.recordEvent(apiv1.EventTypeWarning, "RetryFailed", fmt.Sprintf("Failed to retry NEG sync for %q: %v", s.NegSyncerKey.String(), retryErr))
+		}
+		return
+	}
+
+	s.retry.Reset()
+}
+
+// filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table
+func filterEndpointByTransaction(endpointMap map[string]sets.String, table transactionTable) {
+	for _, endpointSet := range endpointMap {
+		for _, endpoint := range endpointSet.List() {
+			if entry, ok := table.Get(endpoint); ok {
+				glog.V(2).Infof("Endpoint %q is removed from the endpoint set as transaction %v still exists.", endpoint, entry)
+				endpointSet.Delete(endpoint)
+			}
+		}
+	}
+}
+
+// mergeTransactionIntoZoneEndpointMap merges the ongoing transaction into the endpointMap.
+// This converts the existing endpointMap to the state when all transactions completed
+func mergeTransactionIntoZoneEndpointMap(endpointMap map[string]sets.String, transactions transactionTable) {
+	for _, endpointKey := range transactions.Keys() {
+		entry, ok := transactions.Get(endpointKey)
+		// If called in syncInternal, as the transaction table
+		if !ok {
+			glog.V(2).Infof("Transaction entry of key %q was not found.", endpointKey)
+			continue
+		}
+		// Add endpoints in attach transaction
+		if entry.Operation == attachOp {
+			if _, ok := endpointMap[entry.Zone]; !ok {
+				endpointMap[entry.Zone] = sets.NewString()
+			}
+			endpointMap[entry.Zone].Insert(endpointKey)
+		}
+		// Remove endpoints in detach transaction
+		if entry.Operation == detachOp {
+			if _, ok := endpointMap[entry.Zone]; !ok {
+				continue
+			}
+			endpointMap[entry.Zone].Delete(endpointKey)
+		}
+	}
+	return
+}
+
+// reconcileTransactions compares the endpoint map with existing transaction entries in transaction table
+// if transaction does not cu
+func reconcileTransactions(endpointMap map[string]sets.String, transactions transactionTable) {
+	// Identify endpoints that should be in NEG but the current transaction does not match the intention
+	for zone, endpointSet := range endpointMap {
+		for _, endpointKey := range endpointSet.List() {
+			entry, ok := transactions.Get(endpointKey)
+			// if transaction does not contain endpoints, it will be handled in this sync
+			if !ok {
+				continue
+			}
+			needReconcile := false
+			// if zone does not match, need to reconcile
+			if entry.Zone != zone {
+				needReconcile = true
+			}
+			// if the endpoint entry is in detach transaction but shows up endpointMap
+			if entry.Operation == detachOp {
+				needReconcile = true
+			}
+
+			if needReconcile {
+				entry.NeedReconcile = true
+				transactions.Put(endpointKey, entry)
+			}
+		}
+	}
+
+	// Identify endpoints that should not to be in NEG but the current transaction does not match the intention
+	for _, endpointKey := range transactions.Keys() {
+		entry, ok := transactions.Get(endpointKey)
+		if !ok {
+			continue
+		}
+		needReconcile := false
+		if entry.Operation == attachOp {
+			endpointSet, ok := endpointMap[entry.Zone]
+			// If zone is not in endpointMap, then the endpoint must not exist in the endpointMap
+			if !ok {
+				needReconcile = true
+			}
+
+			// If the endpoint that is in attach transaction does not exists in the endpointMap,
+			// Then it means the endpoint needs to be reconciled after attach operation completes.
+			if !endpointSet.Has(endpointKey) {
+				needReconcile = true
+			}
+		}
+
+		if needReconcile {
+			entry.NeedReconcile = true
+			transactions.Put(endpointKey, entry)
+		}
+	}
+
+	return
+}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1,0 +1,611 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned/fake"
+	"k8s.io/ingress-gce/pkg/context"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	// test zone and instances in the zones
+	testZone1     = "zone1"
+	testInstance1 = "instance1"
+	testInstance2 = "instance2"
+	testZone2     = "zone2"
+	testInstance3 = "instance3"
+	testInstance4 = "instance4"
+	testNamespace = "ns"
+	testService   = "svc"
+)
+
+func TestReconcileTransactions(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		endpointMap map[string]sets.String
+		table       func() transactionTable
+		expect      func() transactionTable
+	}{
+		{
+			"empty inputs",
+			map[string]sets.String{},
+			func() transactionTable { return NewTransactionTable() },
+			func() transactionTable { return NewTransactionTable() },
+		},
+		{
+			"1 endpoint, empty transaction table",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 1, testInstance1, "8080")),
+			},
+			func() transactionTable { return NewTransactionTable() },
+			func() transactionTable { return NewTransactionTable() },
+		},
+		{
+			"10 endpoints, empty transaction table",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable { return NewTransactionTable() },
+			func() transactionTable { return NewTransactionTable() },
+		},
+		{
+			"10 endpoints and 5 attaching transactions are expected",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints and 10 attaching transactions are expected",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints, 5 attaching transactions are expected",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints, 5 attaching and 10 detaching transactions are expected",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
+				return table
+			},
+		},
+		{
+			"expect 10 endpoints, but unwanted endpoints are being attached",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints and 5 attaching transaction expected, 5 attaching transactions need reconcile",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints expected, 5 detaching transactions need reconcile",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"10 endpoints and 5 attaching transaction expected, 5 detaching transactions need reconcile",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"transaction entry has the wrong zone information",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				return table
+			},
+		},
+		{
+			"complex case 1: multiple zone and instances. No transaction",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				return table
+			},
+		},
+		{
+			"complex case 2: detaching transactions need reconciliation",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				return table
+			},
+		},
+		{
+			"complex case 2: both attaching and detaching transactions need reconciliation",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
+				return table
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				return table
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		copy := copyMap(tc.endpointMap)
+		table := tc.table()
+		reconcileTransactions(tc.endpointMap, table)
+
+		// Check if endpointMap was modified
+		if !reflect.DeepEqual(copy, tc.endpointMap) {
+			t.Errorf("For test case %q, does not expect endpointMap to change", tc.desc)
+		}
+
+		// Check if the existing entries are matching expected
+		expectTable := tc.expect()
+		for _, key := range table.Keys() {
+			expectEntry, ok := expectTable.Get(key)
+			if !ok {
+				t.Errorf("For test case %q, do not expect key %q to exists", tc.desc, key)
+				continue
+			}
+			gotEntry, _ := table.Get(key)
+			if !reflect.DeepEqual(expectEntry, gotEntry) {
+				t.Errorf("For test case %q, expectEntry of key %q to be %v, but got %v", tc.desc, key, expectEntry, gotEntry)
+			}
+		}
+
+		// Check if there are missing entries that expected to exist in output
+		for _, key := range expectTable.Keys() {
+			_, ok := table.Get(key)
+			if !ok {
+				t.Errorf("For test case %q, expect transaction key %q to exists, but got nil", tc.desc, key)
+				continue
+			}
+		}
+	}
+}
+
+func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		endpointMap       map[string]sets.String
+		table             func() transactionTable
+		expectEndpointMap map[string]sets.String
+	}{
+		{
+			"empty map and transactions",
+			map[string]sets.String{},
+			func() transactionTable { return NewTransactionTable() },
+			map[string]sets.String{},
+		},
+		{
+			"empty transactions",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable { return NewTransactionTable() },
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+		{
+			"empty map",
+			map[string]sets.String{},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: true,
+					Zone:          testZone2,
+				}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: true,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				return table
+			},
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+		{
+			"add existing endpoints",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: true,
+					Zone:          testZone2,
+				}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: true,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				return table
+			},
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+		{
+			"add non-existing endpoints",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: true,
+					Zone:          testZone2,
+				}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: true,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				return table
+			},
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
+			},
+		},
+		{
+			"remove existing endpoints",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				return table
+			},
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+		{
+			"add non-existing endpoints and remove existing endpoints",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: true,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				return table
+			},
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		mergeTransactionIntoZoneEndpointMap(tc.endpointMap, tc.table())
+		if !reflect.DeepEqual(tc.endpointMap, tc.expectEndpointMap) {
+			t.Errorf("For test case %q, expect endpoint map to be %+v, but got %+v", tc.desc, tc.expectEndpointMap, tc.endpointMap)
+		}
+	}
+}
+
+func TestFilterEndpointByTransaction(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		endpointMap       map[string]sets.String
+		table             func() transactionTable
+		expectEndpointMap map[string]sets.String
+	}{
+		{
+			"both emtpy",
+			map[string]sets.String{},
+			func() transactionTable { return NewTransactionTable() },
+			map[string]sets.String{},
+		},
+		{
+			"emtpy map",
+			map[string]sets.String{},
+			func() transactionTable {
+				table := NewTransactionTable()
+				generateTransaction(table, transactionEntry{
+					Operation:     detachOp,
+					NeedReconcile: false,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{
+					Operation:     attachOp,
+					NeedReconcile: true,
+					Zone:          testZone1,
+				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				return table
+			},
+			map[string]sets.String{},
+		},
+		{
+			"emtpy transaction",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable { return NewTransactionTable() },
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+		{
+			"emtpy transaction",
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+			func() transactionTable { return NewTransactionTable() },
+			map[string]sets.String{
+				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		input := tc.endpointMap
+		filterEndpointByTransaction(input, tc.table())
+		if !reflect.DeepEqual(tc.endpointMap, tc.expectEndpointMap) {
+			t.Errorf("For test case %q, expect endpoint map to be %+v, but got %+v", tc.desc, tc.expectEndpointMap, tc.endpointMap)
+		}
+	}
+}
+
+func NewTestTransactionSyncer() negtypes.NegSyncer {
+	kubeClient := fake.NewSimpleClientset()
+	backendConfigClient := backendconfigclient.NewSimpleClientset()
+	namer := utils.NewNamer(clusterID, "")
+	ctxConfig := context.ControllerContextConfig{
+		NEGEnabled:              true,
+		BackendConfigEnabled:    false,
+		Namespace:               apiv1.NamespaceAll,
+		ResyncPeriod:            1 * time.Second,
+		DefaultBackendSvcPortID: defaultBackend,
+	}
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, nil, namer, ctxConfig)
+	svcPort := NegSyncerKey{
+		Namespace:  testNamespace,
+		Name:       testService,
+		Port:       80,
+		TargetPort: "8080",
+	}
+
+	return NewTransactionSyncer(svcPort,
+		testNegName,
+		record.NewFakeRecorder(100),
+		negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-newtork"),
+		negtypes.NewFakeZoneGetter(),
+		context.ServiceInformer.GetIndexer(),
+		context.EndpointInformer.GetIndexer())
+}
+
+func copyMap(endpointMap map[string]sets.String) map[string]sets.String {
+	ret := map[string]sets.String{}
+	for k, v := range endpointMap {
+		ret[k] = sets.NewString(v.List()...)
+	}
+	return ret
+}
+
+func generateTransaction(table transactionTable, entry transactionEntry, initialIp net.IP, num int, instance string, targetPort string) {
+	endpointSet := generateEndpointSet(initialIp, num, instance, targetPort)
+	for _, encodedEndpoint := range endpointSet.List() {
+		table.Put(encodedEndpoint, entry)
+	}
+}
+
+func generateEndpointSet(initialIp net.IP, num int, instance string, targetPort string) sets.String {
+	ret := sets.NewString()
+	ip := initialIp.To4()
+	for i := 1; i <= num; i++ {
+		if i%256 == 0 {
+			ip[2]++
+		}
+		ip[3]++
+		ret.Insert(encodeEndpoint(ip.String(), instance, targetPort))
+	}
+	return ret
+}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -18,6 +18,7 @@ package syncers
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
-	"strconv"
 )
 
 const (

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -18,12 +18,12 @@ package syncers
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"google.golang.org/api/compute/v0.beta"
 	"k8s.io/apimachinery/pkg/util/sets"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
-	"strconv"
 )
 
 func TestEncodeDecodeEndpoint(t *testing.T) {

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -20,8 +20,10 @@ import (
 	"reflect"
 	"testing"
 
+	"google.golang.org/api/compute/v0.beta"
 	"k8s.io/apimachinery/pkg/util/sets"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"strconv"
 )
 
 func TestEncodeDecodeEndpoint(t *testing.T) {
@@ -156,4 +158,286 @@ func TestCalculateDifference(t *testing.T) {
 			t.Errorf("Failed to calculate difference for remove, expecting %v, but got %v", tc.removeSet, removeSet)
 		}
 	}
+}
+
+func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	testCases := []struct {
+		targetPort string
+		expect     map[string]sets.String
+	}{
+		// Non exist
+		{
+			targetPort: "8888",
+			expect:     map[string]sets.String{},
+		},
+		{
+			targetPort: "80",
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString("10.100.1.1||instance1||80", "10.100.1.2||instance1||80", "10.100.2.1||instance2||80"),
+				negtypes.TestZone2: sets.NewString("10.100.3.1||instance3||80"),
+			},
+		},
+		{
+			targetPort: testNamedPort,
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString("10.100.2.2||instance2||81"),
+				negtypes.TestZone2: sets.NewString("10.100.4.1||instance4||81", "10.100.3.2||instance3||8081", "10.100.4.2||instance4||8081"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		res, _ := toZoneNetworkEndpointMap(getDefaultEndpoint(), zoneGetter, tc.targetPort)
+
+		if !reflect.DeepEqual(res, tc.expect) {
+			t.Errorf("Expect %v, but got %v.", tc.expect, res)
+		}
+	}
+}
+
+func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	negCloud := negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-newtork")
+	negName := "test-neg-name"
+	irrelevantNegName := "irrelevant"
+	testIP1 := "1.2.3.4"
+	testIP2 := "1.2.3.5"
+	testIP3 := "1.2.3.6"
+	testIP4 := "1.2.3.7"
+	testPort := int64(80)
+
+	testCases := []struct {
+		desc      string
+		mutate    func(cloud negtypes.NetworkEndpointGroupCloud)
+		expect    map[string]sets.String
+		expectErr bool
+	}{
+		{
+			desc:      "neg not exists",
+			mutate:    func(cloud negtypes.NetworkEndpointGroupCloud) {},
+			expectErr: true,
+		},
+		{
+			desc: "neg only exists in one of the zone",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{Name: testNegName}, negtypes.TestZone1)
+			},
+			expectErr: true,
+		},
+		{
+			desc: "neg only exists in one of the zone plus irrelevant negs",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{Name: irrelevantNegName}, negtypes.TestZone2)
+			},
+			expectErr: true,
+		},
+		{
+			desc: "empty negs exists in both zones",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{Name: testNegName}, negtypes.TestZone2)
+			},
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString(),
+				negtypes.TestZone2: sets.NewString(),
+			},
+			expectErr: false,
+		},
+		{
+			desc: "one empty and one non-empty negs",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.AttachNetworkEndpoints(testNegName, negtypes.TestZone1, []*compute.NetworkEndpoint{
+					{
+						Instance:  negtypes.TestInstance1,
+						IpAddress: testIP1,
+						Port:      testPort,
+					},
+				})
+			},
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString(encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort)))),
+				negtypes.TestZone2: sets.NewString(),
+			},
+			expectErr: false,
+		},
+		{
+			desc: "one neg with multiple endpoints",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.AttachNetworkEndpoints(testNegName, negtypes.TestZone1, []*compute.NetworkEndpoint{
+					{
+						Instance:  negtypes.TestInstance2,
+						IpAddress: testIP2,
+						Port:      testPort,
+					},
+				})
+			},
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString(
+					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
+					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+				),
+				negtypes.TestZone2: sets.NewString(),
+			},
+			expectErr: false,
+		},
+		{
+			desc: "both negs with multiple endpoints",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.AttachNetworkEndpoints(testNegName, negtypes.TestZone2, []*compute.NetworkEndpoint{
+					{
+						Instance:  negtypes.TestInstance3,
+						IpAddress: testIP3,
+						Port:      testPort,
+					},
+					{
+						Instance:  negtypes.TestInstance4,
+						IpAddress: testIP4,
+						Port:      testPort,
+					},
+				})
+			},
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString(
+					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
+					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+				),
+				negtypes.TestZone2: sets.NewString(
+					encodeEndpoint(testIP3, negtypes.TestInstance3, strconv.Itoa(int(testPort))),
+					encodeEndpoint(testIP4, negtypes.TestInstance4, strconv.Itoa(int(testPort))),
+				),
+			},
+			expectErr: false,
+		},
+		{
+			desc: "irrelevant neg",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.AttachNetworkEndpoints(irrelevantNegName, negtypes.TestZone2, []*compute.NetworkEndpoint{
+					{
+						Instance:  negtypes.TestInstance3,
+						IpAddress: testIP4,
+						Port:      testPort,
+					},
+				})
+			},
+			expect: map[string]sets.String{
+				negtypes.TestZone1: sets.NewString(
+					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
+					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+				),
+				negtypes.TestZone2: sets.NewString(
+					encodeEndpoint(testIP3, negtypes.TestInstance3, strconv.Itoa(int(testPort))),
+					encodeEndpoint(testIP4, negtypes.TestInstance4, strconv.Itoa(int(testPort))),
+				),
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.mutate(negCloud)
+		out, err := retrieveExistingZoneNetworkEndpointMap(negName, zoneGetter, negCloud)
+
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("For test case %q, expecting error, but got nil", tc.desc)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("For test case %q, expect err = nil, but got %v", tc.desc, err)
+			}
+		}
+
+		if !tc.expectErr {
+			if !reflect.DeepEqual(out, tc.expect) {
+				t.Errorf("For test case %q, expect output = %+v, but got %+v", tc.desc, tc.expect, out)
+			}
+		}
+	}
+}
+
+func TestMakeEndpointBatch(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		endpointNum int
+		leftOverNum int
+	}{
+		{
+			"input with zero endpoints",
+			0,
+			0,
+		},
+		{
+			"input with 1 endpoints",
+			1,
+			0,
+		},
+		{
+			"input with 500 endpoints",
+			500,
+			0,
+		},
+		{
+			"input with 501 endpoints",
+			501,
+			1,
+		},
+		{
+			"input with 1000 endpoints",
+			1000,
+			500,
+		},
+	}
+
+	for _, tc := range testCases {
+		endpointSet, endpointMap := genTestEndpoints(tc.endpointNum)
+		out, err := makeEndpointBatch(endpointSet)
+
+		if err != nil {
+			t.Errorf("Expect err = nil, but got %v", err)
+		}
+
+		if endpointSet.Len() != tc.leftOverNum {
+			t.Errorf("Expect endpoint set has %d endpoints left, but got %d", tc.leftOverNum, endpointSet.Len())
+		}
+
+		expectOutputEndpoints := tc.endpointNum
+		if tc.endpointNum > MAX_NETWORK_ENDPOINTS_PER_BATCH {
+			expectOutputEndpoints = MAX_NETWORK_ENDPOINTS_PER_BATCH
+		}
+
+		if expectOutputEndpoints != len(out) {
+			t.Errorf("Expect %d endpoint(s) in output, but got %d", expectOutputEndpoints, len(out))
+		}
+
+		for key, endpoint := range out {
+			if endpointSet.Has(key) {
+				t.Errorf("Expect %q endpoint to exist in output endpoint map, but not", key)
+			}
+			expectEndpoint, ok := endpointMap[key]
+			if !ok {
+				t.Errorf("Expect %q endpoint to exist in expected endpoint map, but not", key)
+			} else {
+				if !reflect.DeepEqual(expectEndpoint, endpoint) {
+					t.Errorf("Expect endpoint object %+v, but got %+v", expectEndpoint, endpoint)
+				}
+			}
+		}
+	}
+}
+
+func genTestEndpoints(num int) (sets.String, map[string]*compute.NetworkEndpoint) {
+	endpointSet := sets.NewString()
+	endpointMap := map[string]*compute.NetworkEndpoint{}
+	ip := "1.2.3.4"
+	instance := "instance"
+	for port := 0; port < num; port++ {
+		key := encodeEndpoint(ip, instance, strconv.Itoa(port))
+		endpointSet.Insert(key)
+		endpointMap[key] = &compute.NetworkEndpoint{
+			IpAddress: ip,
+			Instance:  instance,
+			Port:      int64(port),
+		}
+	}
+	return endpointSet, endpointMap
 }


### PR DESCRIPTION
This PR introduces transaction NEG syncer. This syncer is non blocking. It will not wait for batches of NEG operation to finish before trigger more NEG operations. 

PR prerequistes:
#528
#509
#499

TODOs:
- add a flag to switch between batch syncer and transaction syncer
- add more unit test
- make this more readable