### PR TITLE
Add Finalizers for Ingress

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -186,6 +186,12 @@ func TestIngressCreateDelete(t *testing.T) {
 	if err := lbc.sync(ingStoreKey); err != nil {
 		t.Fatalf("lbc.sync(%v) = err %v", ingStoreKey, err)
 	}
+
+	// Check Ingress has been deleted
+	updatedIng, _ = lbc.ctx.KubeClient.Extensions().Ingresses(ing.Namespace).Get(ing.Name, meta_v1.GetOptions{})
+	if updatedIng != nil {
+		t.Fatalf("Ingress was not deleted, got: %+v", updatedIng)
+	}
 }
 
 // TestIngressClassChange asserts that `sync` will not return an error for a good ingress config

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -25,8 +25,9 @@ import (
 
 // gcState is used by the controller to maintain state for garbage collection routines.
 type gcState struct {
-	lbNames  []string
-	svcPorts []utils.ServicePort
+	ingresses []*extensions.Ingress
+	lbNames   []string
+	svcPorts  []utils.ServicePort
 }
 
 // syncState is used by the controller to maintain state for routines that sync GCP resources of an Ingress.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -131,6 +131,10 @@ type Features struct {
 	NEGExposed bool
 	// ManagedCertificates enables using ManagedCertificate CRD
 	ManagedCertificates bool
+	// FinalizerAdd enables adding a finalizer on Ingress
+	FinalizerAdd bool
+	// FinalizerRemove enables removing a finalizer on Ingress.
+	FinalizerRemove bool
 }
 
 var DefaultFeatures = &Features{
@@ -138,6 +142,8 @@ var DefaultFeatures = &Features{
 	NEG:                 true,
 	NEGExposed:          true,
 	ManagedCertificates: false,
+	FinalizerAdd:        false,
+	FinalizerRemove:     false,
 }
 
 func EnabledFeatures() *Features {
@@ -218,6 +224,10 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.DurationVar(&F.NegGCPeriod, "neg-gc-period", 120*time.Second,
 		`Relist and garbage collect NEGs this often.`)
 	flag.StringVar(&F.NegSyncerType, "neg-syncer-type", "transaction", "Define the NEG syncer type to use. Valid values are \"batch\" and \"transaction\"")
+	flag.BoolVar(&F.Features.FinalizerAdd, "enable-finalizer-add",
+		F.Features.FinalizerAdd, "Enable adding Finalizer to Ingress.")
+	flag.BoolVar(&F.Features.FinalizerRemove, "enable-finalizer-remove",
+		F.Features.FinalizerRemove, "Enable removing Finalizer from Ingress.")
 
 	// Deprecated F.
 	flag.BoolVar(&F.Verbose, "verbose", false,

--- a/pkg/utils/finalizer.go
+++ b/pkg/utils/finalizer.go
@@ -23,9 +23,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
-// FinalizerKeySuffix is a suffix for finalizers added by the controller.
-// A full key could be something like "ingress.finalizer.cloud.google.com"
-const FinalizerKeySuffix = "finalizer.cloud.google.com"
+// FinalizerKey is the string representing the Ingress finalizer.
+const FinalizerKey = "networking.gke.io/ingress-finalizer"
 
 // IsDeletionCandidate is true if the passed in meta contains the specified finalizer.
 func IsDeletionCandidate(m meta_v1.ObjectMeta, key string) bool {
@@ -42,15 +41,10 @@ func HasFinalizer(m meta_v1.ObjectMeta, key string) bool {
 	return slice.ContainsString(m.Finalizers, key, nil)
 }
 
-// FinalizerKey generates the finalizer string for Ingress
-func FinalizerKey() string {
-	return fmt.Sprintf("%s.%s", "ingress", FinalizerKeySuffix)
-}
-
 // AddFinalizer tries to add a finalizer to an Ingress. If a finalizer
 // already exists, it does nothing.
 func AddFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
-	ingKey := FinalizerKey()
+	ingKey := FinalizerKey
 	if NeedToAddFinalizer(ing.ObjectMeta, ingKey) {
 		updated := ing.DeepCopy()
 		updated.ObjectMeta.Finalizers = append(updated.ObjectMeta.Finalizers, ingKey)
@@ -66,7 +60,7 @@ func AddFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) er
 // RemoveFinalizer tries to remove a Finalizer from an Ingress. If a
 // finalizer is not on the Ingress, it does nothing.
 func RemoveFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
-	ingKey := FinalizerKey()
+	ingKey := FinalizerKey
 	if HasFinalizer(ing.ObjectMeta, ingKey) {
 		updated := ing.DeepCopy()
 		updated.ObjectMeta.Finalizers = slice.RemoveString(updated.ObjectMeta.Finalizers, ingKey, nil)

--- a/pkg/utils/finalizer.go
+++ b/pkg/utils/finalizer.go
@@ -14,7 +14,12 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
+
+	"github.com/golang/glog"
+	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
@@ -35,4 +40,41 @@ func NeedToAddFinalizer(m meta_v1.ObjectMeta, key string) bool {
 // HasFinalizer is true if the passed in meta has the specified finalizer.
 func HasFinalizer(m meta_v1.ObjectMeta, key string) bool {
 	return slice.ContainsString(m.Finalizers, key, nil)
+}
+
+// FinalizerKey generates the finalizer string for Ingress
+func FinalizerKey() string {
+	return fmt.Sprintf("%s.%s", "ingress", FinalizerKeySuffix)
+}
+
+// AddFinalizer tries to add a finalizer to an Ingress. If a finalizer
+// already exists, it does nothing.
+func AddFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
+	ingKey := FinalizerKey()
+	if NeedToAddFinalizer(ing.ObjectMeta, ingKey) {
+		updated := ing.DeepCopy()
+		updated.ObjectMeta.Finalizers = append(updated.ObjectMeta.Finalizers, ingKey)
+		if _, err := ingClient.Update(updated); err != nil {
+			return fmt.Errorf("error updating Ingress %s/%s: %v", ing.Namespace, ing.Name, err)
+		}
+		glog.V(3).Infof("Added finalizer %q for Ingress %s/%s", ingKey, ing.Namespace, ing.Name)
+	}
+
+	return nil
+}
+
+// RemoveFinalizer tries to remove a Finalizer from an Ingress. If a
+// finalizer is not on the Ingress, it does nothing.
+func RemoveFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
+	ingKey := FinalizerKey()
+	if HasFinalizer(ing.ObjectMeta, ingKey) {
+		updated := ing.DeepCopy()
+		updated.ObjectMeta.Finalizers = slice.RemoveString(updated.ObjectMeta.Finalizers, ingKey, nil)
+		if _, err := ingClient.Update(updated); err != nil {
+			return fmt.Errorf("error updating Ingress %s/%s: %v", ing.Namespace, ing.Name, err)
+		}
+		glog.V(3).Infof("Removed finalizer %q for Ingress %s/%s", ingKey, ing.Namespace, ing.Name)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The finalizer `ingress.finalizer.cloud.google.com` will be applied to the Ingress upon update if it does not have a finalizer yet. It will be removed only after the resources related to the Ingress have been deleted first. Absence of a finalizer means the Ingress itself can be safely deleted.

If a resource used for this ingress fails to be deleted because it’s ‘in use’ by another resource, then the resource will be skipped. If it cannot be deleted for another reason, the controller will attempt deletion at a later attempt.
