### PR TITLE
Return name of validator in error from CheckResponse()

### DIFF
--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -327,7 +327,7 @@ func (v *IngressValidator) checkPath(ctx context.Context, scheme, host, path str
 	for _, f := range v.features {
 		action, err := f.CheckResponse(host, path, resp, body)
 		if err != nil {
-			return err
+			return fmt.Errorf("error from %s validator: %v", f.Name(), err)
 		}
 		switch action {
 		case CheckResponseContinue:


### PR DESCRIPTION
This is a readability thing because it makes it easier to diagnose which validator failed.

/assign @bowei 