### PR TITLE
Add backendconfig v1

### DIFF
--- a/pkg/backendconfig/backendconfig.go
+++ b/pkg/backendconfig/backendconfig.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	apiv1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -33,17 +34,33 @@ var (
 	ErrBackendConfigDoesNotExist = errors.New("no BackendConfig for service port exists.")
 	ErrBackendConfigFailedToGet  = errors.New("client had error getting BackendConfig for service port.")
 	ErrNoBackendConfigForPort    = errors.New("no BackendConfig name found for service port.")
+
+	CRDVersion = []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1beta1",
+			Served:  true,
+			Storage: true,
+		},
+		{
+			Name:    "v1",
+			Served:  true,
+			Storage: false,
+		},
+	}
 )
 
 func CRDMeta() *crd.CRDMeta {
 	meta := crd.NewCRDMeta(
+		CRDVersion,
 		apisbackendconfig.GroupName,
-		"v1beta1",
 		"BackendConfig",
 		"BackendConfigList",
 		"backendconfig",
 		"backendconfigs",
 	)
+
+	// TODO: when we deprecate v1beta1, use v1.BackendConfig, v1.GetOpenAPIDefinitions
+	// Also need to use v1 client and watchers
 	meta.AddValidationInfo("k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.BackendConfig", backendconfigv1beta1.GetOpenAPIDefinitions)
 	return meta
 }

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -98,9 +98,9 @@ func crd(meta *CRDMeta) *apiextensionsv1beta1.CustomResourceDefinition {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: meta.plural + "." + meta.groupName},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   meta.groupName,
-			Version: meta.version,
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Group:    meta.groupName,
+			Versions: meta.versions,
+			Scope:    apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Kind:       meta.kind,
 				ListKind:   meta.listKind,

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -28,11 +28,17 @@ import (
 var (
 	crdMeta = &CRDMeta{
 		groupName: "test.group.com",
-		version:   "v1alpha1",
-		kind:      "Test",
-		listKind:  "TestList",
-		singular:  "test",
-		plural:    "tests",
+		versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			{
+				Name:    "v1alpha1",
+				Served:  true,
+				Storage: true,
+			},
+		},
+		kind:     "Test",
+		listKind: "TestList",
+		singular: "test",
+		plural:   "tests",
 	}
 )
 

--- a/pkg/crd/meta.go
+++ b/pkg/crd/meta.go
@@ -17,13 +17,14 @@ limitations under the License.
 package crd
 
 import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/kube-openapi/pkg/common"
 )
 
 // CRDMeta contains version, validation and API information for a CRD.
 type CRDMeta struct {
 	groupName  string
-	version    string
+	versions   []apiextensionsv1beta1.CustomResourceDefinitionVersion
 	kind       string
 	listKind   string
 	singular   string
@@ -35,10 +36,10 @@ type CRDMeta struct {
 
 // NewCRDMeta creates a CRDMeta type which can be passed to a CRDHandler in
 // order to create/ensure a CRD.
-func NewCRDMeta(groupName, version, kind, listKind, singular, plural string, shortNames ...string) *CRDMeta {
+func NewCRDMeta(versions []apiextensionsv1beta1.CustomResourceDefinitionVersion, groupName, kind, listKind, singular, plural string, shortNames ...string) *CRDMeta {
 	return &CRDMeta{
 		groupName:  groupName,
-		version:    version,
+		versions:   versions,
 		kind:       kind,
 		listKind:   listKind,
 		singular:   singular,

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -74,6 +74,19 @@ func CreateEchoService(s *Sandbox, name string, annotations map[string]string) (
 	return pod, service, nil
 }
 
+// UpdateEchoService updates the service serving echoheaders. Note that if
+// the service passed in is not the most recent version of the object on the
+// k8s cluster, Services.Update will return an error.
+func UpdateEchoService(s *Sandbox, svc *v1.Service) (*v1.Service, error) {
+	service, err := s.f.Clientset.Core().Services(s.Namespace).Update(svc)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(2).Infof("Echo service %q:%q updated", s.Namespace, service.Name)
+
+	return service, nil
+}
+
 // CreateSecret creates a secret from the given data.
 func CreateSecret(s *Sandbox, name string, data map[string][]byte) (*v1.Secret, error) {
 	secret := &v1.Secret{


### PR DESCRIPTION
This PR adds v1 version of the BackendConfig CustomResourceDefinition. It is feature gated behind a flag, `EnableBackendConfigV1`. Note that to enable BackendConfig v1, ingress requires both `EnableBackendConfigV1` and `EnableBackendConfig` to be true.

We also introduce a composite type, `backendconfig.BackendConfig`, to house the shared attributes between v1 and v1beta1. 