### PR TITLE
Do not run as root by default in docker

### DIFF
--- a/Dockerfile.e2e-test
+++ b/Dockerfile.e2e-test
@@ -20,4 +20,7 @@ COPY cmd/e2e-test/run.sh /run.sh
 RUN apt-get update && apt-get install -y curl python
 RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-206.0.0-linux-x86_64.tar.gz | tar -zxf -
 
+# nobody:nobody
+USER 65534:65534
+
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.echo
+++ b/Dockerfile.echo
@@ -15,4 +15,8 @@
 FROM debian:9
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+
+# nobody:nobody
+USER 65534:65534
+
 ENTRYPOINT ["/ARG_BIN"]

--- a/Dockerfile.fuzzer
+++ b/Dockerfile.fuzzer
@@ -16,4 +16,8 @@
 FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+
+# nobody:nobody
+USER 65534:65534
+
 ENTRYPOINT ["/ARG_BIN"]

--- a/Dockerfile.glbc
+++ b/Dockerfile.glbc
@@ -16,4 +16,8 @@
 FROM gcr.io/distroless/static:latest
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+
+# nobody:nobody
+USER 65534:65534
+
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
Processes in a container should not run as root, or assume that they are root. Instead, a good practice is to create a user in your Dockerfile with a known UID and GID, and run your process as this user. Images that follow this pattern are easier to run securely by limiting access to resources