### PR TITLE
Add NegReadinessGate in a shared package

### DIFF
--- a/pkg/neg/types/shared/types.go
+++ b/pkg/neg/types/shared/types.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+const (
+	NegReadinessGate = "cloud.google.com/load-balancer-neg-ready"
+)


### PR DESCRIPTION
This is to make it easier for other repo to import this. 

cc: @cadmuxe