### PR TITLE
Update upgrade_test.go to look for 2 backend services in whitebox test

### DIFF
--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -46,7 +46,7 @@ func TestUpgrade(t *testing.T) {
 				AddPath("foo.com", "/", "service-1", port80).
 				Build(),
 			numForwardingRules: 1,
-			numBackendServices: 1,
+			numBackendServices: 2,
 		},
 	} {
 		tc := tc // Capture tc as we are running this in parallel.


### PR DESCRIPTION
This is a follow up to #654. Since we removed usage of a default backend in the Ingress spec, the system default backend service (404 server) will also be created.