### PR TITLE
Bugfix: Pass updated ingress for validation

### DIFF
--- a/cmd/e2e-test/finalizer_test.go
+++ b/cmd/e2e-test/finalizer_test.go
@@ -226,7 +226,7 @@ func TestUpdateTo1dot7(t *testing.T) {
 			t.Fatalf("create(%s/%s) = %v, want nil; Ingress: %v", ing.Namespace, ing.Name, err, ing)
 		}
 		t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
-		waitForStableIngress(true, ing, s, t)
+		ing = waitForStableIngress(true, ing, s, t)
 
 		// Check that finalizer is not added in old version in which finalizer add is not enabled.
 		ingFinalizers := ing.GetFinalizers()


### PR DESCRIPTION
This fixes a bug with finalizer e2e test. 

The test verifies the old ingress to ensure GCLB, it should be using updated ingress instead.