### PR TITLE
make backoff retry handler unit test faster

### DIFF
--- a/pkg/neg/syncers/retry_handler.go
+++ b/pkg/neg/syncers/retry_handler.go
@@ -74,8 +74,9 @@ func (h *backoffRetryHandler) Retry() error {
 	}
 
 	h.retrying = true
+	ch := h.clock.After(delay)
 	go func() {
-		<-h.clock.After(delay)
+		<-ch
 		func() {
 			h.stateLock.Lock()
 			defer h.stateLock.Unlock()


### PR DESCRIPTION
Use FakeClock to make unit test run faster. 
