### PR TITLE
Change from "extensions.v1beta1" to "networking.v1beta1"

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -104,7 +104,7 @@ func TestAffinity(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -159,7 +159,7 @@ func TestAffinity(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -64,7 +64,7 @@ func TestAppProtocol(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -83,7 +83,7 @@ func TestAppProtocol(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 
@@ -133,7 +133,7 @@ func TestAppProtocolTransition(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -167,7 +167,7 @@ func TestAppProtocolTransition(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -104,7 +104,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 			testIng := fuzz.NewIngressBuilder("", "ingress-1", "").
 				AddPath("test.com", "/", "service-1", port80).
 				Build()
-			testIng, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(testIng)
+			testIng, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
 			if err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
@@ -133,7 +133,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 				t.Fatalf("error waiting for BackendConfig warning event: %v", err)
 			}
 
-			testIng, err = Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Get(testIng.Name, metav1.GetOptions{})
+			testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Get(testIng.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("error retrieving Ingress %q: %v", testIng.Name, err)
 			}

--- a/cmd/e2e-test/basic_https_test.go
+++ b/cmd/e2e-test/basic_https_test.go
@@ -107,7 +107,7 @@ func TestBasicHTTPS(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
 	"k8s.io/ingress-gce/pkg/fuzz"
@@ -78,7 +78,7 @@ func TestBasic(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
@@ -136,7 +136,7 @@ func TestBasicStaticIP(t *testing.T) {
 			DefaultBackend("service-1", intstr.FromInt(80)).
 			AddStaticIP(addrName).
 			Build()
-		testIng, err = Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(testIng)
+		testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
 		}
@@ -198,7 +198,7 @@ func TestEdge(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -90,7 +90,7 @@ func TestCDN(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -114,7 +114,7 @@ func TestCDN(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -86,7 +86,7 @@ func TestDraining(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -149,7 +149,7 @@ func TestDraining(t *testing.T) {
 			deleteOptions := &fuzz.GCLBDeleteOptions{
 				SkipDefaultBackend: true,
 			}
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -72,7 +72,7 @@ func TestIAP(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -91,7 +91,7 @@ func TestIAP(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -107,7 +107,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 
 		port80 := intstr.FromInt(80)
 		testIng := fuzz.NewIngressBuilder("", "ingress-1", "").DefaultBackend("service-1", port80).AddPath("test.com", "/", "service-1", port80).Build()
-		testIng, err = Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(testIng)
+		testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
 		}
@@ -179,7 +179,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 		port80 := intstr.FromInt(80)
 		testIng := fuzz.NewIngressBuilder("", "ingress-1", "").DefaultBackend("service-1", port80).AddPath("test.com", "/", "service-1", port80).Build()
-		testIng, err = Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(testIng)
+		testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
 		}

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -77,7 +77,7 @@ func TestTimeout(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
@@ -110,7 +110,7 @@ func TestTimeout(t *testing.T) {
 			deleteOptions := &fuzz.GCLBDeleteOptions{
 				SkipDefaultBackend: true,
 			}
-			if err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)

--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/kr/pretty"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
 	"k8s.io/ingress-gce/pkg/fuzz"
@@ -59,7 +59,7 @@ func TestUpgrade(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
@@ -85,7 +85,7 @@ func TestUpgrade(t *testing.T) {
 						AddPath("bar.com", "/", "service-1", port80).
 						Build()
 
-					if _, err := Framework.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Update(newIng); err != nil {
+					if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Update(newIng); err != nil {
 						t.Fatalf("error creating Ingress spec: %v", err)
 					} else {
 						// If Ingress upgrade succeeds, we update the status on this Ingress

--- a/cmd/fuzzer/app/validate.go
+++ b/cmd/fuzzer/app/validate.go
@@ -126,7 +126,7 @@ func Validate() {
 	fmt.Printf("Features = %v\n\n", fsNames)
 
 	k8s := k8sClientSet(config)
-	ing, err := k8s.ExtensionsV1beta1().Ingresses(validateOptions.ns).Get(validateOptions.name, metav1.GetOptions{})
+	ing, err := k8s.NetworkingV1beta1().Ingresses(validateOptions.ns).Get(validateOptions.name, metav1.GetOptions{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -19,7 +19,7 @@ package annotations
 import (
 	"strconv"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 const (
@@ -84,7 +84,7 @@ type Ingress struct {
 }
 
 // FromIngress extracts the annotations from an Ingress definition.
-func FromIngress(ing *extensions.Ingress) *Ingress {
+func FromIngress(ing *v1beta1.Ingress) *Ingress {
 	return &Ingress{ing.Annotations}
 }
 

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -19,24 +19,24 @@ package annotations
 import (
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIngress(t *testing.T) {
 	for _, tc := range []struct {
-		ing          *extensions.Ingress
+		ing          *v1beta1.Ingress
 		allowHTTP    bool
 		useNamedTLS  string
 		staticIPName string
 		ingressClass string
 	}{
 		{
-			ing:       &extensions.Ingress{},
+			ing:       &v1beta1.Ingress{},
 			allowHTTP: true, // defaults to true.
 		},
 		{
-			ing: &extensions.Ingress{
+			ing: &v1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						AllowHTTPKey:     "false",

--- a/pkg/common/operator/frontendconfig.go
+++ b/pkg/common/operator/frontendconfig.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"fmt"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 )
@@ -27,7 +27,7 @@ func (op *FrontendConfigsOperator) AsList() []*frontendconfigv1beta1.FrontendCon
 }
 
 // ReferencedByIngress returns the FrontendConfigs that are referenced by the passed in Ingress.
-func (op *FrontendConfigsOperator) ReferencedByIngress(ing *extensions.Ingress) *FrontendConfigsOperator {
+func (op *FrontendConfigsOperator) ReferencedByIngress(ing *v1beta1.Ingress) *FrontendConfigsOperator {
 	dupes := map[string]bool{}
 
 	var f []*frontendconfigv1beta1.FrontendConfig
@@ -43,7 +43,7 @@ func (op *FrontendConfigsOperator) ReferencedByIngress(ing *extensions.Ingress) 
 
 // doesIngressReferenceFrontendConfig returns true if the passed in Ingress directly references
 // the passed in FrontendConfig.
-func doesIngressReferenceFrontendConfig(ing *extensions.Ingress, feConfig *frontendconfigv1beta1.FrontendConfig) bool {
+func doesIngressReferenceFrontendConfig(ing *v1beta1.Ingress, feConfig *frontendconfigv1beta1.FrontendConfig) bool {
 	if ing.Namespace != feConfig.Namespace {
 		return false
 	}

--- a/pkg/common/operator/frontendconfig_test.go
+++ b/pkg/common/operator/frontendconfig_test.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/test"
 )
 
@@ -12,7 +12,7 @@ func TestDoesIngressReferenceFrontendConfig(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		ing      *extensions.Ingress
+		ing      *v1beta1.Ingress
 		expected bool
 	}{
 		{

--- a/pkg/common/operator/ingress.go
+++ b/pkg/common/operator/ingress.go
@@ -7,30 +7,30 @@ import (
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 // Ingresses returns the wrapper
-func Ingresses(i []*extensions.Ingress) *IngressesOperator {
+func Ingresses(i []*v1beta1.Ingress) *IngressesOperator {
 	return &IngressesOperator{i: i}
 }
 
 // IngressesOperator is an operator wrapper for a list of Ingresses.
 type IngressesOperator struct {
-	i []*extensions.Ingress
+	i []*v1beta1.Ingress
 }
 
 // AsList returns the underlying list of Ingresses.
-func (op *IngressesOperator) AsList() []*extensions.Ingress {
+func (op *IngressesOperator) AsList() []*v1beta1.Ingress {
 	if op.i == nil {
-		return []*extensions.Ingress{}
+		return []*v1beta1.Ingress{}
 	}
 	return op.i
 }
 
 // Filter the list of Ingresses based on a predicate.
-func (op *IngressesOperator) Filter(f func(*extensions.Ingress) bool) *IngressesOperator {
-	var i []*extensions.Ingress
+func (op *IngressesOperator) Filter(f func(*v1beta1.Ingress) bool) *IngressesOperator {
+	var i []*v1beta1.Ingress
 	for _, ing := range op.i {
 		if f(ing) {
 			i = append(i, ing)
@@ -43,7 +43,7 @@ func (op *IngressesOperator) Filter(f func(*extensions.Ingress) bool) *Ingresses
 func (op *IngressesOperator) ReferencesService(svc *api_v1.Service) *IngressesOperator {
 	dupes := map[string]bool{}
 
-	var i []*extensions.Ingress
+	var i []*v1beta1.Ingress
 	for _, ing := range op.i {
 		key := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
 		if doesIngressReferenceService(ing, svc) && !dupes[key] {
@@ -58,7 +58,7 @@ func (op *IngressesOperator) ReferencesService(svc *api_v1.Service) *IngressesOp
 func (op *IngressesOperator) ReferencesBackendConfig(beConfig *backendconfigv1beta1.BackendConfig, svcsOp *ServicesOperator) *IngressesOperator {
 	dupes := map[string]bool{}
 
-	var i []*extensions.Ingress
+	var i []*v1beta1.Ingress
 	svcs := svcsOp.ReferencesBackendConfig(beConfig).AsList()
 	for _, ing := range op.i {
 		for _, svc := range svcs {
@@ -76,7 +76,7 @@ func (op *IngressesOperator) ReferencesBackendConfig(beConfig *backendconfigv1be
 func (op *IngressesOperator) ReferencesFrontendConfig(feConfig *frontendconfigv1beta1.FrontendConfig) *IngressesOperator {
 	dupes := map[string]bool{}
 
-	var i []*extensions.Ingress
+	var i []*v1beta1.Ingress
 	for _, ing := range op.i {
 		key := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
 		if doesIngressReferenceFrontendConfig(ing, feConfig) && !dupes[key] {

--- a/pkg/common/operator/service.go
+++ b/pkg/common/operator/service.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 // Services returns the wrapper
@@ -44,7 +44,7 @@ func (op *ServicesOperator) ReferencesBackendConfig(beConfig *backendconfigv1bet
 }
 
 // ReferencedBackendIngress returns the Services that are referenced by the passed in Ingress.
-func (op *ServicesOperator) ReferencedByIngress(ing *extensions.Ingress) *ServicesOperator {
+func (op *ServicesOperator) ReferencedByIngress(ing *v1beta1.Ingress) *ServicesOperator {
 	dupes := map[string]bool{}
 
 	var s []*api_v1.Service
@@ -60,7 +60,7 @@ func (op *ServicesOperator) ReferencedByIngress(ing *extensions.Ingress) *Servic
 
 // doesIngressReferenceService returns true if the passed in Ingress directly references
 // the passed in Service.
-func doesIngressReferenceService(ing *extensions.Ingress, svc *api_v1.Service) bool {
+func doesIngressReferenceService(ing *v1beta1.Ingress, svc *api_v1.Service) bool {
 	if ing.Namespace != svc.Namespace {
 		return false
 	}

--- a/pkg/common/typed/ingress.go
+++ b/pkg/common/typed/ingress.go
@@ -1,8 +1,7 @@
 package typed
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
-
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -17,19 +16,19 @@ type IngressStore struct {
 }
 
 // Add implements Store.
-func (s *IngressStore) Add(i *extensions.Ingress) error { return s.store.Add(i) }
+func (s *IngressStore) Add(i *v1beta1.Ingress) error { return s.store.Add(i) }
 
 // Update implements Store.
-func (s *IngressStore) Update(i *extensions.Ingress) error { return s.store.Update(i) }
+func (s *IngressStore) Update(i *v1beta1.Ingress) error { return s.store.Update(i) }
 
 // Delete implements Store.
-func (s *IngressStore) Delete(i *extensions.Ingress) error { return s.store.Delete(i) }
+func (s *IngressStore) Delete(i *v1beta1.Ingress) error { return s.store.Delete(i) }
 
 // List implements Store.
-func (s *IngressStore) List() []*extensions.Ingress {
-	var ret []*extensions.Ingress
+func (s *IngressStore) List() []*v1beta1.Ingress {
+	var ret []*v1beta1.Ingress
 	for _, obj := range s.store.List() {
-		ret = append(ret, obj.(*extensions.Ingress))
+		ret = append(ret, obj.(*v1beta1.Ingress))
 	}
 	return ret
 }
@@ -38,25 +37,25 @@ func (s *IngressStore) List() []*extensions.Ingress {
 func (s *IngressStore) ListKeys() []string { return s.store.ListKeys() }
 
 // Get implements Store.
-func (s *IngressStore) Get(i *extensions.Ingress) (*extensions.Ingress, bool, error) {
+func (s *IngressStore) Get(i *v1beta1.Ingress) (*v1beta1.Ingress, bool, error) {
 	item, exists, err := s.store.Get(i)
 	if item == nil {
 		return nil, exists, err
 	}
-	return item.(*extensions.Ingress), exists, err
+	return item.(*v1beta1.Ingress), exists, err
 }
 
 // GetByKey implements Store.
-func (s *IngressStore) GetByKey(key string) (*extensions.Ingress, bool, error) {
+func (s *IngressStore) GetByKey(key string) (*v1beta1.Ingress, bool, error) {
 	item, exists, err := s.store.GetByKey(key)
 	if item == nil {
 		return nil, exists, err
 	}
-	return item.(*extensions.Ingress), exists, err
+	return item.(*v1beta1.Ingress), exists, err
 }
 
 // Resync implements Store.
 func (s *IngressStore) Resync() error { return s.store.Resync() }
 
 // This function is mostly likely not useful for ordinary consumers.
-// func (s *IngressStore) Replace(items []*extensions.Ingress, string) error {}
+// func (s *IngressStore) Replace(items []*v1beta1.Ingress, string) error {}

--- a/pkg/controller/translator/testdata/ingress-missing-multi-svc.yaml
+++ b/pkg/controller/translator/testdata/ingress-missing-multi-svc.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-missing-rule-svc.yaml
+++ b/pkg/controller/translator/testdata/ingress-missing-rule-svc.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-multi-empty.yaml
+++ b/pkg/controller/translator/testdata/ingress-multi-empty.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-multi-paths.yaml
+++ b/pkg/controller/translator/testdata/ingress-multi-paths.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-no-host.yaml
+++ b/pkg/controller/translator/testdata/ingress-no-host.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-single-host.yaml
+++ b/pkg/controller/translator/testdata/ingress-single-host.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/testdata/ingress-two-hosts.yaml
+++ b/pkg/controller/translator/testdata/ingress-two-hosts.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/klog"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -131,7 +131,7 @@ func (t *Translator) getServicePort(id utils.ServicePortID) (*utils.ServicePort,
 }
 
 // TranslateIngress converts an Ingress into our internal UrlMap representation.
-func (t *Translator) TranslateIngress(ing *extensions.Ingress, systemDefaultBackend utils.ServicePortID) (*utils.GCEURLMap, []error) {
+func (t *Translator) TranslateIngress(ing *v1beta1.Ingress, systemDefaultBackend utils.ServicePortID) (*utils.GCEURLMap, []error) {
 	var errs []error
 	urlMap := utils.NewGCEURLMap()
 	for _, rule := range ing.Spec.Rules {

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -17,15 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/utils"
-
-	extensions "k8s.io/api/extensions/v1beta1"
 )
 
 // gcState is used by the controller to maintain state for garbage collection routines.
 type gcState struct {
-	ingresses []*extensions.Ingress
+	ingresses []*v1beta1.Ingress
 	lbNames   []string
 	svcPorts  []utils.ServicePort
 }
@@ -33,6 +32,6 @@ type gcState struct {
 // syncState is used by the controller to maintain state for routines that sync GCP resources of an Ingress.
 type syncState struct {
 	urlMap *utils.GCEURLMap
-	ing    *extensions.Ingress
+	ing    *v1beta1.Ingress
 	l7     *loadbalancers.L7
 }

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 
 	compute "google.golang.org/api/compute/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
-
 	api_v1 "k8s.io/api/core/v1"
-
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -70,7 +68,7 @@ func nodeStatusChanged(old, cur *api_v1.Node) bool {
 	return false
 }
 
-func convert(ings []*extensions.Ingress) (retVal []interface{}) {
+func convert(ings []*v1beta1.Ingress) (retVal []interface{}) {
 	for _, ing := range ings {
 		retVal = append(retVal, ing)
 	}

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -25,8 +25,9 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
@@ -88,30 +89,18 @@ func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, s
 		},
 	}
 
-	deployment := &v1beta1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1beta1.DeploymentSpec{
+	deployment := &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: apps.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
 			Template: podTemplate,
-		},
-	}
-
-	scale := &v1beta1.Scale{
-		Spec: v1beta1.ScaleSpec{
-			Replicas: numReplicas,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: s.Namespace,
 		},
 	}
 
 	svc, err := s.f.Clientset.CoreV1().Services(s.Namespace).Get(name, metav1.GetOptions{})
 
 	if svc == nil || err != nil {
-		if deployment, err = s.f.Clientset.ExtensionsV1beta1().Deployments(s.Namespace).Create(deployment); err != nil {
+		if deployment, err = s.f.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 			return nil, err
 		}
 		if svc, err = s.f.Clientset.CoreV1().Services(s.Namespace).Create(expectedSvc); err != nil {
@@ -120,7 +109,8 @@ func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, s
 		return svc, err
 	}
 
-	if _, err = s.f.Clientset.ExtensionsV1beta1().Deployments(s.Namespace).UpdateScale(name, scale); err != nil {
+	*deployment.Spec.Replicas = numReplicas
+	if _, err = s.f.Clientset.AppsV1().Deployments(s.Namespace).Update(deployment); err != nil {
 		return nil, fmt.Errorf("Error updating deployment scale: %v", err)
 	}
 
@@ -167,15 +157,15 @@ func DeleteSecret(s *Sandbox, name string) error {
 
 // EnsureIngress creates a new Ingress or updates an existing one.
 func EnsureIngress(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
-	currentIng, err := s.f.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Get(ing.ObjectMeta.Name, metav1.GetOptions{})
+	currentIng, err := s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Get(ing.ObjectMeta.Name, metav1.GetOptions{})
 
 	if currentIng == nil || err != nil {
-		return s.f.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Create(ing)
+		return s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing)
 	}
 
 	// Update ingress spec if they are not equal
 	if !reflect.DeepEqual(ing.Spec, currentIng.Spec) {
-		return s.f.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Update(ing)
+		return s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Update(ing)
 	}
 
 	return currentIng, nil

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/ingress-gce/pkg/annotations"
@@ -55,7 +55,7 @@ type WaitForIngressOptions struct {
 func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitForIngressOptions) (*v1beta1.Ingress, error) {
 	err := wait.Poll(ingressPollInterval, ingressPollTimeout, func() (bool, error) {
 		var err error
-		ing, err = s.f.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Get(ing.Name, metav1.GetOptions{})
+		ing, err = s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Get(ing.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -79,7 +79,7 @@ func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitForIngressOpt
 // WaitForIngressDeletion deletes the given ingress and waits for the
 // resources associated with it to be deleted.
 func WaitForIngressDeletion(ctx context.Context, g *fuzz.GCLB, s *Sandbox, ing *v1beta1.Ingress, options *fuzz.GCLBDeleteOptions) error {
-	if err := s.f.Clientset.ExtensionsV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("delete(%q) = %v, want nil", ing.Name, err)
 	}
 	klog.Infof("Waiting for GCLB resources to be deleted (%s/%s), IngressDeletionOptions=%+v", s.Namespace, ing.Name, options)

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned/fake"
@@ -73,8 +73,8 @@ func TestFirewallCreateDelete(t *testing.T) {
 	fwc.ctx.KubeClient.CoreV1().Services(defaultSvc.Namespace).Create(defaultSvc)
 	fwc.ctx.ServiceInformer.GetIndexer().Add(defaultSvc)
 
-	ing := test.NewIngress(types.NamespacedName{Name: "my-ingress", Namespace: "default"}, extensions.IngressSpec{})
-	fwc.ctx.KubeClient.ExtensionsV1beta1().Ingresses(ing.Namespace).Create(ing)
+	ing := test.NewIngress(types.NamespacedName{Name: "my-ingress", Namespace: "default"}, v1beta1.IngressSpec{})
+	fwc.ctx.KubeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Create(ing)
 	fwc.ctx.IngressInformer.GetIndexer().Add(ing)
 
 	key, _ := utils.KeyFunc(queueKey)
@@ -88,7 +88,7 @@ func TestFirewallCreateDelete(t *testing.T) {
 		t.Fatalf("cloud.GetFirewall(%v) = _, %v, want _, nil", ruleName, err)
 	}
 
-	fwc.ctx.KubeClient.ExtensionsV1beta1().Ingresses(ing.Namespace).Delete(ing.Name, &meta_v1.DeleteOptions{})
+	fwc.ctx.KubeClient.NetworkingV1beta1().Ingresses(ing.Namespace).Delete(ing.Name, &meta_v1.DeleteOptions{})
 	fwc.ctx.IngressInformer.GetIndexer().Delete(ing)
 
 	if err := fwc.sync(key); err != nil {

--- a/pkg/frontendconfig/frontendconfig.go
+++ b/pkg/frontendconfig/frontendconfig.go
@@ -19,7 +19,7 @@ package frontendconfig
 import (
 	"errors"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	apisfrontendconfig "k8s.io/ingress-gce/pkg/apis/frontendconfig"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
@@ -45,7 +45,7 @@ func CRDMeta() *crd.CRDMeta {
 }
 
 // FrontendConfigForIngress returns the corresponding FrontendConfig for the given Ingress if one was specified.
-func FrontendConfigForIngress(feConfigs []*frontendconfigv1beta1.FrontendConfig, ing *extensions.Ingress) (*frontendconfigv1beta1.FrontendConfig, error) {
+func FrontendConfigForIngress(feConfigs []*frontendconfigv1beta1.FrontendConfig, ing *v1beta1.Ingress) (*frontendconfigv1beta1.FrontendConfig, error) {
 	frontendConfigName := annotations.FromIngress(ing).FrontendConfig()
 	if frontendConfigName == "" {
 		// If the user did not provide the annotation at all, then we

--- a/pkg/frontendconfig/frontendconfig_test.go
+++ b/pkg/frontendconfig/frontendconfig_test.go
@@ -3,7 +3,7 @@ package frontendconfig
 import (
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/test"
 )
@@ -13,7 +13,7 @@ func TestFrontendConfigForIngress(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		ing      *extensions.Ingress
+		ing      *v1beta1.Ingress
 		expected *frontendconfigv1beta1.FrontendConfig
 		err      error
 	}{

--- a/pkg/fuzz/feature.go
+++ b/pkg/fuzz/feature.go
@@ -19,7 +19,7 @@ package fuzz
 import (
 	"net/http"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 // Feature represents an extension to the "vanilla" behavior of Ingress.

--- a/pkg/fuzz/features/affinity.go
+++ b/pkg/fuzz/features/affinity.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/features/allow_http.go
+++ b/pkg/fuzz/features/allow_http.go
@@ -17,7 +17,7 @@ limitations under the License.
 package features
 
 import (
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/features/app_protocol.go
+++ b/pkg/fuzz/features/app_protocol.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	echo "k8s.io/ingress-gce/cmd/echo/app"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"

--- a/pkg/fuzz/features/backendconfig_example.go
+++ b/pkg/fuzz/features/backendconfig_example.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/klog"

--- a/pkg/fuzz/features/cdn.go
+++ b/pkg/fuzz/features/cdn.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/features/iap.go
+++ b/pkg/fuzz/features/iap.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/klog"

--- a/pkg/fuzz/features/neg.go
+++ b/pkg/fuzz/features/neg.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils"

--- a/pkg/fuzz/features/preshared_cert.go
+++ b/pkg/fuzz/features/preshared_cert.go
@@ -17,7 +17,7 @@ limitations under the License.
 package features
 
 import (
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/features/security_policy.go
+++ b/pkg/fuzz/features/security_policy.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/features/static_ip.go
+++ b/pkg/fuzz/features/static_ip.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"

--- a/pkg/fuzz/helpers_test.go
+++ b/pkg/fuzz/helpers_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/kr/pretty"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"

--- a/pkg/fuzz/validator_test.go
+++ b/pkg/fuzz/validator_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"

--- a/pkg/loadbalancers/features/features.go
+++ b/pkg/loadbalancers/features/features.go
@@ -19,7 +19,7 @@ package features
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/pkg/loadbalancers/features/features_test.go
+++ b/pkg/loadbalancers/features/features_test.go
@@ -18,7 +18,7 @@ package features
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -22,22 +22,18 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/legacy-cloud-providers/gce"
-
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
-
 	"google.golang.org/api/compute/v1"
-
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-
 	"k8s.io/ingress-gce/pkg/annotations"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/backends"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog"
+	"k8s.io/legacy-cloud-providers/gce"
 )
 
 const (
@@ -61,7 +57,7 @@ type L7RuntimeInfo struct {
 	// TLSName is the name of the preshared cert to use. Multiple certs can be specified as a comma-separated string
 	TLSName string
 	// Ingress is the processed Ingress API object.
-	Ingress *extensions.Ingress
+	Ingress *v1beta1.Ingress
 	// AllowHTTP will not setup :80, if TLS is nil and AllowHTTP is set,
 	// no loadbalancer is created.
 	AllowHTTP bool

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -20,15 +20,13 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/ingress-gce/pkg/loadbalancers/features"
-	"k8s.io/legacy-cloud-providers/gce"
-
-	"k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog"
+	"k8s.io/legacy-cloud-providers/gce"
 )
 
 // L7s implements LoadBalancerPool.

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/legacy-cloud-providers/gce"
 
 	"google.golang.org/api/compute/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -133,8 +133,8 @@ func (j *testJig) String() string {
 	return "testJig.String() Not implemented"
 }
 
-func newIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func newIngress() *v1beta1.Ingress {
+	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingressName,
 			Namespace: namespace,

--- a/pkg/test/frontendconfig.go
+++ b/pkg/test/frontendconfig.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,14 +18,14 @@ var (
 		},
 	}
 
-	IngressWithoutFrontendConfig = &extensions.Ingress{
+	IngressWithoutFrontendConfig = &v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "ing-no-config",
 			Namespace: "test",
 		},
 	}
 
-	IngressWithFrontendConfig = &extensions.Ingress{
+	IngressWithFrontendConfig = &v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "ing-with-config",
 			Namespace: "test",
@@ -35,7 +35,7 @@ var (
 		},
 	}
 
-	IngressWithFrontendConfigOtherNamespace = &extensions.Ingress{
+	IngressWithFrontendConfigOtherNamespace = &v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "ing-with-config",
 			Namespace: "other-namespace",
@@ -45,7 +45,7 @@ var (
 		},
 	}
 
-	IngressWithOtherFrontendConfig = &extensions.Ingress{
+	IngressWithOtherFrontendConfig = &v1beta1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "ing-with-config",
 			Namespace: "test",

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -22,11 +22,11 @@ var (
 )
 
 // NewIngress returns an Ingress with the given spec.
-func NewIngress(name types.NamespacedName, spec extensions.IngressSpec) *extensions.Ingress {
-	return &extensions.Ingress{
+func NewIngress(name types.NamespacedName, spec v1beta1.IngressSpec) *v1beta1.Ingress {
+	return &v1beta1.Ingress{
 		TypeMeta: meta_v1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "networking/v1beta1",
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name.Name,
@@ -63,20 +63,20 @@ func NewBackendConfig(name types.NamespacedName, spec backendconfig.BackendConfi
 }
 
 // Backend returns an IngressBackend with the given service name/port.
-func Backend(name string, port intstr.IntOrString) *extensions.IngressBackend {
-	return &extensions.IngressBackend{
+func Backend(name string, port intstr.IntOrString) *v1beta1.IngressBackend {
+	return &v1beta1.IngressBackend{
 		ServiceName: name,
 		ServicePort: port,
 	}
 }
 
 // DecodeIngress deserializes an Ingress object.
-func DecodeIngress(data []byte) (*extensions.Ingress, error) {
+func DecodeIngress(data []byte) (*v1beta1.Ingress, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode(data, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return obj.(*extensions.Ingress), nil
+	return obj.(*v1beta1.Ingress), nil
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/klog"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
@@ -31,7 +31,7 @@ import (
 // TlsLoader is the interface for loading the relevant TLSCerts for a given ingress.
 type TlsLoader interface {
 	// Load loads the relevant TLSCerts based on ing.Spec.TLS
-	Load(ing *extensions.Ingress) ([]*loadbalancers.TLSCerts, error)
+	Load(ing *v1beta1.Ingress) ([]*loadbalancers.TLSCerts, error)
 	// Validate validates the given TLSCerts and returns an error if they are invalid.
 	Validate(certs *loadbalancers.TLSCerts) error
 }
@@ -52,7 +52,7 @@ type TLSCertsFromSecretsLoader struct {
 // Ensure that TLSCertsFromSecretsLoader implements TlsLoader interface.
 var _ TlsLoader = &TLSCertsFromSecretsLoader{}
 
-func (t *TLSCertsFromSecretsLoader) Load(ing *extensions.Ingress) ([]*loadbalancers.TLSCerts, error) {
+func (t *TLSCertsFromSecretsLoader) Load(ing *v1beta1.Ingress) ([]*loadbalancers.TLSCerts, error) {
 	if len(ing.Spec.TLS) == 0 {
 		return nil, nil
 	}
@@ -97,7 +97,7 @@ type FakeTLSSecretLoader struct {
 // Ensure that FakeTLSSecretLoader implements TlsLoader interface.
 var _ TlsLoader = &FakeTLSSecretLoader{}
 
-func (f *FakeTLSSecretLoader) Load(ing *extensions.Ingress) ([]*loadbalancers.TLSCerts, error) {
+func (f *FakeTLSSecretLoader) Load(ing *v1beta1.Ingress) ([]*loadbalancers.TLSCerts, error) {
 	if len(ing.Spec.TLS) == 0 {
 		return nil, nil
 	}

--- a/pkg/utils/finalizer.go
+++ b/pkg/utils/finalizer.go
@@ -16,9 +16,9 @@ package utils
 import (
 	"fmt"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	client "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	client "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/slice"
 )
@@ -43,7 +43,7 @@ func HasFinalizer(m meta_v1.ObjectMeta, key string) bool {
 
 // AddFinalizer tries to add a finalizer to an Ingress. If a finalizer
 // already exists, it does nothing.
-func AddFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
+func AddFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface) error {
 	ingKey := FinalizerKey
 	if NeedToAddFinalizer(ing.ObjectMeta, ingKey) {
 		updated := ing.DeepCopy()
@@ -59,7 +59,7 @@ func AddFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) er
 
 // RemoveFinalizer tries to remove a Finalizer from an Ingress. If a
 // finalizer is not on the Ingress, it does nothing.
-func RemoveFinalizer(ing *extensions.Ingress, ingClient client.IngressInterface) error {
+func RemoveFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface) error {
 	ingKey := FinalizerKey
 	if HasFinalizer(ing.ObjectMeta, ingKey) {
 		updated := ing.DeepCopy()

--- a/pkg/utils/patch_test.go
+++ b/pkg/utils/patch_test.go
@@ -16,19 +16,19 @@ package utils
 import (
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestStrategicMergePatchBytes(t *testing.T) {
 	// Patch an Ingress w/ a finalizer
-	ing := &extensions.Ingress{}
-	updated := &extensions.Ingress{
+	ing := &v1beta1.Ingress{}
+	updated := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Finalizers: []string{"foo"},
 		},
 	}
-	b, err := StrategicMergePatchBytes(ing, updated, extensions.Ingress{})
+	b, err := StrategicMergePatchBytes(ing, updated, v1beta1.Ingress{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,8 +39,8 @@ func TestStrategicMergePatchBytes(t *testing.T) {
 
 	// Patch an Ingress with the finalizer removed
 	ing = updated
-	updated = &extensions.Ingress{}
-	b, err = StrategicMergePatchBytes(ing, updated, extensions.Ingress{})
+	updated = &v1beta1.Ingress{}
+	b, err = StrategicMergePatchBytes(ing, updated, v1beta1.Ingress{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -17,11 +17,12 @@ limitations under the License.
 package utils
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"fmt"
+
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
 )
@@ -68,7 +69,7 @@ func (sp ServicePort) BackendName(namer *Namer) string {
 }
 
 // BackendToServicePortID creates a ServicePortID from a given IngressBackend and namespace.
-func BackendToServicePortID(be extensions.IngressBackend, namespace string) ServicePortID {
+func BackendToServicePortID(be v1beta1.IngressBackend, namespace string) ServicePortID {
 	return ServicePortID{
 		Service: types.NamespacedName{
 			Name:      be.ServiceName,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -266,7 +266,7 @@ func IGLinks(igs []*compute.InstanceGroup) (igLinks []string) {
 
 // IsGCEIngress returns true if the Ingress matches the class managed by this
 // controller.
-func IsGCEIngress(ing *extensions.Ingress) bool {
+func IsGCEIngress(ing *v1beta1.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
 	if flags.F.IngressClass == "" {
 		return class == "" || class == annotations.GceIngressClass
@@ -276,13 +276,13 @@ func IsGCEIngress(ing *extensions.Ingress) bool {
 
 // IsGCEMultiClusterIngress returns true if the given Ingress has
 // ingress.class annotation set to "gce-multi-cluster".
-func IsGCEMultiClusterIngress(ing *extensions.Ingress) bool {
+func IsGCEMultiClusterIngress(ing *v1beta1.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
 	return class == annotations.GceMultiIngressClass
 }
 
 // IsGLBCIngress returns true if the given Ingress should be processed by GLBC
-func IsGLBCIngress(ing *extensions.Ingress) bool {
+func IsGLBCIngress(ing *v1beta1.Ingress) bool {
 	return IsGCEIngress(ing) || IsGCEMultiClusterIngress(ing)
 }
 
@@ -369,7 +369,7 @@ func JoinErrs(errs []error) error {
 	return errors.New(strings.Join(errStrs, "; "))
 }
 
-func IngressKeyFunc(ing *extensions.Ingress) string {
+func IngressKeyFunc(ing *v1beta1.Ingress) string {
 	if ing == nil {
 		return ""
 	}
@@ -378,7 +378,7 @@ func IngressKeyFunc(ing *extensions.Ingress) string {
 
 // TraverseIngressBackends traverse thru all backends specified in the input ingress and call process
 // If process return true, then return and stop traversing the backends
-func TraverseIngressBackends(ing *extensions.Ingress, process func(id ServicePortID) bool) {
+func TraverseIngressBackends(ing *v1beta1.Ingress, process func(id ServicePortID) bool) {
 	if ing == nil {
 		return
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	api_v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -285,26 +285,26 @@ func TestTraverseIngressBackends(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		desc           string
-		ing            *extensions.Ingress
-		expectBackends []extensions.IngressBackend
+		ing            *v1beta1.Ingress
+		expectBackends []v1beta1.IngressBackend
 	}{
 		{
 			"empty spec",
-			&extensions.Ingress{},
-			[]extensions.IngressBackend{},
+			&v1beta1.Ingress{},
+			[]v1beta1.IngressBackend{},
 		},
 		{
 			"one default backend",
-			&extensions.Ingress{
-				Spec: extensions.IngressSpec{
-					Backend: &extensions.IngressBackend{
+			&v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
 						ServiceName: "dummy-service",
 						ServicePort: intstr.FromInt(80),
 					},
-					Rules: []extensions.IngressRule{},
+					Rules: []v1beta1.IngressRule{},
 				},
 			},
-			[]extensions.IngressBackend{
+			[]v1beta1.IngressBackend{
 				{
 					ServiceName: "dummy-service",
 					ServicePort: intstr.FromInt(80),
@@ -313,17 +313,17 @@ func TestTraverseIngressBackends(t *testing.T) {
 		},
 		{
 			"one backend in path",
-			&extensions.Ingress{
-				Spec: extensions.IngressSpec{
-					Rules: []extensions.IngressRule{
+			&v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
 						{
 							Host: "foo.bar",
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
 										{
 											Path: "/foo",
-											Backend: extensions.IngressBackend{
+											Backend: v1beta1.IngressBackend{
 												ServiceName: "foo-service",
 												ServicePort: intstr.FromInt(80),
 											},
@@ -335,7 +335,7 @@ func TestTraverseIngressBackends(t *testing.T) {
 					},
 				},
 			},
-			[]extensions.IngressBackend{
+			[]v1beta1.IngressBackend{
 				{
 					ServiceName: "foo-service",
 					ServicePort: intstr.FromInt(80),
@@ -344,41 +344,41 @@ func TestTraverseIngressBackends(t *testing.T) {
 		},
 		{
 			"one rule with only host",
-			&extensions.Ingress{
-				Spec: extensions.IngressSpec{
-					Rules: []extensions.IngressRule{
+			&v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
 						{
 							Host: "foo.bar",
 						},
 					},
 				},
 			},
-			[]extensions.IngressBackend{},
+			[]v1beta1.IngressBackend{},
 		},
 		{
 			"complex ingress spec",
-			&extensions.Ingress{
-				Spec: extensions.IngressSpec{
-					Backend: &extensions.IngressBackend{
+			&v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
 						ServiceName: "backend-service",
 						ServicePort: intstr.FromInt(81),
 					},
-					Rules: []extensions.IngressRule{
+					Rules: []v1beta1.IngressRule{
 						{
 							Host: "foo.bar",
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
 										{
 											Path: "/foo",
-											Backend: extensions.IngressBackend{
+											Backend: v1beta1.IngressBackend{
 												ServiceName: "foo-service",
 												ServicePort: intstr.FromInt(82),
 											},
 										},
 										{
 											Path: "/bar",
-											Backend: extensions.IngressBackend{
+											Backend: v1beta1.IngressBackend{
 												ServiceName: "bar-service",
 												ServicePort: intstr.FromInt(83),
 											},
@@ -388,19 +388,19 @@ func TestTraverseIngressBackends(t *testing.T) {
 							},
 						},
 						{
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
 										{
 											Path: "/a",
-											Backend: extensions.IngressBackend{
+											Backend: v1beta1.IngressBackend{
 												ServiceName: "a-service",
 												ServicePort: intstr.FromInt(84),
 											},
 										},
 										{
 											Path: "/b",
-											Backend: extensions.IngressBackend{
+											Backend: v1beta1.IngressBackend{
 												ServiceName: "b-service",
 												ServicePort: intstr.FromInt(85),
 											},
@@ -418,7 +418,7 @@ func TestTraverseIngressBackends(t *testing.T) {
 					},
 				},
 			},
-			[]extensions.IngressBackend{
+			[]v1beta1.IngressBackend{
 				{
 					ServiceName: "backend-service",
 					ServicePort: intstr.FromInt(81),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -202,11 +202,12 @@ gopkg.in/warnings.v0
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0 => k8s.io/api v0.0.0-20190620085002-8f739060a0b3
 k8s.io/api/core/v1
-k8s.io/api/extensions/v1beta1
-k8s.io/api/coordination/v1
-k8s.io/api/apps/v1beta1
-k8s.io/api/admissionregistration/v1beta1
+k8s.io/api/networking/v1beta1
 k8s.io/api/apps/v1
+k8s.io/api/coordination/v1
+k8s.io/api/extensions/v1beta1
+k8s.io/api/admissionregistration/v1beta1
+k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
 k8s.io/api/auditregistration/v1alpha1
 k8s.io/api/authentication/v1
@@ -223,7 +224,6 @@ k8s.io/api/certificates/v1beta1
 k8s.io/api/coordination/v1beta1
 k8s.io/api/events/v1beta1
 k8s.io/api/networking/v1
-k8s.io/api/networking/v1beta1
 k8s.io/api/node/v1alpha1
 k8s.io/api/node/v1beta1
 k8s.io/api/policy/v1beta1
@@ -310,7 +310,7 @@ k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/kubernetes/typed/core/v1
 k8s.io/client-go/listers/core/v1
 k8s.io/client-go/util/workqueue
-k8s.io/client-go/kubernetes/typed/extensions/v1beta1
+k8s.io/client-go/kubernetes/typed/networking/v1beta1
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
@@ -332,8 +332,8 @@ k8s.io/client-go/kubernetes/typed/certificates/v1beta1
 k8s.io/client-go/kubernetes/typed/coordination/v1
 k8s.io/client-go/kubernetes/typed/coordination/v1beta1
 k8s.io/client-go/kubernetes/typed/events/v1beta1
+k8s.io/client-go/kubernetes/typed/extensions/v1beta1
 k8s.io/client-go/kubernetes/typed/networking/v1
-k8s.io/client-go/kubernetes/typed/networking/v1beta1
 k8s.io/client-go/kubernetes/typed/node/v1alpha1
 k8s.io/client-go/kubernetes/typed/node/v1beta1
 k8s.io/client-go/kubernetes/typed/policy/v1beta1


### PR DESCRIPTION
    Change API group from "extensions" to "networking"
    
    This migrates our code to use the networking.v1beta1.Ingress* API
    types instead of extensions.v1beta1. This also fixes fixture YAMLs
    to use "networking.k8s.io" as the fully-qualified resource kind.
