### PR TITLE
Introduce a flag for creating non-GCP NEGs.

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -87,6 +87,7 @@ var (
 		EnableL7Ilb                 bool
 		EnableCSM                   bool
 		CSMServiceNEGSkipNamespaces []string
+		CreateHybridNeg             bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -204,6 +205,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		`Optional, whether or not to enable L7-ILB.`)
 	flag.BoolVar(&F.EnableCSM, "enable-csm", false, "Enable CSM(Istio) support")
 	flag.StringSliceVar(&F.CSMServiceNEGSkipNamespaces, "csm-service-skip-namespaces", []string{}, "Only for CSM mode, skip the NEG creation for Services in the given namespaces.")
+	flag.BoolVar(&F.CreateHybridNeg, "create-hybrid-neg", false, "Create Negs of type NON_GCP_PRIVATE_IP_PORT instead of GCE_VM_IP_PORT.")
 }
 
 type RateLimitSpecs struct {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -87,7 +87,7 @@ var (
 		EnableL7Ilb                 bool
 		EnableCSM                   bool
 		CSMServiceNEGSkipNamespaces []string
-		EnableHybrid                bool
+		EnableNonGCPMode            bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -205,7 +205,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		`Optional, whether or not to enable L7-ILB.`)
 	flag.BoolVar(&F.EnableCSM, "enable-csm", false, "Enable CSM(Istio) support")
 	flag.StringSliceVar(&F.CSMServiceNEGSkipNamespaces, "csm-service-skip-namespaces", []string{}, "Only for CSM mode, skip the NEG creation for Services in the given namespaces.")
-	flag.BoolVar(&F.EnableHybrid, "enable-hybrid", false, "Enable hybrid support.")
+	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 }
 
 type RateLimitSpecs struct {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -87,7 +87,7 @@ var (
 		EnableL7Ilb                 bool
 		EnableCSM                   bool
 		CSMServiceNEGSkipNamespaces []string
-		CreateHybridNeg             bool
+		EnableHybrid                bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -205,7 +205,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		`Optional, whether or not to enable L7-ILB.`)
 	flag.BoolVar(&F.EnableCSM, "enable-csm", false, "Enable CSM(Istio) support")
 	flag.StringSliceVar(&F.CSMServiceNEGSkipNamespaces, "csm-service-skip-namespaces", []string{}, "Only for CSM mode, skip the NEG creation for Services in the given namespaces.")
-	flag.BoolVar(&F.CreateHybridNeg, "create-hybrid-neg", false, "Create Negs of type NON_GCP_PRIVATE_IP_PORT instead of GCE_VM_IP_PORT.")
+	flag.BoolVar(&F.EnableHybrid, "enable-hybrid", false, "Enable hybrid support.")
 }
 
 type RateLimitSpecs struct {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -315,19 +315,22 @@ func TestGarbageCollectionNEG(t *testing.T) {
 		t.Fatalf("Failed to ensure syncer: %v", err)
 	}
 
-	negName := manager.namer.NEG("test", "test", 80)
-	manager.cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{
-		Name: negName,
-	}, negtypes.TestZone1)
+	for _, networkEndpointType := range []string{"GCE_VM_IP_PORT", "NON_GCP_PRIVATE_IP_PORT"} {
+		negName := manager.namer.NEG("test", "test", 80)
+		manager.cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{
+			Name:                negName,
+			NetworkEndpointType: networkEndpointType,
+		}, negtypes.TestZone1)
 
-	if err := manager.GC(); err != nil {
-		t.Fatalf("Failed to GC: %v", err)
-	}
+		if err := manager.GC(); err != nil {
+			t.Fatalf("Failed to GC: %v", err)
+		}
 
-	negs, _ := manager.cloud.ListNetworkEndpointGroup(negtypes.TestZone1)
-	for _, neg := range negs {
-		if neg.Name == negName {
-			t.Errorf("Expect NEG %q to be GCed.", negName)
+		negs, _ := manager.cloud.ListNetworkEndpointGroup(negtypes.TestZone1)
+		for _, neg := range negs {
+			if neg.Name == negName {
+				t.Errorf("Expect NEG %q to be GCed.", negName)
+			}
 		}
 	}
 

--- a/pkg/neg/syncers/batch_test.go
+++ b/pkg/neg/syncers/batch_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/flags"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/utils"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
@@ -117,53 +116,25 @@ func TestStartAndStopSyncer(t *testing.T) {
 }
 
 func TestEnsureNetworkEndpointGroups(t *testing.T) {
-	testCases := []struct {
-		createHybridNeg             bool
-		expectedNetworkEdnpointType string
-		expectedSubnetwork          string
-	}{
-		{
-			createHybridNeg:             false,
-			expectedNetworkEdnpointType: negIPPortNetworkEndpointType,
-			expectedSubnetwork:          "test-subnetwork",
-		},
-		{
-			createHybridNeg:             true,
-			expectedNetworkEdnpointType: negPrivateIPPortNetworkEdnpointType,
-			expectedSubnetwork:          "",
-		},
+	syncer := NewTestSyncer()
+	if err := syncer.ensureNetworkEndpointGroups(); err != nil {
+		t.Errorf("Failed to ensure NEGs: %v", err)
 	}
 
-	for _, tc := range testCases {
-		flags.F.CreateHybridNeg = tc.createHybridNeg
-		syncer := NewTestSyncer()
-		if err := syncer.ensureNetworkEndpointGroups(); err != nil {
-			t.Errorf("Failed to ensure NEGs: %v", err)
+	ret, _ := syncer.cloud.AggregatedListNetworkEndpointGroup()
+	expectZones := []string{negtypes.TestZone1, negtypes.TestZone2}
+	for _, zone := range expectZones {
+		negs, ok := ret[zone]
+		if !ok {
+			t.Errorf("Failed to find zone %q from ret %v", zone, ret)
+			continue
 		}
 
-		ret, _ := syncer.cloud.AggregatedListNetworkEndpointGroup()
-		expectZones := []string{negtypes.TestZone1, negtypes.TestZone2}
-		for _, zone := range expectZones {
-			negs, ok := ret[zone]
-			if !ok {
-				t.Errorf("Failed to find zone %q from ret %v", zone, ret)
-				continue
-			}
-
-			if len(negs) != 1 {
-				t.Errorf("Unexpected negs %v", negs)
-			} else {
-				if negs[0].Name != testNegName {
-					t.Errorf("Unexpected neg %q", negs[0].Name)
-				}
-
-				if negs[0].NetworkEndpointType != tc.expectedNetworkEdnpointType {
-					t.Errorf("Unexpected NetworkEndpointType, expecting %q but got %q", tc.expectedNetworkEdnpointType, negs[0].NetworkEndpointType)
-				}
-
-				if negs[0].Subnetwork != tc.expectedSubnetwork {
-					t.Errorf("Unexpected Subnetwork, expecting %q but got %q", tc.expectedSubnetwork, negs[0].Subnetwork)
-				}
+		if len(negs) != 1 {
+			t.Errorf("Unexpected negs %v", negs)
+		} else {
+			if negs[0].Name != testNegName {
+				t.Errorf("Unexpected neg %q", negs[0].Name)
 			}
 		}
 	}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -126,8 +126,11 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 	needToCreate := false
 	if neg == nil {
 		needToCreate = true
-	} else if !utils.EqualResourceIDs(neg.Network, cloud.NetworkURL()) ||
-		!utils.EqualResourceIDs(neg.Subnetwork, cloud.SubnetworkURL()) {
+	} else if neg.NetworkEndpointType != nonGCPPrivateEndpointType &&
+		// Only perform the following checks when the NEGs are not Non-GCP NEGs.
+		// Non-GCP NEGs do not have associated network and subnetwork.
+		(!utils.EqualResourceIDs(neg.Network, cloud.NetworkURL()) ||
+			!utils.EqualResourceIDs(neg.Subnetwork, cloud.SubnetworkURL())) {
 		needToCreate = true
 		klog.V(2).Infof("NEG %q in %q does not match network and subnetwork of the cluster. Deleting NEG.", negName, zone)
 		err = cloud.DeleteNetworkEndpointGroup(negName, zone)

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -144,13 +144,16 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 	if needToCreate {
 		klog.V(2).Infof("Creating NEG %q for %s in %q.", negName, negServicePortName, zone)
 		networkEndpointType := negIPPortNetworkEndpointType
+		subnetwork := cloud.SubnetworkURL()
 		if flags.F.CreateHybridNeg {
 			networkEndpointType = negPrivateIPPortNetworkEdnpointType
+			subnetwork = ""
 		}
 		err = cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{
 			Name:                negName,
 			NetworkEndpointType: networkEndpointType,
 			Network:             cloud.NetworkURL(),
+			Subnetwork:          subnetwork,
 		}, zone)
 		if err != nil {
 			return err


### PR DESCRIPTION
With '--enable-non-gcp-mode', NEG controller will create NEGs of type NON_GCP_PRIVATE_IP_PORT instead of GCE_VM_IP_PORT.