### PR TITLE
Add cloud pointer to neg linker and backend syncer

### DIFF
--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -59,7 +59,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	return &Jig{
 		fakeInstancePool: fakeInstancePool,
 		linker:           NewInstanceGroupLinker(fakeInstancePool, fakeBackendPool, defaultNamer),
-		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, defaultNamer),
+		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, defaultNamer, fakeGCE),
 		pool:             fakeBackendPool,
 	}
 }

--- a/pkg/backends/neg_linker_test.go
+++ b/pkg/backends/neg_linker_test.go
@@ -35,7 +35,7 @@ func newTestNEGLinker(fakeNEG negtypes.NetworkEndpointGroupCloud, fakeGCE *gce.C
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaBackendServices.UpdateHook = mock.UpdateBetaBackendServiceHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBackendServices.UpdateHook = mock.UpdateBackendServiceHook
 
-	return &negLinker{fakeBackendPool, fakeNEG, defaultNamer}
+	return &negLinker{fakeBackendPool, fakeNEG, defaultNamer, fakeGCE}
 }
 
 func TestLinkBackendServiceToNEG(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -119,8 +119,8 @@ func NewLoadBalancerController(
 		nodes:         NewNodeController(ctx, instancePool),
 		instancePool:  instancePool,
 		l7Pool:        loadbalancers.NewLoadBalancerPool(ctx.Cloud, ctx.ClusterNamer, ctx),
-		backendSyncer: backends.NewBackendSyncer(backendPool, healthChecker, ctx.ClusterNamer),
-		negLinker:     backends.NewNEGLinker(backendPool, negtypes.NewAdapter(ctx.Cloud), ctx.ClusterNamer),
+		backendSyncer: backends.NewBackendSyncer(backendPool, healthChecker, ctx.ClusterNamer, ctx.Cloud),
+		negLinker:     backends.NewNEGLinker(backendPool, negtypes.NewAdapter(ctx.Cloud), ctx.ClusterNamer, ctx.Cloud),
 		igLinker:      backends.NewInstanceGroupLinker(instancePool, backendPool, ctx.ClusterNamer),
 	}
 	lbc.ingSyncer = ingsync.NewIngressSyncer(&lbc)


### PR DESCRIPTION
Remove BackendPool downcast by adding a cloud pointer to the neg linker and backend syncer