### PR TITLE
Add support for L7-ILB

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -54,6 +54,7 @@ const (
 	IngressClassKey      = "kubernetes.io/ingress.class"
 	GceIngressClass      = "gce"
 	GceMultiIngressClass = "gce-multi-cluster"
+	GceILBIngressClass   = "gce-l7-ilb"
 
 	// Label key to denote which GCE zone a Kubernetes node is in.
 	ZoneKey     = "failure-domain.beta.kubernetes.io/zone"

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -14,10 +14,11 @@ limitations under the License.
 package backends
 
 import (
+	features2 "k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"k8s.io/ingress-gce/pkg/backends/features"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -27,8 +28,9 @@ import (
 
 // Backends handles CRUD operations for backends.
 type Backends struct {
-	cloud *gce.Cloud
-	namer *utils.Namer
+	cloud          *gce.Cloud
+	namer          *utils.Namer
+	compositeCloud *composite.Cloud
 }
 
 // Backends is a Pool.
@@ -36,11 +38,12 @@ var _ Pool = (*Backends)(nil)
 
 // NewPool returns a new backend pool.
 // - cloud: implements BackendServices
-// - namer: procudes names for backends.
+// - namer: produces names for backends.
 func NewPool(cloud *gce.Cloud, namer *utils.Namer) *Backends {
 	return &Backends{
-		cloud: cloud,
-		namer: namer,
+		cloud:          cloud,
+		namer:          namer,
+		compositeCloud: composite.NewCloud(cloud),
 	}
 }
 
@@ -65,6 +68,7 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 	}
 
 	version := features.VersionFromServicePort(&sp)
+	key := b.compositeCloud.CreateKey(name, sp.ILBEnabled)
 	be := &composite.BackendService{
 		Version:      version,
 		Name:         name,
@@ -72,30 +76,37 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 		Port:         namedPort.Port,
 		PortName:     namedPort.Name,
 		HealthChecks: []string{hcLink},
+		Region:       key.Region,
 	}
+
+	if sp.ILBEnabled {
+		be.LoadBalancingScheme = "INTERNAL"
+	}
+
 	ensureDescription(be, &sp)
-	if err := composite.CreateBackendService(be, b.cloud, meta.GlobalKey(be.Name)); err != nil {
+	if err := b.compositeCloud.CreateBackendService(be, key); err != nil {
 		return nil, err
 	}
 	// Note: We need to perform a GCE call to re-fetch the object we just created
 	// so that the "Fingerprint" field is filled in. This is needed to update the
 	// object without error.
-	return b.Get(name, version)
+	return b.Get(name, version, sp.ILBEnabled)
 }
 
 // Update implements Pool.
 func (b *Backends) Update(be *composite.BackendService) error {
 	// Ensure the backend service has the proper version before updating.
 	be.Version = features.VersionFromDescription(be.Description)
-	if err := composite.UpdateBackendService(be, b.cloud, meta.GlobalKey(be.Name)); err != nil {
+	isRegional := be.ResourceType == meta.Regional
+	if err := b.compositeCloud.UpdateBackendService(be, b.compositeCloud.CreateKey(be.Name, isRegional)); err != nil {
 		return err
 	}
 	return nil
 }
 
 // Get implements Pool.
-func (b *Backends) Get(name string, version meta.Version) (*composite.BackendService, error) {
-	be, err := composite.GetBackendService(version, b.cloud, meta.GlobalKey(name))
+func (b *Backends) Get(name string, version meta.Version, regional bool) (*composite.BackendService, error) {
+	be, err := b.compositeCloud.GetBackendService(version, b.compositeCloud.CreateKey(name, regional))
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +114,9 @@ func (b *Backends) Get(name string, version meta.Version) (*composite.BackendSer
 	// API version is required so that we don't lose information from
 	// the existing backend service.
 	versionRequired := features.VersionFromDescription(be.Description)
+
 	if features.IsLowerVersion(versionRequired, version) {
-		be, err = composite.GetBackendService(versionRequired, b.cloud, meta.GlobalKey(name))
+		be, err = b.compositeCloud.GetBackendService(versionRequired, b.compositeCloud.CreateKey(name, regional))
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +125,7 @@ func (b *Backends) Get(name string, version meta.Version) (*composite.BackendSer
 }
 
 // Delete implements Pool.
-func (b *Backends) Delete(name string) (err error) {
+func (b *Backends) Delete(name string, regional bool) (err error) {
 	defer func() {
 		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 			err = nil
@@ -122,23 +134,37 @@ func (b *Backends) Delete(name string) (err error) {
 
 	klog.V(2).Infof("Deleting backend service %v", name)
 
+	var version meta.Version
+	if regional {
+		version = features2.ILBVersion
+	} else {
+		version = meta.VersionGA
+	}
+
 	// Try deleting health checks even if a backend is not found.
-	if err = b.cloud.DeleteGlobalBackendService(name); err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+	// Use GA version since deleting should still work
+	if err = b.compositeCloud.DeleteBackendService(version, b.compositeCloud.CreateKey(name, regional)); err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 		return err
 	}
 	return
 }
 
 // Health implements Pool.
-func (b *Backends) Health(name string) string {
-	be, err := b.Get(name, meta.VersionGA)
+func (b *Backends) Health(name string, version meta.Version, regional bool) string {
+	be, err := b.Get(name, version, regional)
 	if err != nil || len(be.Backends) == 0 {
 		return "Unknown"
 	}
 
 	// TODO: Look at more than one backend's status
 	// TODO: Include port, ip in the status, since it's in the health info.
-	hs, err := b.cloud.GetGlobalBackendServiceHealth(name, be.Backends[0].Group)
+	// TODO (shance) convert to composite types
+	var hs *compute.BackendServiceGroupHealth
+	if regional {
+		hs, err = b.cloud.GetRegionalBackendServiceHealth(name, b.cloud.Region(), be.Backends[0].Group)
+	} else {
+		hs, err = b.cloud.GetGlobalBackendServiceHealth(name, be.Backends[0].Group)
+	}
 	if err != nil || len(hs.HealthStatus) == 0 || hs.HealthStatus[0] == nil {
 		return "Unknown"
 	}
@@ -147,20 +173,21 @@ func (b *Backends) Health(name string) string {
 }
 
 // List lists all backends managed by this controller.
-func (b *Backends) List() ([]string, error) {
+// TODO: (shance) convert to composite types
+func (b *Backends) List() ([]*composite.BackendService, error) {
 	// TODO: for consistency with the rest of this sub-package this method
 	// should return a list of backend ports.
-	backends, err := b.cloud.ListGlobalBackendServices()
+	backends, err := b.compositeCloud.ListAllBackendServices()
 	if err != nil {
 		return nil, err
 	}
 
-	var names []string
+	var clusterBackends []*composite.BackendService
 
 	for _, bs := range backends {
 		if b.namer.NameBelongsToCluster(bs.Name) {
-			names = append(names, bs.Name)
+			clusterBackends = append(clusterBackends, bs)
 		}
 	}
-	return names, nil
+	return clusterBackends, nil
 }

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -14,7 +14,7 @@ limitations under the License.
 package backends
 
 import (
-	features2 "k8s.io/ingress-gce/pkg/loadbalancers/features"
+	lbfeatures "k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -42,8 +42,8 @@ var _ Pool = (*Backends)(nil)
 func NewPool(cloud *gce.Cloud, namer *utils.Namer) *Backends {
 	return &Backends{
 		cloud:          cloud,
-		namer:          namer,
 		compositeCloud: composite.NewCloud(cloud),
+		namer:          namer,
 	}
 }
 
@@ -136,7 +136,7 @@ func (b *Backends) Delete(name string, regional bool) (err error) {
 
 	var version meta.Version
 	if regional {
-		version = features2.ILBVersion
+		version = lbfeatures.ILBVersion
 	} else {
 		version = meta.VersionGA
 	}

--- a/pkg/backends/features/features.go
+++ b/pkg/backends/features/features.go
@@ -33,13 +33,15 @@ const (
 	FeatureSecurityPolicy = "SecurityPolicy"
 	// FeatureNEG defines the feature name of NEG.
 	FeatureNEG = "NEG"
+	// FeatureILB defines the feature name of the l7 internal load balancer
+	FeatureILB = "ILB"
 )
 
 var (
 	// versionToFeatures stores the mapping from the required API
 	// version to feature names.
 	versionToFeatures = map[meta.Version][]string{
-		meta.VersionAlpha: []string{},
+		meta.VersionAlpha: []string{FeatureILB},
 		meta.VersionBeta:  []string{FeatureSecurityPolicy, FeatureHTTP2},
 	}
 )
@@ -61,6 +63,9 @@ func featuresFromServicePort(sp *utils.ServicePort) []string {
 	}
 	if sp.NEGEnabled {
 		features = append(features, FeatureNEG)
+	}
+	if sp.ILBEnabled {
+		features = append(features, FeatureILB)
 	}
 	// Keep feature names sorted to be consistent.
 	sort.Strings(features)

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -93,7 +93,7 @@ func (l *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) erro
 		igLinks = append(igLinks, ig.SelfLink)
 	}
 
-	be, err := l.backendPool.Get(sp.BackendName(l.namer), meta.VersionGA)
+	be, err := l.backendPool.Get(sp.BackendName(l.namer), meta.VersionGA, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -122,6 +122,6 @@ func TestLinkWithCreationModeError(t *testing.T) {
 				t.Fatalf("Wrong balancing mode, expected %v got %v", modes[(i+1)%len(modes)], b.BalancingMode)
 			}
 		}
-		linker.backendPool.Delete(sp.BackendName(defaultNamer))
+		linker.backendPool.Delete(sp.BackendName(defaultNamer), false)
 	}
 }

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -35,17 +35,17 @@ type GroupKey struct {
 // Backend Services.
 type Pool interface {
 	// Get a composite BackendService given a required version.
-	Get(name string, version meta.Version) (*composite.BackendService, error)
+	Get(name string, version meta.Version, regional bool) (*composite.BackendService, error)
 	// Create a composite BackendService and returns it.
 	Create(sp utils.ServicePort, hcLink string) (*composite.BackendService, error)
 	// Update a BackendService given the composite type.
 	Update(be *composite.BackendService) error
 	// Delete a BackendService given its name.
-	Delete(name string) error
+	Delete(name string, regional bool) error
 	// Get the health of a BackendService given its name.
-	Health(name string) string
+	Health(name string, version meta.Version, regional bool) string
 	// Get a list of BackendService names that are managed by this pool.
-	List() ([]string, error)
+	List() ([]*composite.BackendService, error)
 }
 
 // Syncer is an interface to sync Kubernetes services to GCE BackendServices.
@@ -58,7 +58,7 @@ type Syncer interface {
 	// GC garbage collects unused BackendService's
 	GC(svcPorts []utils.ServicePort) error
 	// Status returns the status of a BackendService given its name.
-	Status(name string) string
+	Status(name string, version meta.Version, regional bool) string
 	// Shutdown cleans up all BackendService's previously synced.
 	Shutdown() error
 }

--- a/pkg/backends/neg_linker.go
+++ b/pkg/backends/neg_linker.go
@@ -61,7 +61,6 @@ func (l *negLinker) Link(sp utils.ServicePort, groups []GroupKey) error {
 		negs = append(negs, neg)
 	}
 
-	//cloud := l.backendPool.(*Backends).cloud
 	compositeCloud := l.backendPool.(*Backends).compositeCloud
 	beName := sp.BackendName(l.namer)
 

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -88,7 +88,7 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 	}
 
 	// Ensure health check for backend service exists.
-	hcLink, err := s.ensureHealthCheck(sp, hasLegacyHC, sp.ILBEnabled)
+	hcLink, err := s.ensureHealthCheck(sp, hasLegacyHC)
 	if err != nil {
 		return fmt.Errorf("error ensuring health check: %v", err)
 	}
@@ -184,11 +184,10 @@ func (s *backendSyncer) Shutdown() error {
 	return nil
 }
 
-func (s *backendSyncer) ensureHealthCheck(sp utils.ServicePort, hasLegacyHC bool, isInternalLB bool) (string, error) {
+func (s *backendSyncer) ensureHealthCheck(sp utils.ServicePort, hasLegacyHC bool) (string, error) {
 	if hasLegacyHC {
 		klog.Errorf("Backend %+v has legacy health check", sp.ID)
 	}
-	//klog.V(3).Infof("ensuring health check: %v, hasLegacyHC=%v, isInternalLB=%v", pretty.Sprint(sp), hasLegacyHC, isInternalLB)
 	hc := s.healthChecker.New(sp)
 	if s.prober != nil {
 		probe, err := s.prober.GetProbe(sp)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			beName := sp.BackendName(defaultNamer)
 
 			// Check that the new backend has the right port
-			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp))
+			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), false)
 			if err != nil {
 				t.Fatalf("Did not find expected backend with port %v", sp.NodePort)
 			}
@@ -106,7 +106,7 @@ func TestSync(t *testing.T) {
 				t.Fatalf("Backend %v has wrong port %v, expected %v", be.Name, be.Port, sp)
 			}
 
-			hc, err := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&sp))
+			hc, err := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&sp), false)
 			if err != nil {
 				t.Fatalf("Unexpected err when querying fake healthchecker: %v", err)
 			}
@@ -130,7 +130,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), false)
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -149,7 +149,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTPS
 	syncer.Sync([]utils.ServicePort{p})
 
-	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), false)
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ = syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -174,7 +174,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), false)
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -193,7 +193,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTP2
 	syncer.Sync([]utils.ServicePort{p})
 
-	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), false)
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = syncer.healthChecker.Get(beName, meta.VersionAlpha)
+	hc, _ = syncer.healthChecker.Get(beName, meta.VersionAlpha, false)
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -416,7 +416,7 @@ func TestSyncNEG(t *testing.T) {
 	// GC should garbage collect the Backend on the old naming schema
 	syncer.GC([]utils.ServicePort{svcPort})
 
-	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort))
+	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), false)
 	if err == nil {
 		t.Fatalf("Expected not to get BackendService with name %v, got: %+v", nodePortName, bs)
 	}
@@ -489,7 +489,7 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort))
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), false)
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -533,7 +533,7 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort))
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), false)
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -561,7 +561,7 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 
 	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}}
 	syncer.Sync([]utils.ServicePort{p})
-	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p), false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/composite/cloud.go
+++ b/pkg/composite/cloud.go
@@ -1,0 +1,260 @@
+package composite
+
+import (
+	"fmt"
+	cloudprovider "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/composite/metrics"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+)
+
+type Cloud struct {
+	// TODO: (shance) remove this dependency
+	// Keep a copy of gce.Cloud around to make it easier to implement the loadbalancer interface
+	// This will aid in the transition of removing gceCloud entirely
+	gceCloud *gce.Cloud
+}
+
+func NewCloud(c interface{}) *Cloud {
+	gce, ok := c.(*gce.Cloud)
+	if ok && gce != nil {
+		return &Cloud{gce}
+	}
+
+	return &Cloud{}
+}
+
+func (c *Cloud) GceCloud() *gce.Cloud {
+	return c.gceCloud
+}
+
+func (c *Cloud) CreateKey(name string, regional bool) *meta.Key {
+	region := c.gceCloud.Region()
+	if regional && region != "" {
+		return meta.RegionalKey(name, region)
+	}
+	return meta.GlobalKey(name)
+}
+
+// TODO: (shance) generate this
+// ListAllUrlMaps merges all possible List() calls into one list of composite UrlMaps
+func (c *Cloud) ListAllUrlMaps() ([]*UrlMap, error) {
+	resultMap := map[string]*UrlMap{}
+	keys := []*meta.Key{c.CreateKey("", false), c.CreateKey("", true)}
+
+	for _, version := range meta.AllVersions {
+		for _, key := range keys {
+			list, err := c.ListUrlMaps(version, key)
+			if err != nil {
+				return nil, fmt.Errorf("error listing all urlmaps: %v", err)
+			}
+			for _, um := range list {
+				resultMap[um.Name] = um
+			}
+		}
+	}
+
+	// Convert map to slice
+	result := []*UrlMap{}
+	for _, um := range resultMap {
+		result = append(result, um)
+	}
+
+	return result, nil
+}
+
+// TODO: (shance) generate this
+// ListAllUrlMaps merges all possible List() calls into one list of composite UrlMaps
+func (c *Cloud) ListAllBackendServices() ([]*BackendService, error) {
+	resultMap := map[string]*BackendService{}
+	keys := []*meta.Key{c.CreateKey("", false), c.CreateKey("", true)}
+
+	for _, version := range meta.AllVersions {
+		for _, key := range keys {
+			list, err := c.ListBackendServices(version, key)
+			if err != nil {
+				return nil, fmt.Errorf("error listing all urlmaps: %v", err)
+			}
+			for _, bs := range list {
+				resultMap[bs.Name] = bs
+			}
+		}
+	}
+
+	// Convert map to slice
+	result := []*BackendService{}
+	for _, bs := range resultMap {
+		result = append(result, bs)
+	}
+
+	return result, nil
+}
+
+func IsRegionalUrlMap(um *UrlMap) (bool, error) {
+	if um != nil {
+		return IsRegionalResource(um.SelfLink)
+	}
+	return false, nil
+}
+
+func IsRegionalResource(selfLink string) (bool, error) {
+	// Figure out if cluster is regional
+	// Update L7 if its regional so we can delete the right resources
+	resourceID, err := cloudprovider.ParseResourceURL(selfLink)
+	if err != nil {
+		return false, fmt.Errorf("error parsing self-link for url-map %s: %v", selfLink, err)
+	}
+
+	if resourceID.Key.Region != "" {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Below functions are simply wrapped from gceCloud
+// TODO: (shance) find a way to remove these
+func (c *Cloud) ReserveGlobalAddress(addr *compute.Address) error {
+	return c.gceCloud.ReserveGlobalAddress(addr)
+}
+
+func (c *Cloud) GetGlobalAddress(name string) (*compute.Address, error) {
+	return c.gceCloud.GetGlobalAddress(name)
+}
+
+func (c *Cloud) DeleteGlobalAddress(name string) error {
+	return c.gceCloud.DeleteGlobalAddress(name)
+}
+
+// TODO: (shance) below functions should be generated
+func (c *Cloud) SetUrlMapForTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, urlMapLink string, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := metrics.NewMetricContext("TargetHttpsProxy", "set_url_map", key.Region, key.Zone, string(targetHttpsProxy.Version))
+
+	// Set name in case it is not present in the key
+	key.Name = targetHttpsProxy.Name
+	klog.V(3).Infof("setting URLMap for TargetHttpsProxy %v", targetHttpsProxy.Name)
+
+	switch targetHttpsProxy.Version {
+	case meta.VersionAlpha:
+		ref := &computealpha.UrlMapReference{UrlMap: urlMapLink}
+		switch key.Type() {
+		case meta.Regional:
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().SetUrlMap(ctx, key, ref))
+		default:
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpsProxies().SetUrlMap(ctx, key, ref))
+		}
+	case meta.VersionBeta:
+		ref := &computebeta.UrlMapReference{UrlMap: urlMapLink}
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpsProxies().SetUrlMap(ctx, key, ref))
+	default:
+		ref := &compute.UrlMapReference{UrlMap: urlMapLink}
+		return mc.Observe(c.gceCloud.Compute().TargetHttpsProxies().SetUrlMap(ctx, key, ref))
+	}
+}
+
+func (c *Cloud) SetSslCertificateForTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, sslCertURLs []string, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := metrics.NewMetricContext("TargetHttpsProxy", "set_ssl_certificate", key.Region, key.Zone, string(targetHttpsProxy.Version))
+
+	// Set name in case it is not present in the key
+	key.Name = targetHttpsProxy.Name
+	klog.V(3).Infof("setting URLMap for TargetHttpsProxy %v", targetHttpsProxy.Name)
+
+	switch targetHttpsProxy.Version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			req := &computealpha.RegionTargetHttpsProxiesSetSslCertificatesRequest{
+				SslCertificates: sslCertURLs,
+			}
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().SetSslCertificates(ctx, key, req))
+		default:
+			req := &computealpha.TargetHttpsProxiesSetSslCertificatesRequest{
+				SslCertificates: sslCertURLs,
+			}
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpsProxies().SetSslCertificates(ctx, key, req))
+		}
+	case meta.VersionBeta:
+		req := &computebeta.TargetHttpsProxiesSetSslCertificatesRequest{
+			SslCertificates: sslCertURLs,
+		}
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpsProxies().SetSslCertificates(ctx, key, req))
+	default:
+
+		req := &compute.TargetHttpsProxiesSetSslCertificatesRequest{
+			SslCertificates: sslCertURLs,
+		}
+		return mc.Observe(c.gceCloud.Compute().TargetHttpsProxies().SetSslCertificates(ctx, key, req))
+	}
+}
+
+func (c *Cloud) SetUrlMapForTargetHttpProxy(targetHttpProxy *TargetHttpProxy, urlMapLink string, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := metrics.NewMetricContext("TargetHttpProxy", "set_url_map", key.Region, key.Zone, string(targetHttpProxy.Version))
+
+	// Set name in case it is not present in the key
+	key.Name = targetHttpProxy.Name
+	klog.V(3).Infof("setting URLMap for TargetHttpProxy %v", targetHttpProxy.Name)
+
+	switch targetHttpProxy.Version {
+	case meta.VersionAlpha:
+		ref := &computealpha.UrlMapReference{UrlMap: urlMapLink}
+		switch key.Type() {
+		case meta.Regional:
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpProxies().SetUrlMap(ctx, key, ref))
+		default:
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpProxies().SetUrlMap(ctx, key, ref))
+		}
+	case meta.VersionBeta:
+		ref := &computebeta.UrlMapReference{UrlMap: urlMapLink}
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpProxies().SetUrlMap(ctx, key, ref))
+	default:
+		ref := &compute.UrlMapReference{UrlMap: urlMapLink}
+		return mc.Observe(c.gceCloud.Compute().TargetHttpProxies().SetUrlMap(ctx, key, ref))
+	}
+}
+
+func (c *Cloud) SetProxyForForwardingRule(forwardingRule *ForwardingRule, key *meta.Key, targetProxyLink string) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := metrics.NewMetricContext("ForwardingRule", "set_proxy", key.Region, key.Zone, string(forwardingRule.Version))
+
+	// Set name in case it is not present in the key
+	key.Name = forwardingRule.Name
+	klog.V(3).Infof("setting proxy for forwarding rule ForwardingRule %v", forwardingRule.Name)
+
+	switch forwardingRule.Version {
+	case meta.VersionAlpha:
+		target := &computealpha.TargetReference{Target: targetProxyLink}
+		switch key.Type() {
+		case meta.Regional:
+			return mc.Observe(c.gceCloud.Compute().AlphaForwardingRules().SetTarget(ctx, key, target))
+		default:
+			return mc.Observe(c.gceCloud.Compute().AlphaGlobalForwardingRules().SetTarget(ctx, key, target))
+		}
+	case meta.VersionBeta:
+		target := &computebeta.TargetReference{Target: targetProxyLink}
+		switch key.Type() {
+		case meta.Regional:
+			return mc.Observe(c.gceCloud.Compute().BetaForwardingRules().SetTarget(ctx, key, target))
+		default:
+			return mc.Observe(c.gceCloud.Compute().BetaGlobalForwardingRules().SetTarget(ctx, key, target))
+		}
+	default:
+		target := &compute.TargetReference{Target: targetProxyLink}
+		switch key.Type() {
+		case meta.Regional:
+			return mc.Observe(c.gceCloud.Compute().ForwardingRules().SetTarget(ctx, key, target))
+		default:
+			return mc.Observe(c.gceCloud.Compute().GlobalForwardingRules().SetTarget(ctx, key, target))
+		}
+	}
+}

--- a/pkg/composite/cloud.go
+++ b/pkg/composite/cloud.go
@@ -53,7 +53,7 @@ func (c *Cloud) ListAllUrlMaps() ([]*UrlMap, error) {
 				return nil, fmt.Errorf("error listing all urlmaps: %v", err)
 			}
 			for _, um := range list {
-				resultMap[um.Name] = um
+				resultMap[um.SelfLink] = um
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func (c *Cloud) ListAllBackendServices() ([]*BackendService, error) {
 				return nil, fmt.Errorf("error listing all urlmaps: %v", err)
 			}
 			for _, bs := range list {
-				resultMap[bs.Name] = bs
+				resultMap[bs.SelfLink] = bs
 			}
 		}
 	}

--- a/pkg/composite/composite.go
+++ b/pkg/composite/composite.go
@@ -21,7 +21,8 @@ package composite
 import (
 	"fmt"
 
-	gcecloud "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	cloudprovider "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
@@ -29,7 +30,6 @@ import (
 	"google.golang.org/api/googleapi"
 	compositemetrics "k8s.io/ingress-gce/pkg/composite/metrics"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
 // AuthenticationPolicy is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
@@ -2014,6 +2014,95 @@ type ServiceAccountJwtAccessCredentials struct {
 	NullFields           []string `json:"-"`
 }
 
+// SslCertificate is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
+type SslCertificate struct {
+	// Version keeps track of the intended compute version for this SslCertificate.
+	// Note that the compute API's do not contain this field. It is for our
+	// own bookkeeping purposes.
+	Version meta.Version `json:"-"`
+	// ResourceType keeps track of the intended type of the service (e.g. Global)
+	// This is also an internal field purely for bookkeeping purposes
+	ResourceType meta.KeyType `json:"-"`
+
+	// A local certificate file. The certificate must be in PEM format. The
+	// certificate chain must be no greater than 5 certs long. The chain
+	// must include at least one intermediate cert.
+	Certificate string `json:"certificate,omitempty"`
+	// [Output Only] Creation timestamp in RFC3339 text format.
+	CreationTimestamp string `json:"creationTimestamp,omitempty"`
+	// An optional description of this resource. Provide this property when
+	// you create the resource.
+	Description string `json:"description,omitempty"`
+	// [Output Only] Expire time of the certificate. RFC3339
+	ExpireTime string `json:"expireTime,omitempty"`
+	// [Output Only] The unique identifier for the resource. This identifier
+	// is defined by the server.
+	Id uint64 `json:"id,omitempty,string"`
+	// [Output Only] Type of the resource. Always compute#sslCertificate for
+	// SSL certificates.
+	Kind string `json:"kind,omitempty"`
+	// Configuration and status of a managed SSL certificate.
+	Managed *SslCertificateManagedSslCertificate `json:"managed,omitempty"`
+	// Name of the resource. Provided by the client when the resource is
+	// created. The name must be 1-63 characters long, and comply with
+	// RFC1035. Specifically, the name must be 1-63 characters long and
+	// match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means
+	// the first character must be a lowercase letter, and all following
+	// characters must be a dash, lowercase letter, or digit, except the
+	// last character, which cannot be a dash.
+	Name string `json:"name,omitempty"`
+	// A write-only private key in PEM format. Only insert requests will
+	// include this field.
+	PrivateKey string `json:"privateKey,omitempty"`
+	// [Output Only] URL of the region where the regional SSL Certificate
+	// resides. This field is not applicable to global SSL Certificate.
+	Region string `json:"region,omitempty"`
+	// [Output only] Server-defined URL for the resource.
+	SelfLink string `json:"selfLink,omitempty"`
+	// [Output Only] Server-defined URL for this resource with the resource
+	// id.
+	SelfLinkWithId string `json:"selfLinkWithId,omitempty"`
+	// Configuration and status of a self-managed SSL certificate.
+	SelfManaged *SslCertificateSelfManagedSslCertificate `json:"selfManaged,omitempty"`
+	// [Output Only] Domains associated with the certificate via Subject
+	// Alternative Name.
+	SubjectAlternativeNames []string `json:"subjectAlternativeNames,omitempty"`
+	// (Optional) Specifies the type of SSL certificate, either
+	// "SELF_MANAGED" or "MANAGED". If not specified, the certificate is
+	// self-managed and the fields certificate and private_key are used.
+	Type                     string `json:"type,omitempty"`
+	googleapi.ServerResponse `json:"-"`
+	ForceSendFields          []string `json:"-"`
+	NullFields               []string `json:"-"`
+}
+
+// SslCertificateManagedSslCertificate is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
+type SslCertificateManagedSslCertificate struct {
+	// [Output only] Detailed statuses of the domains specified for managed
+	// certificate resource.
+	DomainStatus map[string]string `json:"domainStatus,omitempty"`
+	// The domains for which a managed SSL certificate will be generated.
+	// Currently only single-domain certs are supported.
+	Domains []string `json:"domains,omitempty"`
+	// [Output only] Status of the managed certificate resource.
+	Status          string   `json:"status,omitempty"`
+	ForceSendFields []string `json:"-"`
+	NullFields      []string `json:"-"`
+}
+
+// SslCertificateSelfManagedSslCertificate is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
+type SslCertificateSelfManagedSslCertificate struct {
+	// A local certificate file. The certificate must be in PEM format. The
+	// certificate chain must be no greater than 5 certs long. The chain
+	// must include at least one intermediate cert.
+	Certificate string `json:"certificate,omitempty"`
+	// A write-only private key in PEM format. Only insert requests will
+	// include this field.
+	PrivateKey      string   `json:"privateKey,omitempty"`
+	ForceSendFields []string `json:"-"`
+	NullFields      []string `json:"-"`
+}
+
 // TCPHealthCheck is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
 type TCPHealthCheck struct {
 	// The TCP port number for the health check request. The default value
@@ -2397,8 +2486,8 @@ type WeightedBackendService struct {
 	NullFields      []string `json:"-"`
 }
 
-func CreateBackendService(backendService *BackendService, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateBackendService(backendService *BackendService, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("BackendService", "create", key.Region, key.Zone, string(backendService.Version))
 
@@ -2408,12 +2497,14 @@ func CreateBackendService(backendService *BackendService, cloud *gce.Cloud, key 
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha BackendService %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionBackendServices().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region BackendService %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionBackendServices().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaBackendServices().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha BackendService %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaBackendServices().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := backendService.ToBeta()
@@ -2421,34 +2512,34 @@ func CreateBackendService(backendService *BackendService, cloud *gce.Cloud, key 
 			return err
 		}
 		klog.V(3).Infof("Creating beta BackendService %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaBackendServices().Insert(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaBackendServices().Insert(ctx, key, beta))
 	default:
 		ga, err := backendService.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Creating ga BackendService %v", ga.Name)
-		return mc.Observe(cloud.Compute().BackendServices().Insert(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().BackendServices().Insert(ctx, key, ga))
 	}
 }
 
-func UpdateBackendService(backendService *BackendService, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) UpdateBackendService(backendService *BackendService, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("BackendService", "update", key.Region, key.Zone, string(backendService.Version))
-
 	switch backendService.Version {
 	case meta.VersionAlpha:
 		alpha, err := backendService.ToAlpha()
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Updating alpha BackendService %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionBackendServices().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha region BackendService %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionBackendServices().Update(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaBackendServices().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha BackendService %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaBackendServices().Update(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := backendService.ToBeta()
@@ -2456,19 +2547,43 @@ func UpdateBackendService(backendService *BackendService, cloud *gce.Cloud, key 
 			return err
 		}
 		klog.V(3).Infof("Updating beta BackendService %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaBackendServices().Update(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaBackendServices().Update(ctx, key, beta))
 	default:
 		ga, err := backendService.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Updating ga BackendService %v", ga.Name)
-		return mc.Observe(cloud.Compute().BackendServices().Update(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().BackendServices().Update(ctx, key, ga))
 	}
 }
 
-func GetBackendService(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*BackendService, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) DeleteBackendService(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("BackendService", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region BackendService %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionBackendServices().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha BackendService %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaBackendServices().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta BackendService %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaBackendServices().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga BackendService %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BackendServices().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetBackendService(version meta.Version, key *meta.Key) (*BackendService, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("BackendService", "get", key.Region, key.Zone, string(version))
 
@@ -2478,19 +2593,71 @@ func GetBackendService(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaRegionBackendServices().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region BackendService %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionBackendServices().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaBackendServices().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha BackendService %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaBackendServices().Get(ctx, key)
 		}
 	case meta.VersionBeta:
-		gceObj, err = cloud.Compute().BetaBackendServices().Get(ctx, key)
+		klog.V(3).Infof("Getting beta BackendService %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaBackendServices().Get(ctx, key)
 	default:
-		gceObj, err = cloud.Compute().BackendServices().Get(ctx, key)
+		klog.V(3).Infof("Getting ga BackendService %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BackendServices().Get(ctx, key)
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToBackendService(gceObj)
+	compositeType, err := ToBackendService(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListBackendServices(version meta.Version, key *meta.Key) ([]*BackendService, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("BackendService", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region BackendService")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionBackendServices().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha BackendService")
+			gceObjs, err = c.gceCloud.Compute().AlphaBackendServices().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta BackendService")
+		gceObjs, err = c.gceCloud.Compute().BetaBackendServices().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga BackendService")
+		gceObjs, err = c.gceCloud.Compute().BackendServices().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToBackendServiceList(gceObjs)
+}
+
+// ToBackendServiceList converts a list of compute alpha, beta or GA
+// BackendService into a list of our composite type.
+func ToBackendServiceList(objs interface{}) ([]*BackendService, error) {
+	result := []*BackendService{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of BackendService via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToBackendService converts a compute alpha, beta or GA
@@ -2562,8 +2729,8 @@ func (backendService *BackendService) ToGA() (*compute.BackendService, error) {
 	return ga, nil
 }
 
-func CreateForwardingRule(forwardingRule *ForwardingRule, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateForwardingRule(forwardingRule *ForwardingRule, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("ForwardingRule", "create", key.Region, key.Zone, string(forwardingRule.Version))
 
@@ -2573,42 +2740,46 @@ func CreateForwardingRule(forwardingRule *ForwardingRule, cloud *gce.Cloud, key 
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha ForwardingRule %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaForwardingRules().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region ForwardingRule %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaForwardingRules().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaGlobalForwardingRules().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha ForwardingRule %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaGlobalForwardingRules().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := forwardingRule.ToBeta()
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating beta ForwardingRule %v", beta.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().BetaForwardingRules().Insert(ctx, key, beta))
+			klog.V(3).Infof("Creating beta region ForwardingRule %v", beta.Name)
+			return mc.Observe(c.gceCloud.Compute().BetaForwardingRules().Insert(ctx, key, beta))
 		default:
-			return mc.Observe(cloud.Compute().BetaGlobalForwardingRules().Insert(ctx, key, beta))
+			klog.V(3).Infof("Creating beta ForwardingRule %v", beta.Name)
+			return mc.Observe(c.gceCloud.Compute().BetaGlobalForwardingRules().Insert(ctx, key, beta))
 		}
 	default:
 		ga, err := forwardingRule.ToGA()
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating ga ForwardingRule %v", ga.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().ForwardingRules().Insert(ctx, key, ga))
+			klog.V(3).Infof("Creating ga region ForwardingRule %v", ga.Name)
+			return mc.Observe(c.gceCloud.Compute().ForwardingRules().Insert(ctx, key, ga))
 		default:
-			return mc.Observe(cloud.Compute().GlobalForwardingRules().Insert(ctx, key, ga))
+			klog.V(3).Infof("Creating ga ForwardingRule %v", ga.Name)
+			return mc.Observe(c.gceCloud.Compute().GlobalForwardingRules().Insert(ctx, key, ga))
 		}
 	}
 }
 
-func GetForwardingRule(name string, version meta.Version, cloud *gce.Cloud, key *meta.Key) (*ForwardingRule, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) GetForwardingRule(version meta.Version, key *meta.Key) (*ForwardingRule, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("ForwardingRule", "get", key.Region, key.Zone, string(version))
 
@@ -2618,29 +2789,135 @@ func GetForwardingRule(name string, version meta.Version, cloud *gce.Cloud, key 
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaForwardingRules().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaGlobalForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaGlobalForwardingRules().Get(ctx, key)
 		}
 	case meta.VersionBeta:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().BetaForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting beta region ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().BetaForwardingRules().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().BetaGlobalForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting beta ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().BetaGlobalForwardingRules().Get(ctx, key)
 		}
 	default:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().ForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting ga region ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().ForwardingRules().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().GlobalForwardingRules().Get(ctx, key)
+			klog.V(3).Infof("Getting ga ForwardingRule %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().GlobalForwardingRules().Get(ctx, key)
 		}
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToForwardingRule(gceObj)
+	compositeType, err := ToForwardingRule(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	if key.Type() == meta.Regional {
+		compositeType.ResourceType = meta.Regional
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListForwardingRules(version meta.Version, key *meta.Key) ([]*ForwardingRule, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("ForwardingRule", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().AlphaForwardingRules().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().AlphaGlobalForwardingRules().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing beta region ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().BetaForwardingRules().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing beta ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().BetaGlobalForwardingRules().List(ctx, filter.None)
+		}
+	default:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing ga region ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().ForwardingRules().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing ga ForwardingRule")
+			gceObjs, err = c.gceCloud.Compute().GlobalForwardingRules().List(ctx, filter.None)
+		}
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToForwardingRuleList(gceObjs)
+}
+
+func (c *Cloud) DeleteForwardingRule(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("ForwardingRule", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaForwardingRules().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaGlobalForwardingRules().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting beta region ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().BetaForwardingRules().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting beta ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().BetaGlobalForwardingRules().Delete(ctx, key))
+		}
+	default:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting ga region ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().ForwardingRules().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting ga ForwardingRule %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().GlobalForwardingRules().Delete(ctx, key))
+		}
+	}
+}
+
+// ToForwardingRuleList converts a list of compute alpha, beta or GA
+// ForwardingRule into a list of our composite type.
+func ToForwardingRuleList(objs interface{}) ([]*ForwardingRule, error) {
+	result := []*ForwardingRule{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("Could not copy object %v to list of ForwardingRule via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToForwardingRule converts a compute alpha, beta or GA
@@ -2691,8 +2968,8 @@ func (forwardingRule *ForwardingRule) ToGA() (*compute.ForwardingRule, error) {
 	return ga, nil
 }
 
-func CreateHealthCheck(healthCheck *HealthCheck, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateHealthCheck(healthCheck *HealthCheck, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("HealthCheck", "create", key.Region, key.Zone, string(healthCheck.Version))
 
@@ -2702,12 +2979,14 @@ func CreateHealthCheck(healthCheck *HealthCheck, cloud *gce.Cloud, key *meta.Key
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha HealthCheck %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionHealthChecks().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region HealthCheck %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionHealthChecks().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaHealthChecks().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha HealthCheck %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaHealthChecks().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := healthCheck.ToBeta()
@@ -2715,34 +2994,34 @@ func CreateHealthCheck(healthCheck *HealthCheck, cloud *gce.Cloud, key *meta.Key
 			return err
 		}
 		klog.V(3).Infof("Creating beta HealthCheck %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaHealthChecks().Insert(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaHealthChecks().Insert(ctx, key, beta))
 	default:
 		ga, err := healthCheck.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Creating ga HealthCheck %v", ga.Name)
-		return mc.Observe(cloud.Compute().HealthChecks().Insert(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().HealthChecks().Insert(ctx, key, ga))
 	}
 }
 
-func UpdateHealthCheck(healthCheck *HealthCheck, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) UpdateHealthCheck(healthCheck *HealthCheck, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("HealthCheck", "update", key.Region, key.Zone, string(healthCheck.Version))
-
 	switch healthCheck.Version {
 	case meta.VersionAlpha:
 		alpha, err := healthCheck.ToAlpha()
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Updating alpha HealthCheck %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionHealthChecks().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha region HealthCheck %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionHealthChecks().Update(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaHealthChecks().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha HealthCheck %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaHealthChecks().Update(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := healthCheck.ToBeta()
@@ -2750,19 +3029,43 @@ func UpdateHealthCheck(healthCheck *HealthCheck, cloud *gce.Cloud, key *meta.Key
 			return err
 		}
 		klog.V(3).Infof("Updating beta HealthCheck %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaHealthChecks().Update(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaHealthChecks().Update(ctx, key, beta))
 	default:
 		ga, err := healthCheck.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Updating ga HealthCheck %v", ga.Name)
-		return mc.Observe(cloud.Compute().HealthChecks().Update(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().HealthChecks().Update(ctx, key, ga))
 	}
 }
 
-func GetHealthCheck(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*HealthCheck, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) DeleteHealthCheck(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("HealthCheck", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region HealthCheck %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionHealthChecks().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha HealthCheck %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaHealthChecks().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta HealthCheck %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaHealthChecks().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga HealthCheck %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().HealthChecks().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetHealthCheck(version meta.Version, key *meta.Key) (*HealthCheck, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("HealthCheck", "get", key.Region, key.Zone, string(version))
 
@@ -2772,19 +3075,71 @@ func GetHealthCheck(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*Hea
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaRegionHealthChecks().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region HealthCheck %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionHealthChecks().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaHealthChecks().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha HealthCheck %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaHealthChecks().Get(ctx, key)
 		}
 	case meta.VersionBeta:
-		gceObj, err = cloud.Compute().BetaHealthChecks().Get(ctx, key)
+		klog.V(3).Infof("Getting beta HealthCheck %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaHealthChecks().Get(ctx, key)
 	default:
-		gceObj, err = cloud.Compute().HealthChecks().Get(ctx, key)
+		klog.V(3).Infof("Getting ga HealthCheck %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().HealthChecks().Get(ctx, key)
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToHealthCheck(gceObj)
+	compositeType, err := ToHealthCheck(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListHealthChecks(version meta.Version, key *meta.Key) ([]*HealthCheck, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("HealthCheck", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region HealthCheck")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionHealthChecks().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha HealthCheck")
+			gceObjs, err = c.gceCloud.Compute().AlphaHealthChecks().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta HealthCheck")
+		gceObjs, err = c.gceCloud.Compute().BetaHealthChecks().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga HealthCheck")
+		gceObjs, err = c.gceCloud.Compute().HealthChecks().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToHealthCheckList(gceObjs)
+}
+
+// ToHealthCheckList converts a list of compute alpha, beta or GA
+// HealthCheck into a list of our composite type.
+func ToHealthCheckList(objs interface{}) ([]*HealthCheck, error) {
+	result := []*HealthCheck{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of HealthCheck via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToHealthCheck converts a compute alpha, beta or GA
@@ -2835,8 +3190,195 @@ func (healthCheck *HealthCheck) ToGA() (*compute.HealthCheck, error) {
 	return ga, nil
 }
 
-func CreateTargetHttpProxy(targetHttpProxy *TargetHttpProxy, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateSslCertificate(sslCertificate *SslCertificate, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("SslCertificate", "create", key.Region, key.Zone, string(sslCertificate.Version))
+
+	switch sslCertificate.Version {
+	case meta.VersionAlpha:
+		alpha, err := sslCertificate.ToAlpha()
+		if err != nil {
+			return err
+		}
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Creating alpha region SslCertificate %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionSslCertificates().Insert(ctx, key, alpha))
+		default:
+			klog.V(3).Infof("Creating alpha SslCertificate %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaSslCertificates().Insert(ctx, key, alpha))
+		}
+	case meta.VersionBeta:
+		beta, err := sslCertificate.ToBeta()
+		if err != nil {
+			return err
+		}
+		klog.V(3).Infof("Creating beta SslCertificate %v", beta.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaSslCertificates().Insert(ctx, key, beta))
+	default:
+		ga, err := sslCertificate.ToGA()
+		if err != nil {
+			return err
+		}
+		klog.V(3).Infof("Creating ga SslCertificate %v", ga.Name)
+		return mc.Observe(c.gceCloud.Compute().SslCertificates().Insert(ctx, key, ga))
+	}
+}
+
+func (c *Cloud) DeleteSslCertificate(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("SslCertificate", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region SslCertificate %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionSslCertificates().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha SslCertificate %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaSslCertificates().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta SslCertificate %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaSslCertificates().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga SslCertificate %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().SslCertificates().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetSslCertificate(version meta.Version, key *meta.Key) (*SslCertificate, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("SslCertificate", "get", key.Region, key.Zone, string(version))
+
+	var gceObj interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Getting alpha region SslCertificate %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionSslCertificates().Get(ctx, key)
+		default:
+			klog.V(3).Infof("Getting alpha SslCertificate %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaSslCertificates().Get(ctx, key)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Getting beta SslCertificate %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaSslCertificates().Get(ctx, key)
+	default:
+		klog.V(3).Infof("Getting ga SslCertificate %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().SslCertificates().Get(ctx, key)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	compositeType, err := ToSslCertificate(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListSslCertificates(version meta.Version, key *meta.Key) ([]*SslCertificate, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("SslCertificate", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region SslCertificate")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionSslCertificates().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha SslCertificate")
+			gceObjs, err = c.gceCloud.Compute().AlphaSslCertificates().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta SslCertificate")
+		gceObjs, err = c.gceCloud.Compute().BetaSslCertificates().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga SslCertificate")
+		gceObjs, err = c.gceCloud.Compute().SslCertificates().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToSslCertificateList(gceObjs)
+}
+
+// ToSslCertificateList converts a list of compute alpha, beta or GA
+// SslCertificate into a list of our composite type.
+func ToSslCertificateList(objs interface{}) ([]*SslCertificate, error) {
+	result := []*SslCertificate{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of SslCertificate via JSON: %v", objs, err)
+	}
+	return result, nil
+}
+
+// ToSslCertificate converts a compute alpha, beta or GA
+// SslCertificate into our composite type.
+func ToSslCertificate(obj interface{}) (*SslCertificate, error) {
+	sslCertificate := &SslCertificate{}
+	err := copyViaJSON(sslCertificate, obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %+v to SslCertificate via JSON: %v", obj, err)
+	}
+
+	return sslCertificate, nil
+}
+
+// ToAlpha converts our composite type into an alpha type.
+// This alpha type can be used in GCE API calls.
+func (sslCertificate *SslCertificate) ToAlpha() (*computealpha.SslCertificate, error) {
+	alpha := &computealpha.SslCertificate{}
+	err := copyViaJSON(alpha, sslCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("error converting SslCertificate to compute alpha type via JSON: %v", err)
+	}
+
+	return alpha, nil
+}
+
+// ToBeta converts our composite type into an beta type.
+// This beta type can be used in GCE API calls.
+func (sslCertificate *SslCertificate) ToBeta() (*computebeta.SslCertificate, error) {
+	beta := &computebeta.SslCertificate{}
+	err := copyViaJSON(beta, sslCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("error converting SslCertificate to compute beta type via JSON: %v", err)
+	}
+
+	return beta, nil
+}
+
+// ToGA converts our composite type into an ga type.
+// This ga type can be used in GCE API calls.
+func (sslCertificate *SslCertificate) ToGA() (*compute.SslCertificate, error) {
+	ga := &compute.SslCertificate{}
+	err := copyViaJSON(ga, sslCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("error converting SslCertificate to compute ga type via JSON: %v", err)
+	}
+
+	return ga, nil
+}
+
+func (c *Cloud) CreateTargetHttpProxy(targetHttpProxy *TargetHttpProxy, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("TargetHttpProxy", "create", key.Region, key.Zone, string(targetHttpProxy.Version))
 
@@ -2846,12 +3388,14 @@ func CreateTargetHttpProxy(targetHttpProxy *TargetHttpProxy, cloud *gce.Cloud, k
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha TargetHttpProxy %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionTargetHttpProxies().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region TargetHttpProxy %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpProxies().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaTargetHttpProxies().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha TargetHttpProxy %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpProxies().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := targetHttpProxy.ToBeta()
@@ -2859,19 +3403,43 @@ func CreateTargetHttpProxy(targetHttpProxy *TargetHttpProxy, cloud *gce.Cloud, k
 			return err
 		}
 		klog.V(3).Infof("Creating beta TargetHttpProxy %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaTargetHttpProxies().Insert(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpProxies().Insert(ctx, key, beta))
 	default:
 		ga, err := targetHttpProxy.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Creating ga TargetHttpProxy %v", ga.Name)
-		return mc.Observe(cloud.Compute().TargetHttpProxies().Insert(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().TargetHttpProxies().Insert(ctx, key, ga))
 	}
 }
 
-func GetTargetHttpProxy(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*TargetHttpProxy, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) DeleteTargetHttpProxy(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("TargetHttpProxy", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region TargetHttpProxy %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpProxies().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha TargetHttpProxy %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpProxies().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta TargetHttpProxy %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpProxies().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga TargetHttpProxy %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().TargetHttpProxies().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetTargetHttpProxy(version meta.Version, key *meta.Key) (*TargetHttpProxy, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("TargetHttpProxy", "get", key.Region, key.Zone, string(version))
 
@@ -2881,19 +3449,71 @@ func GetTargetHttpProxy(version meta.Version, cloud *gce.Cloud, key *meta.Key) (
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaRegionTargetHttpProxies().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region TargetHttpProxy %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionTargetHttpProxies().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaTargetHttpProxies().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha TargetHttpProxy %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaTargetHttpProxies().Get(ctx, key)
 		}
 	case meta.VersionBeta:
-		gceObj, err = cloud.Compute().BetaTargetHttpProxies().Get(ctx, key)
+		klog.V(3).Infof("Getting beta TargetHttpProxy %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaTargetHttpProxies().Get(ctx, key)
 	default:
-		gceObj, err = cloud.Compute().TargetHttpProxies().Get(ctx, key)
+		klog.V(3).Infof("Getting ga TargetHttpProxy %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().TargetHttpProxies().Get(ctx, key)
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToTargetHttpProxy(gceObj)
+	compositeType, err := ToTargetHttpProxy(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListTargetHttpProxies(version meta.Version, key *meta.Key) ([]*TargetHttpProxy, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("TargetHttpProxy", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region TargetHttpProxy")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionTargetHttpProxies().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha TargetHttpProxy")
+			gceObjs, err = c.gceCloud.Compute().AlphaTargetHttpProxies().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta TargetHttpProxy")
+		gceObjs, err = c.gceCloud.Compute().BetaTargetHttpProxies().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga TargetHttpProxy")
+		gceObjs, err = c.gceCloud.Compute().TargetHttpProxies().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToTargetHttpProxyList(gceObjs)
+}
+
+// ToTargetHttpProxyList converts a list of compute alpha, beta or GA
+// TargetHttpProxy into a list of our composite type.
+func ToTargetHttpProxyList(objs interface{}) ([]*TargetHttpProxy, error) {
+	result := []*TargetHttpProxy{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of TargetHttpProxy via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToTargetHttpProxy converts a compute alpha, beta or GA
@@ -2944,8 +3564,8 @@ func (targetHttpProxy *TargetHttpProxy) ToGA() (*compute.TargetHttpProxy, error)
 	return ga, nil
 }
 
-func CreateTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("TargetHttpsProxy", "create", key.Region, key.Zone, string(targetHttpsProxy.Version))
 
@@ -2955,12 +3575,14 @@ func CreateTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, cloud *gce.Cloud
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha TargetHttpsProxy %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionTargetHttpsProxies().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region TargetHttpsProxy %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaTargetHttpsProxies().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha TargetHttpsProxy %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpsProxies().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := targetHttpsProxy.ToBeta()
@@ -2968,19 +3590,43 @@ func CreateTargetHttpsProxy(targetHttpsProxy *TargetHttpsProxy, cloud *gce.Cloud
 			return err
 		}
 		klog.V(3).Infof("Creating beta TargetHttpsProxy %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaTargetHttpsProxies().Insert(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpsProxies().Insert(ctx, key, beta))
 	default:
 		ga, err := targetHttpsProxy.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Creating ga TargetHttpsProxy %v", ga.Name)
-		return mc.Observe(cloud.Compute().TargetHttpsProxies().Insert(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().TargetHttpsProxies().Insert(ctx, key, ga))
 	}
 }
 
-func GetTargetHttpsProxy(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*TargetHttpsProxy, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) DeleteTargetHttpsProxy(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("TargetHttpsProxy", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region TargetHttpsProxy %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha TargetHttpsProxy %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaTargetHttpsProxies().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta TargetHttpsProxy %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaTargetHttpsProxies().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga TargetHttpsProxy %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().TargetHttpsProxies().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetTargetHttpsProxy(version meta.Version, key *meta.Key) (*TargetHttpsProxy, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("TargetHttpsProxy", "get", key.Region, key.Zone, string(version))
 
@@ -2990,19 +3636,71 @@ func GetTargetHttpsProxy(version meta.Version, cloud *gce.Cloud, key *meta.Key) 
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaRegionTargetHttpsProxies().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region TargetHttpsProxy %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaTargetHttpsProxies().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha TargetHttpsProxy %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaTargetHttpsProxies().Get(ctx, key)
 		}
 	case meta.VersionBeta:
-		gceObj, err = cloud.Compute().BetaTargetHttpsProxies().Get(ctx, key)
+		klog.V(3).Infof("Getting beta TargetHttpsProxy %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaTargetHttpsProxies().Get(ctx, key)
 	default:
-		gceObj, err = cloud.Compute().TargetHttpsProxies().Get(ctx, key)
+		klog.V(3).Infof("Getting ga TargetHttpsProxy %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().TargetHttpsProxies().Get(ctx, key)
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToTargetHttpsProxy(gceObj)
+	compositeType, err := ToTargetHttpsProxy(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListTargetHttpsProxies(version meta.Version, key *meta.Key) ([]*TargetHttpsProxy, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("TargetHttpsProxy", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region TargetHttpsProxy")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionTargetHttpsProxies().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha TargetHttpsProxy")
+			gceObjs, err = c.gceCloud.Compute().AlphaTargetHttpsProxies().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta TargetHttpsProxy")
+		gceObjs, err = c.gceCloud.Compute().BetaTargetHttpsProxies().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga TargetHttpsProxy")
+		gceObjs, err = c.gceCloud.Compute().TargetHttpsProxies().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToTargetHttpsProxyList(gceObjs)
+}
+
+// ToTargetHttpsProxyList converts a list of compute alpha, beta or GA
+// TargetHttpsProxy into a list of our composite type.
+func ToTargetHttpsProxyList(objs interface{}) ([]*TargetHttpsProxy, error) {
+	result := []*TargetHttpsProxy{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of TargetHttpsProxy via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToTargetHttpsProxy converts a compute alpha, beta or GA
@@ -3053,8 +3751,8 @@ func (targetHttpsProxy *TargetHttpsProxy) ToGA() (*compute.TargetHttpsProxy, err
 	return ga, nil
 }
 
-func CreateUrlMap(urlMap *UrlMap, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) CreateUrlMap(urlMap *UrlMap, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("UrlMap", "create", key.Region, key.Zone, string(urlMap.Version))
 
@@ -3064,12 +3762,14 @@ func CreateUrlMap(urlMap *UrlMap, cloud *gce.Cloud, key *meta.Key) error {
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Creating alpha UrlMap %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionUrlMaps().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha region UrlMap %v", alpha.Name)
+			alpha.Region = key.Region
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionUrlMaps().Insert(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaUrlMaps().Insert(ctx, key, alpha))
+			klog.V(3).Infof("Creating alpha UrlMap %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaUrlMaps().Insert(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := urlMap.ToBeta()
@@ -3077,34 +3777,34 @@ func CreateUrlMap(urlMap *UrlMap, cloud *gce.Cloud, key *meta.Key) error {
 			return err
 		}
 		klog.V(3).Infof("Creating beta UrlMap %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaUrlMaps().Insert(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaUrlMaps().Insert(ctx, key, beta))
 	default:
 		ga, err := urlMap.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Creating ga UrlMap %v", ga.Name)
-		return mc.Observe(cloud.Compute().UrlMaps().Insert(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().UrlMaps().Insert(ctx, key, ga))
 	}
 }
 
-func UpdateUrlMap(urlMap *UrlMap, cloud *gce.Cloud, key *meta.Key) error {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) UpdateUrlMap(urlMap *UrlMap, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("UrlMap", "update", key.Region, key.Zone, string(urlMap.Version))
-
 	switch urlMap.Version {
 	case meta.VersionAlpha:
 		alpha, err := urlMap.ToAlpha()
 		if err != nil {
 			return err
 		}
-		klog.V(3).Infof("Updating alpha UrlMap %v", alpha.Name)
 		switch key.Type() {
 		case meta.Regional:
-			return mc.Observe(cloud.Compute().AlphaRegionUrlMaps().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha region UrlMap %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionUrlMaps().Update(ctx, key, alpha))
 		default:
-			return mc.Observe(cloud.Compute().AlphaUrlMaps().Update(ctx, key, alpha))
+			klog.V(3).Infof("Updating alpha UrlMap %v", alpha.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaUrlMaps().Update(ctx, key, alpha))
 		}
 	case meta.VersionBeta:
 		beta, err := urlMap.ToBeta()
@@ -3112,19 +3812,43 @@ func UpdateUrlMap(urlMap *UrlMap, cloud *gce.Cloud, key *meta.Key) error {
 			return err
 		}
 		klog.V(3).Infof("Updating beta UrlMap %v", beta.Name)
-		return mc.Observe(cloud.Compute().BetaUrlMaps().Update(ctx, key, beta))
+		return mc.Observe(c.gceCloud.Compute().BetaUrlMaps().Update(ctx, key, beta))
 	default:
 		ga, err := urlMap.ToGA()
 		if err != nil {
 			return err
 		}
 		klog.V(3).Infof("Updating ga UrlMap %v", ga.Name)
-		return mc.Observe(cloud.Compute().UrlMaps().Update(ctx, key, ga))
+		return mc.Observe(c.gceCloud.Compute().UrlMaps().Update(ctx, key, ga))
 	}
 }
 
-func GetUrlMap(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*UrlMap, error) {
-	ctx, cancel := gcecloud.ContextWithCallTimeout()
+func (c *Cloud) DeleteUrlMap(version meta.Version, key *meta.Key) error {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("UrlMap", "delete", key.Region, key.Zone, string(version))
+
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Deleting alpha region UrlMap %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaRegionUrlMaps().Delete(ctx, key))
+		default:
+			klog.V(3).Infof("Deleting alpha UrlMap %v", key.Name)
+			return mc.Observe(c.gceCloud.Compute().AlphaUrlMaps().Delete(ctx, key))
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Deleting beta UrlMap %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().BetaUrlMaps().Delete(ctx, key))
+	default:
+		klog.V(3).Infof("Deleting ga UrlMap %v", key.Name)
+		return mc.Observe(c.gceCloud.Compute().UrlMaps().Delete(ctx, key))
+	}
+}
+
+func (c *Cloud) GetUrlMap(version meta.Version, key *meta.Key) (*UrlMap, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
 	defer cancel()
 	mc := compositemetrics.NewMetricContext("UrlMap", "get", key.Region, key.Zone, string(version))
 
@@ -3134,19 +3858,71 @@ func GetUrlMap(version meta.Version, cloud *gce.Cloud, key *meta.Key) (*UrlMap, 
 	case meta.VersionAlpha:
 		switch key.Type() {
 		case meta.Regional:
-			gceObj, err = cloud.Compute().AlphaRegionUrlMaps().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha region UrlMap %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaRegionUrlMaps().Get(ctx, key)
 		default:
-			gceObj, err = cloud.Compute().AlphaUrlMaps().Get(ctx, key)
+			klog.V(3).Infof("Getting alpha UrlMap %v", key.Name)
+			gceObj, err = c.gceCloud.Compute().AlphaUrlMaps().Get(ctx, key)
 		}
 	case meta.VersionBeta:
-		gceObj, err = cloud.Compute().BetaUrlMaps().Get(ctx, key)
+		klog.V(3).Infof("Getting beta UrlMap %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().BetaUrlMaps().Get(ctx, key)
 	default:
-		gceObj, err = cloud.Compute().UrlMaps().Get(ctx, key)
+		klog.V(3).Infof("Getting ga UrlMap %v", key.Name)
+		gceObj, err = c.gceCloud.Compute().UrlMaps().Get(ctx, key)
 	}
 	if err != nil {
 		return nil, mc.Observe(err)
 	}
-	return ToUrlMap(gceObj)
+	compositeType, err := ToUrlMap(gceObj)
+	if err != nil {
+		return nil, err
+	}
+
+	compositeType.Version = version
+	return compositeType, nil
+}
+
+func (c *Cloud) ListUrlMaps(version meta.Version, key *meta.Key) ([]*UrlMap, error) {
+	ctx, cancel := cloudprovider.ContextWithCallTimeout()
+	defer cancel()
+	mc := compositemetrics.NewMetricContext("UrlMap", "get", key.Region, key.Zone, string(version))
+
+	var gceObjs interface{}
+	var err error
+	switch version {
+	case meta.VersionAlpha:
+		switch key.Type() {
+		case meta.Regional:
+			klog.V(3).Infof("Listing alpha region UrlMap")
+			gceObjs, err = c.gceCloud.Compute().AlphaRegionUrlMaps().List(ctx, key.Region, filter.None)
+		default:
+			klog.V(3).Infof("Listing alpha UrlMap")
+			gceObjs, err = c.gceCloud.Compute().AlphaUrlMaps().List(ctx, filter.None)
+		}
+	case meta.VersionBeta:
+		klog.V(3).Infof("Listing beta UrlMap")
+		gceObjs, err = c.gceCloud.Compute().BetaUrlMaps().List(ctx, filter.None)
+	default:
+		klog.V(3).Infof("Listing ga UrlMap")
+		gceObjs, err = c.gceCloud.Compute().UrlMaps().List(ctx, filter.None)
+	}
+	if err != nil {
+		return nil, mc.Observe(err)
+	}
+	return ToUrlMapList(gceObjs)
+}
+
+// ToUrlMapList converts a list of compute alpha, beta or GA
+// UrlMap into a list of our composite type.
+func ToUrlMapList(objs interface{}) ([]*UrlMap, error) {
+	result := []*UrlMap{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to list of UrlMap via JSON: %v", objs, err)
+	}
+	return result, nil
 }
 
 // ToUrlMap converts a compute alpha, beta or GA

--- a/pkg/composite/composite_test.go
+++ b/pkg/composite/composite_test.go
@@ -797,6 +797,121 @@ func TestServiceAccountJwtAccessCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+func TestSslCertificate(t *testing.T) {
+	// Use reflection to verify that our composite type contains all the
+	// same fields as the alpha type.
+	compositeType := reflect.TypeOf(SslCertificate{})
+	alphaType := reflect.TypeOf(computealpha.SslCertificate{})
+	betaType := reflect.TypeOf(computebeta.SslCertificate{})
+	gaType := reflect.TypeOf(compute.SslCertificate{})
+
+	// For the composite type, remove the Version field from consideration
+	compositeTypeNumFields := compositeType.NumField() - 2
+	if compositeTypeNumFields != alphaType.NumField() {
+		t.Fatalf("%v should contain %v fields. Got %v", alphaType.Name(), alphaType.NumField(), compositeTypeNumFields)
+	}
+
+	// Compare all the fields by doing a lookup since we can't guarantee that they'll be in the same order
+	// Make sure that composite type is strictly alpha fields + internal bookkeeping
+	for i := 2; i < compositeType.NumField(); i++ {
+		lookupField, found := alphaType.FieldByName(compositeType.Field(i).Name)
+		if !found {
+			t.Fatal(fmt.Errorf("Field %v not present in alpha type %v", compositeType.Field(i), alphaType))
+		}
+		if err := compareFields(compositeType.Field(i), lookupField); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify that all beta fields are in composite type
+	if err := typeEquality(betaType, compositeType, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that all GA fields are in composite type
+	if err := typeEquality(gaType, compositeType, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToSslCertificate(t *testing.T) {
+	testCases := []struct {
+		input    interface{}
+		expected *SslCertificate
+	}{
+		{
+			computealpha.SslCertificate{},
+			&SslCertificate{},
+		},
+		{
+			computebeta.SslCertificate{},
+			&SslCertificate{},
+		},
+		{
+			compute.SslCertificate{},
+			&SslCertificate{},
+		},
+	}
+	for _, testCase := range testCases {
+		result, _ := ToSslCertificate(testCase.input)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Fatalf("ToSslCertificate(input) = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(testCase.input), pretty.Sprint(result), pretty.Sprint(testCase.expected))
+		}
+	}
+}
+
+func TestSslCertificateToAlpha(t *testing.T) {
+	composite := SslCertificate{}
+	expected := &computealpha.SslCertificate{}
+	result, err := composite.ToAlpha()
+	if err != nil {
+		t.Fatalf("SslCertificate.ToAlpha() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("SslCertificate.ToAlpha() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestSslCertificateToBeta(t *testing.T) {
+	composite := SslCertificate{}
+	expected := &computebeta.SslCertificate{}
+	result, err := composite.ToBeta()
+	if err != nil {
+		t.Fatalf("SslCertificate.ToBeta() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("SslCertificate.ToBeta() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestSslCertificateToGA(t *testing.T) {
+	composite := SslCertificate{}
+	expected := &compute.SslCertificate{}
+	result, err := composite.ToGA()
+	if err != nil {
+		t.Fatalf("SslCertificate.ToGA() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("SslCertificate.ToGA() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+
+func TestSslCertificateManagedSslCertificate(t *testing.T) {
+	compositeType := reflect.TypeOf(SslCertificateManagedSslCertificate{})
+	alphaType := reflect.TypeOf(computealpha.SslCertificateManagedSslCertificate{})
+	if err := typeEquality(compositeType, alphaType, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSslCertificateSelfManagedSslCertificate(t *testing.T) {
+	compositeType := reflect.TypeOf(SslCertificateSelfManagedSslCertificate{})
+	alphaType := reflect.TypeOf(computealpha.SslCertificateSelfManagedSslCertificate{})
+	if err := typeEquality(compositeType, alphaType, true); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestTCPHealthCheck(t *testing.T) {
 	compositeType := reflect.TypeOf(TCPHealthCheck{})

--- a/pkg/composite/meta/meta.go
+++ b/pkg/composite/meta/meta.go
@@ -42,6 +42,7 @@ var MainServices = map[string]string{
 	"UrlMap":           "UrlMaps",
 	"TargetHttpProxy":  "TargetHttpProxies",
 	"TargetHttpsProxy": "TargetHttpsProxies",
+	"SslCertificate":   "SslCertificates",
 }
 
 // TODO: (shance) Replace this with data gathered from meta.AllServices
@@ -50,6 +51,7 @@ var NoUpdate = sets.NewString(
 	"ForwardingRule",
 	"TargetHttpProxy",
 	"TargetHttpsProxy",
+	"SslCertificate",
 )
 
 var Versions = map[string]string{

--- a/pkg/composite/metrics/metrics_test.go
+++ b/pkg/composite/metrics/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/composite/metrics/metrics_test.go
+++ b/pkg/composite/metrics/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -14,6 +14,7 @@ limitations under the License.
 package context
 
 import (
+	"k8s.io/ingress-gce/pkg/composite"
 	"sync"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	frontendconfigclient "k8s.io/ingress-gce/pkg/frontendconfig/client/clientset/versioned"
 	informerfrontendconfig "k8s.io/ingress-gce/pkg/frontendconfig/client/informers/externalversions/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
 const (
@@ -45,7 +45,7 @@ const (
 type ControllerContext struct {
 	KubeClient kubernetes.Interface
 
-	Cloud *gce.Cloud
+	Cloud *composite.Cloud
 
 	ClusterNamer *utils.Namer
 
@@ -83,7 +83,7 @@ func NewControllerContext(
 	kubeClient kubernetes.Interface,
 	backendConfigClient backendconfigclient.Interface,
 	frontendConfigClient frontendconfigclient.Interface,
-	cloud *gce.Cloud,
+	cloud *composite.Cloud,
 	namer *utils.Namer,
 	config ControllerContextConfig) *ControllerContext {
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -298,18 +298,6 @@ func (lbc *LoadBalancerController) Stop(deleteAll bool) error {
 	return nil
 }
 
-func (lbc *LoadBalancerController) UpdateServicePortsForILB(ingSvcPorts []utils.ServicePort, ing *extensions.Ingress) error {
-	if !utils.IsGCEILBIngress(ing) {
-		return nil
-	}
-
-	for svcPortIdx, _ := range ingSvcPorts {
-		ingSvcPorts[svcPortIdx].ILBEnabled = true
-		ingSvcPorts[svcPortIdx].NEGEnabled = true
-	}
-	return nil
-}
-
 // SyncBackends implements Controller.
 func (lbc *LoadBalancerController) SyncBackends(state interface{}) error {
 	// We expect state to be a syncState
@@ -319,7 +307,7 @@ func (lbc *LoadBalancerController) SyncBackends(state interface{}) error {
 	}
 	ingSvcPorts := syncState.urlMap.AllServicePorts()
 
-	err := lbc.UpdateServicePortsForILB(ingSvcPorts, syncState.ing)
+	err := UpdateServicePortsForILB(ingSvcPorts, syncState.ing)
 	if err != nil {
 		return err
 	}
@@ -665,7 +653,7 @@ func (lbc *LoadBalancerController) ToSvcPorts(ings []*extensions.Ingress) []util
 	for _, ing := range ings {
 		urlMap, _ := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPortID)
 		svcPorts := urlMap.AllServicePorts()
-		lbc.UpdateServicePortsForILB(svcPorts, ing)
+		UpdateServicePortsForILB(svcPorts, ing)
 		knownPorts = append(knownPorts, svcPorts...)
 	}
 	return knownPorts

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -387,46 +386,5 @@ func TestToRuntimeInfoCerts(t *testing.T) {
 	}
 	if len(lbInfo.TLS) != 1 || lbInfo.TLS[0] != tlsCerts[0] {
 		t.Errorf("lbInfo.TLS = %v, want %v", lbInfo.TLS, tlsCerts)
-	}
-}
-
-func TestUpdateServicePortsForILB(t *testing.T) {
-	testCases := []struct {
-		svcPorts []utils.ServicePort
-		ing      extensions.Ingress
-		expected []utils.ServicePort
-	}{
-		{
-			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
-			ing: extensions.Ingress{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Annotations: map[string]string{annotations.IngressClassKey: annotations.GceILBIngressClass},
-				},
-			},
-			expected: []utils.ServicePort{
-				{Port: 80, ILBEnabled: true, NEGEnabled: true},
-				{Port: 8080, ILBEnabled: true, NEGEnabled: true}},
-		},
-		{
-			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
-			ing: extensions.Ingress{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			expected: []utils.ServicePort{
-				{Port: 80, ILBEnabled: false, NEGEnabled: false},
-				{Port: 8080, ILBEnabled: false, NEGEnabled: false}},
-		},
-	}
-	for _, tc := range testCases {
-		lbc := newLoadBalancerController()
-		err := lbc.UpdateServicePortsForILB(tc.svcPorts, &tc.ing)
-		if err != nil {
-			t.Fatalf("updating service ports for ILB failed: %v", err)
-		}
-		if !reflect.DeepEqual(tc.svcPorts, tc.expected) {
-			t.Fatalf("want %v, got %v", tc.expected, tc.svcPorts)
-		}
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	meta "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -386,5 +387,46 @@ func TestToRuntimeInfoCerts(t *testing.T) {
 	}
 	if len(lbInfo.TLS) != 1 || lbInfo.TLS[0] != tlsCerts[0] {
 		t.Errorf("lbInfo.TLS = %v, want %v", lbInfo.TLS, tlsCerts)
+	}
+}
+
+func TestUpdateServicePortsForILB(t *testing.T) {
+	testCases := []struct {
+		svcPorts []utils.ServicePort
+		ing      extensions.Ingress
+		expected []utils.ServicePort
+	}{
+		{
+			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
+			ing: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{annotations.IngressClassKey: annotations.GceILBIngressClass},
+				},
+			},
+			expected: []utils.ServicePort{
+				{Port: 80, ILBEnabled: true, NEGEnabled: true},
+				{Port: 8080, ILBEnabled: true, NEGEnabled: true}},
+		},
+		{
+			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
+			ing: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: []utils.ServicePort{
+				{Port: 80, ILBEnabled: false, NEGEnabled: false},
+				{Port: 8080, ILBEnabled: false, NEGEnabled: false}},
+		},
+	}
+	for _, tc := range testCases {
+		lbc := newLoadBalancerController()
+		err := lbc.UpdateServicePortsForILB(tc.svcPorts, &tc.ing)
+		if err != nil {
+			t.Fatalf("updating service ports for ILB failed: %v", err)
+		}
+		if !reflect.DeepEqual(tc.svcPorts, tc.expected) {
+			t.Fatalf("want %v, got %v", tc.expected, tc.svcPorts)
+		}
 	}
 }

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -88,3 +88,15 @@ func nodePorts(svcPorts []utils.ServicePort) []int64 {
 	}
 	return ports
 }
+
+func UpdateServicePortsForILB(ingSvcPorts []utils.ServicePort, ing *extensions.Ingress) error {
+	if !utils.IsGCEILBIngress(ing) {
+		return nil
+	}
+
+	for svcPortIdx, _ := range ingSvcPorts {
+		ingSvcPorts[svcPortIdx].ILBEnabled = true
+		ingSvcPorts[svcPortIdx].NEGEnabled = true
+	}
+	return nil
+}

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -23,9 +23,9 @@ import (
 	"google.golang.org/api/compute/v1"
 
 	api_v1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	//"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
@@ -404,5 +404,45 @@ func testServicePort(namespace, name, port string, servicePort, nodePort int, en
 		Port:       int32(servicePort),
 		NodePort:   int64(nodePort),
 		NEGEnabled: enableNEG,
+	}
+}
+
+func TestUpdateServicePortsForILB(t *testing.T) {
+	testCases := []struct {
+		svcPorts []utils.ServicePort
+		ing      extensions.Ingress
+		expected []utils.ServicePort
+	}{
+		{
+			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
+			ing: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{annotations.IngressClassKey: annotations.GceILBIngressClass},
+				},
+			},
+			expected: []utils.ServicePort{
+				{Port: 80, ILBEnabled: true, NEGEnabled: true},
+				{Port: 8080, ILBEnabled: true, NEGEnabled: true}},
+		},
+		{
+			svcPorts: []utils.ServicePort{{Port: 80}, {Port: 8080}},
+			ing: extensions.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: []utils.ServicePort{
+				{Port: 80, ILBEnabled: false, NEGEnabled: false},
+				{Port: 8080, ILBEnabled: false, NEGEnabled: false}},
+		},
+	}
+	for _, tc := range testCases {
+		err := UpdateServicePortsForILB(tc.svcPorts, &tc.ing)
+		if err != nil {
+			t.Fatalf("updating service ports for ILB failed: %v", err)
+		}
+		if !reflect.DeepEqual(tc.svcPorts, tc.expected) {
+			t.Fatalf("want %v, got %v", tc.expected, tc.svcPorts)
+		}
 	}
 }

--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -64,7 +64,7 @@ func NewFirewallPool(cloud Firewall, namer *utils.Namer, l7SrcRanges []string, n
 }
 
 // Sync firewall rules with the cloud.
-func (fr *FirewallRules) Sync(nodeNames, additionalPorts []string, ILBSrcRange string) error {
+func (fr *FirewallRules) Sync(nodeNames, additionalPorts, additionalRanges []string) error {
 	klog.V(4).Infof("Sync(%v)", nodeNames)
 	name := fr.namer.FirewallRule()
 	existingFirewall, _ := fr.cloud.GetFirewall(name)
@@ -77,9 +77,7 @@ func (fr *FirewallRules) Sync(nodeNames, additionalPorts []string, ILBSrcRange s
 	}
 	sort.Strings(targetTags)
 
-	if ILBSrcRange != "" {
-		fr.srcRanges = append(fr.srcRanges, ILBSrcRange)
-	}
+	fr.srcRanges = append(fr.srcRanges, additionalRanges...)
 
 	ports := sets.NewString(additionalPorts...)
 	ports.Insert(fr.portRanges...)

--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -63,8 +63,8 @@ func NewFirewallPool(cloud Firewall, namer *utils.Namer, l7SrcRanges []string, n
 	}
 }
 
-// Sync sync firewall rules with the cloud.
-func (fr *FirewallRules) Sync(nodeNames []string, additionalPorts ...string) error {
+// Sync firewall rules with the cloud.
+func (fr *FirewallRules) Sync(nodeNames, additionalPorts []string, ILBSrcRange string) error {
 	klog.V(4).Infof("Sync(%v)", nodeNames)
 	name := fr.namer.FirewallRule()
 	existingFirewall, _ := fr.cloud.GetFirewall(name)
@@ -76,6 +76,10 @@ func (fr *FirewallRules) Sync(nodeNames []string, additionalPorts ...string) err
 		return err
 	}
 	sort.Strings(targetTags)
+
+	if ILBSrcRange != "" {
+		fr.srcRanges = append(fr.srcRanges, ILBSrcRange)
+	}
 
 	ports := sets.NewString(additionalPorts...)
 	ports.Insert(fr.portRanges...)

--- a/pkg/firewalls/firewalls_test.go
+++ b/pkg/firewalls/firewalls_test.go
@@ -38,7 +38,7 @@ func TestFirewallPoolSync(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -49,21 +49,21 @@ func TestFirewallPoolSyncNodes(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Add nodes
 	nodes = append(nodes, "node-d", "node-e")
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Remove nodes
 	nodes = []string{"node-a", "node-c"}
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -74,7 +74,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -86,7 +86,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -97,7 +97,7 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -110,14 +110,14 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	}
 
 	// Expect firewall to be synced back to normal
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Verify additional ports are included
 	negTargetports := []string{"80", "443", "8080"}
-	if err := fp.Sync(nodes, negTargetports, ""); err != nil {
+	if err := fp.Sync(nodes, negTargetports, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, append(portRanges(), negTargetports...), t)
@@ -128,7 +128,7 @@ func TestFirewallPoolGC(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -150,7 +150,7 @@ func TestSyncOnXPNWithPermission(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes, nil, ""); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -164,7 +164,7 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	err := fp.Sync(nodes, nil, "")
+	err := fp.Sync(nodes, nil, nil)
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "create") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}
@@ -187,12 +187,12 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	}
 
 	// Run sync again with same state - expect no event
-	if err = fp.Sync(nodes, nil, ""); err != nil {
+	if err = fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 
 	nodes = append(nodes, "node-d")
-	err = fp.Sync(nodes, nil, "")
+	err = fp.Sync(nodes, nil, nil)
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "update") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}

--- a/pkg/firewalls/firewalls_test.go
+++ b/pkg/firewalls/firewalls_test.go
@@ -38,7 +38,7 @@ func TestFirewallPoolSync(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -49,21 +49,21 @@ func TestFirewallPoolSyncNodes(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Add nodes
 	nodes = append(nodes, "node-d", "node-e")
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Remove nodes
 	nodes = []string{"node-a", "node-c"}
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -74,7 +74,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -86,7 +86,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -97,7 +97,7 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -110,14 +110,14 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	}
 
 	// Expect firewall to be synced back to normal
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Verify additional ports are included
 	negTargetports := []string{"80", "443", "8080"}
-	if err := fp.Sync(nodes, negTargetports...); err != nil {
+	if err := fp.Sync(nodes, negTargetports, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, append(portRanges(), negTargetports...), t)
@@ -128,7 +128,7 @@ func TestFirewallPoolGC(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -150,7 +150,7 @@ func TestSyncOnXPNWithPermission(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -164,7 +164,7 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	err := fp.Sync(nodes)
+	err := fp.Sync(nodes, nil, "")
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "create") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}
@@ -187,12 +187,12 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	}
 
 	// Run sync again with same state - expect no event
-	if err = fp.Sync(nodes); err != nil {
+	if err = fp.Sync(nodes, nil, ""); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 
 	nodes = append(nodes, "node-d")
-	err = fp.Sync(nodes)
+	err = fp.Sync(nodes, nil, "")
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "update") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}

--- a/pkg/firewalls/interfaces.go
+++ b/pkg/firewalls/interfaces.go
@@ -22,7 +22,7 @@ import (
 
 // SingleFirewallPool syncs the firewall rule for L7 traffic.
 type SingleFirewallPool interface {
-	Sync(nodeNames, additionalPorts []string, ILBSrcRange string) error
+	Sync(nodeNames, additionalPorts, additionalRanges []string) error
 	GC() error
 }
 

--- a/pkg/firewalls/interfaces.go
+++ b/pkg/firewalls/interfaces.go
@@ -22,7 +22,7 @@ import (
 
 // SingleFirewallPool syncs the firewall rule for L7 traffic.
 type SingleFirewallPool interface {
-	Sync(nodeNames []string, additionalPorts ...string) error
+	Sync(nodeNames, additionalPorts []string, ILBSrcRange string) error
 	GC() error
 }
 

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -166,7 +166,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(namer.IGBackend(1234))
+	err = healthChecks.Delete(namer.IGBackend(1234), false)
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestHealthCheckDelete(t *testing.T) {
 	}
 
 	// Delete only HTTP 1234
-	err = healthChecks.Delete(namer.IGBackend(1234))
+	err = healthChecks.Delete(namer.IGBackend(1234), false)
 	if err == nil {
 		t.Errorf("expected not-found error when deleting health check, err: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 	hcp.CreateAlphaHealthCheck(alphahc)
 
 	// Delete only HTTP2 1234
-	err := healthChecks.Delete(namer.IGBackend(1234))
+	err := healthChecks.Delete(namer.IGBackend(1234), false)
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	hcp.CreateHealthCheck(v1hc)
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(hc.Name, meta.VersionGA)
+	_, err = healthChecks.Get(hc.Name, meta.VersionGA, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists
-	_, err = healthChecks.Get(hc.Name, meta.VersionGA)
+	_, err = healthChecks.Get(hc.Name, meta.VersionGA, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists. HTTP2 is alpha-only.
-	_, err = healthChecks.Get(hc.Name, meta.VersionAlpha)
+	_, err = healthChecks.Get(hc.Name, meta.VersionAlpha, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(hc.Name, meta.VersionAlpha)
+	hc, err = healthChecks.Get(hc.Name, meta.VersionAlpha, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -295,7 +295,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	}
 
 	// Verify the health check exists.
-	hc, err = healthChecks.Get(hc.Name, meta.VersionAlpha)
+	hc, err = healthChecks.Get(hc.Name, meta.VersionAlpha, false)
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestAlphaHealthCheck(t *testing.T) {
 		t.Fatalf("got %v, want nil", err)
 	}
 
-	ret, err := healthChecks.Get(hc.Name, meta.VersionAlpha)
+	ret, err := healthChecks.Get(hc.Name, meta.VersionAlpha, false)
 	if err != nil {
 		t.Fatalf("got %v, want nil", err)
 	}

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -26,6 +26,7 @@ import (
 )
 
 // HealthCheckProvider is an interface to manage a single GCE health check.
+// TODO: (shance) convert this to use composite types
 type HealthCheckProvider interface {
 	CreateHTTPHealthCheck(hc *compute.HttpHealthCheck) error
 	UpdateHTTPHealthCheck(hc *compute.HttpHealthCheck) error
@@ -48,6 +49,6 @@ type HealthCheckProvider interface {
 type HealthChecker interface {
 	New(sp utils.ServicePort) *HealthCheck
 	Sync(hc *HealthCheck) (string, error)
-	Delete(name string) error
-	Get(name string, version meta.Version) (*HealthCheck, error)
+	Delete(name string, regional bool) error
+	Get(name string, version meta.Version, regional bool) (*HealthCheck, error)
 }

--- a/pkg/loadbalancers/features/doc.go
+++ b/pkg/loadbalancers/features/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/loadbalancers/features/ilb.go
+++ b/pkg/loadbalancers/features/ilb.go
@@ -16,9 +16,9 @@ package features
 import (
 	"context"
 	"fmt"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/ingress-gce/pkg/composite"
 )
 
 const (
@@ -27,8 +27,8 @@ const (
 
 // Get Subnet source range for ILB from FrontendConfig
 // TODO: (shance) refactor to use filter
-func ILBSubnetSourceRange(cloud cloud.Cloud, region string) (string, error) {
-	subnets, err := cloud.AlphaSubnetworks().List(context.Background(), region, filter.None)
+func ILBSubnetSourceRange(cloud *composite.Cloud, region string) (string, error) {
+	subnets, err := cloud.GceCloud().Compute().AlphaSubnetworks().List(context.Background(), region, filter.None)
 	if err != nil {
 		return "", fmt.Errorf("error obtaining subnets for region: %s", region)
 	}
@@ -38,6 +38,5 @@ func ILBSubnetSourceRange(cloud cloud.Cloud, region string) (string, error) {
 			return subnet.IpCidrRange, nil
 		}
 	}
-
 	return "", nil
 }

--- a/pkg/loadbalancers/features/ilb.go
+++ b/pkg/loadbalancers/features/ilb.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"context"
+	"fmt"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+)
+
+const (
+	ILBVersion = meta.VersionAlpha
+)
+
+// Get Subnet source range for ILB from FrontendConfig
+// TODO: (shance) refactor to use filter
+func ILBSubnetSourceRange(cloud cloud.Cloud, region string) (string, error) {
+	subnets, err := cloud.AlphaSubnetworks().List(context.Background(), region, filter.None)
+	if err != nil {
+		return "", fmt.Errorf("error obtaining subnets for region: %s", region)
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Role == "ACTIVE" && subnet.Purpose == "INTERNAL_HTTPS_LOAD_BALANCER" {
+			return subnet.IpCidrRange, nil
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -76,7 +76,7 @@ type LoadBalancers interface {
 type LoadBalancerPool interface {
 	Ensure(ri *L7RuntimeInfo) (*L7, error)
 	Delete(name string, regional bool) error
-	GC(names []string) error
+	GC(names []string, regional []bool) error
 	Shutdown() error
 	List() ([]string, []bool, error)
 }

--- a/pkg/loadbalancers/l7s_test.go
+++ b/pkg/loadbalancers/l7s_test.go
@@ -50,18 +50,21 @@ func TestGC(t *testing.T) {
 	testCases := []struct {
 		desc       string
 		ingressLBs []string
+		regional   []bool
 		gcpLBs     []string
 		expectLBs  []string
 	}{
 		{
 			desc:       "empty",
 			ingressLBs: []string{},
+			regional:   []bool{},
 			gcpLBs:     []string{},
 			expectLBs:  []string{},
 		},
 		{
 			desc:       "remove all lbs",
 			ingressLBs: []string{},
+			regional:   []bool{},
 			gcpLBs: []string{
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName[:20], longName[:20]),
@@ -98,6 +101,7 @@ func TestGC(t *testing.T) {
 				generateKey(longName[:20], longName[:27]),
 				generateKey(longName[:50], longName[:30]),
 			},
+			regional:  []bool{false, false, false, false},
 			gcpLBs:    []string{},
 			expectLBs: []string{},
 		},
@@ -109,6 +113,7 @@ func TestGC(t *testing.T) {
 				generateKey(longName[:20], longName[:30]),
 				generateKey(longName, longName),
 			},
+			regional: []bool{false, false, false, false},
 			gcpLBs: []string{
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName[:20], longName[:20]),
@@ -128,6 +133,7 @@ func TestGC(t *testing.T) {
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName, longName),
 			},
+			regional: []bool{false, false},
 			gcpLBs: []string{
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName[:20], longName[:20]),
@@ -145,6 +151,7 @@ func TestGC(t *testing.T) {
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName, longName),
 			},
+			regional: []bool{false, false},
 			gcpLBs: []string{
 				generateKey(longName[:10], longName[:10]),
 				generateKey(longName[:20], longName[:20]),
@@ -177,7 +184,7 @@ func TestGC(t *testing.T) {
 			createFakeLoadbalancer(l7sPool.cloud, l7sPool.namer, key)
 		}
 
-		err := l7sPool.GC(tc.ingressLBs)
+		err := l7sPool.GC(tc.ingressLBs, tc.regional)
 		if err != nil {
 			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
 		}
@@ -235,7 +242,7 @@ func TestDoNotGCWantedLB(t *testing.T) {
 
 	for _, tc := range testCases {
 		createFakeLoadbalancer(l7sPool.cloud, namer, tc.key)
-		err := l7sPool.GC([]string{tc.key})
+		err := l7sPool.GC([]string{tc.key}, []bool{false})
 		if err != nil {
 			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
 		}
@@ -269,7 +276,7 @@ func TestGCToLeakLB(t *testing.T) {
 
 	for _, tc := range testCases {
 		createFakeLoadbalancer(l7sPool.cloud, namer, tc.key)
-		err := l7sPool.GC([]string{})
+		err := l7sPool.GC([]string{}, []bool{})
 		if err != nil {
 			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
 		}

--- a/pkg/loadbalancers/url_maps_test.go
+++ b/pkg/loadbalancers/url_maps_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/ingress-gce/pkg/composite"
 	"testing"
 
-	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -79,17 +80,17 @@ func TestToComputeURLMap(t *testing.T) {
 	}
 
 	namer := utils.NewNamer("uid1", "fw1")
-	gotComputeURLMap := toComputeURLMap("lb-name", gceURLMap, namer)
+	gotComputeURLMap := toCompositeURLMap("lb-name", gceURLMap, namer, meta.GlobalKey(""))
 	if !mapsEqual(gotComputeURLMap, wantComputeMap) {
-		t.Errorf("toComputeURLMap() = \n%+v\n   want\n%+v", gotComputeURLMap, wantComputeMap)
+		t.Errorf("toCompositeURLMap() = \n%+v\n   want\n%+v", gotComputeURLMap, wantComputeMap)
 	}
 }
 
-func testComputeURLMap() *compute.UrlMap {
-	return &compute.UrlMap{
+func testComputeURLMap() *composite.UrlMap {
+	return &composite.UrlMap{
 		Name:           "k8s-um-lb-name",
 		DefaultService: "global/backendServices/k8s-be-30000--uid1",
-		HostRules: []*compute.HostRule{
+		HostRules: []*composite.HostRule{
 			{
 				Hosts:       []string{"abc.com"},
 				PathMatcher: "host929ba26f492f86d4a9d66a080849865a",
@@ -99,11 +100,11 @@ func testComputeURLMap() *compute.UrlMap {
 				PathMatcher: "host2d50cf9711f59181be6a5e5658e42c21",
 			},
 		},
-		PathMatchers: []*compute.PathMatcher{
+		PathMatchers: []*composite.PathMatcher{
 			{
 				DefaultService: "global/backendServices/k8s-be-30000--uid1",
 				Name:           "host929ba26f492f86d4a9d66a080849865a",
-				PathRules: []*compute.PathRule{
+				PathRules: []*composite.PathRule{
 					{
 						Paths:   []string{"/web"},
 						Service: "global/backendServices/k8s-be-32000--uid1",
@@ -117,7 +118,7 @@ func testComputeURLMap() *compute.UrlMap {
 			{
 				DefaultService: "global/backendServices/k8s-be-30000--uid1",
 				Name:           "host2d50cf9711f59181be6a5e5658e42c21",
-				PathRules: []*compute.PathRule{
+				PathRules: []*composite.PathRule{
 					{
 						Paths:   []string{"/"},
 						Service: "global/backendServices/k8s-be-33000--uid1",
@@ -136,17 +137,17 @@ func TestGetBackendNames(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
-		urlMap    *compute.UrlMap
+		urlMap    *composite.UrlMap
 		wantNames []string
 		wantErr   bool
 	}{
 		"Valid UrlMap": {
-			urlMap: &compute.UrlMap{
+			urlMap: &composite.UrlMap{
 				DefaultService: "global/backendServices/service-A",
-				PathMatchers: []*compute.PathMatcher{
+				PathMatchers: []*composite.PathMatcher{
 					{
 						DefaultService: "global/backendServices/service-B",
-						PathRules: []*compute.PathRule{
+						PathRules: []*composite.PathRule{
 							{
 								Paths:   []string{"/"},
 								Service: "global/backendServices/service-C",
@@ -158,15 +159,15 @@ func TestGetBackendNames(t *testing.T) {
 			wantNames: []string{"service-A", "service-B", "service-C"},
 		},
 		"Invalid DefaultService": {
-			urlMap: &compute.UrlMap{
+			urlMap: &composite.UrlMap{
 				DefaultService: "/global/backendServices/service-A",
 			},
 			wantErr: true,
 		},
 		"Invalid PathMatcher DefaultService": {
-			urlMap: &compute.UrlMap{
+			urlMap: &composite.UrlMap{
 				DefaultService: "global/backendServices/service-A",
-				PathMatchers: []*compute.PathMatcher{
+				PathMatchers: []*composite.PathMatcher{
 					{
 						DefaultService: "/global/backendServices/service-B",
 					},
@@ -175,12 +176,12 @@ func TestGetBackendNames(t *testing.T) {
 			wantErr: true,
 		},
 		"Invalid PathRule Service": {
-			urlMap: &compute.UrlMap{
+			urlMap: &composite.UrlMap{
 				DefaultService: "global/backendServices/service-A",
-				PathMatchers: []*compute.PathMatcher{
+				PathMatchers: []*composite.PathMatcher{
 					{
 						DefaultService: "global/backendServices/service-B",
-						PathRules: []*compute.PathRule{
+						PathRules: []*composite.PathRule{
 							{
 								Paths:   []string{"/"},
 								Service: "/global/backendServices/service-C",

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -19,6 +19,8 @@ package neg
 import (
 	"encoding/json"
 	"fmt"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +39,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"strconv"
 )
 
@@ -53,13 +54,15 @@ var (
 
 func newTestController(kubeClient kubernetes.Interface) *Controller {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
+	compositeCloud := composite.NewCloud(gce.NewFakeGCECloud(gce.DefaultTestClusterValues()))
+	fmt.Printf("%v", compositeCloud)
 	namer := utils.NewNamer(ClusterID, "")
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:               apiv1.NamespaceAll,
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,
 	}
-	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, ctxConfig)
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, compositeCloud, namer, ctxConfig)
 	controller := NewController(
 		negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network"),
 		context,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package neg
 
 import (
+	"k8s.io/ingress-gce/pkg/composite"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 		ResyncPeriod:            1 * time.Second,
 		DefaultBackendSvcPortID: defaultBackend,
 	}
-	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, ctxConfig)
+	context := context.NewControllerContext(kubeClient, backendConfigClient, nil, composite.NewCloud(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), namer, ctxConfig)
 
 	manager := newSyncerManager(
 		namer,

--- a/pkg/neg/readiness/reflector.go
+++ b/pkg/neg/readiness/reflector.go
@@ -76,7 +76,7 @@ func NewReadinessReflector(cc *context.ControllerContext, lookup NegLookup) Refl
 		eventRecorder:    recorder,
 		queue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	}
-	poller := NewPoller(cc.PodInformer.GetIndexer(), lookup, reflector, negtypes.NewAdapter(cc.Cloud))
+	poller := NewPoller(cc.PodInformer.GetIndexer(), lookup, reflector, negtypes.NewAdapter(cc.Cloud.GceCloud()))
 	reflector.poller = poller
 	return reflector
 }

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -22,6 +22,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/context"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
@@ -59,8 +60,9 @@ func fakeContext() *context.ControllerContext {
 		ResyncPeriod: 1 * time.Second,
 	}
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	compositeCloud := composite.NewCloud(fakeGCE)
 	negtypes.MockNetworkEndpointAPIs(fakeGCE)
-	context := context.NewControllerContext(kubeClient, nil, nil, fakeGCE, namer, ctxConfig)
+	context := context.NewControllerContext(kubeClient, nil, nil, compositeCloud, namer, ctxConfig)
 	return context
 }
 

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -47,6 +47,7 @@ type ServicePort struct {
 	Protocol      annotations.AppProtocol
 	TargetPort    string
 	NEGEnabled    bool
+	ILBEnabled    bool
 	BackendConfig *backendconfigv1beta1.BackendConfig
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -266,7 +266,7 @@ func IGLinks(igs []*compute.InstanceGroup) (igLinks []string) {
 func IsGCEIngress(ing *extensions.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
 	if flags.F.IngressClass == "" {
-		return class == "" || class == annotations.GceIngressClass
+		return class == "" || class == annotations.GceIngressClass || class == annotations.GceILBIngressClass
 	}
 	return class == flags.F.IngressClass
 }
@@ -278,9 +278,14 @@ func IsGCEMultiClusterIngress(ing *extensions.Ingress) bool {
 	return class == annotations.GceMultiIngressClass
 }
 
+func IsGCEILBIngress(ing *extensions.Ingress) bool {
+	class := annotations.FromIngress(ing).IngressClass()
+	return class == annotations.GceILBIngressClass
+}
+
 // IsGLBCIngress returns true if the given Ingress should be processed by GLBC
 func IsGLBCIngress(ing *extensions.Ingress) bool {
-	return IsGCEIngress(ing) || IsGCEMultiClusterIngress(ing)
+	return IsGCEIngress(ing) || IsGCEMultiClusterIngress(ing) || IsGCEILBIngress(ing)
 }
 
 // GetReadyNodeNames returns names of schedulable, ready nodes from the node lister


### PR DESCRIPTION
**DO NOT MERGE**
This PR is being broken up into smaller PRs but I'm keeping this here in the meantime for reference.

Adds a new ingress class for the l7-ILB and integrates it throughout the controller.  This involves switching most things over to composite types, with a few things spared momentarily to improve short-term stability, or spared indefinitely (e.g. health checks, NEGs).  Additionally, includes some handwritten composite functions for more complex things.

Also adds a few unit tests specific to ILB and refactors the mocks, but most of the changes should already be covered by the current tests.

A follow up PR will be added with some e2e tests.