### PR TITLE
De-dupe additional source ranges for firewall

### DIFF
--- a/pkg/firewalls/firewalls_test.go
+++ b/pkg/firewalls/firewalls_test.go
@@ -141,6 +141,10 @@ func TestFirewallPoolSyncRanges(t *testing.T) {
 			desc:             "Multiple ranges",
 			additionalRanges: []string{"10.128.0.0/24", "10.132.0.0/24", "10.134.0.0/24"},
 		},
+		{
+			desc:             "Duplicate ranges",
+			additionalRanges: []string{"10.128.0.0/24", "10.132.0.0/24", "10.134.0.0/24", "10.132.0.0/24", "10.134.0.0/24"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
- Fixes a bug where ILB subnet range is added multiple times
- Fixes a bug where empty ilb subnet is added to firewall

/assign @rramkumar1 