### PR TITLE
Bugfix: don't GC instance groups while multi-cluster ingresses exist

### DIFF
--- a/pkg/common/operator/ingress.go
+++ b/pkg/common/operator/ingress.go
@@ -39,6 +39,20 @@ func (op *IngressesOperator) Filter(f func(*v1beta1.Ingress) bool) *IngressesOpe
 	return Ingresses(i)
 }
 
+// Partition partitions the list of Ingresses into two: Ingresses that match given predicate and those that don't.
+func (op *IngressesOperator) Partition(f func(*v1beta1.Ingress) bool) (*IngressesOperator, *IngressesOperator) {
+	// A list of ingresses that satisfy the predicate condition and it's complement
+	var i, ci []*v1beta1.Ingress
+	for _, ing := range op.i {
+		if f(ing) {
+			i = append(i, ing)
+		} else {
+			ci = append(ci, ing)
+		}
+	}
+	return Ingresses(i), Ingresses(ci)
+}
+
 // ReferencesService returns the Ingresses that references the given Service.
 func (op *IngressesOperator) ReferencesService(svc *api_v1.Service) *IngressesOperator {
 	dupes := map[string]bool{}

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -22,16 +22,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
-// gcState is used by the controller to maintain state for garbage collection routines.
-type gcState struct {
-	// ingressesToCleanup is the list of ingressesToCleanup that needs to be cleaned up during GC.
-	ingressesToCleanup []*v1beta1.Ingress
-	// lbNamesToKeep is the list of GCE Ingress load-balancers that will not be effected by GC.
-	lbNamesToKeep []string
-	// svcPortsToKeep is the list of GCE Ingress service ports that that will not be effected by GC.
-	svcPortsToKeep []utils.ServicePort
-}
-
 // syncState is used by the controller to maintain state for routines that sync GCP resources of an Ingress.
 type syncState struct {
 	urlMap *utils.GCEURLMap

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package sync
 
+import (
+	"k8s.io/api/networking/v1beta1"
+)
+
 // Syncer is an interface to sync GCP resources associated with an Ingress.
 type Syncer interface {
 	// Sync creates a full GCLB given some state related to an Ingress.
@@ -24,7 +28,7 @@ type Syncer interface {
 	// use some arbitrary to help with the process.
 	// TODO(rramkumar): Do we need to rethink the strategy of GC'ing
 	// all Ingresses at once?
-	GC(state interface{}) error
+	GC(ings []*v1beta1.Ingress) error
 }
 
 // Controller is an interface for ingress controllers and declares methods
@@ -32,14 +36,14 @@ type Syncer interface {
 type Controller interface {
 	// SyncBackends syncs the backends for a GCLB given some existing state.
 	SyncBackends(state interface{}) error
-	// GCBackends garbage collects backends for all Ingresses given some existing state.
-	GCBackends(state interface{}) error
+	// GCBackends garbage collects backends for all ingresses given a list of ingresses to exclude from GC.
+	GCBackends(toKeep []*v1beta1.Ingress) error
 	// SyncLoadBalancer syncs the front-end load balancer resources for a GCLB given some existing state.
 	SyncLoadBalancer(state interface{}) error
-	// GCLoadBalancers garbage collects front-end load balancer resources for all Ingresses given some existing state.
-	GCLoadBalancers(state interface{}) error
+	// GCLoadBalancers garbage collects front-end load balancer resources for all ingresses given a list of ingresses to exclude from GC.
+	GCLoadBalancers(toKeep []*v1beta1.Ingress) error
 	// PostProcess allows for doing some post-processing after an Ingress is synced to a GCLB.
 	PostProcess(state interface{}) error
-	// MaybeRemoveFinalizers removes Finalizers after all the resources used by Ingresses are deleted.
-	MaybeRemoveFinalizers(state interface{}) error
+	// MaybeRemoveFinalizers removes finalizers from a list of ingresses one by one after all of its associated resources are deleted.
+	MaybeRemoveFinalizers(toCleanup []*v1beta1.Ingress) error
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/ingress-gce/issues/836

Existing GC workflow deletes instance groups as soon all GCE ingresses are deleted. But, instance groups should be retained as they are shared by multi-cluster ingresses as well. 