### PR TITLE
Update IngressPollTimeout to 45 minutes

### DIFF
--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -47,7 +47,8 @@ import (
 
 const (
 	ingressPollInterval = 30 * time.Second
-	ingressPollTimeout  = 25 * time.Minute
+	// TODO(shance): Find a way to lower this timeout
+	ingressPollTimeout = 45 * time.Minute
 
 	gclbDeletionInterval = 30 * time.Second
 	gclbDeletionTimeout  = 15 * time.Minute


### PR DESCRIPTION
Our e2e tests need a longer timeout since we are creating more ingresses.  We should ideally lower this back down a bit later on if we can.