### PR TITLE
Log description for NEG transition e2e tests

### DIFF
--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -128,7 +128,7 @@ func TestNEGTransition(t *testing.T) {
 
 	ctx := context.Background()
 
-	Framework.RunWithSandbox("Basic NEG Tests", t, func(t *testing.T, s *e2e.Sandbox) {
+	Framework.RunWithSandbox("NEG State Transition Tests", t, func(t *testing.T, s *e2e.Sandbox) {
 
 		ing := fuzz.NewIngressBuilder("", "ingress-1", "").
 			DefaultBackend("service-1", port80).
@@ -173,6 +173,8 @@ func TestNEGTransition(t *testing.T) {
 				numBackendServices: 1,
 			},
 		} {
+			t.Logf("Running test case: %s", tc.desc)
+
 			svcAnnotations := map[string]string{}
 			if tc.annotations != nil {
 				svcAnnotations[annotations.NEGAnnotationKey] = tc.annotations.String()


### PR DESCRIPTION
Log the test case description for the NEG transition tests since they're all run within one sandbox.  Should make debugging more transparent.