### PR TITLE
[Upgrade Test] After path addition to Ingress post-upgrade, do not error out if we receive 404's.

### DIFF
--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -100,7 +100,7 @@ func TestUpgrade(t *testing.T) {
 
 			// Verify the Ingress has stabilized after the master upgrade and we
 			// trigger an Ingress update
-			ing = waitForStableIngress(false, ing, s, t)
+			ing = waitForStableIngress(true, ing, s, t)
 			t.Logf("GCLB is stable (%s/%s)", s.Namespace, tc.ing.Name)
 			whiteboxTest(ing, s, tc.numForwardingRules, tc.numBackendServices, t)
 


### PR DESCRIPTION
Since we add a new host to the Ingress, some amount of 404's are expected. 