### PR TITLE
Updates for usability of GKE self managed setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ bin/
 .*-dockerfile
 .*-push
 bin/
-docs/deploy/resources/gce.conf.custom
-docs/deploy/resources/glbc.yaml.custom
+docs/deploy/resources/*.gen

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bin/
 .*-dockerfile
 .*-push
 bin/
+docs/deploy/resources/gce.conf.custom

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bin/
 .*-push
 bin/
 docs/deploy/resources/gce.conf.custom
+docs/deploy/resources/glbc.yaml.custom

--- a/docs/deploy/gke/README.md
+++ b/docs/deploy/gke/README.md
@@ -30,9 +30,6 @@ permission to do basically anything so all commands the script runs should
 theoretically work. If not, the script will do its best to fail gracefully
 and let you know what might have went wrong.
 
-The second step is to make sure you populate the [gce.conf](../resources/gce.conf) file. The instructions
-for populating the file are in the file itself. You just have to fill it in.
-
 # Important Details
 
 Most likely, you want to know what this script is doing to your cluster in order
@@ -41,11 +38,9 @@ can go ahead and skip this section.
 
 Here is a brief summary of each major thing we do and why:
 
-1. Turn off GLBC and turn on new GLBC in the cluster
-    * To be brief, the maintenance cost of running a new controller on the master
-      is actually pretty high. This is why we chose to move the controller
-      to the cluster.
-1. Create a new k8s RBAC role
+1. (If applicable) figure out information you didn't provide from the cluster and
+   build and push the GLBC image.
+2. Create a new k8s RBAC role
     * On the master, the GLBC has unauthenticated access to the k8s API server.
       Once we move the GLBC to the cluster, that path is gone. Therefore, we need to
       configure a new RBAC role that allows GLBC the same access.
@@ -54,10 +49,13 @@ Here is a brief summary of each major thing we do and why:
       token pulled from a private GKE endpoint. Moving to the cluster will result in
       us not being able to utilize this. Therefore, we need to create a new GCP
       service account and a corresponding key which will grant access.
-4. Start new GLBC (and default backend) in the cluster
-    * As stated before, we need to run the GLBC in the cluster. We also need to
-      startup a new default backend because the mechanism we use to turn off the
-      master GLBC removes both the GLBC and the default backend.
+4. Update the cluster to turn off the default GLBC
+    * This restarts the cluster master. The API server will be temporarily unavailable.
+5. Create our own default backend and custom GLBC on the cluster
+    * We need to startup a new default backend because the mechanism we
+      use to turn off the master GLBC removes both the GLBC and the default backend.
+    * This is dependent on the default GLBC being running initially, as we use
+      the same nodeport.
     * Because we have to recreate the default backend, there will be a small
       segment of time when requests to the default backend will time out.
 
@@ -71,30 +69,46 @@ Here is an explanation of each script dependency.
 1. [gce.conf](../resources/gce.conf)
     * This file normally sits on the GKE master and provides important config for
       the GCP Compute API client within the GLBC. The GLBC is configured to know
-      where to look for this file. In this case, we simply mount the file as a
-      volume and tell GLBC to look for it there.
+      where to look for this file. In this case, we simply mount a customized copy
+      of the file as a volume and tell GLBC to look for it there.
 2. [default-http-backend.yaml](../resources/default-http-backend.yaml)
     * This file contains the specifications for both the default-http-backend
       deployment and service. This is no different than what you are used to
       seeing in your cluster. In this case, we need to recreate the default
-      backend since turning off the GLBC on the master removes it.
+      backend since turning off the GLBC on the master removes it. Note that we
+      modify the file to use the same node port as before before we create the resource.
 3. [rbac.yaml](../resources/rbac.yaml)
     * This file contains specification for an RBAC role which gives the GLBC
       access to the resources it needs from the k8s API server.
 4. [glbc.yaml](../resources/glbc.yaml)
     * This file contains the specification for the GLBC deployment. Notice that in
       this case, we need a deployment because we want to preserve the controller
-      in case of node restarts.
+      in case of node restarts. The resource we create is from a customized copy of
+      this file that uses the specified (or newly built) image.
 
 Take a look at the script to understand where each file is used.
 
 # Running the Script
 
-Run the command below to see the usage:
+The script can take in a number of settings, but only really requires the cluster
+name and zone. You can provide other settings for if we incorrectly intuit any
+values. Usage:
 
-`./gke-self-managed.sh --help`
+```shell
+# Must be in the script directory
+cd docs/deploy/gke
+./gke-self-managed.sh -n CLUSTER_NAME -z ZONE
+```
 
-After that, it should be self-explanatory!
+For other options, see the `--help` output.
+
+Can speed things up if you've already pushed an image (or want to use a specific
+version) with `--image-url PATH` (eg,
+`--image-url k8s.gcr.io/ingress-gce-glbc-amd64:v1.5.2`). Can also set the `REGISTRY`
+env var to provide a custom place to push your image to if it's not the same project
+as your cluster is in. The tags pushed to will be that of the
+`git describe --tags --always --dirty` command. If the `VERSION` env var is set, that
+will be used as the tag.
 
 # Common Issues
 

--- a/docs/deploy/gke/README.md
+++ b/docs/deploy/gke/README.md
@@ -91,7 +91,7 @@ Take a look at the script to understand where each file is used.
 # Running the Script
 
 The script can take in a number of settings, but only really requires the cluster
-name and zone. You can provide other settings for if we incorrectly intuit any
+name and zone. You can provide other settings for if we incorrectly deduce any
 values. Usage:
 
 ```shell

--- a/docs/deploy/resources/gce.conf
+++ b/docs/deploy/resources/gce.conf
@@ -1,8 +1,14 @@
 [global]
 token-url = nil
-project-id = YOUR CLUSTER'S PROJECT
-network-name = YOUR CLUSTER'S NETWORK
-subnetwork-name = YOUR CLUSTER'S SUBNETWORK
-node-instance-prefix = gke-YOUR CLUSTER'S NAME
-node-tags = NETWORK TAGS FOR YOUR CLUSTER'S INSTANCE GROUP
-local-zone = YOUR CLUSTER'S ZONE
+# Your cluster's project
+project-id = [PROJECT]
+# Your cluster's network
+network-name =  [NETWORK]
+# Your cluster's subnetwork
+subnetwork-name = [SUBNETWORK]
+# Prefix for your cluster's IG
+node-instance-prefix = gke-[CLUSTER_NAME]
+# Network tags for your cluster's IG
+node-tags = [NETWORK_TAGS]
+# Zone the cluster lives in
+local-zone = [ZONE]

--- a/docs/deploy/resources/gce.conf
+++ b/docs/deploy/resources/gce.conf
@@ -5,4 +5,4 @@ network-name = YOUR CLUSTER'S NETWORK
 subnetwork-name = YOUR CLUSTER'S SUBNETWORK
 node-instance-prefix = gke-YOUR CLUSTER'S NAME
 node-tags = NETWORK TAGS FOR YOUR CLUSTER'S INSTANCE GROUP
-local-zone= YOUR CLUSTER'S ZONE
+local-zone = YOUR CLUSTER'S ZONE

--- a/docs/deploy/resources/glbc.yaml
+++ b/docs/deploy/resources/glbc.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 600
       hostNetwork: true
       containers:
-      - image: ### IMAGE URL HERE ###
+      - image: [IMAGE_URL]
         livenessProbe:
           httpGet:
             path: /healthz
@@ -54,7 +54,7 @@ spec:
         command:
         - /glbc
         - -v2
-        - --config-file-path=/etc/gce/gce.conf.custom
+        - --config-file-path=/etc/gce/gce.conf.gen
         - --healthz-port=8086
         - --logtostderr
         - --sync-period=600s
@@ -71,5 +71,5 @@ spec:
         configMap:
           name: gce-config
           items:
-          - key: gce.conf.custom
-            path: gce.conf.custom
+          - key: gce.conf.gen
+            path: gce.conf.gen

--- a/docs/deploy/resources/glbc.yaml
+++ b/docs/deploy/resources/glbc.yaml
@@ -54,7 +54,7 @@ spec:
         command:
         - /glbc
         - -v2
-        - --config-file-path=/etc/gce/gce.conf
+        - --config-file-path=/etc/gce/gce.conf.custom
         - --healthz-port=8086
         - --logtostderr
         - --sync-period=600s
@@ -71,5 +71,5 @@ spec:
         configMap:
           name: gce-config
           items:
-          - key: gce.conf
-            path: gce.conf
+          - key: gce.conf.custom
+            path: gce.conf.custom

--- a/docs/deploy/resources/glbc.yaml
+++ b/docs/deploy/resources/glbc.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 600
       hostNetwork: true
       containers:
-      - image: k8s.gcr.io/ingress-gce-glbc-amd64:[SET VERSION HERE]
+      - image: ### IMAGE URL HERE ###
         livenessProbe:
           httpGet:
             path: /healthz
@@ -52,10 +52,17 @@ spec:
             cpu: 10m
             memory: 50Mi
         command:
-        # TODO: split this out into args when we no longer need to pipe stdout to a file #6428
-        - sh
-        - -c
-        - 'exec /glbc --gce-ratelimit=ga.Operations.Get,qps,10,100 --gce-ratelimit=alpha.Operations.Get,qps,10,100 --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1 --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1 --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1 --verbose --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=true --use-real-cloud=true --config-file-path=/etc/gce/gce.conf --healthz-port=8086 --enable-backend-config 2>&1'
+        - /glbc
+        - -v2
+        - --config-file-path=/etc/gce/gce.conf
+        - --healthz-port=8086
+        - --logtostderr
+        - --sync-period=600s
+        - --gce-ratelimit=ga.Operations.Get,qps,10,100
+        - --gce-ratelimit=alpha.Operations.Get,qps,10,100
+        - --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1
+        - --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1
+        - --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1
       volumes:
       - name: google-cloud-key
         secret:


### PR DESCRIPTION
For issue #758.

This does several things to make this setup much easier. But in short, it allows a single command to be used to setup for the vast majority of cases (with just `./gke-self-managed.sh -n CLUSTER_NAME -z ZONE`).

1. The CLI flags are updated to actually work (ie, represent those used by the GLBC now).
2. The gce.conf file is automatically populated from querying the cluster. All options can be instead provided as CLI flags if the querying gets them wrong or to speed things up slightly (the time to query is pretty negligible compared to the time to restart the cluster to turn off the default GLBC, though).
3. The `glbc.yaml` file is automatically setup with the image instead of letting users create an invalid deployment that won't be caught till runtime.
4. The script defaults to building and pushing the image, making the script usable for quickly testing changes. The image to use can be specified as a flag instead. The registry to use is customizable the same way `make push` does.
5. We handle progress better. No more winging it by hoping the API server is up  and running.

Opted not to make a test for it this ticket. We really should have some kinda test (since the script got terribly broken in 2 ways), but it's quite difficult to test given that it requires cluster ownership, needs push access to some container registry, requires an existing cluster, and is very slow no matter how you cut it (it needs to restart a cluster and realistically, a test would also need to create an ingress, which takes a few minutes). I'll make a new issue for testing it, but it's likely to be lower priority as the ROI is complicated.

This is a non-breaking change, since the existing `gce.conf` file is used as a template and if it were already filled in, those fields would just be ignored. The files that need modification are now copied to and `.gitignored`, too, so no risks of accidental commits or annoyance of having them show up in the `git status`.