### PR TITLE
Disable Http on ILB Https e2e tests

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -126,6 +126,7 @@ func TestILB(t *testing.T) {
 	}
 }
 
+// TODO(shance): Remove the SetAllowHttp() calls once L7-ILB supports sharing VIPs
 func TestILBHttps(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +150,8 @@ func TestILBHttps(t *testing.T) {
 			desc: "https ILB one path, pre-shared cert",
 			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
 				AddPath("test.com", "/", serviceName, port80).
-				ConfigureForILB(),
+				ConfigureForILB().
+				SetAllowHttp(false),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 			certType:           e2e.GCPCert,
@@ -159,7 +161,8 @@ func TestILBHttps(t *testing.T) {
 			desc: "https ILB one path, tls",
 			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
 				AddPath("test.com", "/", serviceName, port80).
-				ConfigureForILB(),
+				ConfigureForILB().
+				SetAllowHttp(false),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 			certType:           e2e.K8sCert,
@@ -170,7 +173,8 @@ func TestILBHttps(t *testing.T) {
 			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
 				AddPath("test.com", "/foo", serviceName, port80).
 				AddPath("baz.com", "/bar", serviceName, port80).
-				ConfigureForILB(),
+				ConfigureForILB().
+				SetAllowHttp(false),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 			certType:           e2e.GCPCert,
@@ -181,7 +185,8 @@ func TestILBHttps(t *testing.T) {
 			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
 				AddPath("test.com", "/foo", serviceName, port80).
 				AddPath("baz.com", "/bar", serviceName, port80).
-				ConfigureForILB(),
+				ConfigureForILB().
+				SetAllowHttp(false),
 			numForwardingRules: 1,
 			numBackendServices: 2,
 			certType:           e2e.K8sCert,

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -18,6 +18,7 @@ package fuzz
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -273,6 +274,15 @@ func (i *IngressBuilder) ConfigureForILB() *IngressBuilder {
 		i.ing.Annotations = make(map[string]string)
 	}
 	i.ing.Annotations[annotations.IngressClassKey] = annotations.GceL7ILBIngressClass
+	return i
+}
+
+// SetAllowHttp sets the AllowHTTP annotation on the ingress
+func (i *IngressBuilder) SetAllowHttp(val bool) *IngressBuilder {
+	if i.ing.Annotations == nil {
+		i.ing.Annotations = make(map[string]string)
+	}
+	i.ing.Annotations[annotations.AllowHTTPKey] = strconv.FormatBool(val)
 	return i
 }
 


### PR DESCRIPTION
Set the AllowHttp annotation to false for all L7-ILB HTTPS e2e tests since allowing both
HTTP and HTTPS on the same VIP is not currently supported.