### PR TITLE
Refactor NEG Type

### DIFF
--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -191,7 +191,7 @@ func TestNEGStatus(t *testing.T) {
 					},
 				},
 			},
-			expectNegStatus: &types.NegStatus{NetworkEndpointGroups: types.PortNameMap{80: "neg-name"}, Zones: []string{"us-central1-a"}},
+			expectNegStatus: &types.NegStatus{NetworkEndpointGroups: types.PortNegMap{"80": "neg-name"}, Zones: []string{"us-central1-a"}},
 			expectFound:     true,
 			expectError:     nil,
 		},

--- a/pkg/fuzz/features/neg.go
+++ b/pkg/fuzz/features/neg.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -115,7 +116,7 @@ func (v *negValidator) getNegNameForServicePort(svc *v1.Service, svcPort *v1.Ser
 		return true, negName, fmt.Errorf("NEG status not found for service %v/%v", svc.Namespace, svc.Name)
 	}
 
-	negName, negFound := status.NetworkEndpointGroups[svcPort.Port]
+	negName, negFound := status.NetworkEndpointGroups[strconv.Itoa(int(svcPort.Port))]
 	if !negFound {
 		return true, negName, fmt.Errorf("NEG for service port %d not found for service %v/%v in NEG status %v", svcPort.Port, svc.Namespace, svc.Name, status)
 	}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -356,29 +356,31 @@ func TestSyncNegAnnotation(t *testing.T) {
 	defer controller.stop()
 	svcClient := controller.client.CoreV1().Services(testServiceNamespace)
 	newTestService(controller, false, []int32{})
-
+	namespace := "ns"
+	name := "svc"
+	namer := controller.namer
 	testCases := []struct {
 		desc            string
-		previousPortMap negtypes.PortNameMap
-		portMap         negtypes.PortNameMap
+		previousPortMap negtypes.PortInfoMap
+		portMap         negtypes.PortInfoMap
 	}{
 		{
 			desc:    "apply new annotation with no previous annotation",
-			portMap: negtypes.PortNameMap{80: "named_port", 443: "other_port"},
+			portMap: negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{80: "named_port", 443: "other_port"}, namer),
 		},
 		{
 			desc:            "same annotation applied twice",
-			previousPortMap: negtypes.PortNameMap{80: "named_port", 4040: "other_port"},
-			portMap:         negtypes.PortNameMap{80: "named_port", 4040: "other_port"},
+			previousPortMap: negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{80: "named_port", 4040: "other_port"}, namer),
+			portMap:         negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{80: "named_port", 4040: "other_port"}, namer),
 		},
 		{
 			desc:            "apply new annotation and override previous annotation",
-			previousPortMap: negtypes.PortNameMap{80: "named_port", 4040: "other_port"},
-			portMap:         negtypes.PortNameMap{3000: "6000", 4000: "8000"},
+			previousPortMap: negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{80: "named_port", 4040: "other_port"}, namer),
+			portMap:         negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{3000: "6000", 4000: "8000"}, namer),
 		},
 		{
 			desc:            "remove previous annotation",
-			previousPortMap: negtypes.PortNameMap{80: "named_port", 4040: "other_port"},
+			previousPortMap: negtypes.NewPortInfoMap(namespace, name, negtypes.SvcPortMap{80: "named_port", 4040: "other_port"}, namer),
 		},
 		{
 			desc: "remove annotation with no previous annotation",

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -64,7 +64,7 @@ type NegSyncer interface {
 type NegSyncerManager interface {
 	// EnsureSyncer ensures corresponding syncers are started and stops any unnecessary syncer
 	// portMap is a map of ServicePort Port to TargetPort
-	EnsureSyncers(namespace, name string, portMap PortNameMap) error
+	EnsureSyncers(namespace, name string, portMap PortInfoMap) error
 	// StopSyncer stops all syncers related to the service. This call is asynchronous. It will not wait for all syncers to stop.
 	StopSyncer(namespace, name string)
 	// Sync signals all syncers related to the service to sync. This call is asynchronous.

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -16,43 +16,98 @@ limitations under the License.
 
 package types
 
-import "k8s.io/apimachinery/pkg/util/json"
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/json"
+	"reflect"
+	"strconv"
+)
 
-// PortNameMap is a map of ServicePort:TargetPort.
-type PortNameMap map[int32]string
+// SvcPortMap is a map of ServicePort:TargetPort
+type SvcPortMap map[int32]string
 
-// Union returns the union of the Port:TargetPort mappings
-func (p1 PortNameMap) Union(p2 PortNameMap) PortNameMap {
-	result := make(PortNameMap)
-	for svcPort, targetPort := range p1 {
-		result[svcPort] = targetPort
-	}
-
-	for svcPort, targetPort := range p2 {
-		result[svcPort] = targetPort
-	}
-
-	return result
+// PortInfo contains information associated with service port
+type PortInfo struct {
+	// TargetPort is the target port of the service port
+	// This can be port number or a named port
+	TargetPort string
+	// NegName is the name of the NEG
+	NegName string
 }
 
-// Difference returns the set of Port:TargetPorts in p2 that aren't present in p1
-func (p1 PortNameMap) Difference(p2 PortNameMap) PortNameMap {
-	result := make(PortNameMap)
-	for svcPort, targetPort := range p1 {
-		if p1[svcPort] != p2[svcPort] {
-			result[svcPort] = targetPort
+// PortInfoMap is a map of ServicePort:PortInfo
+type PortInfoMap map[int32]PortInfo
+
+func NewPortInfoMap(namespace, name string, svcPortMap SvcPortMap, namer NetworkEndpointGroupNamer) PortInfoMap {
+	ret := PortInfoMap{}
+	for svcPort, targetPort := range svcPortMap {
+		ret[svcPort] = PortInfo{
+			TargetPort: targetPort,
+			NegName:    namer.NEG(namespace, name, svcPort),
 		}
 	}
+	return ret
+}
+
+// Merge merges p2 into p1 PortInfoMap
+// It assumes the same key will have the same PortInfo
+// If not, it will throw error
+func (p1 PortInfoMap) Merge(p2 PortInfoMap) error {
+	var err error
+	for svcPort, portInfo := range p2 {
+		if existingPortInfo, ok := p1[svcPort]; ok {
+			if !reflect.DeepEqual(existingPortInfo, portInfo) {
+				return fmt.Errorf("key %q in PortInfoMaps has different values. Existing value %v while new value: %v", svcPort, existingPortInfo, portInfo)
+			}
+		}
+		p1[svcPort] = portInfo
+	}
+	return err
+}
+
+// Difference returns the entries of PortInfoMap which satisfies one of the following 2 conditions:
+// 1. portInfo entry is not the present in p1
+// 2. or the portInfo entry is not the same in p1 and p2.
+func (p1 PortInfoMap) Difference(p2 PortInfoMap) PortInfoMap {
+	result := make(PortInfoMap)
+	for svcPort, p1PortInfo := range p1 {
+		p2PortInfo, ok := p2[svcPort]
+		if ok && reflect.DeepEqual(p1[svcPort], p2PortInfo) {
+			continue
+		}
+		result[svcPort] = p1PortInfo
+	}
 	return result
 }
+
+func (p1 PortInfoMap) ToPortNegMap() PortNegMap {
+	ret := PortNegMap{}
+	for svcPort, portInfo := range p1 {
+		ret[strconv.Itoa(int(svcPort))] = portInfo.NegName
+	}
+	return ret
+}
+
+// PortNegMap is the mapping between service port to NEG name
+type PortNegMap map[string]string
 
 // NegStatus contains name and zone of the Network Endpoint Group
 // resources associated with this service
 type NegStatus struct {
 	// NetworkEndpointGroups returns the mapping between service port and NEG
 	// resource. key is service port, value is the name of the NEG resource.
-	NetworkEndpointGroups PortNameMap `json:"network_endpoint_groups,omitempty"`
-	Zones                 []string    `json:"zones,omitempty"`
+	NetworkEndpointGroups PortNegMap `json:"network_endpoint_groups,omitempty"`
+	// Zones is a list of zones where the NEGs exist.
+	Zones []string `json:"zones,omitempty"`
+}
+
+// NewNegStatus generates a NegStatus denoting the current NEGs
+// associated with the given ports.
+func NewNegStatus(zones []string, portToNegs PortNegMap) NegStatus {
+	res := NegStatus{}
+	res.Zones = zones
+	res.NetworkEndpointGroups = portToNegs
+	return res
 }
 
 // ParseNegStatus parses the given annotation into NEG status struct

--- a/pkg/neg/utils.go
+++ b/pkg/neg/utils.go
@@ -32,12 +32,12 @@ const (
 // NegSyncerType represents the the neg syncer type
 type NegSyncerType string
 
-// NEGServicePorts returns the parsed ServicePorts from the annotation.
+// negServicePorts returns the parsed ServicePorts from the annotation.
 // knownPorts represents the known Port:TargetPort attributes of servicePorts
 // that already exist on the service. This function returns an error if
 // any of the parsed ServicePorts from the annotation is not in knownPorts.
-func NEGServicePorts(ann *annotations.NegAnnotation, knownPorts types.PortNameMap) (types.PortNameMap, error) {
-	portSet := make(types.PortNameMap)
+func negServicePorts(ann *annotations.NegAnnotation, knownPorts types.SvcPortMap) (types.SvcPortMap, error) {
+	portSet := make(types.SvcPortMap)
 	var errList []error
 	for port := range ann.ExposedPorts {
 		// TODO: also validate ServicePorts in the exposed NEG annotation via webhook
@@ -48,16 +48,4 @@ func NEGServicePorts(ann *annotations.NegAnnotation, knownPorts types.PortNameMa
 	}
 
 	return portSet, utilerrors.NewAggregate(errList)
-}
-
-// GetNegStatus generates a NegStatus denoting the current NEGs
-// associated with the given ports.
-// NetworkEndpointGroups is a mapping between ServicePort and NEG name
-// Zones is a list of zones where the NEGs exist.
-func GetNegStatus(zones []string, portToNegs types.PortNameMap) types.NegStatus {
-	res := types.NegStatus{}
-	res.NetworkEndpointGroups = make(types.PortNameMap)
-	res.Zones = zones
-	res.NetworkEndpointGroups = portToNegs
-	return res
 }

--- a/pkg/neg/utils_test.go
+++ b/pkg/neg/utils_test.go
@@ -32,8 +32,8 @@ func TestNEGServicePorts(t *testing.T) {
 	testcases := []struct {
 		desc            string
 		annotation      string
-		knownPortMap    types.PortNameMap
-		expectedPortMap types.PortNameMap
+		knownPortMap    types.SvcPortMap
+		expectedPortMap types.SvcPortMap
 		expectedErr     error
 	}{
 		{
@@ -42,21 +42,21 @@ func TestNEGServicePorts(t *testing.T) {
 			expectedErr: utilerrors.NewAggregate([]error{
 				fmt.Errorf("port %v specified in %q doesn't exist in the service", 3000, annotations.NEGAnnotationKey),
 			}),
-			knownPortMap:    types.PortNameMap{80: "some_port", 443: "another_port"},
-			expectedPortMap: types.PortNameMap{3000: ""},
+			knownPortMap:    types.SvcPortMap{80: "some_port", 443: "another_port"},
+			expectedPortMap: types.SvcPortMap{3000: ""},
 		},
 		{
 			desc:            "NEG annotation references existing service ports",
 			annotation:      `{"exposed_ports":{"80":{},"443":{}}}`,
-			knownPortMap:    types.PortNameMap{80: "namedport", 443: "3000"},
-			expectedPortMap: types.PortNameMap{80: "namedport", 443: "3000"},
+			knownPortMap:    types.SvcPortMap{80: "namedport", 443: "3000"},
+			expectedPortMap: types.SvcPortMap{80: "namedport", 443: "3000"},
 		},
 
 		{
 			desc:            "NEGServicePort takes the union of known ports and ports referenced in the annotation",
 			annotation:      `{"exposed_ports":{"80":{}}}`,
-			knownPortMap:    types.PortNameMap{80: "8080", 3000: "3030", 4000: "4040"},
-			expectedPortMap: types.PortNameMap{80: "8080"},
+			knownPortMap:    types.SvcPortMap{80: "8080", 3000: "3030", 4000: "4040"},
+			expectedPortMap: types.SvcPortMap{80: "8080"},
 		},
 	}
 
@@ -75,18 +75,18 @@ func TestNEGServicePorts(t *testing.T) {
 		exposeNegStruct, _, _ := svc.NEGAnnotation()
 
 		t.Run(tc.desc, func(t *testing.T) {
-			svcPorts, err := NEGServicePorts(exposeNegStruct, tc.knownPortMap)
+			svcPorts, err := negServicePorts(exposeNegStruct, tc.knownPortMap)
 			if tc.expectedErr == nil && err != nil {
 				t.Errorf("ExpectedNEGServicePorts to not return an error, got: %v", err)
 			}
 
 			if !reflect.DeepEqual(svcPorts, tc.expectedPortMap) {
-				t.Errorf("Expected NEGServicePorts to equal: %v; got: %v; err: %v", tc.expectedPortMap, svcPorts, err)
+				t.Errorf("Expected negServicePorts to equal: %v; got: %v; err: %v", tc.expectedPortMap, svcPorts, err)
 			}
 
 			if tc.expectedErr != nil {
 				if !reflect.DeepEqual(err, tc.expectedErr) {
-					t.Errorf("Expected NEGServicePorts to return a %v error, got: %v", tc.expectedErr, err)
+					t.Errorf("Expected negServicePorts to return a %v error, got: %v", tc.expectedErr, err)
 				}
 			}
 		})


### PR DESCRIPTION
- No functional changes
- Split `PortNameMap` type into
  - `PortNegMap`   (used by NEG Status Annotation)
  - `SvcPortMap`   (Internal plumbing)
  - `PortInfoMap`   (Syncer Manager interface)

- Include NEG name in PortInfo, so that no need to recalculate NEG name at multiple places. 

This is prerequisite for Readiness Reflector

cc: @spencerhance 