### PR TITLE
Parse the gce endpoint flag the same way as k8s

### DIFF
--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -64,7 +64,7 @@ func init() {
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
-	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/projects/")
+	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/")
 }
 
 // TestMain is the entrypoint for the end-to-end test suite. This is where

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -232,9 +232,9 @@ func NewCloud(project, GceEndpointOverride string) (cloud.Cloud, error) {
 	}
 
 	if GceEndpointOverride != "" {
-		service.BasePath = GceEndpointOverride
-		serviceAlpha.BasePath = strings.Replace(GceEndpointOverride, "v1", "alpha", -1)
-		serviceBeta.BasePath = strings.Replace(GceEndpointOverride, "v1", "beta", -1)
+		service.BasePath = fmt.Sprintf("%sprojects/", GceEndpointOverride)
+		serviceBeta.BasePath = fmt.Sprintf("%sprojects/", strings.Replace(GceEndpointOverride, "v1", "beta", -1))
+		serviceAlpha.BasePath = fmt.Sprintf("%sprojects/", strings.Replace(GceEndpointOverride, "v1", "alpha", -1))
 	}
 
 	cloudService := &cloud.Service{


### PR DESCRIPTION
Unfortunately this flag has to be the same as https://github.com/kubernetes/kubernetes/blob/8765fa2e48974e005ad16e65cb5c3acf5acff17b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L421-L429

/assign @MrHohn @rramkumar1 