### PR TITLE
Follow up on #774

### DIFF
--- a/pkg/neg/types/mock.go
+++ b/pkg/neg/types/mock.go
@@ -36,6 +36,23 @@ type NetworkEndpointEntry struct {
 
 type NetworkEndpointStore map[meta.Key][]NetworkEndpointEntry
 
+func (s NetworkEndpointStore) AddNetworkEndpointHealthStatus(key meta.Key, entry NetworkEndpointEntry) {
+	v, ok := s[key]
+	if !ok {
+		v = []NetworkEndpointEntry{}
+	}
+	v = append(v, entry)
+	s[key] = v
+}
+
+// GetNetworkEndpointStore is a helper function to access the NetworkEndpointStore of the mock NEG cloud
+func GetNetworkEndpointStore(negCloud NetworkEndpointGroupCloud) NetworkEndpointStore {
+	adapter := negCloud.(*cloudProviderAdapter)
+	mockedCloud := adapter.c.(*cloud.MockGCE)
+	ret := mockedCloud.MockNetworkEndpointGroups.X.(NetworkEndpointStore)
+	return ret
+}
+
 func MockNetworkEndpointAPIs(fakeGCE *gce.Cloud) {
 	m := (fakeGCE.Compute().(*cloud.MockGCE))
 	m.MockNetworkEndpointGroups.X = NetworkEndpointStore{}


### PR DESCRIPTION
Addressing https://github.com/kubernetes/ingress-gce/pull/774#discussion_r293940618

Unit test coverage up a little bit https://github.com/kubernetes/ingress-gce/pull/774#issuecomment-502868951
```
$ go test -coverprofile=coverage.out ./...
ok  	k8s.io/ingress-gce/pkg/neg	2.463s	coverage: 64.1% of statements
?   	k8s.io/ingress-gce/pkg/neg/metrics	[no test files]
ok  	k8s.io/ingress-gce/pkg/neg/readiness	0.315s	coverage: 73.0% of statements
ok  	k8s.io/ingress-gce/pkg/neg/syncers	2.316s	coverage: 72.2% of statements
ok  	k8s.io/ingress-gce/pkg/neg/types	0.423s	coverage: 28.0% of statements
?   	k8s.io/ingress-gce/pkg/neg/types/shared	[no test files]
```