### PR TITLE
e2e StatusManager init() handle existing config map

### DIFF
--- a/pkg/e2e/status.go
+++ b/pkg/e2e/status.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -91,6 +92,12 @@ func NewStatusManager(f *Framework) *StatusManager {
 
 func (sm *StatusManager) init() error {
 	var err error
+
+	// Optimistically delete a leftover config map
+	if err := sm.f.Clientset.Core().ConfigMaps("default").Delete(sm.cm.Name, &metav1.DeleteOptions{}); !errors.IsNotFound(err) {
+		klog.V(3).Infof("Error deleting config map %s: %v", sm.cm.Name, err)
+	}
+
 	sm.cm, err = sm.f.Clientset.Core().ConfigMaps("default").Create(sm.cm)
 	if err != nil {
 		return fmt.Errorf("error creating ConfigMap: %v", err)


### PR DESCRIPTION
If the status manager does not shut down correctly, the config map will still exist the next time a test starts and prevent the test from running until you delete it via kubectl. This deletes and replaces the config map if it already exists.