### PR TITLE
Connection Draining E2E: Fix test log message level

### DIFF
--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -137,7 +137,8 @@ func TestDraining(t *testing.T) {
 					return false, nil
 				}
 				if err := verifyConnectionDrainingTimeout(t, gclb, s.Namespace, "service-1", tc.transitionTo); err != nil {
-					t.Errorf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", tc.transitionTo, err)
+					t.Logf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", tc.transitionTo, err)
+					return false, nil
 				}
 				return true, nil
 			}); err != nil {


### PR DESCRIPTION
While polling for the connection draining transition, the test calls t.Errorf() instead of t.Logf(). This causes the test to fail rather than perform the poll-loop again, as intended.

/assign @bowei 