### PR TITLE
e2e test framework add support for ilb subnet

### DIFF
--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -42,6 +42,7 @@ var (
 		inCluster           bool
 		kubeconfig          string
 		project             string
+		region              string
 		seed                int64
 		destroySandboxes    bool
 		handleSIGINT        bool
@@ -61,6 +62,7 @@ func init() {
 	flag.BoolVar(&flags.run, "run", false, "set to true to run tests (suppresses test suite from 'go test ./...')")
 	flag.BoolVar(&flags.inCluster, "inCluster", false, "set to true if running in the cluster")
 	flag.StringVar(&flags.project, "project", "", "GCP project")
+	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
@@ -79,6 +81,10 @@ func TestMain(m *testing.M) {
 	}
 	if flags.project == "" {
 		fmt.Fprintln(os.Stderr, "-project must be set to the Google Cloud test project")
+		os.Exit(1)
+	}
+	if flags.region == "" {
+		fmt.Println("-region must be set to the region of the cluster")
 		os.Exit(1)
 	}
 
@@ -106,6 +112,7 @@ func TestMain(m *testing.M) {
 
 	Framework = e2e.NewFramework(kubeconfig, e2e.Options{
 		Project:             flags.project,
+		Region:              flags.region,
 		Seed:                flags.seed,
 		DestroySandboxes:    flags.destroySandboxes,
 		GceEndpointOverride: flags.gceEndpointOverride,

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -42,6 +42,7 @@ import (
 // Options for the test framework.
 type Options struct {
 	Project             string
+	Region              string
 	Seed                int64
 	DestroySandboxes    bool
 	GceEndpointOverride string
@@ -62,6 +63,7 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 		Clientset:           kubernetes.NewForConfigOrDie(config),
 		BackendConfigClient: backendConfigClient,
 		Project:             options.Project,
+		Region:              options.Region,
 		Cloud:               theCloud,
 		Rand:                rand.New(rand.NewSource(options.Seed)),
 		destroySandboxes:    options.DestroySandboxes,
@@ -76,6 +78,7 @@ type Framework struct {
 	Clientset           *kubernetes.Clientset
 	BackendConfigClient *backendconfigclient.Clientset
 	Project             string
+	Region              string
 	Cloud               cloud.Cloud
 	Rand                *rand.Rand
 	statusManager       *StatusManager


### PR DESCRIPTION
Adds support for creating and deleting ilb subnets to the e2e test framwork
Also adds optional "region" CLI flag to e2e binary which is needed for the subnet
Region will also be necessary for part 2 of the e2e test framework changes