### PR TITLE
Add TODO in allow_http feature to verify that HTTPS resources are cleaned up

### DIFF
--- a/pkg/fuzz/features/allow_http.go
+++ b/pkg/fuzz/features/allow_http.go
@@ -47,5 +47,8 @@ func (*AllowHTTPFeature) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1
 	if !an.AllowHTTP() {
 		a.CheckHTTP = false
 	}
+
+	//TODO(rramkumar): Verify that all HTTPS resources were garbage collected.
+
 	return nil
 }


### PR DESCRIPTION
Currently, the feature validator only turns off the HTTPS path check but we also need to verify that the HTTPS resources are cleaned up. It is actually a known bug that we do not do this so once we fix the bug, we will need to add the corresponding validation here.

/assign @MrHohn 
