### PR TITLE
make NEGTransition test unflakey under load

### DIFF
--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -21,18 +21,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/ingress-gce/cmd/glbc/app"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
 	bcclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 )
 
 // DefaultValidatorEnv is a ValidatorEnv that gets data from the Kubernetes
 // clientset.
 type DefaultValidatorEnv struct {
-	ns  string
-	k8s *kubernetes.Clientset
-	bc  *bcclient.Clientset
-	gce cloud.Cloud
+	ns    string
+	k8s   *kubernetes.Clientset
+	bc    *bcclient.Clientset
+	gce   cloud.Cloud
+	namer *utils.Namer
 }
 
 // NewDefaultValidatorEnv returns a new ValidatorEnv.
@@ -47,7 +50,8 @@ func NewDefaultValidatorEnv(config *rest.Config, ns string, gce cloud.Cloud) (Va
 	if err != nil {
 		return nil, err
 	}
-	return ret, nil
+	ret.namer, err = app.NewNamer(ret.k8s, "", "")
+	return ret, err
 }
 
 // BackendConfigs implements ValidatorEnv.
@@ -79,4 +83,9 @@ func (e *DefaultValidatorEnv) Services() (map[string]*v1.Service, error) {
 // DefaultValidatorEnv implements ValidatorEnv.
 func (e *DefaultValidatorEnv) Cloud() cloud.Cloud {
 	return e.gce
+}
+
+// DefaultValidatorEnv implements ValidatorEnv.
+func (e *DefaultValidatorEnv) Namer() *utils.Namer {
+	return e.namer
 }

--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 )
@@ -41,6 +42,7 @@ type ValidatorEnv interface {
 	BackendConfigs() (map[string]*backendconfig.BackendConfig, error)
 	Services() (map[string]*v1.Service, error)
 	Cloud() cloud.Cloud
+	Namer() *utils.Namer
 }
 
 // MockValidatorEnv is an environment that is used for mock testing.
@@ -48,6 +50,7 @@ type MockValidatorEnv struct {
 	BackendConfigsMap map[string]*backendconfig.BackendConfig
 	ServicesMap       map[string]*v1.Service
 	MockCloud         *cloud.MockGCE
+	IngressNamer      *utils.Namer
 }
 
 // BackendConfigs implements ValidatorEnv.
@@ -63,6 +66,11 @@ func (e *MockValidatorEnv) Services() (map[string]*v1.Service, error) {
 // Cloud implements ValidatorEnv.
 func (e *MockValidatorEnv) Cloud() cloud.Cloud {
 	return e.MockCloud
+}
+
+// Cloud implements ValidatorEnv.
+func (e *MockValidatorEnv) Namer() *utils.Namer {
+	return e.IngressNamer
 }
 
 // IngressValidatorAttributes are derived attributes governing how the Ingress


### PR DESCRIPTION
In NEGTransition test, for every test case, after applying the new setup, it waits for ingress to stablize by calling https://github.com/kubernetes/ingress-gce/blob/master/cmd/e2e-test/neg_test.go#L90

However, if ingress-gce controller is under load, it takes more time to configure the LB based on the new config. Then the old LB setup will stays the same. And `WaitForIngress` will not block because the old setup is already working.

This PR makes the NEG feature validator to validate the reverse case (IG backends). So that `WaitForIngress` will block when NEG is disabled and wait for the ingress-gce to adjust backend service to use IG