### PR TITLE
Support secret-based and pre-shared certs at the same time

### DIFF
--- a/pkg/loadbalancers/fakes.go
+++ b/pkg/loadbalancers/fakes.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
-const FakeCertLimit = 15
+const FakeCertQuota = 15
 
 var testIPManager = testIP{}
 
@@ -417,9 +417,9 @@ func (f *FakeLoadBalancers) ListSslCertificates() ([]*compute.SslCertificate, er
 func (f *FakeLoadBalancers) CreateSslCertificate(cert *compute.SslCertificate) (*compute.SslCertificate, error) {
 	f.calls = append(f.calls, "CreateSslCertificate")
 	cert.SelfLink = cloud.NewSslCertificatesResourceID("mock-project", cert.Name).SelfLink(meta.VersionGA)
-	if len(f.Certs) == FakeCertLimit {
+	if len(f.Certs) == FakeCertQuota {
 		// Simulate cert creation failure
-		return nil, fmt.Errorf("unable to create cert, Exceeded cert limit of %d.", FakeCertLimit)
+		return nil, fmt.Errorf("unable to create cert, Exceeded cert limit of %d.", FakeCertQuota)
 	}
 	f.Certs = append(f.Certs, cert)
 	return cert, nil


### PR DESCRIPTION
This should allow for a no-downtime migration from secret-based to pre-shared certs, as the secret-based cert will be still used until the secret is removed.