### PR TITLE
use GlobalForwardingRules().Get() when detected a global fw rule

### DIFF
--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -119,7 +119,12 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, options
 	var resources []meta.Key
 
 	for k := range g.ForwardingRule {
-		_, err := c.ForwardingRules().Get(ctx, &k)
+		var err error
+		if k.Region != "" {
+			_, err = c.ForwardingRules().Get(ctx, &k)
+		} else {
+			_, err = c.GlobalForwardingRules().Get(ctx, &k)
+		}
 		if err != nil {
 			if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 				return fmt.Errorf("ForwardingRule %s is not deleted/error to get: %s", k.Name, err)


### PR DESCRIPTION
I feel like we can just change all `ForwardingRule` to `GlobalForwardingRule`... but, anyway, let me try to fix test first...

Still unsure why it works for prod though.

```
// Get: Returns the specified GlobalForwardingRule resource. Gets a list
// of available forwarding rules by making a list() request.
// For details, see https://cloud.google.com/compute/docs/reference/latest/globalForwardingRules/get
func (r *GlobalForwardingRulesService) Get(project string, forwardingRule string) *GlobalForwardingRulesGetCall {
	c := &GlobalForwardingRulesGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
	c.project = project
	c.forwardingRule = forwardingRule
	return c
}
```

/assign @MrHohn @rramkumar1 