### PR TITLE
Add ClusterIP test case to NEG e2e tests

### DIFF
--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -38,6 +38,7 @@ func TestNEG(t *testing.T) {
 	for _, tc := range []struct {
 		desc               string
 		annotations        annotations.NegAnnotation
+		svcType						 v1.ServiceType
 		negExpected        bool
 		numForwardingRules int
 		numBackendServices int
@@ -45,6 +46,7 @@ func TestNEG(t *testing.T) {
 		{
 			desc:               "Create a basic NEG",
 			annotations:        annotations.NegAnnotation{Ingress: true},
+			svcType: v1.ServiceTypeNodePort,
 			negExpected:        true,
 			numForwardingRules: 1,
 			numBackendServices: 1,
@@ -53,6 +55,15 @@ func TestNEG(t *testing.T) {
 			desc:               "Annotation with no NEG",
 			annotations:        annotations.NegAnnotation{Ingress: false},
 			negExpected:        false,
+			svcType:	v1.ServiceTypeNodePort,
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc:               "Ingress can reference ClusterIP service NEG enabled",
+			annotations:        annotations.NegAnnotation{Ingress: true},
+			negExpected:        true,
+			svcType:	v1.ServiceTypeClusterIP,
 			numForwardingRules: 1,
 			numBackendServices: 1,
 		},
@@ -60,7 +71,7 @@ func TestNEG(t *testing.T) {
 		tc := tc // Capture tc as we are running this in parallel.
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
-				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort, 1)
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, tc.svcType, 1)
 			if err != nil {
 				t.Fatalf("error ensuring echo service: %v", err)
 			}

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -38,7 +38,7 @@ func TestNEG(t *testing.T) {
 	for _, tc := range []struct {
 		desc               string
 		annotations        annotations.NegAnnotation
-		svcType						 v1.ServiceType
+		svcType            v1.ServiceType
 		negExpected        bool
 		numForwardingRules int
 		numBackendServices int
@@ -46,7 +46,7 @@ func TestNEG(t *testing.T) {
 		{
 			desc:               "Create a basic NEG",
 			annotations:        annotations.NegAnnotation{Ingress: true},
-			svcType: v1.ServiceTypeNodePort,
+			svcType:            v1.ServiceTypeNodePort,
 			negExpected:        true,
 			numForwardingRules: 1,
 			numBackendServices: 1,
@@ -55,7 +55,7 @@ func TestNEG(t *testing.T) {
 			desc:               "Annotation with no NEG",
 			annotations:        annotations.NegAnnotation{Ingress: false},
 			negExpected:        false,
-			svcType:	v1.ServiceTypeNodePort,
+			svcType:            v1.ServiceTypeNodePort,
 			numForwardingRules: 1,
 			numBackendServices: 1,
 		},
@@ -63,7 +63,7 @@ func TestNEG(t *testing.T) {
 			desc:               "Ingress can reference ClusterIP service NEG enabled",
 			annotations:        annotations.NegAnnotation{Ingress: true},
 			negExpected:        true,
-			svcType:	v1.ServiceTypeClusterIP,
+			svcType:            v1.ServiceTypeClusterIP,
 			numForwardingRules: 1,
 			numBackendServices: 1,
 		},
@@ -71,7 +71,7 @@ func TestNEG(t *testing.T) {
 		tc := tc // Capture tc as we are running this in parallel.
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
-				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, tc.svcType, 1)
+				annotations.NEGAnnotationKey: tc.annotations.String()}, tc.svcType, 1)
 			if err != nil {
 				t.Fatalf("error ensuring echo service: %v", err)
 			}
@@ -175,7 +175,7 @@ func TestNEGTransition(t *testing.T) {
 		} {
 			// First create the echo service, we will be adapting it throughout the basic tests
 			_, err := e2e.EnsureEchoService(s, "service-1", map[string]string{
-				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort, 1)
+				annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ServiceTypeNodePort, 1)
 			if err != nil {
 				t.Fatalf("error ensuring echo service: %v", err)
 			}

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -36,12 +36,11 @@ const (
 // CreateEchoService creates the pod and service serving echoheaders
 // Todo: (shance) remove this and replace uses with EnsureEchoService()
 func CreateEchoService(s *Sandbox, name string, annotations map[string]string) (*v1.Service, error) {
-	return EnsureEchoService(s, name, annotations, v1.ProtocolTCP, 80, v1.ServiceTypeNodePort, 1)
+	return EnsureEchoService(s, name, annotations, v1.ServiceTypeNodePort, 1)
 }
 
 // Ensures that the Echo service with the given description is set up
-func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, protocol v1.Protocol, port int32, svcType v1.ServiceType, numReplicas int32) (*v1.Service, error) {
-
+func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, svcType v1.ServiceType, numReplicas int32) (*v1.Service, error) {
 	expectedSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -50,8 +49,8 @@ func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, p
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Name:       "web",
-				Protocol:   protocol,
-				Port:       port,
+				Protocol:   v1.ProtocolTCP,
+				Port:       80,
 				TargetPort: intstr.FromString("web"),
 			}},
 			Selector: map[string]string{"app": name},


### PR DESCRIPTION
Also:
- Removes the Protocol and ServicePort fields from EnsureEchoService() since using non-default values only makes the service invalid.
- Fix EnsureEchoService() to also update deployment scale