### PR TITLE
Move tests for app protocols from k/k to Ingress-GCE repo

### DIFF
--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestAppProtocol(t *testing.T) {
+	t.Parallel()
+
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		DefaultBackend("service-1", intstr.FromString("https-port")).
+		AddPath("test.com", "/", "service-1", intstr.FromString("https-port")).
+		Build()
+
+	for _, tc := range []struct {
+		desc          string
+		annotationVal string
+	}{
+		{
+			desc:          "https",
+			annotationVal: `{"https-port":"HTTPS"}`,
+		},
+		{
+			desc:          "http2",
+			annotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			if _, err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, ing, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestAppProtocolTransition(t *testing.T) {
+	t.Parallel()
+
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		DefaultBackend("service-1", intstr.FromString("https-port")).
+		AddPath("test.com", "/", "service-1", intstr.FromString("https-port")).
+		Build()
+
+	for _, tc := range []struct {
+		desc             string
+		annotationVal    string
+		newAnnotationVal string
+	}{
+		{
+			desc:             "https",
+			annotationVal:    `{"https-port":"HTTPS"}`,
+			newAnnotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			if _, err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			_, err = e2e.WaitForIngress(s, ing, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Update the service with the new app protocol.
+			svcAnnotation = map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.newAnnotationVal,
+			}
+
+			// TODO(rramkumar): Replace this with a call to Ensure()
+			if _, err = e2e.CreateEchoService(s, "service-1", svcAnnotation); err != nil {
+				t.Fatalf("Error updating echo service: %v", err)
+			}
+
+			ing, err := e2e.WaitForIngress(s, ing, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := Framework.Clientset.Extensions().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}

--- a/cmd/echo/app/handlers.go
+++ b/cmd/echo/app/handlers.go
@@ -32,6 +32,20 @@ const (
 	queryStringCacheKey = "cache"
 )
 
+// ResponseBody is the structure returned by the echo server.
+type ResponseBody struct {
+	Host          string              `json:"host"`
+	Method        string              `json:"method"`
+	URI           string              `json:"uri"`
+	HTTPVersion   string              `json:"httpVersion"`
+	Time          time.Time           `json:"time"`
+	K8sEnv        Env                 `json:"k8sEnv"`
+	RemoteAddr    string              `json:"remoteAddr"`
+	TLS           bool                `json:"tls"`
+	Header        map[string][]string `json:"header"`
+	ServerVersion string              `json:"serverVersion"`
+}
+
 // RunHTTPServer runs HTTP and HTTPS goroutines and blocks.
 func RunHTTPServer(ctx context.Context) {
 	http.HandleFunc("/healthcheck", healthCheck)
@@ -81,18 +95,7 @@ func echo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	setHeadersFromQueryString(w, r)
 
-	var dump = struct {
-		Host          string              `json:"host"`
-		Method        string              `json:"method"`
-		URI           string              `json:"uri"`
-		HTTPVersion   string              `json:"httpVersion"`
-		Time          time.Time           `json:"time"`
-		K8sEnv        Env                 `json:"k8sEnv"`
-		RemoteAddr    string              `json:"remoteAddr"`
-		TLS           bool                `json:"tls"`
-		Header        map[string][]string `json:"header"`
-		ServerVersion string              `json:"serverVersion"`
-	}{
+	dump := ResponseBody{
 		Host:          r.Host,
 		Method:        r.Method,
 		URI:           r.RequestURI,

--- a/pkg/fuzz/features/app_protocol.go
+++ b/pkg/fuzz/features/app_protocol.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/api/extensions/v1beta1"
+	echo "k8s.io/ingress-gce/cmd/echo/app"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/fuzz"
+)
+
+// AppProtocol is the "service.alpha.kubernetes.io/app-protocols" annotation
+var AppProtocol = &AppProtocolFeature{}
+
+// AppProtocolFeature implements the associated feature.
+type AppProtocolFeature struct{}
+
+// Name implements fuzz.Feature.
+func (*AppProtocolFeature) Name() string {
+	return "AppProtocol"
+}
+
+// NewValidator implements fuzz.Feature.
+func (f *AppProtocolFeature) NewValidator() fuzz.FeatureValidator {
+	return &appProtocolValidator{}
+}
+
+// appProtocolValidator is a validator for AppProtocolFeature
+type appProtocolValidator struct {
+	fuzz.NullValidator
+
+	env fuzz.ValidatorEnv
+	ing *v1beta1.Ingress
+}
+
+// Name implements fuzz.FeatureValidator
+func (*appProtocolValidator) Name() string {
+	return "AppProtocol"
+}
+
+// ConfigureAttributes implements fuzz.FeatureValidator.
+func (v *appProtocolValidator) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1.Ingress, a *fuzz.IngressValidatorAttributes) error {
+	// Capture the env for use later in CheckResponse
+	v.ing = ing
+	v.env = env
+
+	return nil
+}
+
+// CheckResponse implements fuzz.FeatureValidator
+func (v *appProtocolValidator) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
+	service, servicePort, err := fuzz.ServiceForPath(host, path, v.ing, v.env)
+	if err != nil {
+		return fuzz.CheckResponseContinue, err
+	}
+	ap, err := annotations.FromService(service).ApplicationProtocols()
+	if err != nil {
+		return fuzz.CheckResponseContinue, err
+	}
+	var proto annotations.AppProtocol
+	if protoStr, ok := ap[servicePort.Name]; ok {
+		proto = annotations.AppProtocol(protoStr)
+	}
+
+	if resp.StatusCode != 200 {
+		// This test is contigent on a proper response being returned so
+		// bail if don't get a 200.
+		return fuzz.CheckResponseContinue, nil
+	}
+
+	var r echo.ResponseBody
+	if err := json.Unmarshal(body, &r); err != nil {
+		return fuzz.CheckResponseContinue, err
+	}
+
+	switch proto {
+	case annotations.ProtocolHTTPS:
+		if !(strings.HasPrefix(r.HTTPVersion, "1.") && r.TLS) {
+			return fuzz.CheckResponseContinue, fmt.Errorf("expected HTTP/1.x response with TLS configured on request: %+v", r)
+		}
+	case annotations.ProtocolHTTP2:
+		if !strings.HasPrefix(r.HTTPVersion, "2.") {
+			return fuzz.CheckResponseContinue, fmt.Errorf("expected HTTP/2.x response: %+v", resp)
+		}
+	default:
+		if !(strings.HasPrefix(r.HTTPVersion, "1.") && !r.TLS) {
+			return fuzz.CheckResponseContinue, fmt.Errorf("expected HTTP/1.x response with no TLS configured on request: %+v", r)
+		}
+	}
+
+	return fuzz.CheckResponseContinue, nil
+}

--- a/pkg/fuzz/features/features.go
+++ b/pkg/fuzz/features/features.go
@@ -30,4 +30,5 @@ var All = []fuzz.Feature{
 	SecurityPolicy,
 	Affinity,
 	NEG,
+	AppProtocol,
 }

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -29,6 +29,7 @@ import (
 	translatorutil "k8s.io/ingress-gce/pkg/controller/translator"
 )
 
+// ServiceForPath returns the Service and ServicePort associated with the given path.
 func ServiceForPath(host, path string, ing *v1beta1.Ingress, env ValidatorEnv) (*v1.Service, *v1.ServicePort, error) {
 	sm := ServiceMapFromIngress(ing)
 	if path == pathForDefaultBackend {
@@ -101,7 +102,7 @@ type HostPath struct {
 	Path string
 }
 
-// ServiceMap is a map of (host, path) to the appropriate BackendConfig(s).
+// ServiceMap is a map of (host, path) to the appropriate backend.
 type ServiceMap map[HostPath]*v1beta1.IngressBackend
 
 // ServiceMapFromIngress creates a service map from the Ingress object. Note:


### PR DESCRIPTION
The PR is split into two commits:

1. Extract echoheaders response body into public struct so it can be used elsewhere
2. Porting of tests

Note that the PR to remove the tests from k/k is https://github.com/kubernetes/kubernetes/pull/75143