### PR TITLE
Integrate composite types into controller

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -39,7 +39,7 @@ import (
 
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller"
-	neg "k8s.io/ingress-gce/pkg/neg"
+	"k8s.io/ingress-gce/pkg/neg"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 
 	"k8s.io/ingress-gce/cmd/glbc/app"

--- a/pkg/backends/features/features.go
+++ b/pkg/backends/features/features.go
@@ -39,9 +39,13 @@ var (
 	// versionToFeatures stores the mapping from the required API
 	// version to feature names.
 	versionToFeatures = map[meta.Version][]string{
-		meta.VersionAlpha: []string{},
-		meta.VersionBeta:  []string{FeatureSecurityPolicy, FeatureHTTP2},
+		meta.VersionBeta: []string{FeatureSecurityPolicy, FeatureHTTP2},
 	}
+
+	// TODO: (shance) refactor all scope to be above the serviceport level
+	// scopeToFeatures stores the mapping from the required meta.KeyType
+	// to feature names
+	scopeToFeatures = map[meta.KeyType][]string{}
 )
 
 // SetDescription sets the XFeatures field for the given Description.
@@ -73,6 +77,13 @@ func VersionFromServicePort(sp *utils.ServicePort) meta.Version {
 	return VersionFromFeatures(featuresFromServicePort(sp))
 }
 
+// ScopeFromServicePort returns the meta.KeyType for the backend that this ServicePort
+// is associated with
+// TODO: (shance) refactor all scope to be above the serviceport level
+func ScopeFromServicePort(sp *utils.ServicePort) meta.KeyType {
+	return ScopeFromFeatures(featuresFromServicePort(sp))
+}
+
 // VersionFromDescription returns the meta.Version required for the given
 // description.
 func VersionFromDescription(desc string) meta.Version {
@@ -90,6 +101,17 @@ func VersionFromFeatures(features []string) meta.Version {
 		return meta.VersionBeta
 	}
 	return meta.VersionGA
+}
+
+// ScopeFromFeatures returns the meta.KeyType required for the given list of features
+// (e.g.) if a regional feature is added, the backend will be regional
+// TODO: (shance) refactor all scope to be above the serviceport level
+func ScopeFromFeatures(features []string) meta.KeyType {
+	fs := sets.NewString(features...)
+	if fs.HasAny(scopeToFeatures[meta.Regional]...) {
+		return meta.Regional
+	}
+	return meta.Global
 }
 
 var (

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -93,7 +93,8 @@ func (l *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) erro
 		igLinks = append(igLinks, ig.SelfLink)
 	}
 
-	be, err := l.backendPool.Get(sp.BackendName(l.namer), meta.VersionGA)
+	// ig_linker only supports L7 HTTP(s) External Load Balancer
+	be, err := l.backendPool.Get(sp.BackendName(l.namer), meta.VersionGA, meta.Global)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -15,6 +15,7 @@ package backends
 
 import (
 	"context"
+	"k8s.io/ingress-gce/pkg/backends/features"
 	"net/http"
 	"testing"
 
@@ -122,6 +123,6 @@ func TestLinkWithCreationModeError(t *testing.T) {
 				t.Fatalf("Wrong balancing mode, expected %v got %v", modes[(i+1)%len(modes)], b.BalancingMode)
 			}
 		}
-		linker.backendPool.Delete(sp.BackendName(defaultNamer))
+		linker.backendPool.Delete(sp.BackendName(defaultNamer), features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp))
 	}
 }

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -35,17 +35,17 @@ type GroupKey struct {
 // Backend Services.
 type Pool interface {
 	// Get a composite BackendService given a required version.
-	Get(name string, version meta.Version) (*composite.BackendService, error)
+	Get(name string, version meta.Version, scope meta.KeyType) (*composite.BackendService, error)
 	// Create a composite BackendService and returns it.
 	Create(sp utils.ServicePort, hcLink string) (*composite.BackendService, error)
 	// Update a BackendService given the composite type.
 	Update(be *composite.BackendService) error
 	// Delete a BackendService given its name.
-	Delete(name string) error
+	Delete(name string, version meta.Version, scope meta.KeyType) error
 	// Get the health of a BackendService given its name.
-	Health(name string) string
+	Health(name string, version meta.Version, scope meta.KeyType) string
 	// Get a list of BackendService names that are managed by this pool.
-	List() ([]string, error)
+	List() ([]*composite.BackendService, error)
 }
 
 // Syncer is an interface to sync Kubernetes services to GCE BackendServices.
@@ -58,7 +58,7 @@ type Syncer interface {
 	// GC garbage collects unused BackendService's
 	GC(svcPorts []utils.ServicePort) error
 	// Status returns the status of a BackendService given its name.
-	Status(name string) string
+	Status(name string, version meta.Version, scope meta.KeyType) string
 	// Shutdown cleans up all BackendService's previously synced.
 	Shutdown() error
 }

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -100,7 +100,7 @@ func TestSync(t *testing.T) {
 			beName := sp.BackendName(defaultNamer)
 
 			// Check that the new backend has the right port
-			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp))
+			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), meta.Global)
 			if err != nil {
 				t.Fatalf("Did not find expected backend with port %v", sp.NodePort)
 			}
@@ -132,7 +132,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTPS
 	syncer.Sync([]utils.ServicePort{p})
 
-	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTP2
 	syncer.Sync([]utils.ServicePort{p})
 
-	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p))
+	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestSyncNEG(t *testing.T) {
 	// GC should garbage collect the Backend on the old naming schema
 	syncer.GC([]utils.ServicePort{svcPort})
 
-	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort))
+	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), meta.Global)
 	if err == nil {
 		t.Fatalf("Expected not to get BackendService with name %v, got: %+v", nodePortName, bs)
 	}
@@ -491,7 +491,7 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort))
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), meta.Global)
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -535,7 +535,7 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort))
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), meta.Global)
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -563,7 +563,7 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 
 	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}}
 	syncer.Sync([]utils.ServicePort{p})
-	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p))
+	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p), meta.Global)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/composite/gen/main.go
+++ b/pkg/composite/gen/main.go
@@ -190,7 +190,9 @@ func genTypes(wr io.Writer) {
 
 // genFuncs() generates helper methods attached to composite structs.
 // TODO: (shance) Fix force send fields hack
-// TODO: (shance) Have To*() Functions set Scope and Version fields
+// TODO: (shance) Have To*() Functions set ResourceType and Version fields
+// TODO: (shance) Figure out a better solution so that the List() functions don't have to take a meta.Key
+// that ignores the name field
 func genFuncs(wr io.Writer) {
 	const text = `
 {{$All := .All}}

--- a/pkg/composite/utils.go
+++ b/pkg/composite/utils.go
@@ -46,6 +46,8 @@ func CreateKey(gceCloud *gce.Cloud, name string, scope meta.KeyType) (*meta.Key,
 }
 
 // TODO: (shance) generate this
+// TODO: (shance) add regional and alpha
+// TODO: (shance) populate scope
 // ListAllUrlMaps() merges all configured List() calls into one list of composite UrlMaps
 func ListAllUrlMaps(gceCloud *gce.Cloud) ([]*UrlMap, error) {
 	resultMap := map[string]*UrlMap{}
@@ -53,14 +55,10 @@ func ListAllUrlMaps(gceCloud *gce.Cloud) ([]*UrlMap, error) {
 	if err != nil {
 		return nil, err
 	}
-	key2, err := CreateKey(gceCloud, "", meta.Regional)
-	if err != nil {
-		return nil, err
-	}
 
 	// List ga-global and regional-alpha
-	versions := []meta.Version{meta.VersionGA, meta.VersionAlpha}
-	keys := []*meta.Key{key1, key2}
+	versions := []meta.Version{meta.VersionGA}
+	keys := []*meta.Key{key1}
 
 	for i := range versions {
 		list, err := ListUrlMaps(gceCloud, keys[i], versions[i])
@@ -82,6 +80,8 @@ func ListAllUrlMaps(gceCloud *gce.Cloud) ([]*UrlMap, error) {
 }
 
 // TODO: (shance) generate this
+// TODO: (shance) add regional and alpha
+// TODO: (shance) populate scope
 // ListAllUrlMaps() merges all configured List() calls into one list of composite UrlMaps
 func ListAllBackendServices(gceCloud *gce.Cloud) ([]*BackendService, error) {
 	resultMap := map[string]*BackendService{}
@@ -89,14 +89,10 @@ func ListAllBackendServices(gceCloud *gce.Cloud) ([]*BackendService, error) {
 	if err != nil {
 		return nil, err
 	}
-	key2, err := CreateKey(gceCloud, "", meta.Regional)
-	if err != nil {
-		return nil, err
-	}
 
 	// List ga-global and regional-alpha
-	versions := []meta.Version{meta.VersionGA, meta.VersionAlpha}
-	keys := []*meta.Key{key1, key2}
+	versions := []meta.Version{meta.VersionGA}
+	keys := []*meta.Key{key1}
 
 	for i := range versions {
 		list, err := ListBackendServices(gceCloud, keys[i], versions[i])

--- a/pkg/composite/utils_test.go
+++ b/pkg/composite/utils_test.go
@@ -117,7 +117,7 @@ func TestIsRegionalResource(t *testing.T) {
 	}
 }
 
-func TestParseScope(t *testing.T) {
+func TestScopeFromSelfLink(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		desc     string

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -236,7 +236,7 @@ func NewLoadBalancerController(
 
 	// Register health check on controller context.
 	ctx.AddHealthCheck("ingress", func() error {
-		_, err := backendPool.Get("foo", meta.VersionGA)
+		_, err := backendPool.Get("foo", meta.VersionGA, meta.Global)
 
 		// If this container is scheduled on a node without compute/rw it is
 		// effectively useless, but it is healthy. Reporting it as unhealthy

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -56,7 +56,6 @@ type FirewallController struct {
 func NewFirewallController(
 	ctx *context.ControllerContext,
 	portRanges []string) *FirewallController {
-
 	firewallPool := NewFirewallPool(ctx.Cloud, ctx.ClusterNamer, gce.LoadBalancerSrcRanges(), portRanges)
 
 	fwc := &FirewallController{

--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -63,7 +63,7 @@ func NewFirewallPool(cloud Firewall, namer *utils.Namer, l7SrcRanges []string, n
 	}
 }
 
-// Sync sync firewall rules with the cloud.
+// Sync syncs firewall rules with the cloud.
 func (fr *FirewallRules) Sync(nodeNames []string, additionalPorts ...string) error {
 	klog.V(4).Infof("Sync(%v)", nodeNames)
 	name := fr.namer.FirewallRule()

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -183,7 +183,6 @@ func (h *HealthChecks) update(oldHC, newHC *HealthCheck) error {
 		return h.cloud.UpdateHealthCheck(v1hc)
 	default:
 		return fmt.Errorf("unknown Version: %q", newHC.Version())
-
 	}
 }
 

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -26,6 +26,7 @@ import (
 )
 
 // HealthCheckProvider is an interface to manage a single GCE health check.
+// TODO: (shance) convert this to use composite types
 type HealthCheckProvider interface {
 	CreateHTTPHealthCheck(hc *compute.HttpHealthCheck) error
 	UpdateHTTPHealthCheck(hc *compute.HttpHealthCheck) error

--- a/pkg/loadbalancers/certificates.go
+++ b/pkg/loadbalancers/certificates.go
@@ -19,10 +19,11 @@ package loadbalancers
 import (
 	"crypto/sha256"
 	"fmt"
+	"net/http"
 	"strings"
 
-	compute "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
 )
@@ -63,8 +64,8 @@ func (l *L7) checkSSLCert() error {
 }
 
 // createSslCertificates creates SslCertificates based on kubernetes secrets in Ingress configuration.
-func (l *L7) createSslCertificates(existingCerts []*compute.SslCertificate) ([]*compute.SslCertificate, error) {
-	var result []*compute.SslCertificate
+func (l *L7) createSslCertificates(existingCerts []*composite.SslCertificate) ([]*composite.SslCertificate, error) {
+	var result []*composite.SslCertificate
 
 	existingCertsMap := getMapfromCertList(existingCerts)
 
@@ -98,17 +99,31 @@ func (l *L7) createSslCertificates(existingCerts []*compute.SslCertificate) ([]*
 		// Controller needs to create the certificate, no need to check if it exists and delete. If it did exist, it
 		// would have been listed in the populateSSLCert function and matched in the check above.
 		klog.V(2).Infof("Creating new sslCertificate %q for LB %q", gcpCertName, l.Name)
-		cert, err := l.cloud.CreateSslCertificate(&compute.SslCertificate{
+		cert := &composite.SslCertificate{
 			Name:        gcpCertName,
 			Certificate: ingCert,
 			PrivateKey:  ingKey,
-		})
+			Version:     l.version,
+		}
+		key, err := l.CreateKey(gcpCertName)
+		if err != nil {
+			klog.Errorf("l.CreateKey(%s) = %v", gcpCertName, err)
+			return nil, err
+		}
+		err = composite.CreateSslCertificate(l.cloud, key, cert)
 		if err != nil {
 			klog.Errorf("Failed to create new sslCertificate %q for %q - %v", gcpCertName, l.Name, err)
 			failedCerts = append(failedCerts, gcpCertName+" Error:"+err.Error())
 			continue
 		}
 		visitedCertMap[gcpCertName] = fmt.Sprintf("secret:%q", tlsCert.Name)
+
+		// Get SSLCert
+		cert, err = composite.GetSslCertificate(l.cloud, key, cert.Version)
+		if err != nil {
+			klog.Errorf("GetSslCertificate(_, %v, %v) = %v", key, cert.Version, err)
+			return nil, err
+		}
 		result = append(result, cert)
 	}
 
@@ -120,15 +135,21 @@ func (l *L7) createSslCertificates(existingCerts []*compute.SslCertificate) ([]*
 }
 
 // getSslCertificates fetches GCE SslCertificate resources by names.
-func (l *L7) getSslCertificates(names []string) ([]*compute.SslCertificate, error) {
-	var result []*compute.SslCertificate
+func (l *L7) getSslCertificates(names []string) ([]*composite.SslCertificate, error) {
+	var result []*composite.SslCertificate
 	var failedCerts []string
 	for _, name := range names {
 		// Ask GCE for the cert, checking for problems and existence.
-		cert, err := l.cloud.GetSslCertificate(name)
+		key, err := l.CreateKey(name)
+		if err != nil {
+			return nil, err
+		}
+		cert, err := composite.GetSslCertificate(l.cloud, key, l.version)
 		if err != nil {
 			failedCerts = append(failedCerts, name+": "+err.Error())
-			l.recorder.Eventf(l.runtimeInfo.Ingress, corev1.EventTypeNormal, SslCertificateMissing, err.Error())
+			if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+				l.recorder.Eventf(l.runtimeInfo.Ingress, corev1.EventTypeNormal, SslCertificateMissing, err.Error())
+			}
 			continue
 		}
 		if cert == nil {
@@ -147,7 +168,7 @@ func (l *L7) getSslCertificates(names []string) ([]*compute.SslCertificate, erro
 }
 
 // getPreSharedCertificates fetches SslCertificates specified via pre-shared-cert annotation.
-func (l *L7) getPreSharedCertificates() ([]*compute.SslCertificate, error) {
+func (l *L7) getPreSharedCertificates() ([]*composite.SslCertificate, error) {
 	if l.runtimeInfo.TLSName == "" {
 		return nil, nil
 	}
@@ -160,11 +181,11 @@ func (l *L7) getPreSharedCertificates() ([]*compute.SslCertificate, error) {
 	return sslCerts, nil
 }
 
-func getMapfromCertList(certs []*compute.SslCertificate) map[string]*compute.SslCertificate {
+func getMapfromCertList(certs []*composite.SslCertificate) map[string]*composite.SslCertificate {
 	if len(certs) == 0 {
 		return nil
 	}
-	certMap := make(map[string]*compute.SslCertificate)
+	certMap := make(map[string]*composite.SslCertificate)
 	for _, cert := range certs {
 		certMap[cert.Name] = cert
 	}
@@ -174,13 +195,19 @@ func getMapfromCertList(certs []*compute.SslCertificate) map[string]*compute.Ssl
 // getIngressManagedSslCerts fetches SslCertificate resources created and managed by this load balancer
 // instance. These SslCertificate resources were created based on kubernetes secrets in Ingress
 // configuration.
-func (l *L7) getIngressManagedSslCerts() ([]*compute.SslCertificate, error) {
-	var result []*compute.SslCertificate
+func (l *L7) getIngressManagedSslCerts() ([]*composite.SslCertificate, error) {
+	var result []*composite.SslCertificate
 
 	// Currently we list all certs available in gcloud and filter the ones managed by this loadbalancer instance. This is
 	// to make sure we garbage collect any old certs that this instance might have lost track of due to crashes.
 	// Can be a performance issue if there are too many global certs, default quota is only 10.
-	certs, err := l.cloud.ListSslCertificates()
+	// Use an empty name parameter since we only care about the scope
+	// TODO: (shance) refactor this so we don't need an empty arg
+	key, err := l.CreateKey("")
+	if err != nil {
+		return nil, err
+	}
+	certs, err := composite.ListSslCertificates(l.cloud, key, l.version)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +236,11 @@ func (l *L7) getIngressManagedSslCerts() ([]*compute.SslCertificate, error) {
 			if !l.namer.IsLegacySSLCert(l.Name, name) {
 				continue
 			}
-			cert, _ := l.cloud.GetSslCertificate(name)
+			key, err := l.CreateKey(name)
+			if err != nil {
+				return nil, err
+			}
+			cert, _ := composite.GetSslCertificate(l.cloud, key, l.version)
 			if cert != nil {
 				klog.V(4).Infof("Populating legacy ssl cert %s for l7 %s", cert.Name, l.Name)
 				result = append(result, cert)
@@ -234,8 +265,9 @@ func (l *L7) deleteOldSSLCerts() {
 			continue
 		}
 		klog.V(3).Infof("Cleaning up old SSL Certificate %s", cert.Name)
-		if certErr := utils.IgnoreHTTPNotFound(l.cloud.DeleteSslCertificate(cert.Name)); certErr != nil {
-			klog.Errorf("Old cert delete failed - %v", certErr)
+		key, _ := l.CreateKey(cert.Name)
+		if certErr := utils.IgnoreHTTPNotFound(composite.DeleteSslCertificate(l.cloud, key, l.version)); certErr != nil {
+			klog.Errorf("Old cert %s delete failed - %v", cert.Name, certErr)
 		}
 	}
 }
@@ -271,7 +303,7 @@ func GetCertHash(contents string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents)))[:16]
 }
 
-func toCertNames(certs []*compute.SslCertificate) (names []string) {
+func toCertNames(certs []*composite.SslCertificate) (names []string) {
 	for _, v := range certs {
 		names = append(names, v.Name)
 	}

--- a/pkg/loadbalancers/features/doc.go
+++ b/pkg/loadbalancers/features/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/loadbalancers/features/features.go
+++ b/pkg/loadbalancers/features/features.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO: (shance) this file should ideally be combined with backends/features
+package features
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	// versionToFeatures stores the mapping from the required API
+	// version to feature names.
+	// TODO: (shance) Add L7-ILB here
+	versionToFeatures = map[meta.Version][]string{}
+	// scopeToFeatures stores the mapping from the required resource type
+	// to feature names
+	// TODO: (shance) add L7-ILB here
+	// Only add features that have a hard scope requirement
+	// TODO: (shance) refactor scope to be per-resource
+	scopeToFeatures = map[meta.KeyType][]string{}
+)
+
+// featuresFromIngress returns the features enabled by an ingress
+func featuresFromIngress(ing *v1beta1.Ingress) []string {
+	result := []string{}
+	return result
+}
+
+// versionFromFeatures returns the meta.Version required for a list of features
+func versionFromFeatures(features []string) meta.Version {
+	fs := sets.NewString(features...)
+	if fs.HasAny(versionToFeatures[meta.VersionAlpha]...) {
+		return meta.VersionAlpha
+	}
+	if fs.HasAny(versionToFeatures[meta.VersionBeta]...) {
+		return meta.VersionBeta
+	}
+	return meta.VersionGA
+}
+
+// TODO: (shance) refactor scope to be per-resource
+// scopeFromFeatures returns the required scope for a list of features
+func scopeFromFeatures(features []string) meta.KeyType {
+	fs := sets.NewString(features...)
+	if fs.HasAny(scopeToFeatures[meta.Zonal]...) {
+		return meta.Zonal
+	}
+	if fs.HasAny(scopeToFeatures[meta.Regional]...) {
+		return meta.Regional
+	}
+	return meta.Global
+}
+
+// TODO: (shance) refactor scope to be per-resource
+// ScopeFromIngress returns the required scope of features for an Ingress
+func ScopeFromIngress(ing *v1beta1.Ingress) meta.KeyType {
+	return scopeFromFeatures(featuresFromIngress(ing))
+}
+
+// VersionFromIngress returns the required meta.Version of features for an Ingress
+func VersionFromIngress(ing *v1beta1.Ingress) meta.Version {
+	return versionFromFeatures(featuresFromIngress(ing))
+}

--- a/pkg/loadbalancers/features/features_test.go
+++ b/pkg/loadbalancers/features/features_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+const (
+	fakeGaFeature    = "fakegafeature"
+	fakeAlphaFeature = "fakealphafeature"
+	fakeBetaFeature  = "fakebetafeature"
+
+	fakeGlobalFeature   = "fakeglobalfeature"
+	fakeRegionalFeature = "fakeRegionalFeature"
+	fakeZonalFeature    = "fakeZonalFeature"
+)
+
+var (
+	emptyIng = v1beta1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	fakeScopeToFeatures = map[meta.KeyType][]string{
+		meta.Global:   {fakeGlobalFeature},
+		meta.Regional: {fakeRegionalFeature},
+		meta.Zonal:    {fakeZonalFeature},
+	}
+
+	fakeVersionToFeatures = map[meta.Version][]string{
+		meta.VersionGA:    {fakeGaFeature},
+		meta.VersionAlpha: {fakeAlphaFeature},
+		meta.VersionBeta:  {fakeBetaFeature},
+	}
+)
+
+// TODO: (shance) add real test cases once features are added
+func TestScopeFromIngress(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		ing   v1beta1.Ingress
+		scope meta.KeyType
+	}{
+		{
+			desc:  "Empty Ingress",
+			ing:   emptyIng,
+			scope: meta.Global,
+		},
+	}
+
+	// Override features with fakes
+	scopeToFeatures = fakeScopeToFeatures
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := ScopeFromIngress(&tc.ing)
+
+			if result != tc.scope {
+				t.Fatalf("want scope %s, got %s", tc.scope, result)
+			}
+		})
+	}
+}
+
+// TODO: (shance) add real test cases once features are added
+func TestVersionFromIngress(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		ing     v1beta1.Ingress
+		version meta.Version
+	}{
+		{
+			desc:    "Empty Ingress",
+			ing:     emptyIng,
+			version: meta.VersionGA,
+		},
+	}
+
+	// Override features with fakes
+	versionToFeatures = fakeVersionToFeatures
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := VersionFromIngress(&tc.ing)
+
+			if result != tc.version {
+				t.Fatalf("want scope %s, got %s", tc.version, result)
+			}
+		})
+	}
+}
+
+func TestVersionFromFeatures(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		features []string
+		version  meta.Version
+	}{
+		{
+			desc:     "One Ga feature",
+			features: []string{fakeGaFeature},
+			version:  meta.VersionGA,
+		},
+		{
+			desc:     "One Alpha feature",
+			features: []string{fakeAlphaFeature},
+			version:  meta.VersionAlpha,
+		},
+		{
+			desc:     "One Beta feature",
+			features: []string{fakeBetaFeature},
+			version:  meta.VersionBeta,
+		},
+		{
+			desc:     "Beta and GA feature",
+			features: []string{fakeBetaFeature, fakeGaFeature},
+			version:  meta.VersionBeta,
+		},
+		{
+			desc:     "Alpha, Beta, and GA feature",
+			features: []string{fakeAlphaFeature, fakeBetaFeature, fakeGaFeature},
+			version:  meta.VersionAlpha,
+		},
+		{
+			desc:     "Unknown features",
+			features: []string{"unknownfeature"},
+			version:  meta.VersionGA,
+		},
+	}
+
+	// Override features with fakes
+	scopeToFeatures = fakeScopeToFeatures
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := versionFromFeatures(tc.features)
+
+			if result != tc.version {
+				t.Fatalf("want scope %s, got %s", tc.version, result)
+			}
+		})
+	}
+}
+
+func TestScopeFromFeatures(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		features []string
+		scope    meta.KeyType
+	}{
+		{
+			desc:     "One Global feature",
+			features: []string{fakeGlobalFeature},
+			scope:    meta.Global,
+		},
+		{
+			desc:     "One Regional feature",
+			features: []string{fakeRegionalFeature},
+			scope:    meta.Regional,
+		},
+		{
+			desc:     "One Zonal feature",
+			features: []string{fakeZonalFeature},
+			scope:    meta.Zonal,
+		},
+		{
+			desc:     "Unknown features",
+			features: []string{"unknownfeature"},
+			scope:    meta.Global,
+		},
+	}
+
+	// Override features with fakes
+	scopeToFeatures = fakeScopeToFeatures
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := scopeFromFeatures(tc.features)
+
+			if result != tc.scope {
+				t.Fatalf("want scope %s, got %s", tc.scope, result)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package loadbalancers
 
+import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+)
+
 // LoadBalancerPool is an interface to manage the cloud resources associated
 // with a gce loadbalancer.
 type LoadBalancerPool interface {
 	Ensure(ri *L7RuntimeInfo) (*L7, error)
-	Delete(name string) error
+	Delete(name string, version meta.Version, scope meta.KeyType) error
 	GC(names []string) error
 	Shutdown() error
-	List() ([]string, error)
+	List() ([]string, []meta.KeyType, error)
 }

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -20,9 +20,10 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/ingress-gce/pkg/composite"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
@@ -41,16 +42,24 @@ func (l *L7) ensureComputeURLMap() error {
 	}
 
 	// Every update replaces the entire urlmap.
-	expectedMap := toComputeURLMap(l.Name, l.runtimeInfo.UrlMap, l.namer)
+	// Use an empty name parameter since we only care about the scope
+	// TODO: (shance) refactor this so we don't need an empty arg
+	key, err := l.CreateKey("")
+	if err != nil {
+		return err
+	}
+	expectedMap := toCompositeURLMap(l.Name, l.runtimeInfo.UrlMap, l.namer, key)
+	key.Name = expectedMap.Name
 
-	currentMap, err := l.cloud.GetURLMap(expectedMap.Name)
+	expectedMap.Version = meta.VersionGA
+	currentMap, err := composite.GetUrlMap(l.cloud, key, l.version)
 	if utils.IgnoreHTTPNotFound(err) != nil {
 		return err
 	}
 
 	if currentMap == nil {
 		klog.V(3).Infof("Creating URLMap %q", expectedMap.Name)
-		if err := l.cloud.CreateURLMap(expectedMap); err != nil {
+		if err := composite.CreateUrlMap(l.cloud, key, expectedMap); err != nil {
 			return fmt.Errorf("CreateUrlMap: %v", err)
 		}
 		l.um = expectedMap
@@ -65,7 +74,7 @@ func (l *L7) ensureComputeURLMap() error {
 
 	klog.V(3).Infof("Updating URLMap for %q", l.Name)
 	expectedMap.Fingerprint = currentMap.Fingerprint
-	if err := l.cloud.UpdateURLMap(expectedMap); err != nil {
+	if err := composite.UpdateUrlMap(l.cloud, key, expectedMap); err != nil {
 		return fmt.Errorf("UpdateURLMap: %v", err)
 	}
 
@@ -74,7 +83,7 @@ func (l *L7) ensureComputeURLMap() error {
 }
 
 // getBackendNames returns the names of backends in this L7 urlmap.
-func getBackendNames(computeURLMap *compute.UrlMap) ([]string, error) {
+func getBackendNames(computeURLMap *composite.UrlMap) ([]string, error) {
 	beNames := sets.NewString()
 	for _, pathMatcher := range computeURLMap.PathMatchers {
 		name, err := utils.KeyName(pathMatcher.DefaultService)
@@ -105,7 +114,7 @@ func getBackendNames(computeURLMap *compute.UrlMap) ([]string, error) {
 // mapsEqual compares the structure of two compute.UrlMaps.
 // The service strings are parsed and compared as resource paths (such as
 // "global/backendServices/my-service") to ignore variables: endpoint, version, and project.
-func mapsEqual(a, b *compute.UrlMap) bool {
+func mapsEqual(a, b *composite.UrlMap) bool {
 	if !utils.EqualResourcePaths(a.DefaultService, b.DefaultService) {
 		return false
 	}
@@ -167,7 +176,7 @@ func mapsEqual(a, b *compute.UrlMap) bool {
 	return true
 }
 
-// toComputeURLMap translates the given hostname: endpoint->port mapping into a gce url map.
+// toCompositeURLMap translates the given hostname: endpoint->port mapping into a gce url map.
 //
 // HostRule: Conceptually contains all PathRules for a given host.
 // PathMatcher: Associates a path rule with a host rule. Mostly an optimization.
@@ -208,11 +217,13 @@ func mapsEqual(a, b *compute.UrlMap) bool {
 // and remove the mapping. When a new path is added to a host (happens
 // more frequently than service deletion) we just need to lookup the 1
 // pathmatcher of the host.
-func toComputeURLMap(lbName string, g *utils.GCEURLMap, namer *utils.Namer) *compute.UrlMap {
+func toCompositeURLMap(lbName string, g *utils.GCEURLMap, namer *utils.Namer, key *meta.Key) *composite.UrlMap {
 	defaultBackendName := g.DefaultBackend.BackendName(namer)
-	m := &compute.UrlMap{
+	key.Name = defaultBackendName
+	resourceID := cloud.ResourceID{ProjectID: "", Resource: "backendServices", Key: key}
+	m := &composite.UrlMap{
 		Name:           namer.UrlMap(lbName),
-		DefaultService: cloud.NewBackendServicesResourceID("", defaultBackendName).ResourcePath(),
+		DefaultService: resourceID.ResourcePath(),
 	}
 
 	for _, hostRule := range g.HostRules {
@@ -220,22 +231,24 @@ func toComputeURLMap(lbName string, g *utils.GCEURLMap, namer *utils.Namer) *com
 		// Create a path matcher
 		// Add all given endpoint:backends to pathRules in path matcher
 		pmName := getNameForPathMatcher(hostRule.Hostname)
-		m.HostRules = append(m.HostRules, &compute.HostRule{
+		m.HostRules = append(m.HostRules, &composite.HostRule{
 			Hosts:       []string{hostRule.Hostname},
 			PathMatcher: pmName,
 		})
 
-		pathMatcher := &compute.PathMatcher{
+		pathMatcher := &composite.PathMatcher{
 			Name:           pmName,
 			DefaultService: m.DefaultService,
-			PathRules:      []*compute.PathRule{},
+			PathRules:      []*composite.PathRule{},
 		}
 
 		// GCE ensures that matched rule with longest prefix wins.
 		for _, rule := range hostRule.Paths {
 			beName := rule.Backend.BackendName(namer)
-			beLink := cloud.NewBackendServicesResourceID("", beName).ResourcePath()
-			pathMatcher.PathRules = append(pathMatcher.PathRules, &compute.PathRule{
+			key.Name = beName
+			resourceID := cloud.ResourceID{ProjectID: "", Resource: "backendServices", Key: key}
+			beLink := resourceID.ResourcePath()
+			pathMatcher.PathRules = append(pathMatcher.PathRules, &composite.PathRule{
 				Paths:   []string{rule.Path},
 				Service: beLink,
 			})


### PR DESCRIPTION
Just when you thought I couldn't possibly have another XL PR up my sleeves... :eyes: 

Replaces most resources with their composite version to enable L7-ILB and additional work.
Notable exceptions are health checks and firewall rules which will require some more careful changes.  I've tried to use as few constants as possible, but there are still cases where we need to just to default to GA-Global since we don't use any other types yet.

Additionally, basic e2e tests pass but I'll probably run more of them overnight to see if there are any regressions.

blocked by https://github.com/kubernetes/ingress-gce/pull/790