### PR TITLE
Shorten the name of the namespace for test sandboxes

### DIFF
--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -149,7 +149,7 @@ func (f *Framework) shutdown(exitCode int) {
 // cleanup and isolation.
 func (f *Framework) WithSandbox(testFunc func(*Sandbox) error) error {
 	sandbox := &Sandbox{
-		Namespace: fmt.Sprintf("test-sandbox-%x", f.Rand.Int63()),
+		Namespace: fmt.Sprintf("sandbox-%x", f.Rand.Int63()),
 		f:         f,
 	}
 	glog.V(2).Infof("Using namespace %q for test sandbox", sandbox.Namespace)
@@ -173,7 +173,7 @@ func (f *Framework) WithSandbox(testFunc func(*Sandbox) error) error {
 func (f *Framework) RunWithSandbox(name string, t *testing.T, testFunc func(*testing.T, *Sandbox)) {
 	t.Run(name, func(t *testing.T) {
 		sandbox := &Sandbox{
-			Namespace: fmt.Sprintf("test-sandbox-%x", f.Rand.Int63()),
+			Namespace: fmt.Sprintf("sandbox-%x", f.Rand.Int63()),
 			f:         f,
 		}
 		glog.V(2).Infof("Using namespace %q for test sandbox", sandbox.Namespace)


### PR DESCRIPTION
Shortening the name of the namespace will allow us to not hit the name truncation bug that currently exists.

This is a temporary measure until we have a concrete design on how to fix the bug. 