### PR TITLE
Use readinessProbe HC spec for platform HC

### DIFF
--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -17,24 +17,26 @@ limitations under the License.
 package backends
 
 import (
-	api_v1 "k8s.io/api/core/v1"
 
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // FakeProbeProvider implements the probeProvider interface for tests.
 type FakeProbeProvider struct {
-	probes map[utils.ServicePort]*api_v1.Probe
+	//probes map[utils.ServicePort]*api_v1.Probe
+	probes map[utils.ServicePort]*ServicePortAndProbe
 }
 
 // NewFakeProbeProvider returns a struct which satisfies probeProvider interface
-func NewFakeProbeProvider(probes map[utils.ServicePort]*api_v1.Probe) *FakeProbeProvider {
+//func NewFakeProbeProvider(probes map[utils.ServicePort]*api_v1.Probe) *FakeProbeProvider {
+func NewFakeProbeProvider(probes map[utils.ServicePort]*ServicePortAndProbe) *FakeProbeProvider {
 	return &FakeProbeProvider{probes}
 }
 
 // GetProbe returns the probe for a given nodePort
-func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*api_v1.Probe, error) {
-	if probe, exists := pp.probes[port]; exists && probe.HTTPGet != nil {
+//func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*api_v1.Probe, error) {
+func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*ServicePortAndProbe, error) {
+	if probe, exists := pp.probes[port]; exists && probe.Probe.HTTPGet != nil {
 		return probe, nil
 	}
 	return nil, nil

--- a/pkg/backends/fakes.go
+++ b/pkg/backends/fakes.go
@@ -17,24 +17,20 @@ limitations under the License.
 package backends
 
 import (
-
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // FakeProbeProvider implements the probeProvider interface for tests.
 type FakeProbeProvider struct {
-	//probes map[utils.ServicePort]*api_v1.Probe
 	probes map[utils.ServicePort]*ServicePortAndProbe
 }
 
 // NewFakeProbeProvider returns a struct which satisfies probeProvider interface
-//func NewFakeProbeProvider(probes map[utils.ServicePort]*api_v1.Probe) *FakeProbeProvider {
 func NewFakeProbeProvider(probes map[utils.ServicePort]*ServicePortAndProbe) *FakeProbeProvider {
 	return &FakeProbeProvider{probes}
 }
 
 // GetProbe returns the probe for a given nodePort
-//func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*api_v1.Probe, error) {
 func (pp *FakeProbeProvider) GetProbe(port utils.ServicePort) (*ServicePortAndProbe, error) {
 	if probe, exists := pp.probes[port]; exists && probe.Probe.HTTPGet != nil {
 		return probe, nil

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -31,11 +31,11 @@ type GroupKey struct {
 	Name string
 }
 
-// ServicePortAndProbe represents the Node and Container redinessProbe
-// specifications for aservice
+// ServicePortAndProbe encapsulates a service port and the associated
+// readiness probe specification.
 type ServicePortAndProbe struct {
-	Probe   *api_v1.Probe
-	Service *api_v1.ServicePort
+	Probe       *api_v1.Probe
+	ServicePort *api_v1.ServicePort
 }
 
 // Pool is an interface to perform CRUD operations on a pool of GCE
@@ -81,7 +81,7 @@ type NEGGetter interface {
 	GetNetworkEndpointGroup(name string, zone string) (*compute.NetworkEndpointGroup, error)
 }
 
-// ProbeProvider retrieves a ServicePortAndProbe struct given a nodePort
+// ProbeProvider retrieves a ServicePortAndProbe given a ServicePort
 type ProbeProvider interface {
 	GetProbe(sp utils.ServicePort) (*ServicePortAndProbe, error)
 }

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -85,4 +85,3 @@ type NEGGetter interface {
 type ProbeProvider interface {
 	GetProbe(sp utils.ServicePort) (*ServicePortAndProbe, error)
 }
-

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -31,6 +31,13 @@ type GroupKey struct {
 	Name string
 }
 
+// ServicePortAndProbe represents the Node and Container redinessProbe
+// specifications for aservice
+type ServicePortAndProbe struct {
+	Probe   *api_v1.Probe
+	Service *api_v1.ServicePort
+}
+
 // Pool is an interface to perform CRUD operations on a pool of GCE
 // Backend Services.
 type Pool interface {
@@ -74,7 +81,8 @@ type NEGGetter interface {
 	GetNetworkEndpointGroup(name string, zone string) (*compute.NetworkEndpointGroup, error)
 }
 
-// ProbeProvider retrieves a probe struct given a nodePort
+// ProbeProvider retrieves a ServicePortAndProbe struct given a nodePort
 type ProbeProvider interface {
-	GetProbe(sp utils.ServicePort) (*api_v1.Probe, error)
+	GetProbe(sp utils.ServicePort) (*ServicePortAndProbe, error)
 }
+

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -276,10 +276,10 @@ func applyProbeSettingsToHC(p *ServicePortAndProbe, hc *healthchecks.HealthCheck
 	hc.Host = host
 	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
 	hc.TimeoutSec = int64(p.Probe.TimeoutSeconds)
-	if p.Service != nil && p.Probe.HTTPGet != nil {
-		hc.Port = int64(p.Service.NodePort)
+	if p.ServicePort != nil && p.Probe.HTTPGet != nil {
+		hc.Port = int64(p.ServicePort.NodePort)
 		hc.Type = string(p.Probe.HTTPGet.Scheme)
-	}	
+	}
 	if hc.ForNEG {
 		// For NEG mode, we can support more aggressive healthcheck interval.
 		hc.CheckIntervalSec = int64(p.Probe.PeriodSeconds)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -67,10 +67,7 @@ func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
 		namer:         defaultNamer,
 	}
 
-	sp := &ServicePortAndProbe{
-		Service: &api_v1.ServicePort{},
-		Probe:   existingProbe,
-	}
+	sp := &ServicePortAndProbe{ServicePort: &api_v1.ServicePort{}, Probe: existingProbe}
 	probes := map[utils.ServicePort]*ServicePortAndProbe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS}: sp}
 	syncer.Init(NewFakeProbeProvider(probes))
 

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -473,8 +473,8 @@ func TestApplyProbeSettingsToHC(t *testing.T) {
 		NodePort: 30001,
 	}
 	sp := &ServicePortAndProbe{
-		Probe:   probe,
-		Service: svc,
+		Probe:       probe,
+		ServicePort: svc,
 	}
 
 	// update HC to mirror what was in the probe

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -250,11 +250,11 @@ func (t *Translator) getHTTPProbe(svc api_v1.Service, targetPort intstr.IntOrStr
 				continue
 			}
 			for _, np := range svc.Spec.Ports {
-				if ((np.TargetPort.Type == intstr.Int && c.ReadinessProbe.HTTPGet.Port.IntValue() == np.TargetPort.IntValue() ) || 
-				    (c.ReadinessProbe.HTTPGet.Port.Type == intstr.String)) {
+				if (np.TargetPort.Type == intstr.Int && c.ReadinessProbe.HTTPGet.Port.IntValue() == np.TargetPort.IntValue()) ||
+					(c.ReadinessProbe.HTTPGet.Port.Type == intstr.String) {
 					return &backends.ServicePortAndProbe{
-						Probe:   c.ReadinessProbe,
-						Service: &np,
+						Probe:       c.ReadinessProbe,
+						ServicePort: &np,
 					}, nil
 				}
 			}

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -607,10 +607,10 @@ func TestHealthCheckOverride(t *testing.T) {
 			t.Errorf("Wrong path for node port %v, got %v expected %v", p, getProbePath(got.Probe), exp)
 		}
 
-		if got.Service == nil {
+		if got.ServicePort == nil {
 			t.Errorf("Failed to extract Service NodePort for healthcheck")
-		} else if got.Service.NodePort != 3001 {
-			t.Errorf("Failed to match Service NodePort for healthcheck wanted 3001, got %s, %v", got.Service, err)
+		} else if got.ServicePort.NodePort != 3001 {
+			t.Errorf("Failed to match Service NodePort for healthcheck wanted 3001, got %s, %v", got.ServicePort, err)
 		}
 	}
 }
@@ -689,7 +689,7 @@ func TestHealthCheckOverrideOrder(t *testing.T) {
 								},
 							},
 						},
-					},					
+					},
 				},
 				{
 					Ports: []apiv1.ContainerPort{{ContainerPort: 8080}},
@@ -727,10 +727,10 @@ func TestHealthCheckOverrideOrder(t *testing.T) {
 			t.Errorf("Wrong path for node port %v, got %v expected %v", p, getProbePath(got.Probe), exp)
 		}
 
-		if got.Service == nil {
+		if got.ServicePort == nil {
 			t.Errorf("Failed to extract Service NodePort for healthcheck")
-		} else if got.Service.NodePort != 3001 {
-			t.Errorf("Failed to match Service NodePort for healthcheck wanted 80, got %s, %v", got.Service, err)
+		} else if got.ServicePort.NodePort != 3001 {
+			t.Errorf("Failed to match Service NodePort for healthcheck wanted 80, got %s, %v", got.ServicePort, err)
 		}
 	}
 }


### PR DESCRIPTION
Proposal+PR:  Overide GCP healthcheck to allow gRPC protocol services.

This change will override the GCP healthcheck settings with the first container which has an HTTP/HTTPS  `readinessProbe` defined

--


At the moment, customers deploying a gRPC service on GCP that utilizes `ingress-gce` need to either run a mux server or a proxy that handles HTTP and gRPC because the GCP healthcheck uses the _servingPort_ for HTTP healthchecks.  If i run a gRPC service on the serving port, then the GCP healthchecks will never pass.  Users have to implement a workaround like this:
- ref: https://github.com/kubernetes/ingress-gce/issues/18#issuecomment-498669572

With this change if i have a `Deployment` which includes a `readinessProbe` of type HTTP, then the GCP Instance group Healthcheck settings will be overrided and will use the specifications (path/port/protocol) defined in the container.

The attached PR has the changes and i've tested the scenarios  that i've documented here:

- https://github.com/salrashid123/salrashid123.github.io/tree/master/ingress-gce/tmp

(this needs much more exhaustive testing still).

One scenario i did not account for is using NEG+gRPC since the NEG HC will still use HTTP2 against the gRPC service directly.  In that case, customers may have to go back to using the mux.





