### PR TITLE
Revert "Rebase base images from scratch and alpine to distroless"

### DIFF
--- a/Dockerfile.404-server
+++ b/Dockerfile.404-server
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/static:latest
+FROM scratch
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 

--- a/Dockerfile.fuzzer
+++ b/Dockerfile.fuzzer
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This image requires ca-certificate, which is pre-installed in distroless.
-FROM gcr.io/distroless/static:latest
+FROM alpine:3.8
+
+RUN apk add --no-cache ca-certificates
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 ENTRYPOINT ["/ARG_BIN"]

--- a/Dockerfile.glbc
+++ b/Dockerfile.glbc
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This image requires ca-certificate, which is pre-installed in distroless.
-FROM gcr.io/distroless/static:latest
+FROM alpine:3.8
+
+RUN apk add --no-cache ca-certificates
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#655.

Since this was merged, our CI has been failing [1] with the following error:

oci runtime error: container_linux.go:247: starting container process caused "exec: \"sh\": executable file not found in $PATH"

[1] https://k8s-testgrid.appspot.com/sig-network-ingress-gce-e2e