### PR TITLE
Refactor Transaction NEG syncer to use strong type instead of string

### DIFF
--- a/pkg/neg/syncers/transaction_table.go
+++ b/pkg/neg/syncers/transaction_table.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package syncers
 
+import negtypes "k8s.io/ingress-gce/pkg/neg/types"
+
 const (
 	attachOp = iota
 	detachOp
@@ -47,32 +49,32 @@ type transactionEntry struct {
 // It uses the encoded endpoint as key and associate attributes of an transaction as value
 // WARNING: transactionTable is not thread safe
 type transactionTable struct {
-	data map[string]transactionEntry
+	data map[negtypes.NetworkEndpoint]transactionEntry
 }
 
 func NewTransactionTable() transactionTable {
 	return transactionTable{
-		data: make(map[string]transactionEntry),
+		data: make(map[negtypes.NetworkEndpoint]transactionEntry),
 	}
 }
 
-func (tt transactionTable) Keys() []string {
-	res := []string{}
+func (tt transactionTable) Keys() []negtypes.NetworkEndpoint {
+	res := []negtypes.NetworkEndpoint{}
 	for key := range tt.data {
 		res = append(res, key)
 	}
 	return res
 }
 
-func (tt transactionTable) Get(key string) (transactionEntry, bool) {
+func (tt transactionTable) Get(key negtypes.NetworkEndpoint) (transactionEntry, bool) {
 	ret, ok := tt.data[key]
 	return ret, ok
 }
 
-func (tt transactionTable) Delete(key string) {
+func (tt transactionTable) Delete(key negtypes.NetworkEndpoint) {
 	delete(tt.data, key)
 }
 
-func (tt transactionTable) Put(key string, entry transactionEntry) {
+func (tt transactionTable) Put(key negtypes.NetworkEndpoint, entry transactionEntry) {
 	tt.data[key] = entry
 }

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/api/compute/v0.beta"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -56,84 +55,84 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 	_, transactionSyncer := newTestTransactionSyncer(fakeCloud)
 	testCases := []struct {
 		desc            string
-		addEndpoints    map[string]sets.String
-		removeEndpoints map[string]sets.String
-		expectEndpoints map[string]sets.String
+		addEndpoints    map[string]negtypes.NetworkEndpointSet
+		removeEndpoints map[string]negtypes.NetworkEndpointSet
+		expectEndpoints map[string]negtypes.NetworkEndpointSet
 	}{
 		{
 			"empty input",
-			map[string]sets.String{},
-			map[string]sets.String{},
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"add some endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
-			map[string]sets.String{},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
 		},
 		{
 			"remove some endpoints",
-			map[string]sets.String{},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
 			},
-			map[string]sets.String{
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
 		},
 		{
 			"add duplicate endpoints",
-			map[string]sets.String{
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
-			map[string]sets.String{},
-			map[string]sets.String{
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
 		},
 		{
 			"add and remove endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
-			map[string]sets.String{
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 		},
 		{
 			"add more endpoints",
-			map[string]sets.String{
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
-			map[string]sets.String{},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{},
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add and remove endpoints in both zones",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
 			},
 		},
 	}
@@ -158,9 +157,9 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				t.Errorf("For case %q,, expect error == nil, but got %v", tc.desc, err)
 			}
 
-			endpointSet := sets.NewString()
+			endpointSet := negtypes.NewNetworkEndpointSet()
 			for _, ep := range list {
-				endpointSet.Insert(encodeEndpoint(ep.NetworkEndpoint.IpAddress, ep.NetworkEndpoint.Instance, strconv.FormatInt(ep.NetworkEndpoint.Port, 10)))
+				endpointSet.Insert(negtypes.NetworkEndpoint{IP: ep.NetworkEndpoint.IpAddress, Node: ep.NetworkEndpoint.Instance, Port: strconv.FormatInt(ep.NetworkEndpoint.Port, 10)})
 			}
 
 			if !endpoints.Equal(endpointSet) {
@@ -183,7 +182,7 @@ func TestCommitTransaction(t *testing.T) {
 	testCases := []struct {
 		desc            string
 		err             error
-		endpointMap     map[string]*compute.NetworkEndpoint
+		endpointMap     map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint
 		table           func() transactionTable
 		expect          func() transactionTable
 		expectSyncCount int
@@ -192,7 +191,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"empty inputs",
 			nil,
-			map[string]*compute.NetworkEndpoint{},
+			map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint{},
 			func() transactionTable { return NewTransactionTable() },
 			func() transactionTable { return NewTransactionTable() },
 			0,
@@ -214,7 +213,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"detach 20 endpoints on 2 instances successfully",
 			nil,
-			generateEndpointBatch(sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
+			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -228,7 +227,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"attach 20 endpoints on 2 instances successfully with unrelated 10 entries in the transaction table",
 			nil,
-			generateEndpointBatch(sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
+			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -247,7 +246,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"error and retry",
 			fmt.Errorf("dummy error"),
-			map[string]*compute.NetworkEndpoint{},
+			map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint{},
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
@@ -264,7 +263,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"error and retry #2",
 			fmt.Errorf("dummy error"),
-			generateEndpointBatch(sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
+			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -283,7 +282,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"detach 20 endpoints on 2 instance but missing transaction entries on 1 instance",
 			nil,
-			generateEndpointBatch(sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
+			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -296,7 +295,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			"detach 20 endpoints on 2 instance but 10 endpoints needs reconcile",
 			nil,
-			generateEndpointBatch(sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
+			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -341,36 +340,36 @@ func TestCommitTransaction(t *testing.T) {
 func TestReconcileTransactions(t *testing.T) {
 	testCases := []struct {
 		desc        string
-		endpointMap map[string]sets.String
+		endpointMap map[string]negtypes.NetworkEndpointSet
 		table       func() transactionTable
 		expect      func() transactionTable
 	}{
 		{
 			"empty inputs",
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 			func() transactionTable { return NewTransactionTable() },
 			func() transactionTable { return NewTransactionTable() },
 		},
 		{
 			"1 endpoint, empty transaction table",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 1, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 1, testInstance1, "8080")),
 			},
 			func() transactionTable { return NewTransactionTable() },
 			func() transactionTable { return NewTransactionTable() },
 		},
 		{
 			"10 endpoints, empty transaction table",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable { return NewTransactionTable() },
 			func() transactionTable { return NewTransactionTable() },
 		},
 		{
 			"10 endpoints and 5 attaching transactions are expected",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -385,8 +384,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints and 10 attaching transactions are expected",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -401,8 +400,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints, 5 attaching transactions are expected",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -417,8 +416,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints, 5 attaching and 10 detaching transactions are expected",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -437,8 +436,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"expect 10 endpoints, but unwanted endpoints are being attached",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -457,8 +456,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints and 5 attaching transaction expected, 5 attaching transactions need reconcile",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -475,8 +474,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints expected, 5 detaching transactions need reconcile",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -491,8 +490,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"10 endpoints and 5 attaching transaction expected, 5 detaching transactions need reconcile",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -509,8 +508,8 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"transaction entry has the wrong zone information",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -525,9 +524,9 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"complex case 1: multiple zone and instances. No transaction",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -540,9 +539,9 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"complex case 2: detaching transactions need reconciliation",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -558,9 +557,9 @@ func TestReconcileTransactions(t *testing.T) {
 		},
 		{
 			"complex case 2: both attaching and detaching transactions need reconciliation",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -596,31 +595,31 @@ func TestReconcileTransactions(t *testing.T) {
 func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[string]sets.String
+		endpointMap       map[string]negtypes.NetworkEndpointSet
 		table             func() transactionTable
-		expectEndpointMap map[string]sets.String
+		expectEndpointMap map[string]negtypes.NetworkEndpointSet
 	}{
 		{
 			"empty map and transactions",
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 			func() transactionTable { return NewTransactionTable() },
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty transactions",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable { return NewTransactionTable() },
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"empty map",
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -640,16 +639,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add existing endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -670,16 +669,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -700,16 +699,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
 			},
 		},
 		{
 			"remove existing endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -720,16 +719,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				return table
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints and remove existing endpoints",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable {
 				table := NewTransactionTable()
@@ -745,9 +744,9 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 	}
@@ -763,19 +762,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 func TestFilterEndpointByTransaction(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[string]sets.String
+		endpointMap       map[string]negtypes.NetworkEndpointSet
 		table             func() transactionTable
-		expectEndpointMap map[string]sets.String
+		expectEndpointMap map[string]negtypes.NetworkEndpointSet
 	}{
 		{
 			"both emtpy",
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 			func() transactionTable { return NewTransactionTable() },
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"emtpy map",
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 			func() transactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -790,30 +789,30 @@ func TestFilterEndpointByTransaction(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]sets.String{},
+			map[string]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"emtpy transaction",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable { return NewTransactionTable() },
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"emtpy transaction",
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() transactionTable { return NewTransactionTable() },
-			map[string]sets.String{
-				testZone1: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: sets.NewString().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[string]negtypes.NetworkEndpointSet{
+				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 	}
@@ -855,10 +854,10 @@ func newTestTransactionSyncer(fakeGCE *gce.Cloud) (negtypes.NegSyncer, *transact
 	return negsyncer, transactionSyncer
 }
 
-func copyMap(endpointMap map[string]sets.String) map[string]sets.String {
-	ret := map[string]sets.String{}
+func copyMap(endpointMap map[string]negtypes.NetworkEndpointSet) map[string]negtypes.NetworkEndpointSet {
+	ret := map[string]negtypes.NetworkEndpointSet{}
 	for k, v := range endpointMap {
-		ret[k] = sets.NewString(v.List()...)
+		ret[k] = negtypes.NewNetworkEndpointSet(v.List()...)
 	}
 	return ret
 }
@@ -870,20 +869,20 @@ func generateTransaction(table transactionTable, entry transactionEntry, initial
 	}
 }
 
-func generateEndpointSet(initialIp net.IP, num int, instance string, targetPort string) sets.String {
-	ret := sets.NewString()
+func generateEndpointSet(initialIp net.IP, num int, instance string, targetPort string) negtypes.NetworkEndpointSet {
+	ret := negtypes.NewNetworkEndpointSet()
 	ip := initialIp.To4()
 	for i := 1; i <= num; i++ {
 		if i%256 == 0 {
 			ip[2]++
 		}
 		ip[3]++
-		ret.Insert(encodeEndpoint(ip.String(), instance, targetPort))
+		ret.Insert(negtypes.NetworkEndpoint{IP: ip.String(), Node: instance, Port: targetPort})
 	}
 	return ret
 }
 
-func generateEndpointBatch(endpointSet sets.String) map[string]*compute.NetworkEndpoint {
+func generateEndpointBatch(endpointSet negtypes.NetworkEndpointSet) map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint {
 	ret, _ := makeEndpointBatch(endpointSet)
 	return ret
 }

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -160,29 +160,151 @@ func TestCalculateDifference(t *testing.T) {
 	}
 }
 
+func TestNetworkEndpointCalculateDifference(t *testing.T) {
+	testCases := []struct {
+		targetSet  map[string]negtypes.NetworkEndpointSet
+		currentSet map[string]negtypes.NetworkEndpointSet
+		addSet     map[string]negtypes.NetworkEndpointSet
+		removeSet  map[string]negtypes.NetworkEndpointSet
+	}{
+		// unchanged
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			currentSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			addSet:    map[string]negtypes.NetworkEndpointSet{},
+			removeSet: map[string]negtypes.NetworkEndpointSet{},
+		},
+		// unchanged
+		{
+			targetSet:  map[string]negtypes.NetworkEndpointSet{},
+			currentSet: map[string]negtypes.NetworkEndpointSet{},
+			addSet:     map[string]negtypes.NetworkEndpointSet{},
+			removeSet:  map[string]negtypes.NetworkEndpointSet{},
+		},
+		// add in one zone
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			currentSet: map[string]negtypes.NetworkEndpointSet{},
+			addSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			removeSet: map[string]negtypes.NetworkEndpointSet{},
+		},
+		// add in 2 zones
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			},
+			currentSet: map[string]negtypes.NetworkEndpointSet{},
+			addSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			},
+			removeSet: map[string]negtypes.NetworkEndpointSet{},
+		},
+		// remove in one zone
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{},
+			currentSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			addSet: map[string]negtypes.NetworkEndpointSet{},
+			removeSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+		},
+		// remove in 2 zones
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{},
+			currentSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			},
+			addSet: map[string]negtypes.NetworkEndpointSet{},
+			removeSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			},
+		},
+		// add and delete in one zone
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			currentSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+			},
+			addSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+			},
+			removeSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+			},
+		},
+		// add and delete in 2 zones
+		{
+			targetSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			},
+			currentSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+			},
+			addSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+			},
+			removeSet: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		addSet, removeSet := calculateNetworkEndpointDifference(tc.targetSet, tc.currentSet)
+
+		if !reflect.DeepEqual(addSet, tc.addSet) {
+			t.Errorf("Failed to calculate difference for add, expecting %v, but got %v", tc.addSet, addSet)
+		}
+
+		if !reflect.DeepEqual(removeSet, tc.removeSet) {
+			t.Errorf("Failed to calculate difference for remove, expecting %v, but got %v", tc.removeSet, removeSet)
+		}
+	}
+}
+
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	testCases := []struct {
 		targetPort string
-		expect     map[string]sets.String
+		expect     map[string]negtypes.NetworkEndpointSet
 	}{
 		// Non exist
 		{
 			targetPort: "8888",
-			expect:     map[string]sets.String{},
+			expect:     map[string]negtypes.NetworkEndpointSet{},
 		},
 		{
 			targetPort: "80",
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("10.100.1.1||instance1||80", "10.100.1.2||instance1||80", "10.100.2.1||instance2||80"),
-				negtypes.TestZone2: sets.NewString("10.100.3.1||instance3||80"),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"), networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"), networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
 		},
 		{
 			targetPort: testNamedPort,
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("10.100.2.2||instance2||81"),
-				negtypes.TestZone2: sets.NewString("10.100.4.1||instance4||81", "10.100.3.2||instance3||8081", "10.100.4.2||instance4||8081"),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"), networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"), networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081")),
 			},
 		},
 	}
@@ -210,7 +332,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc      string
 		mutate    func(cloud negtypes.NetworkEndpointGroupCloud)
-		expect    map[string]sets.String
+		expect    map[string]negtypes.NetworkEndpointSet
 		expectErr bool
 	}{
 		{
@@ -237,9 +359,9 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
 				cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{Name: testNegName}, negtypes.TestZone2)
 			},
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString(),
-				negtypes.TestZone2: sets.NewString(),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
 			},
 			expectErr: false,
 		},
@@ -254,9 +376,9 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				})
 			},
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString(encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort)))),
-				negtypes.TestZone2: sets.NewString(),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
 			},
 			expectErr: false,
 		},
@@ -271,12 +393,12 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				})
 			},
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString(
-					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
-					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))},
+					negtypes.NetworkEndpoint{IP: testIP2, Node: negtypes.TestInstance2, Port: strconv.Itoa(int(testPort))},
 				),
-				negtypes.TestZone2: sets.NewString(),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
 			},
 			expectErr: false,
 		},
@@ -296,14 +418,14 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				})
 			},
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString(
-					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
-					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))},
+					negtypes.NetworkEndpoint{IP: testIP2, Node: negtypes.TestInstance2, Port: strconv.Itoa(int(testPort))},
 				),
-				negtypes.TestZone2: sets.NewString(
-					encodeEndpoint(testIP3, negtypes.TestInstance3, strconv.Itoa(int(testPort))),
-					encodeEndpoint(testIP4, negtypes.TestInstance4, strconv.Itoa(int(testPort))),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: testIP3, Node: negtypes.TestInstance3, Port: strconv.Itoa(int(testPort))},
+					negtypes.NetworkEndpoint{IP: testIP4, Node: negtypes.TestInstance4, Port: strconv.Itoa(int(testPort))},
 				),
 			},
 			expectErr: false,
@@ -319,14 +441,14 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				})
 			},
-			expect: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString(
-					encodeEndpoint(testIP1, negtypes.TestInstance1, strconv.Itoa(int(testPort))),
-					encodeEndpoint(testIP2, negtypes.TestInstance2, strconv.Itoa(int(testPort))),
+			expect: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))},
+					negtypes.NetworkEndpoint{IP: testIP2, Node: negtypes.TestInstance2, Port: strconv.Itoa(int(testPort))},
 				),
-				negtypes.TestZone2: sets.NewString(
-					encodeEndpoint(testIP3, negtypes.TestInstance3, strconv.Itoa(int(testPort))),
-					encodeEndpoint(testIP4, negtypes.TestInstance4, strconv.Itoa(int(testPort))),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: testIP3, Node: negtypes.TestInstance3, Port: strconv.Itoa(int(testPort))},
+					negtypes.NetworkEndpoint{IP: testIP4, Node: negtypes.TestInstance4, Port: strconv.Itoa(int(testPort))},
 				),
 			},
 			expectErr: false,
@@ -425,13 +547,13 @@ func TestMakeEndpointBatch(t *testing.T) {
 	}
 }
 
-func genTestEndpoints(num int) (sets.String, map[string]*compute.NetworkEndpoint) {
-	endpointSet := sets.NewString()
-	endpointMap := map[string]*compute.NetworkEndpoint{}
+func genTestEndpoints(num int) (negtypes.NetworkEndpointSet, map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint) {
+	endpointSet := negtypes.NewNetworkEndpointSet()
+	endpointMap := map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint{}
 	ip := "1.2.3.4"
 	instance := "instance"
 	for port := 0; port < num; port++ {
-		key := encodeEndpoint(ip, instance, strconv.Itoa(port))
+		key := negtypes.NetworkEndpoint{IP: ip, Node: instance, Port: strconv.Itoa(port)}
 		endpointSet.Insert(key)
 		endpointMap[key] = &compute.NetworkEndpoint{
 			IpAddress: ip,
@@ -440,4 +562,9 @@ func genTestEndpoints(num int) (sets.String, map[string]*compute.NetworkEndpoint
 		}
 	}
 	return endpointSet, endpointMap
+}
+
+func networkEndpointFromEncodedEndpoint(encodedEndpoint string) negtypes.NetworkEndpoint {
+	ip, node, port := decodeEndpoint(encodedEndpoint)
+	return negtypes.NetworkEndpoint{IP: ip, Node: node, Port: port}
 }

--- a/pkg/neg/types/network_endpoint.go
+++ b/pkg/neg/types/network_endpoint.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+)
+
+// NetworkEndpoint contains the essential information for each network endpoint in a NEG
+type NetworkEndpoint struct {
+	IP   string
+	Port string
+	Node string
+}
+
+// sets.NetworkEndpointSet is a set of NetworkEndpoints, implemented via map[NetworkEndpoint]struct{} for minimal memory consumption.
+type NetworkEndpointSet map[NetworkEndpoint]struct{}
+
+// NewNetworkEndpointSet creates a NetworkEndpointSet from a list of values.
+func NewNetworkEndpointSet(items ...NetworkEndpoint) NetworkEndpointSet {
+	ss := NetworkEndpointSet{}
+	ss.Insert(items...)
+	return ss
+}
+
+// NetworkEndpointSetKeySet creates a NetworkEndpointSet from a keys of a map[NetworkEndpoint](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func NetworkEndpointSetKeySet(theMap interface{}) NetworkEndpointSet {
+	v := reflect.ValueOf(theMap)
+	ret := NetworkEndpointSet{}
+
+	for _, keyValue := range v.MapKeys() {
+		ret.Insert(keyValue.Interface().(NetworkEndpoint))
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s NetworkEndpointSet) Insert(items ...NetworkEndpoint) {
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+}
+
+// Delete removes all items from the set.
+func (s NetworkEndpointSet) Delete(items ...NetworkEndpoint) {
+	for _, item := range items {
+		delete(s, item)
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s NetworkEndpointSet) Has(item NetworkEndpoint) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s NetworkEndpointSet) HasAll(items ...NetworkEndpoint) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s NetworkEndpointSet) HasAny(items ...NetworkEndpoint) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s NetworkEndpointSet) Difference(s2 NetworkEndpointSet) NetworkEndpointSet {
+	result := NewNetworkEndpointSet()
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 NetworkEndpointSet) Union(s2 NetworkEndpointSet) NetworkEndpointSet {
+	result := NewNetworkEndpointSet()
+	for key := range s1 {
+		result.Insert(key)
+	}
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 NetworkEndpointSet) Intersection(s2 NetworkEndpointSet) NetworkEndpointSet {
+	var walk, other NetworkEndpointSet
+	result := NewNetworkEndpointSet()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 NetworkEndpointSet) IsSuperset(s2 NetworkEndpointSet) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 NetworkEndpointSet) Equal(s2 NetworkEndpointSet) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+// List returns the slice with contents in random order.
+func (s NetworkEndpointSet) List() []NetworkEndpoint {
+	res := make([]NetworkEndpoint, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return []NetworkEndpoint(res)
+}
+
+// Returns a single element from the set.
+func (s NetworkEndpointSet) PopAny() (NetworkEndpoint, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue NetworkEndpoint
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s NetworkEndpointSet) Len() int {
+	return len(s)
+}

--- a/pkg/neg/types/network_endpoint_test.go
+++ b/pkg/neg/types/network_endpoint_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+)
+
+func TestNetworkEndpointSetSet(t *testing.T) {
+	s := NetworkEndpointSet{}
+	s2 := NetworkEndpointSet{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	s.Insert(genNetworkEndpoint("a"), genNetworkEndpoint("b"))
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert(genNetworkEndpoint("c"))
+	if s.Has(genNetworkEndpoint("d")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has(genNetworkEndpoint("a")) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete(genNetworkEndpoint("a"))
+	if s.Has(genNetworkEndpoint("a")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert(genNetworkEndpoint("a"))
+	if s.HasAll(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("d")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll(genNetworkEndpoint("a"), genNetworkEndpoint("b")) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("d"))
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete(genNetworkEndpoint("d"))
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestNetworkEndpointSetSetDeleteMultiples(t *testing.T) {
+	s := NetworkEndpointSet{}
+	s.Insert(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c"))
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete(genNetworkEndpoint("a"), genNetworkEndpoint("c"))
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has(genNetworkEndpoint("a")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has(genNetworkEndpoint("c")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has(genNetworkEndpoint("b")) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+
+}
+
+func TestNewNetworkEndpointSetSet(t *testing.T) {
+	s := NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c"))
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has(genNetworkEndpoint("a")) || !s.Has(genNetworkEndpoint("b")) || !s.Has(genNetworkEndpoint("c")) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestNetworkEndpointSetSetList(t *testing.T) {
+	s := NewNetworkEndpointSet(genNetworkEndpoint("z"), genNetworkEndpoint("y"), genNetworkEndpoint("x"), genNetworkEndpoint("a"))
+	list := s.List()
+	if len(s) != 4 {
+		t.Errorf("Expected len=4: %d", len(s))
+	}
+
+	for _, ne := range list {
+		if !s.Has(ne) {
+			t.Errorf("Item %v from the list is not in set", ne)
+		}
+	}
+}
+
+func TestNetworkEndpointSetSetDifference(t *testing.T) {
+	a := NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"))
+	b := NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("4"), genNetworkEndpoint("5"))
+	c := a.Difference(b)
+	d := b.Difference(a)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has(genNetworkEndpoint("3")) {
+		t.Errorf("Unexpected contents: %#v", c.List())
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has(genNetworkEndpoint("4")) || !d.Has(genNetworkEndpoint("5")) {
+		t.Errorf("Unexpected contents: %#v", d.List())
+	}
+}
+
+func TestNetworkEndpointSetSetHasAny(t *testing.T) {
+	a := NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"))
+
+	if !a.HasAny(genNetworkEndpoint("1"), genNetworkEndpoint("4")) {
+		t.Errorf("expected true, got false")
+	}
+
+	if a.HasAny(genNetworkEndpoint("0"), genNetworkEndpoint("4")) {
+		t.Errorf("expected false, got true")
+	}
+}
+
+func TestNetworkEndpointSetSetEquals(t *testing.T) {
+	// Simple case (order doesn't matter)
+	a := NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"))
+	b := NewNetworkEndpointSet(genNetworkEndpoint("2"), genNetworkEndpoint("1"))
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// It is a set; duplicates are ignored
+	b = NewNetworkEndpointSet(genNetworkEndpoint("2"), genNetworkEndpoint("2"), genNetworkEndpoint("1"))
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// Edge cases around empty sets / empty NetworkEndpoints
+	a = NewNetworkEndpointSet()
+	b = NewNetworkEndpointSet()
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	b = NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"))
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	b = NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint(""))
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	// Check for equality after mutation
+	a = NewNetworkEndpointSet()
+	a.Insert(genNetworkEndpoint("1"))
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert(genNetworkEndpoint("2"))
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert(genNetworkEndpoint(""))
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	a.Delete(genNetworkEndpoint(""))
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+}
+
+func TestNetworkEndpointSetUnion(t *testing.T) {
+	tests := []struct {
+		s1       NetworkEndpointSet
+		s2       NetworkEndpointSet
+		expected NetworkEndpointSet
+	}{
+		{
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(genNetworkEndpoint("3"), genNetworkEndpoint("4"), genNetworkEndpoint("5"), genNetworkEndpoint("6")),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4"), genNetworkEndpoint("5"), genNetworkEndpoint("6")),
+		},
+		{
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+		},
+		{
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+		},
+		{
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(),
+		},
+	}
+
+	for _, test := range tests {
+		union := test.s1.Union(test.s2)
+		if union.Len() != test.expected.Len() {
+			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
+		}
+
+		if !union.Equal(test.expected) {
+			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
+		}
+	}
+}
+
+func TestNetworkEndpointSetIntersection(t *testing.T) {
+	tests := []struct {
+		s1       NetworkEndpointSet
+		s2       NetworkEndpointSet
+		expected NetworkEndpointSet
+	}{
+		{
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(genNetworkEndpoint("3"), genNetworkEndpoint("4"), genNetworkEndpoint("5"), genNetworkEndpoint("6")),
+			NewNetworkEndpointSet(genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+		},
+		{
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+		},
+		{
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(),
+		},
+		{
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(genNetworkEndpoint("1"), genNetworkEndpoint("2"), genNetworkEndpoint("3"), genNetworkEndpoint("4")),
+			NewNetworkEndpointSet(),
+		},
+		{
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(),
+			NewNetworkEndpointSet(),
+		},
+	}
+
+	for _, test := range tests {
+		intersection := test.s1.Intersection(test.s2)
+		if intersection.Len() != test.expected.Len() {
+			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
+		}
+
+		if !intersection.Equal(test.expected) {
+			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
+		}
+	}
+}
+
+func genNetworkEndpoint(key string) NetworkEndpoint {
+	return NetworkEndpoint{
+		IP:   key,
+		Port: key,
+		Node: key,
+	}
+}


### PR DESCRIPTION
- Introduce a NetworkEndpoint Type to represent the meta information contained in NE.
- Introduce NetworkEndpointSet Type to support fast Get, Insert and DIfference calculation
- Adjust Transaction table to use NetworkEndpoint Type as key
- Adjust Transaction Syncer to use NetworkEndpoint and NetworkEndpointSet Type for internal plumbing. 
- Completely remove use of sets.String type for endpoint calculation. 