### PR TITLE
Add support for L7-ILB (take 2)

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -54,6 +54,7 @@ const (
 	IngressClassKey      = "kubernetes.io/ingress.class"
 	GceIngressClass      = "gce"
 	GceMultiIngressClass = "gce-multi-cluster"
+	GceL7ILBIngressClass = "gce-internal"
 
 	// Label key to denote which GCE zone a Kubernetes node is in.
 	ZoneKey     = "failure-domain.beta.kubernetes.io/zone"

--- a/pkg/backends/features/features.go
+++ b/pkg/backends/features/features.go
@@ -33,19 +33,22 @@ const (
 	FeatureSecurityPolicy = "SecurityPolicy"
 	// FeatureNEG defines the feature name of NEG.
 	FeatureNEG = "NEG"
+	// FeatureL7ILB defines the feature name of L7 Internal Load Balancer
+	// L7-ILB Resources are currently alpha and regional
+	FeatureL7ILB = "L7ILB"
 )
 
 var (
 	// versionToFeatures stores the mapping from the required API
 	// version to feature names.
 	versionToFeatures = map[meta.Version][]string{
-		meta.VersionBeta: []string{FeatureSecurityPolicy, FeatureHTTP2},
+		meta.VersionAlpha: []string{FeatureL7ILB},
+		meta.VersionBeta:  []string{FeatureSecurityPolicy, FeatureHTTP2},
 	}
-
 	// TODO: (shance) refactor all scope to be above the serviceport level
-	// scopeToFeatures stores the mapping from the required meta.KeyType
-	// to feature names
-	scopeToFeatures = map[meta.KeyType][]string{}
+	scopeToFeatures = map[meta.KeyType][]string{
+		meta.Regional: []string{FeatureL7ILB},
+	}
 )
 
 // SetDescription sets the XFeatures field for the given Description.
@@ -65,6 +68,9 @@ func featuresFromServicePort(sp *utils.ServicePort) []string {
 	}
 	if sp.NEGEnabled {
 		features = append(features, FeatureNEG)
+	}
+	if sp.L7ILBEnabled {
+		features = append(features, FeatureL7ILB)
 	}
 	// Keep feature names sorted to be consistent.
 	sort.Strings(features)

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -94,6 +94,8 @@ func (l *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) erro
 	}
 
 	// ig_linker only supports L7 HTTP(s) External Load Balancer
+	// Hardcoded here since IGs are not supported for non GA-Global right now
+	// TODO(shance): find a way to remove hardcoded values
 	be, err := l.backendPool.Get(sp.BackendName(l.namer), meta.VersionGA, meta.Global)
 	if err != nil {
 		return err

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -43,7 +43,7 @@ type Pool interface {
 	// Delete a BackendService given its name.
 	Delete(name string, version meta.Version, scope meta.KeyType) error
 	// Get the health of a BackendService given its name.
-	Health(name string, version meta.Version, scope meta.KeyType) string
+	Health(name string, version meta.Version, scope meta.KeyType) (string, error)
 	// Get a list of BackendService names that are managed by this pool.
 	List() ([]*composite.BackendService, error)
 }
@@ -58,7 +58,7 @@ type Syncer interface {
 	// GC garbage collects unused BackendService's
 	GC(svcPorts []utils.ServicePort) error
 	// Status returns the status of a BackendService given its name.
-	Status(name string, version meta.Version, scope meta.KeyType) string
+	Status(name string, version meta.Version, scope meta.KeyType) (string, error)
 	// Shutdown cleans up all BackendService's previously synced.
 	Shutdown() error
 }

--- a/pkg/backends/neg_linker.go
+++ b/pkg/backends/neg_linker.go
@@ -14,9 +14,9 @@ limitations under the License.
 package backends
 
 import (
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	befeatures "k8s.io/ingress-gce/pkg/backends/features"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -63,8 +63,10 @@ func (l *negLinker) Link(sp utils.ServicePort, groups []GroupKey) error {
 	cloud := l.backendPool.(*Backends).cloud
 	beName := sp.BackendName(l.namer)
 
-	version := meta.VersionGA
-	key, err := composite.CreateKey(cloud, beName, meta.Global)
+	version := befeatures.VersionFromServicePort(&sp)
+	scope := befeatures.ScopeFromServicePort(&sp)
+
+	key, err := composite.CreateKey(cloud, beName, scope)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -100,7 +100,7 @@ func TestSync(t *testing.T) {
 			beName := sp.BackendName(defaultNamer)
 
 			// Check that the new backend has the right port
-			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), meta.Global)
+			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp))
 			if err != nil {
 				t.Fatalf("Did not find expected backend with port %v", sp.NodePort)
 			}
@@ -108,7 +108,7 @@ func TestSync(t *testing.T) {
 				t.Fatalf("Backend %v has wrong port %v, expected %v", be.Name, be.Port, sp)
 			}
 
-			hc, err := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&sp))
+			hc, err := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp))
 			if err != nil {
 				t.Fatalf("Unexpected err when querying fake healthchecker: %v", err)
 			}
@@ -132,7 +132,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -151,7 +151,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTPS
 	syncer.Sync([]utils.ServicePort{p})
 
-	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
+	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ = syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -176,7 +176,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	syncer.Sync([]utils.ServicePort{p})
 	beName := p.BackendName(defaultNamer)
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p))
+	hc, _ := syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -195,7 +195,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	p.Protocol = annotations.ProtocolHTTP2
 	syncer.Sync([]utils.ServicePort{p})
 
-	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), meta.Global)
+	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	}
 
 	// Assert the proper health check was created
-	hc, _ = syncer.healthChecker.Get(beName, meta.VersionAlpha)
+	hc, _ = syncer.healthChecker.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if hc == nil || hc.Protocol() != p.Protocol {
 		t.Fatalf("Expected %s health check, received %v: ", p.Protocol, hc)
 	}
@@ -418,7 +418,7 @@ func TestSyncNEG(t *testing.T) {
 	// GC should garbage collect the Backend on the old naming schema
 	syncer.GC([]utils.ServicePort{svcPort})
 
-	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), meta.Global)
+	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), features.ScopeFromServicePort(&svcPort))
 	if err == nil {
 		t.Fatalf("Expected not to get BackendService with name %v, got: %+v", nodePortName, bs)
 	}
@@ -491,7 +491,7 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), meta.Global)
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort))
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -535,7 +535,7 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
 					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), meta.Global)
+					be, err := syncer.backendPool.Get(oldPort.BackendName(defaultNamer), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort))
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -563,7 +563,7 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 
 	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: intstr.FromInt(1)}}
 	syncer.Sync([]utils.ServicePort{p})
-	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p), meta.Global)
+	be, err := syncer.backendPool.Get(p.BackendName(defaultNamer), features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog"
-
 	apiv1 "k8s.io/api/core/v1"
 	informerv1 "k8s.io/client-go/informers/core/v1"
 	informerv1beta1 "k8s.io/client-go/informers/extensions/v1beta1"
@@ -33,6 +31,7 @@ import (
 	frontendconfigclient "k8s.io/ingress-gce/pkg/frontendconfig/client/clientset/versioned"
 	informerfrontendconfig "k8s.io/ingress-gce/pkg/frontendconfig/client/informers/externalversions/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -86,3 +86,11 @@ func nodePorts(svcPorts []utils.ServicePort) []int64 {
 	}
 	return ports
 }
+
+func UpdateServicePortsForILB(ingSvcPorts []utils.ServicePort, ing *v1beta1.Ingress) error {
+	for svcPortIdx, _ := range ingSvcPorts {
+		ingSvcPorts[svcPortIdx].L7ILBEnabled = true
+		ingSvcPorts[svcPortIdx].NEGEnabled = true
+	}
+	return nil
+}

--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -63,8 +63,8 @@ func NewFirewallPool(cloud Firewall, namer *utils.Namer, l7SrcRanges []string, n
 	}
 }
 
-// Sync syncs firewall rules with the cloud.
-func (fr *FirewallRules) Sync(nodeNames []string, additionalPorts ...string) error {
+// Sync firewall rules with the cloud.
+func (fr *FirewallRules) Sync(nodeNames, additionalPorts, additionalRanges []string) error {
 	klog.V(4).Infof("Sync(%v)", nodeNames)
 	name := fr.namer.FirewallRule()
 	existingFirewall, _ := fr.cloud.GetFirewall(name)
@@ -78,6 +78,7 @@ func (fr *FirewallRules) Sync(nodeNames []string, additionalPorts ...string) err
 	sort.Strings(targetTags)
 
 	ports := sets.NewString(additionalPorts...)
+	fr.srcRanges = append(fr.srcRanges, additionalRanges...)
 	ports.Insert(fr.portRanges...)
 	expectedFirewall := &compute.Firewall{
 		Name:         name,

--- a/pkg/firewalls/firewalls_test.go
+++ b/pkg/firewalls/firewalls_test.go
@@ -38,7 +38,7 @@ func TestFirewallPoolSync(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -49,21 +49,21 @@ func TestFirewallPoolSyncNodes(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Add nodes
 	nodes = append(nodes, "node-d", "node-e")
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Remove nodes
 	nodes = []string{"node-a", "node-c"}
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -74,7 +74,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -86,7 +86,7 @@ func TestFirewallPoolSyncSrcRanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -97,7 +97,7 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -110,17 +110,52 @@ func TestFirewallPoolSyncPorts(t *testing.T) {
 	}
 
 	// Expect firewall to be synced back to normal
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
 
 	// Verify additional ports are included
 	negTargetports := []string{"80", "443", "8080"}
-	if err := fp.Sync(nodes, negTargetports...); err != nil {
+	if err := fp.Sync(nodes, negTargetports, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, append(portRanges(), negTargetports...), t)
+}
+
+func TestFirewallPoolSyncRanges(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		desc             string
+		additionalRanges []string
+	}{
+		{
+			desc:             "Empty list",
+			additionalRanges: []string{},
+		},
+		{
+			desc:             "One additional Range",
+			additionalRanges: []string{"10.128.0.0/24"},
+		},
+		{
+			desc:             "Multiple ranges",
+			additionalRanges: []string{"10.128.0.0/24", "10.132.0.0/24", "10.134.0.0/24"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fwp := NewFakeFirewallsProvider(false, false)
+			fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
+			nodes := []string{"node-a", "node-b", "node-c"}
+
+			if err := fp.Sync(nodes, nil, tc.additionalRanges); err != nil {
+				t.Fatalf("fp.Sync(%v, nil, %v) = %v; want nil", nodes, tc.additionalRanges, err)
+			}
+
+			resultRanges := append(srcRanges, tc.additionalRanges...)
+			verifyFirewallRule(fwp, ruleName, nodes, resultRanges, portRanges(), t)
+		})
+	}
 }
 
 func TestFirewallPoolGC(t *testing.T) {
@@ -128,7 +163,7 @@ func TestFirewallPoolGC(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -150,7 +185,7 @@ func TestSyncOnXPNWithPermission(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	if err := fp.Sync(nodes); err != nil {
+	if err := fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 	verifyFirewallRule(fwp, ruleName, nodes, srcRanges, portRanges(), t)
@@ -164,7 +199,7 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	fp := NewFirewallPool(fwp, namer, srcRanges, portRanges())
 	nodes := []string{"node-a", "node-b", "node-c"}
 
-	err := fp.Sync(nodes)
+	err := fp.Sync(nodes, nil, nil)
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "create") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}
@@ -187,12 +222,12 @@ func TestSyncXPNReadOnly(t *testing.T) {
 	}
 
 	// Run sync again with same state - expect no event
-	if err = fp.Sync(nodes); err != nil {
+	if err = fp.Sync(nodes, nil, nil); err != nil {
 		t.Errorf("unexpected err when syncing firewall, err: %v", err)
 	}
 
 	nodes = append(nodes, "node-d")
-	err = fp.Sync(nodes)
+	err = fp.Sync(nodes, nil, nil)
 	if fwErr, ok := err.(*FirewallXPNError); !ok || !strings.Contains(fwErr.Message, "update") {
 		t.Errorf("Expected firewall sync error with a user message. Received err: %v", err)
 	}

--- a/pkg/firewalls/interfaces.go
+++ b/pkg/firewalls/interfaces.go
@@ -22,7 +22,8 @@ import (
 
 // SingleFirewallPool syncs the firewall rule for L7 traffic.
 type SingleFirewallPool interface {
-	Sync(nodeNames []string, additionalPorts ...string) error
+	// Sync syncs firewall rules with the cloud
+	Sync(nodeNames, additionalPorts, additionalRanges []string) error
 	GC() error
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -84,6 +84,7 @@ var (
 		EnableReadinessReflector  bool
 		FinalizerAdd              bool
 		FinalizerRemove           bool
+		EnableL7Ilb               bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -197,6 +198,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		F.FinalizerAdd, "Enable adding Finalizer to Ingress.")
 	flag.BoolVar(&F.FinalizerRemove, "enable-finalizer-remove",
 		F.FinalizerRemove, "Enable removing Finalizer from Ingress.")
+	flag.BoolVar(&F.EnableL7Ilb, "enable-l7-ilb", false,
+		`Optional, whether or not to enable L7-ILB.`)
 }
 
 type RateLimitSpecs struct {

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -49,6 +49,6 @@ type HealthCheckProvider interface {
 type HealthChecker interface {
 	New(sp utils.ServicePort) *HealthCheck
 	Sync(hc *HealthCheck) (string, error)
-	Delete(name string) error
-	Get(name string, version meta.Version) (*HealthCheck, error)
+	Delete(name string, scope meta.KeyType) error
+	Get(name string, version meta.Version, scope meta.KeyType) (*HealthCheck, error)
 }

--- a/pkg/loadbalancers/features/l7ilb.go
+++ b/pkg/loadbalancers/features/l7ilb.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functionality and constants for the L7-ILB feature
+// Since this also currently affects backend resources (since they are alpha-regional
+// instead of ga-global), this feature is also included in pkg/backends/features.go
+package features
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/klog"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+var ErrSubnetNotFound = errors.New("active subnet not found")
+
+// Get Subnet source range for ILB
+// TODO: (shance) refactor to use filter
+func ILBSubnetSourceRange(cloud *gce.Cloud, region string) (string, error) {
+	subnets, err := cloud.Compute().AlphaSubnetworks().List(context.Background(), region, filter.None)
+	if err != nil {
+		return "", fmt.Errorf("error obtaining subnets for region %s, %v", region, err)
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Role == "ACTIVE" && subnet.Purpose == "INTERNAL_HTTPS_LOAD_BALANCER" {
+			klog.V(3).Infof("Found L7-ILB Subnet %s - %s", subnet.Name, subnet.IpCidrRange)
+			return subnet.IpCidrRange, nil
+		}
+	}
+	return "", ErrSubnetNotFound
+}
+
+// L7ILBVersion is a helper to get the version of L7-ILB
+func L7ILBVersion(resource LBResource) meta.Version {
+	return versionFromFeatures([]string{FeatureL7ILB}, resource)
+}
+
+// L7ILBScope is a helper to get the scope of L7-ILB
+func L7ILBScope() meta.KeyType {
+	return scopeFromFeatures([]string{FeatureL7ILB})
+}

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -19,6 +19,7 @@ package loadbalancers
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
 )
@@ -41,7 +42,8 @@ func (l *L7) checkProxy() (err error) {
 	if err != nil {
 		return err
 	}
-	proxy, _ := composite.GetTargetHttpProxy(l.cloud, key, l.version)
+	version := l.Version(features.TargetHttpProxy)
+	proxy, _ := composite.GetTargetHttpProxy(l.cloud, key, version)
 	if proxy == nil {
 		klog.V(3).Infof("Creating new http proxy for urlmap %v", l.um.Name)
 		description, err := l.description()
@@ -52,7 +54,7 @@ func (l *L7) checkProxy() (err error) {
 			Name:        proxyName,
 			UrlMap:      urlMapLink,
 			Description: description,
-			Version:     l.version,
+			Version:     version,
 		}
 		key, err := l.CreateKey(newProxy.Name)
 		if err != nil {
@@ -65,7 +67,7 @@ func (l *L7) checkProxy() (err error) {
 		if err != nil {
 			return err
 		}
-		proxy, err = composite.GetTargetHttpProxy(l.cloud, key, l.version)
+		proxy, err = composite.GetTargetHttpProxy(l.cloud, key, version)
 		if err != nil {
 			return err
 		}
@@ -104,7 +106,8 @@ func (l *L7) checkHttpsProxy() (err error) {
 	if err != nil {
 		return err
 	}
-	proxy, _ := composite.GetTargetHttpsProxy(l.cloud, key, l.version)
+	version := l.Version(features.TargetHttpProxy)
+	proxy, _ := composite.GetTargetHttpsProxy(l.cloud, key, version)
 	description, err := l.description()
 	if err != nil {
 		return err
@@ -115,7 +118,7 @@ func (l *L7) checkHttpsProxy() (err error) {
 			Name:        proxyName,
 			UrlMap:      urlMapLink,
 			Description: description,
-			Version:     l.version,
+			Version:     version,
 		}
 
 		for _, c := range l.sslCerts {
@@ -134,7 +137,7 @@ func (l *L7) checkHttpsProxy() (err error) {
 		if err != nil {
 			return err
 		}
-		proxy, err = composite.GetTargetHttpsProxy(l.cloud, key, l.version)
+		proxy, err = composite.GetTargetHttpsProxy(l.cloud, key, version)
 		if err != nil {
 			return err
 		}
@@ -180,7 +183,7 @@ func (l *L7) getSslCertLinkInUse() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	proxy, err := composite.GetTargetHttpsProxy(l.cloud, key, l.version)
+	proxy, err := composite.GetTargetHttpsProxy(l.cloud, key, l.Version(features.TargetHttpsProxy))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -51,8 +52,8 @@ func (l *L7) ensureComputeURLMap() error {
 	expectedMap := toCompositeURLMap(l.Name, l.runtimeInfo.UrlMap, l.namer, key)
 	key.Name = expectedMap.Name
 
-	expectedMap.Version = meta.VersionGA
-	currentMap, err := composite.GetUrlMap(l.cloud, key, l.version)
+	expectedMap.Version = l.Version(features.UrlMap)
+	currentMap, err := composite.GetUrlMap(l.cloud, key, expectedMap.Version)
 	if utils.IgnoreHTTPNotFound(err) != nil {
 		return err
 	}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -48,6 +48,7 @@ type ServicePort struct {
 	Protocol      annotations.AppProtocol
 	TargetPort    string
 	NEGEnabled    bool
+	L7ILBEnabled  bool
 	BackendConfig *backendconfigv1beta1.BackendConfig
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -268,10 +268,21 @@ func IGLinks(igs []*compute.InstanceGroup) (igLinks []string) {
 // controller.
 func IsGCEIngress(ing *v1beta1.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
-	if flags.F.IngressClass == "" {
-		return class == "" || class == annotations.GceIngressClass
+	if flags.F.IngressClass != "" && class == flags.F.IngressClass {
+		return true
 	}
-	return class == flags.F.IngressClass
+
+	switch class {
+	case "":
+		return true
+	case annotations.GceIngressClass:
+		return true
+	case annotations.GceL7ILBIngressClass:
+		// TODO: (shance) remove flag check for L7-ILB once fully rolled out
+		return flags.F.EnableL7Ilb
+	default:
+		return false
+	}
 }
 
 // IsGCEMultiClusterIngress returns true if the given Ingress has
@@ -279,6 +290,13 @@ func IsGCEIngress(ing *v1beta1.Ingress) bool {
 func IsGCEMultiClusterIngress(ing *v1beta1.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
 	return class == annotations.GceMultiIngressClass
+}
+
+// IsGCEL7ILBIngress returns true if the given Ingress has
+// ingress.class annotation set to "gce-l7-ilb"
+func IsGCEL7ILBIngress(ing *v1beta1.Ingress) bool {
+	class := annotations.FromIngress(ing).IngressClass()
+	return class == annotations.GceL7ILBIngressClass
 }
 
 // IsGLBCIngress returns true if the given Ingress should be processed by GLBC


### PR DESCRIPTION
**This PR supersedes https://github.com/kubernetes/ingress-gce/pull/773**

Adds support for the L7 Internal Load Balancer to the controller.  A follow up PR with e2e tests will be added.

In the interest of time, I've added the L7-ILB work on top of https://github.com/kubernetes/ingress-gce/pull/788 so that it can be reviewed in tandem.  Unless you foresee *gigantic* changes in that PR, I would review this as well so it can be merged shortly after.  The first commit on this PR is from that branch.

Currently, the feature is flag-gated with the '--enable-l7-ilb' flag.  Enabling the flag will require resolving https://github.com/kubernetes/ingress-gce/issues/767