### PR TITLE
Deploying to GKE self managed has invalid YAML

### DIFF
--- a/docs/deploy/resources/rbac.yaml
+++ b/docs/deploy/resources/rbac.yaml
@@ -25,6 +25,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: system:controller:glbc
+subjects:
 - kind: ServiceAccount
   name: glbc
   namespace: kube-system


### PR DESCRIPTION
This is for issue #755. Straightforward fix for the invalid syntax. I tested the script with this change.

Given that the invalid syntax should have prevented anyone from using the script, it is rather concerning. Implies no tests for this. But creating a meaningful test for it is quite non-trivial, so not doing that here.