### PR TITLE
Increase deletion timeout for e2e tests

### DIFF
--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -35,7 +35,7 @@ const (
 	ingressPollTimeout  = 20 * time.Minute
 
 	gclbDeletionInterval = 30 * time.Second
-	gclbDeletionTimeout  = 10 * time.Minute
+	gclbDeletionTimeout  = 15 * time.Minute
 )
 
 // WaitForIngressOptions holds options dictating how we wait for an ingress to stabilize.


### PR DESCRIPTION
Hoping this will mitigate some of the errors we are seeing. We need to figure out a way to maybe increase/decrease the timeout based on the environment (e.g how many ingresses are being synced)

/assign @MrHohn 