### PR TITLE
Rebase base images from scratch and alpine to distroless

### DIFF
--- a/Dockerfile.404-server
+++ b/Dockerfile.404-server
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 

--- a/Dockerfile.fuzzer
+++ b/Dockerfile.fuzzer
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.8
-
-RUN apk add --no-cache ca-certificates
+# This image requires ca-certificate, which is pre-installed in distroless.
+FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 ENTRYPOINT ["/ARG_BIN"]

--- a/Dockerfile.glbc
+++ b/Dockerfile.glbc
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.8
-
-RUN apk add --no-cache ca-certificates
+# This image requires ca-certificate, which is pre-installed in distroless.
+FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
[Kubernetes issue/70249
](https://github.com/kubernetes/kubernetes/issues/70249)

Internal Doc: go/rebase-gke-image-to-distroless

Test: Tested the Dockerfile files validation via "make build bin".
