### PR TITLE
Fix backend services whitebox test to take into account the default backend

### DIFF
--- a/pkg/fuzz/whitebox/num_backend_services.go
+++ b/pkg/fuzz/whitebox/num_backend_services.go
@@ -40,6 +40,10 @@ func (t *numBackendServicesTest) Test(ing *v1beta1.Ingress, gclb *fuzz.GCLB) err
 	t.uniqSvcPorts = make(map[utils.ServicePortID]bool)
 	expectedBackendServices := 0
 
+	if ing.Spec.Backend == nil {
+		expectedBackendServices++
+	}
+
 	utils.TraverseIngressBackends(ing, func(id utils.ServicePortID) bool {
 		if _, ok := t.uniqSvcPorts[id]; !ok {
 			expectedBackendServices++


### PR DESCRIPTION
When there is no default backend set in the Ingress specification, the controller creates a 404 backend service. This was previously not taken into account. 

/assign @MrHohn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/878)
<!-- Reviewable:end -->
