### PR TITLE
Refactor EnsureEchoService() for e2e tests to use a deployment

### DIFF
--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kr/pretty"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
@@ -101,12 +100,9 @@ func TestBasic(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			// Do some cursory checks on the GCP objects.
-			if len(gclb.ForwardingRule) != tc.numForwardingRules {
-				t.Errorf("got %d fowarding rules, want %d;\n%s", len(gclb.ForwardingRule), tc.numForwardingRules, pretty.Sprint(gclb.ForwardingRule))
-			}
-			if len(gclb.BackendService) != tc.numBackendServices {
-				t.Errorf("got %d backend services, want %d;\n%s", len(gclb.BackendService), tc.numBackendServices, pretty.Sprint(gclb.BackendService))
+			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
+			if err != nil {
+				t.Error(err)
 			}
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{
@@ -176,12 +172,9 @@ func TestEdge(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			// Do some cursory checks on the GCP objects.
-			if len(gclb.ForwardingRule) != tc.numForwardingRules {
-				t.Errorf("got %d fowarding rules, want %d;\n%s", len(gclb.ForwardingRule), tc.numForwardingRules, pretty.Sprint(gclb.ForwardingRule))
-			}
-			if len(gclb.BackendService) != tc.numBackendServices {
-				t.Errorf("got %d backend services, want %d;\n%s", len(gclb.BackendService), tc.numBackendServices, pretty.Sprint(gclb.BackendService))
+			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
+			if err != nil {
+				t.Error(err)
 			}
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -100,8 +100,7 @@ func TestBasic(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
-			if err != nil {
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
 				t.Error(err)
 			}
 
@@ -172,8 +171,7 @@ func TestEdge(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
-			if err != nil {
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
 				t.Error(err)
 			}
 

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -60,7 +60,7 @@ func TestNEG(t *testing.T) {
 		tc := tc // Capture tc as we are running this in parallel.
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
-				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort)
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort, 1)
 			if err != nil {
 				t.Fatalf("error ensuring echo service: %v", err)
 			}
@@ -95,8 +95,7 @@ func TestNEG(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
-			if err != nil {
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
 				t.Error(err)
 			}
 
@@ -165,7 +164,7 @@ func TestNEGTransition(t *testing.T) {
 		} {
 			// First create the echo service, we will be adapting it throughout the basic tests
 			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
-				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort)
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort, 1)
 			if err != nil {
 				t.Fatalf("error ensuring echo service: %v", err)
 			}
@@ -197,10 +196,10 @@ func TestNEGTransition(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
-			if err != nil {
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
 				t.Error(err)
 			}
+
 			if tc.negGC {
 				if len(gclb.NetworkEndpointGroup) != 0 {
 					t.Errorf("NegGC = true, expected 0 negs for gclb %v, got %d", gclb, len(gclb.NetworkEndpointGroup))

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -95,12 +95,9 @@ func TestNEG(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			// Do some cursory checks on the GCP objects.
-			if len(gclb.ForwardingRule) != tc.numForwardingRules {
-				t.Errorf("got %d fowarding rules, want %d", len(gclb.ForwardingRule), tc.numForwardingRules)
-			}
-			if len(gclb.BackendService) != tc.numBackendServices {
-				t.Errorf("got %d backend services, want %d", len(gclb.BackendService), tc.numBackendServices)
+			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
+			if err != nil {
+				t.Error(err)
 			}
 
 			if (len(gclb.NetworkEndpointGroup) > 0) != tc.negExpected {
@@ -200,14 +197,10 @@ func TestNEGTransition(t *testing.T) {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
 
-			// Do some cursory checks on the GCP objects.
-			if len(gclb.ForwardingRule) != tc.numForwardingRules {
-				t.Errorf("got %d fowarding rules, want %d", len(gclb.ForwardingRule), tc.numForwardingRules)
+			err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices)
+			if err != nil {
+				t.Error(err)
 			}
-			if len(gclb.BackendService) != tc.numBackendServices {
-				t.Errorf("got %d backend services, want %d", len(gclb.BackendService), tc.numBackendServices)
-			}
-
 			if tc.negGC {
 				if len(gclb.NetworkEndpointGroup) != 0 {
 					t.Errorf("NegGC = true, expected 0 negs for gclb %v, got %d", gclb, len(gclb.NetworkEndpointGroup))

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -107,7 +107,7 @@ func WaitForGCLBDeletion(ctx context.Context, c cloud.Cloud, g *fuzz.GCLB, optio
 func WaitForNEGDeletion(ctx context.Context, c cloud.Cloud, g *fuzz.GCLB, options *fuzz.GCLBDeleteOptions) error {
 	return wait.Poll(negPollInterval, negPollTimeout, func() (bool, error) {
 		if err := g.CheckNEGDeletion(ctx, c, options); err != nil {
-			klog.Infof("format: WaitForNegDeletion(%q) = %v", g.VIP, err)
+			klog.Infof("WaitForNegDeletion(%q) = %v", g.VIP, err)
 			return false, nil
 		}
 		return true, nil
@@ -134,4 +134,17 @@ func WaitForNEGConfiguration(svc *v1.Service, f *Framework, s *Sandbox) error {
 
 		return false, nil
 	})
+}
+
+func CheckGCLB(gclb *fuzz.GCLB, numForwardingRules int, numBackendServices int) error {
+
+	// Do some cursory checks on the GCP objects.
+	if len(gclb.ForwardingRule) != numForwardingRules {
+		return fmt.Errorf("got %d forwarding rules, want %d", len(gclb.ForwardingRule), numForwardingRules)
+	}
+	if len(gclb.BackendService) != numBackendServices {
+		return fmt.Errorf("got %d backend services, want %d", len(gclb.BackendService), numBackendServices)
+	}
+
+	return nil
 }

--- a/pkg/fuzz/features/neg.go
+++ b/pkg/fuzz/features/neg.go
@@ -38,7 +38,7 @@ var NEG = &NegFeature{}
 type NegFeature struct{}
 
 // NewValidator implements fuzz.Feature.
-func (NegFeature) NewValidator() fuzz.FeatureValidator {
+func (*NegFeature) NewValidator() fuzz.FeatureValidator {
 	return &negValidator{}
 }
 


### PR DESCRIPTION
EnsureEchoService() now creates a deployment instead of a single pod (existing tests use 1 replica).  This will be useful for e2e tests that test the creation of multiple NEGs.

Also includes some fixes from comments made on https://github.com/kubernetes/ingress-gce/pull/679, mainly refactoring some common checks into checkGCLB().
