### PR TITLE
Introduce function to create a static namer that does not change naming policy

### DIFF
--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -50,7 +50,7 @@ func NewDefaultValidatorEnv(config *rest.Config, ns string, gce cloud.Cloud) (Va
 	if err != nil {
 		return nil, err
 	}
-	ret.namer, err = app.NewNamer(ret.k8s, "", "")
+	ret.namer, err = app.NewStaticNamer(ret.k8s, "", "")
 	return ret, err
 }
 


### PR DESCRIPTION
Use this new function in our e2e test framework as opposed to the namer which dynamically changes its naming policy. 

Reason is that during a master upgrade, the previous function would spit out a klog.Errorf() every time it could not read the ConfigMap which is expected since the master is upgrading. Since we know the uid will not change during our tests (for now), we would prefer to not have the error log showing up repeatedly in our test logs.

/assign @freehan  