### PR TITLE
Refactor Backend GC

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -15,7 +15,6 @@ package backends
 
 import (
 	"fmt"
-	"k8s.io/ingress-gce/pkg/flags"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -195,17 +194,13 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType)
 }
 
 // List lists all backends managed by this controller.
-func (b *Backends) List() ([]*composite.BackendService, error) {
+func (b *Backends) List(key *meta.Key, version meta.Version) ([]*composite.BackendService, error) {
 	// TODO: for consistency with the rest of this sub-package this method
 	// should return a list of backend ports.
 	var backends []*composite.BackendService
 	var err error
-	if flags.F.EnableL7Ilb {
-		backends, err = composite.ListAllBackendServices(b.cloud)
-	} else {
-		// TODO: (shance) this needs to be changed to not take a key
-		backends, err = composite.ListBackendServices(b.cloud, meta.GlobalKey(""), meta.VersionGA)
-	}
+
+	backends, err = composite.ListBackendServices(b.cloud, key, version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -45,7 +45,7 @@ type Pool interface {
 	// Get the health of a BackendService given its name.
 	Health(name string, version meta.Version, scope meta.KeyType) (string, error)
 	// Get a list of BackendService names that are managed by this pool.
-	List() ([]*composite.BackendService, error)
+	List(key *meta.Key, version meta.Version) ([]*composite.BackendService, error)
 }
 
 // Syncer is an interface to sync Kubernetes services to GCE BackendServices.

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -639,6 +639,7 @@ func TestIdenticalHostnameCerts(t *testing.T) {
 		UrlMap:    gceUrlMap,
 		Ingress:   newIngress(),
 	}
+
 	// Sync multiple times to make sure ordering is preserved
 	for i := 0; i < 10; i++ {
 		if _, err := j.pool.Ensure(lbInfo); err != nil {


### PR DESCRIPTION
Refactor backends GC so that we don't need ListAllBackendServices() anymore.  That way, if one of the api calls fails, it won't block the others.