### PR TITLE
Update e2e framework for ILB and add basic test

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"testing"
+)
+
+func TestILBBasic(t *testing.T) {
+	t.Parallel()
+
+	port80 := intstr.FromInt(80)
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1beta1.Ingress
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "http ILB default backend",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc: "http ILB one path",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/", "service-1", port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+		{
+			desc: "http ILB multiple paths",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/foo", "service-1", port80).
+				AddPath("test.com", "/bar", "service-1", port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			t.Logf("Ingress = %s", tc.ing.String())
+
+			negAnnotation := annotations.NegAnnotation{Ingress: true}
+			annotation := map[string]string{annotations.NEGAnnotationKey: negAnnotation.String()}
+
+			_, err := e2e.CreateEchoService(s, "service-1", annotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			if _, err := Framework.Clientset.NetworkingV1beta1().Ingresses(s.Namespace).Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}

--- a/pkg/fuzz/feature.go
+++ b/pkg/fuzz/feature.go
@@ -70,6 +70,7 @@ type FeatureValidator interface {
 	CheckResponse(host, path string, resp *http.Response, body []byte) (CheckResponseAction, error)
 
 	HasAlphaResource(resourceType string) bool
+	HasAlphaRegionResource(resourceType string) bool
 	HasBetaResource(resourceType string) bool
 }
 
@@ -94,6 +95,10 @@ func (*NullValidator) CheckResponse(string, string, *http.Response, []byte) (Che
 
 // HasAlphaResource implements Feature.
 func (*NullValidator) HasAlphaResource(resourceType string) bool {
+	return false
+}
+
+func (*NullValidator) HasAlphaRegionResource(resourceType string) bool {
 	return false
 }
 

--- a/pkg/fuzz/features/features.go
+++ b/pkg/fuzz/features/features.go
@@ -31,4 +31,5 @@ var All = []fuzz.Feature{
 	Affinity,
 	NEG,
 	AppProtocol,
+	ILB,
 }

--- a/pkg/fuzz/features/ilb.go
+++ b/pkg/fuzz/features/ilb.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"net/http"
+)
+
+// ILB is an internal load balancer
+var ILB = &ILBFeature{}
+
+// ILBFeature implements the associated feature
+type ILBFeature struct{}
+
+// NewValidator implements fuzz.Feature.
+func (*ILBFeature) NewValidator() fuzz.FeatureValidator {
+	return &ILBValidator{}
+}
+
+// Name implements fuzz.Feature.
+func (*ILBFeature) Name() string {
+	return "ILB"
+}
+
+// ILBValidator is an example validator.
+type ILBValidator struct {
+	fuzz.NullValidator
+
+	ing *v1beta1.Ingress
+	env fuzz.ValidatorEnv
+}
+
+// Name implements fuzz.FeatureValidator.
+func (*ILBValidator) Name() string {
+	return "ILB"
+}
+
+// ConfigureAttributes implements fuzz.FeatureValidator.
+func (v *ILBValidator) ConfigureAttributes(env fuzz.ValidatorEnv, ing *v1beta1.Ingress, a *fuzz.IngressValidatorAttributes) error {
+	// Capture the env for use later in CheckResponse.
+	v.ing = ing
+	v.env = env
+	return nil
+}
+
+// CheckResponse implements fuzz.FeatureValidator.
+func (v *ILBValidator) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
+	return fuzz.CheckResponseContinue, nil
+}
+
+func (v *ILBValidator) HasAlphaRegionResource(resourceType string) bool {
+	return true
+}

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -258,6 +258,15 @@ func (i *IngressBuilder) AddStaticIP(name string) *IngressBuilder {
 	return i
 }
 
+// Configure for ILB adds the ILB ingress class annotation
+func (i *IngressBuilder) ConfigureForILB() *IngressBuilder {
+	if i.ing.Annotations == nil {
+		i.ing.Annotations = make(map[string]string)
+	}
+	i.ing.Annotations[annotations.IngressClassKey] = annotations.GceL7ILBIngressClass
+	return i
+}
+
 // BackendConfigBuilder is syntactic sugar for creating BackendConfig specs for testing
 // purposes.
 //


### PR DESCRIPTION
Adds HasAlphaRegionResource() to handle L7-ILB and adds it as a feature.  Ideally we should switch e2e to use composites and ResourceVersions.

The actual tests will be added in a seperate PR.