### PR TITLE
Clean up unused feature flags for NEG and BackendConfig

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -117,11 +117,8 @@ func main() {
 	}
 
 	cloud := app.NewGCEClient()
-	enableNEG := flags.F.Features.NEG
 	defaultBackendServicePortID := app.DefaultBackendServicePortID(kubeClient)
 	ctxConfig := ingctx.ControllerContextConfig{
-		NEGEnabled:                    enableNEG,
-		BackendConfigEnabled:          flags.F.EnableBackendConfig,
 		Namespace:                     flags.F.WatchNamespace,
 		ResyncPeriod:                  flags.F.ResyncPeriod,
 		DefaultBackendSvcPortID:       defaultBackendServicePortID,
@@ -190,12 +187,10 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	fwc := firewalls.NewFirewallController(ctx, flags.F.NodePortRanges.Values())
 
-	if ctx.NEGEnabled {
-		// TODO: Refactor NEG to use cloud mocks so ctx.Cloud can be referenced within NewController.
-		negController := neg.NewController(neg.NewAdapter(ctx.Cloud), ctx, lbc.Translator, ctx.ClusterNamer, flags.F.ResyncPeriod, flags.F.NegGCPeriod, neg.NegSyncerType(flags.F.NegSyncerType))
-		go negController.Run(stopCh)
-		glog.V(0).Infof("negController started")
-	}
+	// TODO: Refactor NEG to use cloud mocks so ctx.Cloud can be referenced within NewController.
+	negController := neg.NewController(neg.NewAdapter(ctx.Cloud), ctx, lbc.Translator, ctx.ClusterNamer, flags.F.ResyncPeriod, flags.F.NegGCPeriod, neg.NegSyncerType(flags.F.NegSyncerType))
+	go negController.Run(stopCh)
+	glog.V(0).Infof("negController started")
 
 	go app.RunSIGTERMHandler(lbc, flags.F.DeleteAllOnQuit)
 

--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/ingress-gce/pkg/flags"
 )
 
 const (
@@ -143,9 +142,6 @@ func (svc *Service) ApplicationProtocols() (map[string]AppProtocol, error) {
 		switch proto {
 		case ProtocolHTTP, ProtocolHTTPS:
 		case ProtocolHTTP2:
-			if !flags.F.Features.Http2 {
-				return nil, fmt.Errorf("http2 not enabled as port application protocol")
-			}
 		default:
 			return nil, fmt.Errorf("invalid port application protocol: %v", proto)
 		}

--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/ingress-gce/pkg/flags"
 )
 
 func TestNEGAnnotation(t *testing.T) {
@@ -173,7 +172,6 @@ func TestService(t *testing.T) {
 		svc             *v1.Service
 		appProtocolsErr bool
 		appProtocols    map[string]AppProtocol
-		http2           bool
 	}{
 		{
 			svc:          &v1.Service{},
@@ -218,19 +216,7 @@ func TestService(t *testing.T) {
 					},
 				},
 			},
-			appProtocols:    map[string]AppProtocol{"443": "HTTP2"},
-			appProtocolsErr: true, // Without the http2 flag enabled, expect error
-		},
-		{
-			svc: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						ServiceApplicationProtocolKey: `{"443": "HTTP2"}`,
-					},
-				},
-			},
 			appProtocols: map[string]AppProtocol{"443": "HTTP2"},
-			http2:        true,
 		},
 		{
 			svc: &v1.Service{
@@ -253,7 +239,6 @@ func TestService(t *testing.T) {
 			appProtocolsErr: true,
 		},
 	} {
-		flags.F.Features.Http2 = tc.http2
 		svc := FromService(tc.svc)
 		ap, err := svc.ApplicationProtocols()
 		if tc.appProtocolsErr {

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -57,7 +57,7 @@ func newTestJig(fakeGCE *gce.GCECloud) *Jig {
 	return &Jig{
 		fakeInstancePool: fakeInstancePool,
 		linker:           NewInstanceGroupLinker(fakeInstancePool, fakeBackendPool, defaultNamer),
-		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, defaultNamer, false),
+		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, defaultNamer),
 		pool:             fakeBackendPool,
 	}
 }

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -29,11 +29,10 @@ import (
 
 // backendSyncer manages the lifecycle of backends.
 type backendSyncer struct {
-	backendPool          Pool
-	healthChecker        healthchecks.HealthChecker
-	backendConfigEnabled bool
-	prober               ProbeProvider
-	namer                *utils.Namer
+	backendPool   Pool
+	healthChecker healthchecks.HealthChecker
+	prober        ProbeProvider
+	namer         *utils.Namer
 }
 
 // backendSyncer is a Syncer
@@ -42,13 +41,11 @@ var _ Syncer = (*backendSyncer)(nil)
 func NewBackendSyncer(
 	backendPool Pool,
 	healthChecker healthchecks.HealthChecker,
-	namer *utils.Namer,
-	backendConfigEnabled bool) Syncer {
+	namer *utils.Namer) Syncer {
 	return &backendSyncer{
-		backendPool:          backendPool,
-		healthChecker:        healthChecker,
-		namer:                namer,
-		backendConfigEnabled: backendConfigEnabled,
+		backendPool:   backendPool,
+		healthChecker: healthChecker,
+		namer:         namer,
 	}
 }
 
@@ -110,7 +107,7 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 	needUpdate := ensureProtocol(be, sp)
 	needUpdate = ensureHealthCheckLink(be, hcLink) || needUpdate
 	needUpdate = ensureDescription(be, &sp) || needUpdate
-	if s.backendConfigEnabled && sp.BackendConfig != nil {
+	if sp.BackendConfig != nil {
 		needUpdate = features.EnsureCDN(sp, be) || needUpdate
 		needUpdate = features.EnsureIAP(sp, be) || needUpdate
 		needUpdate = features.EnsureTimeout(sp, be) || needUpdate
@@ -124,7 +121,7 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 		}
 	}
 
-	if s.backendConfigEnabled && sp.BackendConfig != nil {
+	if sp.BackendConfig != nil {
 		cloud := s.backendPool.(*Backends).cloud
 		if err := features.EnsureSecurityPolicy(cloud, sp, be, beName); err != nil {
 			return err

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -63,10 +63,9 @@ func newTestSyncer(fakeGCE *gce.GCECloud) *backendSyncer {
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	syncer := &backendSyncer{
-		backendPool:          fakeBackendPool,
-		healthChecker:        fakeHealthChecks,
-		namer:                defaultNamer,
-		backendConfigEnabled: false,
+		backendPool:   fakeBackendPool,
+		healthChecker: fakeHealthChecks,
+		namer:         defaultNamer,
 	}
 
 	probes := map[utils.ServicePort]*api_v1.Probe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS}: existingProbe}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -54,8 +54,6 @@ func newLoadBalancerController() *LoadBalancerController {
 
 	stopCh := make(chan struct{})
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:                    true,
-		BackendConfigEnabled:          false,
 		Namespace:                     api_v1.NamespaceAll,
 		ResyncPeriod:                  1 * time.Minute,
 		DefaultBackendSvcPortID:       test.DefaultBeSvcPort.ID,
@@ -197,8 +195,8 @@ func TestIngressCreateDeleteFinalizer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			flags.F.Features.FinalizerAdd = tc.enableFinalizerAdd
-			flags.F.Features.FinalizerRemove = tc.enableFinalizerRemove
+			flags.F.FinalizerAdd = tc.enableFinalizerAdd
+			flags.F.FinalizerRemove = tc.enableFinalizerRemove
 
 			lbc := newLoadBalancerController()
 			svc := test.NewService(types.NamespacedName{Name: "my-service", Namespace: "default"}, api_v1.ServiceSpec{

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -40,8 +40,6 @@ func newFirewallController() *FirewallController {
 	fakeGCE := gce.FakeGCECloud(gce.DefaultTestClusterValues())
 
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               api_v1.NamespaceAll,
 		ResyncPeriod:            1 * time.Minute,
 		DefaultBackendSvcPortID: test.DefaultBeSvcPort.ID,

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -53,8 +53,6 @@ func newTestController(kubeClient kubernetes.Interface) *Controller {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	namer := utils.NewNamer(ClusterID, "")
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -43,8 +43,6 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	namer := utils.NewNamer(ClusterID, "")
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,

--- a/pkg/neg/syncers/batch_test.go
+++ b/pkg/neg/syncers/batch_test.go
@@ -36,8 +36,6 @@ func NewTestSyncer() *batchSyncer {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	namer := utils.NewNamer(clusterID, "")
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -60,8 +60,6 @@ func newSyncerTester() *syncerTester {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	namer := utils.NewNamer(clusterID, "")
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -832,8 +832,6 @@ func newTestTransactionSyncer(fakeGCE *gce.GCECloud) (negtypes.NegSyncer, *trans
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	namer := utils.NewNamer(clusterID, "")
 	ctxConfig := context.ControllerContextConfig{
-		NEGEnabled:              true,
-		BackendConfigEnabled:    false,
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,


### PR DESCRIPTION
Remove feature flags for both NEG and BackendConfig. Both these features are stable and about to go GA soon so there is no reason to flag gate them.

Any further improvements to both these features will have their own flag-gate, if necessary. 