### PR TITLE
Update e2e framework for ILB - Part 2

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -117,7 +117,7 @@ func TestAffinity(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -145,7 +145,7 @@ func TestAffinity(t *testing.T) {
 			}
 
 			if err := wait.Poll(tansitionPollInterval, transitionPollTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 					return false, nil

--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -117,7 +117,9 @@ func TestAffinity(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -145,7 +147,7 @@ func TestAffinity(t *testing.T) {
 			}
 
 			if err := wait.Poll(tansitionPollInterval, transitionPollTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 					return false, nil

--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -76,7 +76,7 @@ func TestAppProtocol(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -160,7 +160,7 @@ func TestAppProtocolTransition(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -76,7 +76,8 @@ func TestAppProtocol(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -160,7 +161,8 @@ func TestAppProtocolTransition(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/basic_https_test.go
+++ b/cmd/e2e-test/basic_https_test.go
@@ -111,7 +111,7 @@ func TestBasicHTTPS(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb := whiteboxTest(ing, s, t)
+			gclb := whiteboxTest(ing, s, t, "")
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{
 				SkipDefaultBackend: true,

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -132,7 +132,7 @@ func TestBasicStaticIP(t *testing.T) {
 		}
 
 		vip := testIng.Status.LoadBalancer.Ingress[0].IP
-		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
 		if err != nil {
 			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 		}
@@ -218,12 +218,12 @@ func whiteboxTest(ing *v1beta1.Ingress, s *e2e.Sandbox, t *testing.T) *fuzz.GCLB
 		t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
 	}
 
-	vip := ing.Status.LoadBalancer.Ingress[0].IP
-	t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-	gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
-	if err != nil {
-		t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
-	}
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
 
 	if err := e2e.PerformWhiteboxTests(s, ing, gclb); err != nil {
 		t.Fatalf("Error performing whitebox tests: %v", err)

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -83,7 +83,7 @@ func TestBasic(t *testing.T) {
 			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, tc.ing.Name)
 
 			// Perform whitebox testing.
-			gclb := whiteboxTest(ing, s, t)
+			gclb := whiteboxTest(ing, s, t, "")
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{
 				SkipDefaultBackend: true,
@@ -132,7 +132,11 @@ func TestBasicStaticIP(t *testing.T) {
 		}
 
 		vip := testIng.Status.LoadBalancer.Ingress[0].IP
-		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+		params := &fuzz.GCLBForVIPParams{
+			VIP:        vip,
+			Validators: fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}),
+		}
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
 		if err != nil {
 			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 		}
@@ -187,7 +191,7 @@ func TestEdge(t *testing.T) {
 			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, tc.ing.Name)
 
 			// Perform whitebox testing.
-			gclb := whiteboxTest(ing, s, t)
+			gclb := whiteboxTest(ing, s, t, "")
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{
 				SkipDefaultBackend: true,
@@ -213,17 +217,22 @@ func waitForStableIngress(expectUnreachable bool, ing *v1beta1.Ingress, s *e2e.S
 	return ing
 }
 
-func whiteboxTest(ing *v1beta1.Ingress, s *e2e.Sandbox, t *testing.T) *fuzz.GCLB {
+func whiteboxTest(ing *v1beta1.Ingress, s *e2e.Sandbox, t *testing.T, region string) *fuzz.GCLB {
 	if len(ing.Status.LoadBalancer.Ingress) < 1 {
 		t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
 	}
 
-			vip := ing.Status.LoadBalancer.Ingress[0].IP
-			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
-			if err != nil {
-				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
-			}
+	vip := ing.Status.LoadBalancer.Ingress[0].IP
+	t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+	params := &fuzz.GCLBForVIPParams{
+		VIP:        vip,
+		Region:     region,
+		Validators: fuzz.FeatureValidators(features.All),
+	}
+	gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+	if err != nil {
+		t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+	}
 
 	if err := e2e.PerformWhiteboxTests(s, ing, gclb); err != nil {
 		t.Fatalf("Error performing whitebox tests: %v", err)

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -102,7 +102,7 @@ func TestCDN(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -102,7 +102,8 @@ func TestCDN(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/customrequestheaders_test.go
+++ b/cmd/e2e-test/customrequestheaders_test.go
@@ -84,7 +84,8 @@ func TestCustomRequestHeaders(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/customrequestheaders_test.go
+++ b/cmd/e2e-test/customrequestheaders_test.go
@@ -84,7 +84,7 @@ func TestCustomRequestHeaders(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -100,7 +100,8 @@ func TestDraining(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -132,7 +133,8 @@ func TestDraining(t *testing.T) {
 			}
 
 			if err := wait.Poll(drainingTansitionPollInterval, drainingTransitionPollTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 					return false, nil

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -100,7 +100,7 @@ func TestDraining(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}
@@ -132,7 +132,7 @@ func TestDraining(t *testing.T) {
 			}
 
 			if err := wait.Poll(drainingTansitionPollInterval, drainingTransitionPollTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 					return false, nil

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -84,7 +84,7 @@ func TestIAP(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -84,7 +84,8 @@ func TestIAP(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -116,7 +116,7 @@ func TestNEG(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb := whiteboxTest(ing, s, t)
+			gclb := whiteboxTest(ing, s, t, "")
 
 			// TODO(mixia): The below checks should be merged into PerformWhiteboxTests().
 			if (len(gclb.NetworkEndpointGroup) > 0) != tc.expectNegBackend {
@@ -211,8 +211,8 @@ func TestNEGTransition(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip,
-				fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -128,7 +128,8 @@ func TestSecurityPolicyEnable(t *testing.T) {
 		}
 
 		vip := testIng.Status.LoadBalancer.Ingress[0].IP
-		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy})}
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
 		if err != nil {
 			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 		}
@@ -231,7 +232,8 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 			t.Logf("Waiting %v for security policy to be updated on relevant backend service", policyUpdateTimeout)
 			if err := wait.Poll(policyUpdateInterval, policyUpdateTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
 				if err != nil {
 					t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 				}

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -128,7 +128,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 		}
 
 		vip := testIng.Status.LoadBalancer.Ingress[0].IP
-		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
 		if err != nil {
 			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 		}
@@ -231,7 +231,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 			t.Logf("Waiting %v for security policy to be updated on relevant backend service", policyUpdateTimeout)
 			if err := wait.Poll(policyUpdateInterval, policyUpdateTimeout, func() (bool, error) {
-				gclb, err = fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
+				gclb, err = fuzz.GCLBForVIP(ctx, Framework.Cloud, vip, "", fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}))
 				if err != nil {
 					t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
 				}

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -89,7 +89,7 @@ func TestTimeout(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, fuzz.FeatureValidators(features.All))
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -89,7 +89,8 @@ func TestTimeout(t *testing.T) {
 
 			vip := ing.Status.LoadBalancer.Ingress[0].IP
 			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, vip, "", fuzz.FeatureValidators(features.All))
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
 			}

--- a/cmd/e2e-test/upgrade_test.go
+++ b/cmd/e2e-test/upgrade_test.go
@@ -63,7 +63,7 @@ func TestUpgrade(t *testing.T) {
 			ing := waitForStableIngress(true, tc.ing, s, t)
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
 
-			whiteboxTest(ing, s, t)
+			whiteboxTest(ing, s, t, "")
 
 			for {
 				// While k8s master is upgrading, it will return a connection refused
@@ -98,7 +98,7 @@ func TestUpgrade(t *testing.T) {
 			// trigger an Ingress update
 			ing = waitForStableIngress(true, ing, s, t)
 			t.Logf("GCLB is stable (%s/%s)", s.Namespace, tc.ing.Name)
-			gclb := whiteboxTest(ing, s, t)
+			gclb := whiteboxTest(ing, s, t, "")
 
 			// If the Master has upgraded and the Ingress is stable,
 			// we delete the Ingress and exit out of the loop to indicate that

--- a/cmd/fuzzer/app/validate.go
+++ b/cmd/fuzzer/app/validate.go
@@ -147,7 +147,8 @@ func Validate() {
 	}
 
 	vip := ing.Status.LoadBalancer.Ingress[0].IP
-	gclb, err := fuzz.GCLBForVIP(context.Background(), gce, vip, "", []fuzz.FeatureValidator{})
+	params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+	gclb, err := fuzz.GCLBForVIP(context.Background(), gce, params)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/fuzzer/app/validate.go
+++ b/cmd/fuzzer/app/validate.go
@@ -147,7 +147,7 @@ func Validate() {
 	}
 
 	vip := ing.Status.LoadBalancer.Ingress[0].IP
-	gclb, err := fuzz.GCLBForVIP(context.Background(), gce, vip, []fuzz.FeatureValidator{})
+	gclb, err := fuzz.GCLBForVIP(context.Background(), gce, vip, "", []fuzz.FeatureValidator{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/fuzz/feature.go
+++ b/pkg/fuzz/feature.go
@@ -69,6 +69,7 @@ type FeatureValidator interface {
 	// an error.
 	CheckResponse(host, path string, resp *http.Response, body []byte) (CheckResponseAction, error)
 
+	// TODO(shance): ideally we should use features.ResourceVersions and scope here
 	HasAlphaResource(resourceType string) bool
 	HasBetaResource(resourceType string) bool
 }

--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -153,7 +153,13 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, options
 		}
 	}
 	for k := range g.TargetHTTPProxy {
-		_, err := c.TargetHttpProxies().Get(ctx, &k)
+		var err error
+		if k.Region != "" {
+			// Use beta since GA isn't available yet
+			_, err = c.BetaRegionTargetHttpProxies().Get(ctx, &k)
+		} else {
+			_, err = c.TargetHttpProxies().Get(ctx, &k)
+		}
 		if err != nil {
 			if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 				return fmt.Errorf("TargetHTTPProxy %s is not deleted/error to get: %s", k.Name, err)
@@ -163,7 +169,13 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, options
 		}
 	}
 	for k := range g.TargetHTTPSProxy {
-		_, err := c.TargetHttpsProxies().Get(ctx, &k)
+		var err error
+		if k.Region != "" {
+			// Use beta since GA isn't available yet
+			_, err = c.BetaRegionTargetHttpsProxies().Get(ctx, &k)
+		} else {
+			_, err = c.TargetHttpsProxies().Get(ctx, &k)
+		}
 		if err != nil {
 			if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 				return fmt.Errorf("TargetHTTPSProxy %s is not deleted/error to get: %s", k.Name, err)
@@ -173,7 +185,12 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, options
 		}
 	}
 	for k := range g.URLMap {
-		_, err := c.UrlMaps().Get(ctx, &k)
+		var err error
+		if k.Region != "" {
+			_, err = c.BetaRegionUrlMaps().Get(ctx, &k)
+		} else {
+			_, err = c.UrlMaps().Get(ctx, &k)
+		}
 		if err != nil {
 			if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 				return fmt.Errorf("URLMap %s is not deleted/error to get: %s", k.Name, err)
@@ -184,7 +201,13 @@ func (g *GCLB) CheckResourceDeletion(ctx context.Context, c cloud.Cloud, options
 	}
 	if options == nil || !options.SkipBackends {
 		for k := range g.BackendService {
-			bs, err := c.BackendServices().Get(ctx, &k)
+			var err error
+			var bs *compute.BackendService
+			if k.Region != "" {
+				bs, err = c.RegionBackendServices().Get(ctx, &k)
+			} else {
+				bs, err = c.BackendServices().Get(ctx, &k)
+			}
 			if err != nil {
 				if err.(*googleapi.Error) == nil || err.(*googleapi.Error).Code != http.StatusNotFound {
 					return fmt.Errorf("BackendService %s is not deleted/error to get: %s", k.Name, err)
@@ -268,8 +291,14 @@ func hasBetaResource(resourceType string, validators []FeatureValidator) bool {
 
 // GCLBForVIP retrieves all of the resources associated with the GCLB for a
 // given VIP.
-func GCLBForVIP(ctx context.Context, c cloud.Cloud, vip string, validators []FeatureValidator) (*GCLB, error) {
+func GCLBForVIP(ctx context.Context, c cloud.Cloud, vip string, region string, validators []FeatureValidator) (*GCLB, error) {
 	gclb := NewGCLB(vip)
+
+	if region != "" {
+		if err := RegionalGCLBForVIP(ctx, c, gclb, vip, region, validators); err != nil {
+			return nil, err
+		}
+	}
 
 	allGFRs, err := c.GlobalForwardingRules().List(ctx, filter.None)
 	if err != nil {
@@ -282,6 +311,11 @@ func GCLBForVIP(ctx context.Context, c cloud.Cloud, vip string, validators []Fea
 		if gfr.IPAddress == vip {
 			gfrs = append(gfrs, gfr)
 		}
+	}
+
+	if len(gfrs) == 0 {
+		klog.Warningf("No global forwarding rules found, can't get all GCLB resources")
+		return gclb, nil
 	}
 
 	var urlMapKey *meta.Key
@@ -489,6 +523,243 @@ func GCLBForVIP(ctx context.Context, c cloud.Cloud, vip string, validators []Fea
 	}
 
 	return gclb, err
+}
+
+// GCLBForVIP retrieves all of the resources associated with the GCLB for a
+// given VIP.
+func RegionalGCLBForVIP(ctx context.Context, c cloud.Cloud, gclb *GCLB, vip string, region string, validators []FeatureValidator) error {
+
+	allRFRs, err := c.ForwardingRules().List(ctx, region, filter.None)
+	if err != nil {
+		klog.Warningf("Error listing forwarding rules: %v", err)
+		return err
+	}
+
+	var rfrs []*compute.ForwardingRule
+	for _, gfr := range allRFRs {
+		if gfr.IPAddress == vip {
+			rfrs = append(rfrs, gfr)
+		}
+	}
+
+	if len(rfrs) == 0 {
+		klog.Warningf("No regional forwarding rules found, can't get all GCLB resources")
+		return nil
+	}
+
+	var urlMapKey *meta.Key
+	for _, rfr := range rfrs {
+		frKey := meta.RegionalKey(rfr.Name, region)
+		gclb.ForwardingRule[*frKey] = &ForwardingRule{GA: rfr}
+		if hasAlphaResource("forwardingRule", validators) {
+			fr, err := c.AlphaForwardingRules().Get(ctx, frKey)
+			if err != nil {
+				klog.Warningf("Error getting alpha forwarding rules: %v", err)
+				return err
+			}
+			gclb.ForwardingRule[*frKey].Alpha = fr
+		}
+		if hasBetaResource("forwardingRule", validators) {
+			fr, err := c.BetaForwardingRules().Get(ctx, frKey)
+			if err != nil {
+				klog.Warningf("Error getting alpha forwarding rules: %v", err)
+				return err
+			}
+			gclb.ForwardingRule[*frKey].Beta = fr
+		}
+
+		// ForwardingRule => TargetProxy
+		resID, err := cloud.ParseResourceURL(rfr.Target)
+		if err != nil {
+			klog.Warningf("Error parsing Target (%q): %v", rfr.Target, err)
+			return err
+		}
+		switch resID.Resource {
+		case "targetHttpProxies":
+			// Use beta by default since not GA yet
+			p, err := c.BetaRegionTargetHttpProxies().Get(ctx, resID.Key)
+			if err != nil {
+				klog.Warningf("Error getting TargetHttpProxy %s: %v", resID.Key, err)
+				return err
+			}
+			gclb.TargetHTTPProxy[*resID.Key] = &TargetHTTPProxy{Beta: p}
+			if hasAlphaResource("targetHttpProxy", validators) || hasBetaResource("targetHttpProxy", validators) {
+				return errors.New("unsupported targetHttpProxy version")
+			}
+
+			urlMapResID, err := cloud.ParseResourceURL(p.UrlMap)
+			if err != nil {
+				klog.Warningf("Error parsing urlmap URL (%q): %v", p.UrlMap, err)
+				return err
+			}
+			if urlMapKey == nil {
+				urlMapKey = urlMapResID.Key
+			}
+			if *urlMapKey != *urlMapResID.Key {
+				klog.Warningf("Error targetHttpProxy references are not the same (%s != %s)", *urlMapKey, *urlMapResID.Key)
+				return fmt.Errorf("targetHttpProxy references are not the same: %+v != %+v", *urlMapKey, *urlMapResID.Key)
+			}
+		case "targetHttpsProxies":
+			// Use Beta by default since not GA yet
+			p, err := c.BetaRegionTargetHttpsProxies().Get(ctx, resID.Key)
+			if err != nil {
+				klog.Warningf("Error getting targetHttpsProxy (%s): %v", resID.Key, err)
+				return err
+			}
+			gclb.TargetHTTPSProxy[*resID.Key] = &TargetHTTPSProxy{Beta: p}
+			if hasAlphaResource("targetHttpsProxy", validators) || hasBetaResource("targetHttpsProxy", validators) {
+				return errors.New("unsupported targetHttpsProxy version")
+			}
+
+			urlMapResID, err := cloud.ParseResourceURL(p.UrlMap)
+			if err != nil {
+				klog.Warningf("Error parsing urlmap URL (%q): %v", p.UrlMap, err)
+				return err
+			}
+			if urlMapKey == nil {
+				urlMapKey = urlMapResID.Key
+			}
+			if *urlMapKey != *urlMapResID.Key {
+				klog.Warningf("Error targetHttpsProxy references are not the same (%s != %s)", *urlMapKey, *urlMapResID.Key)
+				return fmt.Errorf("targetHttpsProxy references are not the same: %+v != %+v", *urlMapKey, *urlMapResID.Key)
+			}
+		default:
+			klog.Errorf("Unhandled resource: %q, grf = %+v", resID.Resource, rfr)
+			return fmt.Errorf("unhandled resource %q", resID.Resource)
+		}
+	}
+
+	// TargetProxy => URLMap
+	// Use beta since region is not GA yet
+	urlMap, err := c.BetaRegionUrlMaps().Get(ctx, urlMapKey)
+	if err != nil {
+		return err
+	}
+	gclb.URLMap[*urlMapKey] = &URLMap{Beta: urlMap}
+	if hasAlphaResource("urlMap", validators) || hasBetaResource("urlMap", validators) {
+		return errors.New("unsupported urlMap version")
+	}
+
+	// URLMap => BackendService(s)
+	var bsKeys []*meta.Key
+	resID, err := cloud.ParseResourceURL(urlMap.DefaultService)
+	if err != nil {
+		return err
+	}
+	bsKeys = append(bsKeys, resID.Key)
+
+	for _, pm := range urlMap.PathMatchers {
+		resID, err := cloud.ParseResourceURL(pm.DefaultService)
+		if err != nil {
+			return err
+		}
+		bsKeys = append(bsKeys, resID.Key)
+
+		for _, pr := range pm.PathRules {
+			resID, err := cloud.ParseResourceURL(pr.Service)
+			if err != nil {
+				return err
+			}
+			bsKeys = append(bsKeys, resID.Key)
+		}
+	}
+
+	for _, bsKey := range bsKeys {
+		bs, err := c.RegionBackendServices().Get(ctx, bsKey)
+		if err != nil {
+			return err
+		}
+		gclb.BackendService[*bsKey] = &BackendService{GA: bs}
+
+		if hasAlphaResource("backendService", validators) {
+			bs, err := c.AlphaRegionBackendServices().Get(ctx, bsKey)
+			if err != nil {
+				return err
+			}
+			gclb.BackendService[*bsKey].Alpha = bs
+		}
+		if hasBetaResource("backendService", validators) {
+			bs, err := c.BetaRegionBackendServices().Get(ctx, bsKey)
+			if err != nil {
+				return err
+			}
+			gclb.BackendService[*bsKey].Beta = bs
+		}
+	}
+
+	negKeys := []*meta.Key{}
+	igKeys := []*meta.Key{}
+	// Fetch NEG Backends
+	for _, bsKey := range bsKeys {
+		beGroups := []string{}
+		if hasAlphaResource("backendService", validators) {
+			bs, err := c.AlphaRegionBackendServices().Get(ctx, bsKey)
+			if err != nil {
+				return err
+			}
+			for _, be := range bs.Backends {
+				beGroups = append(beGroups, be.Group)
+			}
+		} else {
+			bs, err := c.BetaRegionBackendServices().Get(ctx, bsKey)
+			if err != nil {
+				return err
+			}
+			for _, be := range bs.Backends {
+				beGroups = append(beGroups, be.Group)
+			}
+		}
+		for _, group := range beGroups {
+			if strings.Contains(group, NegResourceType) {
+				resourceId, err := cloud.ParseResourceURL(group)
+				if err != nil {
+					return err
+				}
+				negKeys = append(negKeys, resourceId.Key)
+			}
+
+			if strings.Contains(group, IgResourceType) {
+				resourceId, err := cloud.ParseResourceURL(group)
+				if err != nil {
+					return err
+				}
+				igKeys = append(igKeys, resourceId.Key)
+			}
+
+		}
+	}
+
+	for _, negKey := range negKeys {
+		neg, err := c.NetworkEndpointGroups().Get(ctx, negKey)
+		if err != nil {
+			return err
+		}
+		gclb.NetworkEndpointGroup[*negKey] = &NetworkEndpointGroup{GA: neg}
+		if hasAlphaResource(NegResourceType, validators) {
+			neg, err := c.AlphaNetworkEndpointGroups().Get(ctx, negKey)
+			if err != nil {
+				return err
+			}
+			gclb.NetworkEndpointGroup[*negKey].Alpha = neg
+		}
+		if hasBetaResource(NegResourceType, validators) {
+			neg, err := c.BetaNetworkEndpointGroups().Get(ctx, negKey)
+			if err != nil {
+				return err
+			}
+			gclb.NetworkEndpointGroup[*negKey].Beta = neg
+		}
+	}
+
+	for _, igKey := range igKeys {
+		ig, err := c.InstanceGroups().Get(ctx, igKey)
+		if err != nil {
+			return err
+		}
+		gclb.InstanceGroup[*igKey] = &InstanceGroup{GA: ig}
+	}
+
+	return err
 }
 
 // NetworkEndpointsInNegs retrieves the network Endpoints from NEGs with one name in multiple zones


### PR DESCRIPTION
Add support for regional resources to gcp.go with minimal changes to the existing fuzzer logic
This allows for whitebox and GC testing of l7-ilb