### PR TITLE
Do not load secret from Ingress spec if provided name is empty

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -59,6 +59,9 @@ func (t *TLSCertsFromSecretsLoader) Load(ing *extensions.Ingress) ([]*loadbalanc
 	var certs []*loadbalancers.TLSCerts
 
 	for _, tlsSecret := range ing.Spec.TLS {
+		if tlsSecret.SecretName == "" {
+			continue
+		}
 		// TODO: Replace this for a secret watcher.
 		klog.V(3).Infof("Retrieving secret for ing %v with name %v", ing.Name, tlsSecret.SecretName)
 		secret, err := t.Client.Core().Secrets(ing.Namespace).Get(tlsSecret.SecretName, meta_v1.GetOptions{})


### PR DESCRIPTION
Addresses a portion of #713. We may decide to cherry-pick this back to the 1.5 branch as well depending on the urgency.

/assign @MrHohn 