### PR TITLE
Rebase from scratch images to distroless

### DIFF
--- a/Dockerfile.404-server
+++ b/Dockerfile.404-server
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 


### PR DESCRIPTION
Only rebase the empty base image to distroless. Previous PR 655 rebased both empty and alpine and was reverted in [PR/664](https://github.com/kubernetes/ingress-gce/pull/664/files) due to the fact that the alpine images are run in kubelet with bash commands (which distroless doesn't have).  

