### PR TITLE
GCP forwarding rule/target proxy description field populated

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -70,12 +70,17 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 	}
 	if fw == nil {
 		klog.V(3).Infof("Creating forwarding rule for proxy %q and ip %v:%v", proxyLink, ip, portRange)
+		description, err := l.description()
+		if err != nil {
+			return nil, err
+		}
 		rule := &compute.ForwardingRule{
-			Name:       name,
-			IPAddress:  ip,
-			Target:     proxyLink,
-			PortRange:  portRange,
-			IPProtocol: "TCP",
+			Name:        name,
+			IPAddress:   ip,
+			Target:      proxyLink,
+			PortRange:   portRange,
+			IPProtocol:  "TCP",
+			Description: description,
 		}
 		if err = l.cloud.CreateGlobalForwardingRule(rule); err != nil {
 			return nil, err

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
 	compute "google.golang.org/api/compute/v1"
@@ -307,4 +308,17 @@ func GCEResourceName(ingAnnotations map[string]string, resourceName string) stri
 	// parsing logic in a single location.
 	resourceName, _ = ingAnnotations[fmt.Sprintf("%v/%v", annotations.StatusPrefix, resourceName)]
 	return resourceName
+}
+
+// description gets a description for the ingress GCP resources.
+func (l *L7) description() (string, error) {
+	if l.runtimeInfo.Ingress == nil {
+		return "", fmt.Errorf("missing Ingress object to construct description for %s", l.Name)
+	}
+
+	namespace := l.runtimeInfo.Ingress.ObjectMeta.Namespace
+	ingressName := l.runtimeInfo.Ingress.ObjectMeta.Name
+	namespacedName := types.NamespacedName{Name: ingressName, Namespace: namespace}
+
+	return fmt.Sprintf(`{"kubernetes.io/ingress-name": %q}`, namespacedName.String()), nil
 }

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -34,9 +34,14 @@ func (l *L7) checkProxy() (err error) {
 	proxy, _ := l.cloud.GetTargetHTTPProxy(proxyName)
 	if proxy == nil {
 		klog.V(3).Infof("Creating new http proxy for urlmap %v", l.um.Name)
+		description, err := l.description()
+		if err != nil {
+			return err
+		}
 		newProxy := &compute.TargetHttpProxy{
-			Name:   proxyName,
-			UrlMap: urlMapLink,
+			Name:        proxyName,
+			Description: description,
+			UrlMap:      urlMapLink,
 		}
 		if err = l.cloud.CreateTargetHTTPProxy(newProxy); err != nil {
 			return err
@@ -70,9 +75,14 @@ func (l *L7) checkHttpsProxy() (err error) {
 	proxy, _ := l.cloud.GetTargetHTTPSProxy(proxyName)
 	if proxy == nil {
 		klog.V(3).Infof("Creating new https proxy for urlmap %q", l.um.Name)
+		description, err := l.description()
+		if err != nil {
+			return err
+		}
 		newProxy := &compute.TargetHttpsProxy{
-			Name:   proxyName,
-			UrlMap: urlMapLink,
+			Name:        proxyName,
+			Description: description,
+			UrlMap:      urlMapLink,
 		}
 
 		for _, c := range l.sslCerts {


### PR DESCRIPTION
This is for issue #661.

The description are the [same values as AWS uses in their Ingress](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#resource-tags).

Unit tests were updated. Can be viewed by creating an ingress and in Cloud Console, go to Network services > Load balancing > advanced view (description column). Note that the cluster name field is probably not the actual cluster name, but does identify the cluster (and instance group, etc).