### PR TITLE
do not use condition predicate while getting zone for node

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -196,7 +196,7 @@ func getZone(n *api_v1.Node) string {
 // GetZoneForNode returns the zone for a given node by looking up its zone label.
 func (t *Translator) GetZoneForNode(name string) (string, error) {
 	nodeLister := t.ctx.NodeInformer.GetIndexer()
-	nodes, err := listers.NewNodeLister(nodeLister).ListWithPredicate(utils.GetNodeConditionPredicate())
+	nodes, err := listers.NewNodeLister(nodeLister).List(labels.Everything())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is small part of fix for #50 (fixes this log messages https://github.com/kubernetes/ingress-gce/issues/50#issuecomment-335960715)

GetNodeConditionPredicate filtered nodes with conditions different from "Ready", and we're getting this messages when node is deleting from instance group.