### PR TITLE
Get gke-self-managed.sh working on macOS

### DIFF
--- a/docs/deploy/gke/gke-self-managed.sh
+++ b/docs/deploy/gke/gke-self-managed.sh
@@ -392,8 +392,8 @@ while true; do
 done
 
 # Recreates the deployment and service for the default backend.
-# Note: We do sed on a copy so that the original file stays clean for future runs.
-sed "/name: http/a \ \ \ \ nodePort: ${NODE_PORT}" ../resources/default-http-backend.yaml > ../resources/default-http-backend.yaml.gen
+# Note: We do awk on a copy so that the original file stays clean for future runs.
+awk "1;/name: http/{ print \"    nodePort: ${NODE_PORT}\" }" ../resources/default-http-backend.yaml > ../resources/default-http-backend.yaml.gen
 run_maybe_dry_kubectl kubectl create -f ../resources/default-http-backend.yaml.gen
 if [[ $? -eq 1 ]];
 then


### PR DESCRIPTION
As using sed for appending a line doesn't work on macOS, changed to use awk.
```sh
# on macOS
$ sed "/name: http/a \ \ \ \ nodePort: ${NODE_PORT}" ../resources/default-http-backend.yaml
sed: 1: "/name: http/a \ \ \ \ n ...": extra characters after \ at the end of a command
```