### PR TITLE
remove "addonmanager.kubernetes.io/mode: Reconcile" annotation from

### DIFF
--- a/docs/deploy/gke/csm/default-http-backend.yaml
+++ b/docs/deploy/gke/csm/default-http-backend.yaml
@@ -51,7 +51,6 @@ metadata:
   labels:
     k8s-app: glbc
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "GLBCDefaultBackend"
 spec:
   # The default backend must be of type NodePort.

--- a/docs/deploy/resources/default-http-backend.yaml
+++ b/docs/deploy/resources/default-http-backend.yaml
@@ -51,7 +51,6 @@ metadata:
   labels:
     k8s-app: glbc
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "GLBCDefaultBackend"
 spec:
   # The default backend must be of type NodePort.


### PR DESCRIPTION
user space default backend service.

With this annotation, the backend service will be deleted if created with kubectl apply -f 