### PR TITLE
make SandboxEventDump a deferred function to avoid being skipped by t.Fatal

### DIFF
--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -206,9 +206,8 @@ func (f *Framework) RunWithSandbox(name string, t *testing.T, testFunc func(*tes
 			defer sandbox.Destroy()
 		}
 
+		defer sandbox.DumpSandboxInfo(t)
 		testFunc(t, sandbox)
-
-		sandbox.DumpSandboxInfo(t)
 	})
 }
 


### PR DESCRIPTION
Deferred function will be executed after t.Fatal.  https://golang.org/pkg/testing/#B.FailNow