### PR TITLE
standardize loadbalancer naming for GC

### DIFF
--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -99,7 +99,8 @@ func (l *L7s) List() ([]string, error) {
 	for _, um := range urlMaps {
 		if l.namer.NameBelongsToCluster(um.Name) {
 			nameParts := l.namer.ParseName(um.Name)
-			names = append(names, nameParts.LbName)
+			l7Name := l.namer.LoadBalancerFromLbName(nameParts.LbName)
+			names = append(names, l7Name)
 		}
 	}
 
@@ -108,11 +109,11 @@ func (l *L7s) List() ([]string, error) {
 
 // GC garbage collects loadbalancers not in the input list.
 func (l *L7s) GC(names []string) error {
-	glog.V(4).Infof("GC(%v)", names)
+	glog.V(2).Infof("GC(%v)", names)
 
 	knownLoadBalancers := sets.NewString()
 	for _, n := range names {
-		knownLoadBalancers.Insert(n)
+		knownLoadBalancers.Insert(l.namer.LoadBalancer(n))
 	}
 	pool, err := l.List()
 	if err != nil {

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -1243,7 +1243,7 @@ func TestList(t *testing.T) {
 		t.Fatalf("pool.List() = err %v", err)
 	}
 
-	expected := []string{"old-l7", "test"}
+	expected := []string{"old-l7--uid1", "test--uid1"}
 
 	if !reflect.DeepEqual(lbNames, expected) {
 		t.Fatalf("pool.List() returned %+v, want %+v", lbNames, expected)

--- a/pkg/utils/namer.go
+++ b/pkg/utils/namer.go
@@ -309,6 +309,12 @@ func (n *Namer) LoadBalancer(key string) string {
 	return truncate(fmt.Sprintf("%v%v%v", scrubbedName, clusterNameDelimiter, clusterName))
 }
 
+// LoadBalancerFromLbName reconstructs the full loadbalancer name, given the
+// lbName portion from NameComponents
+func (n *Namer) LoadBalancerFromLbName(lbName string) string {
+	return fmt.Sprintf("%v%v%v", lbName, clusterNameDelimiter, n.UID())
+}
+
 // TargetProxy returns the name for target proxy given the load
 // balancer name and the protocol.
 func (n *Namer) TargetProxy(lbName string, protocol NamerProtocol) string {


### PR DESCRIPTION
Addresses https://github.com/kubernetes/ingress-gce/issues/606

Fixes the Garbage Collection routine in l7s. GC takes in `names` as an argument, where `names` comes from the garbage collection state, which is a list of Ingress names which are formatted something like `something-a/something-b`. We derive the loadbalancer name from the `something-a` portion, by affixing the clusterid to it.