### PR TITLE
In E2E runner script, exit with error code 2 if encountered error with bootstrapping

### DIFF
--- a/cmd/e2e-test/run.sh
+++ b/cmd/e2e-test/run.sh
@@ -29,7 +29,9 @@ done
 
 if [[ -z "$PROJECT" ]]; then
   echo "Error: could not get Compute project name from the metadata server"
-  exit 1
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
 fi
 
 echo


### PR DESCRIPTION
This makes it easier for an external framework to distinguish between an error with the bootstrapping or an error due to the test failing (test failures return error code 1)