### PR TITLE
Port basic NEG test from k/k

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -98,7 +98,7 @@ func TestAffinity(t *testing.T) {
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -96,7 +96,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 				}
 			}
 
-			if _, _, err := e2e.CreateEchoService(s, "service-1", tc.svcAnnotations); err != nil {
+			if _, err := e2e.CreateEchoService(s, "service-1", tc.svcAnnotations); err != nil {
 				t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", tc.svcAnnotations, err)
 			}
 

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -72,7 +72,7 @@ func TestBasic(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", nil)
+			_, err := e2e.CreateEchoService(s, "service-1", nil)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}
@@ -147,7 +147,7 @@ func TestEdge(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", nil)
+			_, err := e2e.CreateEchoService(s, "service-1", nil)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -84,7 +84,7 @@ func TestCDN(t *testing.T) {
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -80,7 +80,7 @@ func TestDraining(t *testing.T) {
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -66,7 +66,7 @@ func TestIAP(t *testing.T) {
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestNEG(t *testing.T) {
+	t.Parallel()
+
+	port80 := intstr.FromInt(80)
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		desc               string
+		annotations        annotations.NegAnnotation
+		negExpected        bool
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc:               "Create a basic NEG",
+			annotations:        annotations.NegAnnotation{Ingress: true},
+			negExpected:        true,
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc:               "Annotation with no NEG",
+			annotations:        annotations.NegAnnotation{Ingress: false},
+			negExpected:        false,
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort)
+			if err != nil {
+				t.Fatalf("error ensuring echo service: %v", err)
+			}
+			t.Logf("Echo service ensured (%s/%s)", s.Namespace, "service-1")
+
+			// Create the ingress
+			ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				Build()
+			ing, err = e2e.EnsureIngress(s, ing)
+			if err != nil {
+				t.Fatalf("error ensuring Ingress spec: %v", err)
+			}
+			t.Logf("Ingress ensured (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip,
+				fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Do some cursory checks on the GCP objects.
+			if len(gclb.ForwardingRule) != tc.numForwardingRules {
+				t.Errorf("got %d fowarding rules, want %d", len(gclb.ForwardingRule), tc.numForwardingRules)
+			}
+			if len(gclb.BackendService) != tc.numBackendServices {
+				t.Errorf("got %d backend services, want %d", len(gclb.BackendService), tc.numBackendServices)
+			}
+
+			if (len(gclb.NetworkEndpointGroup) > 0) != tc.negExpected {
+				t.Errorf("Error: negExpected = %v, %d negs found for gclb %v", tc.negExpected, len(gclb.NetworkEndpointGroup), gclb)
+			}
+
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, &fuzz.GCLBDeleteOptions{}); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+func TestNEGTransition(t *testing.T) {
+	t.Parallel()
+
+	port80 := intstr.FromInt(80)
+
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("Basic NEG Tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			Build()
+
+		var previousGCLBState *fuzz.GCLB
+
+		for _, tc := range []struct {
+			desc        string
+			annotations annotations.NegAnnotation
+			// negGC is true if a NEG should be garbage collected after applying the annotations
+			negGC              bool
+			numForwardingRules int
+			numBackendServices int
+		}{
+			{
+				desc:               "Using ingress only",
+				annotations:        annotations.NegAnnotation{Ingress: true},
+				negGC:              false,
+				numForwardingRules: 1,
+				numBackendServices: 1,
+			},
+			{
+				desc:               "Disable NEG for ingress",
+				annotations:        annotations.NegAnnotation{Ingress: false},
+				negGC:              true,
+				numForwardingRules: 1,
+				numBackendServices: 1,
+			},
+			{
+				desc:               "Re-enable NEG for ingress",
+				annotations:        annotations.NegAnnotation{Ingress: true},
+				negGC:              false,
+				numForwardingRules: 1,
+				numBackendServices: 1,
+			},
+			{
+				desc:               "No annotations",
+				annotations:        annotations.NegAnnotation{},
+				negGC:              true,
+				numForwardingRules: 1,
+				numBackendServices: 1,
+			},
+		} {
+			// First create the echo service, we will be adapting it throughout the basic tests
+			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort)
+			if err != nil {
+				t.Fatalf("error ensuring echo service: %v", err)
+			}
+			t.Logf("Echo service ensured (%s/%s)", s.Namespace, "service-1")
+
+			// Create the ingress
+			ing, err = e2e.EnsureIngress(s, ing)
+			if err != nil {
+				t.Fatalf("error ensuring Ingress spec: %v", err)
+			}
+			t.Logf("Ingress ensured (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip,
+				fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Do some cursory checks on the GCP objects.
+			if len(gclb.ForwardingRule) != tc.numForwardingRules {
+				t.Errorf("got %d fowarding rules, want %d", len(gclb.ForwardingRule), tc.numForwardingRules)
+			}
+			if len(gclb.BackendService) != tc.numBackendServices {
+				t.Errorf("got %d backend services, want %d", len(gclb.BackendService), tc.numBackendServices)
+			}
+
+			if tc.negGC {
+				if len(gclb.NetworkEndpointGroup) != 0 {
+					t.Errorf("NegGC = true, expected 0 negs for gclb %v, got %d", gclb, len(gclb.NetworkEndpointGroup))
+				}
+				if err = e2e.WaitForNEGDeletion(ctx, s.ValidatorEnv.Cloud(), previousGCLBState, nil); err != nil {
+					t.Errorf("Error waiting for NEGDeletion: %v", err)
+				}
+			} else {
+				if len(gclb.NetworkEndpointGroup) < 1 {
+					t.Errorf("Error, no NEGS associated with gclb %v, expected at least one", gclb)
+				}
+			}
+			previousGCLBState = gclb
+		}
+
+		if ing != nil && previousGCLBState != nil {
+			if err := e2e.WaitForIngressDeletion(ctx, previousGCLBState, s, ing, &fuzz.GCLBDeleteOptions{}); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		}
+	})
+}

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -93,7 +93,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 		testBackendConfigAnnotation := map[string]string{
 			annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
 		}
-		_, testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
+		testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
 		if err != nil {
 			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
 		}
@@ -165,7 +165,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 		testBackendConfigAnnotation := map[string]string{
 			annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
 		}
-		_, testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
+		testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
 		if err != nil {
 			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
 		}

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -71,7 +71,7 @@ func TestTimeout(t *testing.T) {
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -53,7 +53,7 @@ func TestUpgrade(t *testing.T) {
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			t.Parallel()
 
-			_, _, err := e2e.CreateEchoService(s, "service-1", nil)
+			_, err := e2e.CreateEchoService(s, "service-1", nil)
 			if err != nil {
 				t.Fatalf("error creating echo service: %v", err)
 			}

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -80,7 +80,7 @@ func (t *Translator) getServicePort(id utils.ServicePortID) (*utils.ServicePort,
 	}
 
 	var negEnabled bool
-	ok, negAnnotation, err := annotations.FromService(svc).NEGAnnotation()
+	negAnnotation, ok, err := annotations.FromService(svc).NEGAnnotation()
 	if ok && err == nil {
 		negEnabled = negAnnotation.NEGEnabledForIngress()
 	}

--- a/pkg/fuzz/features/features.go
+++ b/pkg/fuzz/features/features.go
@@ -29,4 +29,5 @@ var All = []fuzz.Feature{
 	IAP,
 	SecurityPolicy,
 	Affinity,
+	NEG,
 }

--- a/pkg/fuzz/features/iap.go
+++ b/pkg/fuzz/features/iap.go
@@ -42,7 +42,7 @@ func (*IAPFeature) Name() string {
 	return "IAP"
 }
 
-// iapValidator is a validator the CDN feature.
+// iapValidator is a validator for the IAP feature.
 type iapValidator struct {
 	fuzz.NullValidator
 

--- a/pkg/fuzz/features/neg.go
+++ b/pkg/fuzz/features/neg.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package features configures additional extra features for the Ingress.
+// Examples for how to implement additional features can be found in the
+// *_example.go files.
+
+package features
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
+	"net/http"
+	"strings"
+)
+
+// NEG is a feature in GCP to support pod as Loadbalancer backends
+var NEG = &NegFeature{}
+
+// NegFeature implements the associated feature.
+type NegFeature struct{}
+
+// NewValidator implements fuzz.Feature.
+func (NegFeature) NewValidator() fuzz.FeatureValidator {
+	return &negValidator{}
+}
+
+// Name implements fuzz.Feature.
+func (*NegFeature) Name() string {
+	return "NEG"
+}
+
+// negValidator is a validator for the NEG feature
+type negValidator struct {
+	fuzz.NullValidator
+
+	ing *v1beta1.Ingress
+	env fuzz.ValidatorEnv
+}
+
+// Name implements fuzz.FeatureValidator.
+func (*negValidator) Name() string {
+	return "NEG"
+}
+
+// ConfigureAttributes implements fuzz.FeatureValidator.
+func (v *negValidator) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1.Ingress, a *fuzz.IngressValidatorAttributes) error {
+	// Capture the env for use later in CheckResponse.
+	v.ing = ing
+	v.env = env
+	return nil
+}
+
+// CheckResponse implements fuzz.FeatureValidator.
+// Check that the neg is being used for the path if it is configured
+func (v *negValidator) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
+	svc, svcPort, err := fuzz.ServiceForPath(host, path, v.ing, v.env)
+	if err != nil {
+		return fuzz.CheckResponseContinue, err
+	}
+
+	// Check neg status for ingress enabled
+	// TODO: (shance) update this to support exposed_port as well
+	annotationSvc := annotations.FromService(svc)
+	negAnnotation, found, err := annotationSvc.NEGAnnotation()
+	if err != nil {
+		return fuzz.CheckResponseContinue, fmt.Errorf("Error getting NEG annotation for service %v: %v", svc, err)
+	}
+
+	// Path does not have a NEG annotation, nothing to check here
+	if !found {
+		return fuzz.CheckResponseContinue, nil
+	}
+
+	ctx := context.Background()
+
+	negStatus, found, err := annotationSvc.NEGStatus()
+
+	if err != nil {
+		return fuzz.CheckResponseContinue, fmt.Errorf("Error obtaining Neg status for service: %v, error: %v", svc, err)
+	}
+
+	// Do whitebox verifications
+	// Check if the corresponding backend service is targeting NEGs instead of IGs
+	// WARNING: assumes the backend service naming scheme is using the NEG naming scheme
+	if negAnnotation.NEGEnabledForIngress() {
+		if found && len(negStatus.NetworkEndpointGroups) > 0 {
+			// Check backend services as well
+			if backendIsNeg, err := verifyNegBackend(&ctx, v.env, negStatus.NetworkEndpointGroups[svcPort.Port]); !backendIsNeg {
+				return fuzz.CheckResponseContinue, err
+			}
+			return fuzz.CheckResponseContinue, nil
+		} else {
+			return fuzz.CheckResponseContinue, fmt.Errorf("Error, path %v for service %v is not targeting a neg", path, svc)
+		}
+	} else {
+		if found {
+			return fuzz.CheckResponseContinue, fmt.Errorf("Error, path %v for service %v should not be targetting a neg", path, svc)
+		} else {
+			return fuzz.CheckResponseContinue, nil
+		}
+	}
+}
+
+func verifyNegBackend(ctx *context.Context, env fuzz.ValidatorEnv, negName string) (bool, error) {
+	beService, err := env.Cloud().BackendServices().Get(*ctx, &meta.Key{Name: negName})
+
+	if beService == nil {
+		return false, fmt.Errorf("No backend service returned for name %s", negName)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, be := range beService.Backends {
+		if !strings.Contains(be.Group, negName) {
+			return false, fmt.Errorf("Backend %v group %v is not a NEG", be, be.Group)
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/fuzz/features/security_policy.go
+++ b/pkg/fuzz/features/security_policy.go
@@ -22,10 +22,9 @@ import (
 	"net/http"
 
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
-
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 )
 
 // SecurityPolicy is a feature in BackendConfig that supports using GCP

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -273,7 +273,7 @@ func (c *Controller) processService(key string) error {
 	var negAnnotation *annotations.NegAnnotation
 	if exists {
 		service = svc.(*apiv1.Service)
-		foundNEGAnnotation, negAnnotation, err = annotations.FromService(service).NEGAnnotation()
+		negAnnotation, foundNEGAnnotation, err = annotations.FromService(service).NEGAnnotation()
 		if err != nil {
 			return err
 		}

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package types
 
+import "k8s.io/apimachinery/pkg/util/json"
+
 // PortNameMap is a map of ServicePort:TargetPort.
 type PortNameMap map[int32]string
 
@@ -51,4 +53,11 @@ type NegStatus struct {
 	// resource. key is service port, value is the name of the NEG resource.
 	NetworkEndpointGroups PortNameMap `json:"network_endpoint_groups,omitempty"`
 	Zones                 []string    `json:"zones,omitempty"`
+}
+
+// ParseNegStatus parses the given annotation into NEG status struct
+func ParseNegStatus(annotation string) (NegStatus, error) {
+	ret := &NegStatus{}
+	err := json.Unmarshal([]byte(annotation), ret)
+	return *ret, err
 }

--- a/pkg/neg/utils_test.go
+++ b/pkg/neg/utils_test.go
@@ -72,7 +72,7 @@ func TestNEGServicePorts(t *testing.T) {
 		}
 
 		svc := annotations.FromService(service)
-		_, exposeNegStruct, _ := svc.NEGAnnotation()
+		exposeNegStruct, _, _ := svc.NEGAnnotation()
 
 		t.Run(tc.desc, func(t *testing.T) {
 			svcPorts, err := NEGServicePorts(exposeNegStruct, tc.knownPortMap)


### PR DESCRIPTION
Related Issue: https://github.com/kubernetes/ingress-gce/issues/667

Adds a basic NEG test "TestNEGBasic" that tests the functionality of enabling/disabling NEG for ingress, and verifying that the corresponding actions/GC are correct.

Adds NEG as a component to the fuzz validator framework

Adds helper functions:
- pkg/annotations/service.go: 
  - NegAnnotation.String()
  - Service.NEGAnnotation()
  - Service.NEGStatus()
- pkgg/e2e/helpers.go
  - WaitForNEGDeletion()
  - WaitForNEGConfiguration()
- pkg/e2e/fixtures.go
  - EnsureEchoService()
  - EnsureIngress()
- pkg/fuzz/gcp.go
  - GCLB.CheckNEGDeletion()
- pkg/neg/types/types.go
  - ParseNegStatus()
- pkg/fuzz/features/neg.go
  - verifyNegBackend()
- pkg/fuzz/helpers.go
  - ServiceForPath()

