### PR TITLE
Legacy api e2e

### DIFF
--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -101,10 +101,11 @@ func TestBackendConfigNegatives(t *testing.T) {
 			}
 
 			port80 := intstr.FromInt(80)
-			testIng := fuzz.NewIngressBuilder("", "ingress-1", "").
+			testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", port80).
 				Build()
-			testIng, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			testIng, err := crud.Create(testIng)
 			if err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
@@ -133,7 +134,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 				t.Fatalf("error waiting for BackendConfig warning event: %v", err)
 			}
 
-			testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Get(testIng.Name, metav1.GetOptions{})
+			testIng, err = crud.Get(s.Namespace, testIng.Name)
 			if err != nil {
 				t.Fatalf("error retrieving Ingress %q: %v", testIng.Name, err)
 			}

--- a/cmd/e2e-test/basic_https_test.go
+++ b/cmd/e2e-test/basic_https_test.go
@@ -100,6 +100,7 @@ func TestBasicHTTPS(t *testing.T) {
 				}
 			}
 			ing := tc.ingBuilder.Build()
+			ing.Namespace = s.Namespace // namespace depends on sandbox
 
 			_, err := e2e.CreateEchoService(s, "service-1", nil)
 			if err != nil {
@@ -107,7 +108,8 @@ func TestBasicHTTPS(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -78,7 +78,9 @@ func TestBasic(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
+			if _, err = crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
@@ -132,11 +134,12 @@ func TestBasicStaticIP(t *testing.T) {
 		}
 		defer e2e.DeleteGCPAddress(s, addrName)
 
-		testIng := fuzz.NewIngressBuilder("", "ingress-1", "").
+		testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 			DefaultBackend("service-1", intstr.FromInt(80)).
 			AddStaticIP(addrName).
 			Build()
-		testIng, err = Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(testIng)
+		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		testIng, err = crud.Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
 		}
@@ -197,8 +200,9 @@ func TestEdge(t *testing.T) {
 				t.Fatalf("error creating echo service: %v", err)
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
-
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
+			if _, err = crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
@@ -36,10 +35,6 @@ import (
 
 func TestCDN(t *testing.T) {
 	t.Parallel()
-
-	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
-		AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
-		Build()
 
 	for _, tc := range []struct {
 		desc     string
@@ -90,12 +85,16 @@ func TestCDN(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
+				Build()
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing, nil)
+			ing, err = e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}
@@ -114,7 +113,7 @@ func TestCDN(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
@@ -35,10 +34,6 @@ import (
 
 func TestIAP(t *testing.T) {
 	t.Parallel()
-
-	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
-		AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
-		Build()
 
 	for _, tc := range []struct {
 		desc     string
@@ -72,12 +67,16 @@ func TestIAP(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing); err != nil {
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
+				Build()
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err := e2e.WaitForIngress(s, ing, nil)
+			ing, err = e2e.WaitForIngress(s, ing, nil)
 			if err != nil {
 				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
 			}
@@ -91,7 +90,7 @@ func TestIAP(t *testing.T) {
 			}
 
 			// Wait for GCLB resources to be deleted.
-			if err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Delete(ing.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
 				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
 			}
 

--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -59,7 +59,9 @@ func TestUpgrade(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
+			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
 			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
@@ -84,8 +86,9 @@ func TestUpgrade(t *testing.T) {
 					newIng := fuzz.NewIngressBuilderFromExisting(tc.ing).
 						AddPath("bar.com", "/", "service-1", port80).
 						Build()
-
-					if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Update(newIng); err != nil {
+					newIng.Namespace = s.Namespace // namespace depends on sandbox
+					// TODO: does the path need to be different for each upgrade
+					if _, err := crud.Update(newIng); err != nil {
 						t.Fatalf("error creating Ingress spec: %v", err)
 					} else {
 						// If Ingress upgrade succeeds, we update the status on this Ingress

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -43,7 +43,7 @@ func CreateEchoService(s *Sandbox, name string, annotations map[string]string) (
 	return EnsureEchoService(s, name, annotations, v1.ServiceTypeNodePort, 1)
 }
 
-// Ensures that the Echo service with the given description is set up
+// EnsureEchoService that the Echo service with the given description is set up
 func EnsureEchoService(s *Sandbox, name string, annotations map[string]string, svcType v1.ServiceType, numReplicas int32) (*v1.Service, error) {
 	expectedSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -157,18 +157,16 @@ func DeleteSecret(s *Sandbox, name string) error {
 
 // EnsureIngress creates a new Ingress or updates an existing one.
 func EnsureIngress(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
-	currentIng, err := s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Get(ing.ObjectMeta.Name, metav1.GetOptions{})
-
+	crud := &IngressCRUD{s.f.Clientset}
+	currentIng, err := crud.Get(ing.ObjectMeta.Namespace, ing.ObjectMeta.Name)
 	if currentIng == nil || err != nil {
-		return s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(ing)
+		return crud.Create(ing)
 	}
-
 	// Update ingress spec if they are not equal
 	if !reflect.DeepEqual(ing.Spec, currentIng.Spec) {
-		return s.f.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Update(ing)
+		return crud.Update(ing)
 	}
-
-	return currentIng, nil
+	return ing, nil
 }
 
 // NewGCPAddress reserves a global static IP address with the given name.

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -159,7 +159,7 @@ func (f *Framework) WithSandbox(testFunc func(*Sandbox) error) error {
 	for _, s := range f.sandboxes {
 		if s.Namespace == sandbox.Namespace {
 			f.lock.Unlock()
-			return fmt.Errorf("sandbox %s was created previously by the framework.", s.Namespace)
+			return fmt.Errorf("sandbox %s was created previously by the framework", s.Namespace)
 		}
 	}
 	klog.V(2).Infof("Using namespace %q for test sandbox", sandbox.Namespace)

--- a/pkg/e2e/legacy.go
+++ b/pkg/e2e/legacy.go
@@ -1,0 +1,138 @@
+package e2e
+
+// Legacy conversion code for the old extensions v1beta1 API group.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+// IngressCRUD wraps basic CRUD to allow use of old and new APIs.
+type IngressCRUD struct {
+	C *kubernetes.Clientset
+}
+
+// Get Ingress resource.
+func (crud *IngressCRUD) Get(ns, name string) (*v1beta1.Ingress, error) {
+	new, err := crud.supportsNewAPI()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Get %s/%s", ns, name)
+	if new {
+		return crud.C.NetworkingV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
+	}
+	klog.Warning("Using legacy API")
+	ing, err := crud.C.ExtensionsV1beta1().Ingresses(ns).Get(name, metav1.GetOptions{})
+	return toIngressNetworkingGroup(ing), err
+}
+
+// Create Ingress resource.
+func (crud *IngressCRUD) Create(ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
+	new, err := crud.supportsNewAPI()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Create %s/%s", ing.Namespace, ing.Name)
+	if new {
+		return crud.C.NetworkingV1beta1().Ingresses(ing.Namespace).Create(ing)
+	}
+	klog.Warning("Using legacy API")
+	legacyIng := toIngressExtensionsGroup(ing)
+	legacyIng, err = crud.C.ExtensionsV1beta1().Ingresses(ing.Namespace).Create(legacyIng)
+	return toIngressNetworkingGroup(legacyIng), err
+}
+
+// Update Ingress resource.
+func (crud *IngressCRUD) Update(ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
+	new, err := crud.supportsNewAPI()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Update %s/%s", ing.Namespace, ing.Name)
+	if new {
+		return crud.C.NetworkingV1beta1().Ingresses(ing.Namespace).Update(ing)
+	}
+	klog.Warning("Using legacy API")
+	legacyIng := toIngressExtensionsGroup(ing)
+	legacyIng, err = crud.C.ExtensionsV1beta1().Ingresses(ing.Namespace).Update(legacyIng)
+	return toIngressNetworkingGroup(legacyIng), err
+}
+
+// Delete Ingress resource.
+func (crud *IngressCRUD) Delete(ns, name string) error {
+	new, err := crud.supportsNewAPI()
+	if err != nil {
+		return err
+	}
+	klog.Infof("Delete %s/%s", ns, name)
+	if new {
+		return crud.C.NetworkingV1beta1().Ingresses(ns).Delete(name, &metav1.DeleteOptions{})
+	}
+	klog.Warning("Using legacy API")
+	return crud.C.ExtensionsV1beta1().Ingresses(ns).Delete(name, &metav1.DeleteOptions{})
+}
+
+func (crud *IngressCRUD) supportsNewAPI() (bool, error) {
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion("networking/v1beta1"); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == "Ingress" {
+				return true, nil
+			}
+		}
+	}
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion("extensions/v1beta1"); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == "Ingress" {
+				return false, nil
+			}
+		}
+	}
+	return false, errors.New("no Ingress resource found")
+}
+
+func toIngressExtensionsGroup(ing *v1beta1.Ingress) *extv1beta1.Ingress {
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	// This is used by test cases from test data, so we assume no issues with
+	// conversion.
+	if err := e.Encode(ing); err != nil {
+		panic(err)
+	}
+
+	ret := &extv1beta1.Ingress{}
+	d := json.NewDecoder(b)
+	if err := d.Decode(ret); err != nil {
+		panic(err)
+	}
+
+	ret.APIVersion = "extensions/v1beta1"
+
+	return ret
+}
+
+func toIngressNetworkingGroup(ing *extv1beta1.Ingress) *v1beta1.Ingress {
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	// This is used by test cases from test data, so we assume no issues with
+	// conversion.
+	if err := e.Encode(ing); err != nil {
+		panic(err)
+	}
+
+	ret := &v1beta1.Ingress{}
+	d := json.NewDecoder(b)
+	if err := d.Decode(ret); err != nil {
+		panic(err)
+	}
+
+	ret.APIVersion = "networking.k8s.io/v1beta1"
+	return ret
+}

--- a/pkg/e2e/legacy_test.go
+++ b/pkg/e2e/legacy_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kr/pretty"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLegacyConversions(t *testing.T) {
+	for _, tc := range []struct {
+		ext *extv1beta1.Ingress
+		net *v1beta1.Ingress
+	}{
+		{
+			ext: &extv1beta1.Ingress{
+				TypeMeta:   v1.TypeMeta{APIVersion: "extensions/v1beta1"},
+				ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "foo"},
+				Spec: extv1beta1.IngressSpec{
+					Backend: &extv1beta1.IngressBackend{
+						ServiceName: "svc1",
+					},
+				},
+			},
+			net: &v1beta1.Ingress{
+				TypeMeta:   v1.TypeMeta{APIVersion: "networking.k8s.io/v1beta1"},
+				ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "foo"},
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: "svc1",
+					},
+				},
+			},
+		},
+	} {
+		gotExt := toIngressExtensionsGroup(tc.net)
+		gotNet := toIngressNetworkingGroup(tc.ext)
+
+		if !reflect.DeepEqual(gotExt, tc.ext) {
+			t.Errorf("Got\n%s\nwant\n%s", pretty.Sprint(gotExt), pretty.Sprint(tc.ext))
+		}
+		if !reflect.DeepEqual(gotNet, tc.net) {
+			t.Errorf("Got%s\nwant\n%s", pretty.Sprint(gotNet), pretty.Sprint(tc.net))
+		}
+	}
+}

--- a/pkg/e2e/sandbox.go
+++ b/pkg/e2e/sandbox.go
@@ -80,6 +80,7 @@ func (s *Sandbox) Destroy() {
 	s.destroyed = true
 }
 
+// PutStatus into the status manager.
 func (s *Sandbox) PutStatus(status IngressStability) {
 	s.f.statusManager.putStatus(s.Namespace, status)
 }

--- a/pkg/e2e/status.go
+++ b/pkg/e2e/status.go
@@ -79,6 +79,7 @@ type StatusManager struct {
 	informerRunning bool
 }
 
+// NewStatusManager returns a new status manager.
 func NewStatusManager(f *Framework) *StatusManager {
 	return &StatusManager{
 		cm: &v1.ConfigMap{
@@ -104,7 +105,7 @@ func (sm *StatusManager) init() error {
 	}
 
 	go func() {
-		for _ = range time.NewTicker(flushInterval).C {
+		for range time.NewTicker(flushInterval).C {
 			sm.flush()
 		}
 	}()


### PR DESCRIPTION
Make the e2e framework use an adapter so it can use both the old (extensions) and new (networking) APIs