### PR TITLE
methods should use parts of l7 that they need, not whole l7 object

### DIFF
--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -71,16 +71,9 @@ func (l *L7s) Ensure(ri *L7RuntimeInfo) (*L7, error) {
 
 // Delete deletes a load balancer by name.
 func (l *L7s) Delete(name string) error {
-	lb := &L7{
-		runtimeInfo: &L7RuntimeInfo{Name: name},
-		Name:        l.namer.LoadBalancer(name),
-		cloud:       l.cloud,
-		namer:       l.namer,
-		mcrt:        l.mcrt,
-	}
-
-	glog.V(3).Infof("Deleting lb %v", lb.Name)
-	if err := lb.Cleanup(); err != nil {
+	lbName := l.namer.LoadBalancer(name)
+	glog.V(3).Infof("Deleting lb %v", lbName)
+	if err := Cleanup(lbName, l.cloud, l.namer); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -99,7 +99,7 @@ func (l *L7) checkHttpsProxy() (err error) {
 		}
 	}
 
-	if !l.compareCerts(proxy.SslCertificates) {
+	if !compareCerts(l.sslCerts, proxy.SslCertificates) {
 		glog.V(3).Infof("Https proxy %q has the wrong ssl certs, setting %v overwriting %v",
 			proxy.Name, toCertNames(l.sslCerts), proxy.SslCertificates)
 		var sslCertURLs []string
@@ -115,9 +115,9 @@ func (l *L7) checkHttpsProxy() (err error) {
 	return nil
 }
 
-func (l *L7) getSslCertLinkInUse() ([]string, error) {
-	proxyName := l.namer.TargetProxy(l.Name, utils.HTTPSProtocol)
-	proxy, err := l.cloud.GetTargetHttpsProxy(proxyName)
+func getSslCertLinkInUse(name string, cloud LoadBalancers, namer *utils.Namer) ([]string, error) {
+	proxyName := namer.TargetProxy(name, utils.HTTPSProtocol)
+	proxy, err := cloud.GetTargetHttpsProxy(proxyName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow-up to comment on https://github.com/kubernetes/ingress-gce/pull/590

Change method signatures in pkg/loadbalancers such that `Cleanup()` does not need to instantiate a new L7 object to work.