### PR TITLE
Add V2 frontend namer

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -20,6 +20,7 @@ import (
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	informerv1 "k8s.io/client-go/informers/core/v1"
@@ -55,7 +56,8 @@ type ControllerContext struct {
 
 	Cloud *gce.Cloud
 
-	ClusterNamer *namer.Namer
+	ClusterNamer  *namer.Namer
+	KubeSystemUID types.UID
 
 	ControllerContextConfig
 	ASMConfigController *cmconfig.ConfigMapConfigController
@@ -100,6 +102,7 @@ func NewControllerContext(
 	frontendConfigClient frontendconfigclient.Interface,
 	cloud *gce.Cloud,
 	namer *namer.Namer,
+	kubeSystemUID types.UID,
 	config ControllerContextConfig) *ControllerContext {
 
 	context := &ControllerContext{
@@ -107,6 +110,7 @@ func NewControllerContext(
 		KubeClient:              kubeClient,
 		Cloud:                   cloud,
 		ClusterNamer:            namer,
+		KubeSystemUID:           kubeSystemUID,
 		ControllerContextConfig: config,
 		IngressInformer:         informerv1beta1.NewIngressInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		ServiceInformer:         informerv1.NewServiceInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -65,7 +65,7 @@ func fakeTranslator() *Translator {
 		HealthCheckPath:               "/",
 		DefaultBackendHealthCheckPath: "/healthz",
 	}
-	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, defaultNamer, ctxConfig)
+	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	gce := &Translator{
 		ctx: ctx,
 	}

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -46,7 +46,7 @@ func newFirewallController() *FirewallController {
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
 	}
 
-	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, fakeGCE, defaultNamer, ctxConfig)
+	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	fwc := NewFirewallController(ctx, []string{"30000-32767"})
 	fwc.hasSynced = func() bool { return true }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -89,6 +89,7 @@ var (
 		ASMConfigMapBasedConfigCMName    string
 		EnableNonGCPMode                 bool
 		EnableDeleteUnusedFrontends      bool
+		EnableV2FrontendNamer            bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -208,6 +209,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.ASMConfigMapBasedConfigCMName, "asm-configmap-based-config-cmname", "ingress-controller-asm-cm-config", "ASM Configmap based config: configmap name")
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
+	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
 }
 
 type RateLimitSpecs struct {

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -17,17 +17,20 @@ limitations under the License.
 package loadbalancers
 
 import (
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/loadbalancers/features"
+	"k8s.io/api/networking/v1beta1"
 )
 
 // LoadBalancerPool is an interface to manage the cloud resources associated
 // with a gce loadbalancer.
 type LoadBalancerPool interface {
+	// Ensure ensures a loadbalancer and its resources given the RuntimeInfo.
 	Ensure(ri *L7RuntimeInfo) (*L7, error)
-	Delete(name string, versions *features.ResourceVersions, scope meta.KeyType) error
-	GC(names []string) error
-	Shutdown() error
-	List(key *meta.Key, version meta.Version) ([]*composite.UrlMap, error)
+	// GCv2 garbage collects loadbalancer associated with given ingress using v2 naming scheme.
+	GCv2(ing *v1beta1.Ingress) error
+	// GCv1 garbage collects loadbalancers not in the input list using v1 naming scheme.
+	GCv1(names []string) error
+	// Shutdown deletes all loadbalancers for given list of ingresses.
+	Shutdown(ings []*v1beta1.Ingress) error
+	// HasUrlMap returns true if an URL map exists in GCE for given ingress.
+	HasUrlMap(ing *v1beta1.Ingress) (bool, error)
 }

--- a/pkg/loadbalancers/url_maps_test.go
+++ b/pkg/loadbalancers/url_maps_test.go
@@ -81,7 +81,7 @@ func TestToComputeURLMap(t *testing.T) {
 		},
 	}
 
-	namerFactory := namer_util.NewFrontendNamerFactory(namer)
+	namerFactory := namer_util.NewFrontendNamerFactory(namer, "")
 	feNamer := namerFactory.NamerForLbName("ns/lb-name")
 	gotComputeURLMap := toCompositeURLMap(gceURLMap, feNamer, meta.GlobalKey("ns-lb-name"))
 	if !mapsEqual(gotComputeURLMap, wantComputeMap) {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -89,7 +89,7 @@ func newTestController(kubeClient kubernetes.Interface) *Controller {
 		ASMConfigMapNamespace: "kube-system",
 		ASMConfigMapName:      "ingress-controller-config-test",
 	}
-	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, "" /*kubeSystemUID*/, ctxConfig)
 
 	// Hack the context.Init func.
 	configMapInformer := informerv1.NewConfigMapInformer(kubeClient, context.Namespace, context.ResyncPeriod, utils.NewNamespaceIndexer())

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -74,7 +74,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 		ResyncPeriod:          1 * time.Second,
 		DefaultBackendSvcPort: defaultBackend,
 	}
-	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, "" /*kubeSystemUID*/, ctxConfig)
 
 	manager := newSyncerManager(
 		namer,

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -62,7 +62,7 @@ func fakeContext() *context.ControllerContext {
 	}
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	negtypes.MockNetworkEndpointAPIs(fakeGCE)
-	context := context.NewControllerContext(nil, kubeClient, nil, nil, fakeGCE, namer, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	return context
 }
 

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -88,7 +88,7 @@ func newSyncerTester() *syncerTester {
 		ResyncPeriod:          1 * time.Second,
 		DefaultBackendSvcPort: defaultBackend,
 	}
-	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, namer, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, namer, "" /*kubeSystemUID*/, ctxConfig)
 	negSyncerKey := negtypes.NegSyncerKey{
 		Namespace: testServiceNamespace,
 		Name:      testServiceName,

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -824,7 +824,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud) (negty
 		ResyncPeriod:          1 * time.Second,
 		DefaultBackendSvcPort: defaultBackend,
 	}
-	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, namer, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, namer, "" /*kubeSystemUID*/, ctxConfig)
 	svcPort := negtypes.NegSyncerKey{
 		Namespace: testNamespace,
 		Name:      testService,

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -12,6 +12,12 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
+const (
+	FinalizerAddFlag          = flag("enable-finalizer-add")
+	FinalizerRemoveFlag       = flag("enable-finalizer-remove")
+	EnableV2FrontendNamerFlag = flag("enable-v2-frontend-namer")
+)
+
 var (
 	BackendPort      = intstr.IntOrString{Type: intstr.Int, IntVal: 80}
 	DefaultBeSvcPort = utils.ServicePort{
@@ -79,4 +85,28 @@ func DecodeIngress(data []byte) (*v1beta1.Ingress, error) {
 	}
 
 	return obj.(*v1beta1.Ingress), nil
+}
+
+// flag is a type representing controller flag.
+type flag string
+
+// FlagSaver is an utility type to capture the value of a flag and reset back to the saved value.
+type FlagSaver struct{ flags map[flag]bool }
+
+// NewFlagSaver returns a flag saver by initializing the map.
+func NewFlagSaver() FlagSaver {
+	return FlagSaver{make(map[flag]bool)}
+}
+
+// Save captures the value of given flag.
+func (s *FlagSaver) Save(key flag, flagPointer *bool) {
+	s.flags[key] = *flagPointer
+}
+
+// Reset resets the value of given flag to a previously saved value.
+// This does nothing if the flag value was not captured.
+func (s *FlagSaver) Reset(key flag, flagPointer *bool) {
+	if val, ok := s.flags[key]; ok {
+		*flagPointer = val
+	}
 }

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -17,6 +17,9 @@ limitations under the License.
 package common
 
 import (
+	"crypto/sha256"
+	"strconv"
+
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -26,6 +29,32 @@ import (
 var (
 	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 )
+
+// charMap is a list of string represented values of first 10 integers and lowercase
+// alphabets. This is a lookup table to maintain entropy when converting bytes to string.
+var charMap []string
+
+// WARNING: PLEASE DO NOT CHANGE THE HASH FUNCTION.
+func init() {
+	for i := 0; i < 10; i++ {
+		charMap = append(charMap, strconv.Itoa(i))
+	}
+	for i := 0; i < 26; i++ {
+		charMap = append(charMap, string('a'+rune(i)))
+	}
+}
+
+// ContentHash creates a content hash string of length n of s utilizing sha256.
+// WARNING: PLEASE DO NOT CHANGE THE HASH FUNCTION.
+func ContentHash(s string, n int) string {
+	var h string
+	bytes := sha256.Sum256(([]byte)(s))
+	for i := 0; i < n && i < len(bytes); i++ {
+		idx := int(bytes[i]) % len(charMap)
+		h += charMap[idx]
+	}
+	return h
+}
 
 // NamespacedName returns namespaced name string of a given ingress.
 // Note: This is used for logging.

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -23,52 +23,63 @@ import (
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
-// FinalizerKey is the string representing the Ingress finalizer.
-const FinalizerKey = "networking.gke.io/ingress-finalizer"
+const (
+	// FinalizerKey is the string representing the Ingress finalizer.
+	FinalizerKey = "networking.gke.io/ingress-finalizer"
+	// FinalizerKeyV2 is the string representing the Ingress finalizer version.
+	// Ingress with V2 finalizer uses V2 frontend naming scheme.
+	FinalizerKeyV2 = "networking.gke.io/ingress-finalizer-V2"
+)
 
-// IsDeletionCandidate is true if the passed in meta contains the specified finalizer.
-func IsDeletionCandidate(m meta_v1.ObjectMeta, key string) bool {
-	return m.DeletionTimestamp != nil && HasFinalizer(m, key)
+// IsDeletionCandidate is true if the passed in meta contains an ingress finalizer.
+func IsDeletionCandidate(m meta_v1.ObjectMeta) bool {
+	return IsDeletionCandidateForGivenFinalizer(m, FinalizerKey) || IsDeletionCandidateForGivenFinalizer(m, FinalizerKeyV2)
 }
 
-// NeedToAddFinalizer is true if the passed in meta does not contain the specified finalizer.
-func NeedToAddFinalizer(m meta_v1.ObjectMeta, key string) bool {
-	return m.DeletionTimestamp == nil && !HasFinalizer(m, key)
+// IsDeletionCandidateForGivenFinalizer is true if the passed in meta contains the specified finalizer.
+func IsDeletionCandidateForGivenFinalizer(m meta_v1.ObjectMeta, key string) bool {
+	return m.DeletionTimestamp != nil && HasGivenFinalizer(m, key)
 }
 
-// HasFinalizer is true if the passed in meta has the specified finalizer.
-func HasFinalizer(m meta_v1.ObjectMeta, key string) bool {
+// HasFinalizer is true if the passed in meta has an ingress finalizer.
+func HasFinalizer(m meta_v1.ObjectMeta) bool {
+	return HasGivenFinalizer(m, FinalizerKey) || HasGivenFinalizer(m, FinalizerKeyV2)
+}
+
+// HasGivenFinalizer is true if the passed in meta has the specified finalizer.
+func HasGivenFinalizer(m meta_v1.ObjectMeta, key string) bool {
 	return slice.ContainsString(m.Finalizers, key, nil)
 }
 
-// AddFinalizer tries to add a finalizer to an Ingress. If a finalizer
-// already exists, it does nothing.
-func AddFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface) error {
-	ingKey := FinalizerKey
-	if NeedToAddFinalizer(ing.ObjectMeta, ingKey) {
+// EnsureFinalizer ensures that the specified finalizer exists on given Ingress.
+func EnsureFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface, finalizerKey string) error {
+	if needToAddFinalizer(ing.ObjectMeta, finalizerKey) {
 		updated := ing.DeepCopy()
-		updated.ObjectMeta.Finalizers = append(updated.ObjectMeta.Finalizers, ingKey)
+		updated.ObjectMeta.Finalizers = append(updated.ObjectMeta.Finalizers, finalizerKey)
+		// TODO(smatti): Make this optimistic concurrency control compliant on write.
+		// Refer: https://github.com/eBay/Kubernetes/blob/master/docs/devel/api-conventions.md#concurrency-control-and-consistency
 		if _, err := ingClient.Update(updated); err != nil {
 			return fmt.Errorf("error updating Ingress %s/%s: %v", ing.Namespace, ing.Name, err)
 		}
-		klog.V(3).Infof("Added finalizer %q for Ingress %s/%s", ingKey, ing.Namespace, ing.Name)
+		klog.V(2).Infof("Added finalizer %q for Ingress %s/%s", finalizerKey, ing.Namespace, ing.Name)
 	}
-
 	return nil
 }
 
-// RemoveFinalizer tries to remove a Finalizer from an Ingress. If a
-// finalizer is not on the Ingress, it does nothing.
-func RemoveFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface) error {
-	ingKey := FinalizerKey
-	if HasFinalizer(ing.ObjectMeta, ingKey) {
+// needToAddFinalizer is true if the passed in meta does not contain the specified finalizer.
+func needToAddFinalizer(m meta_v1.ObjectMeta, key string) bool {
+	return m.DeletionTimestamp == nil && !HasGivenFinalizer(m, key)
+}
+
+// EnsureDeleteFinalizer ensures that the specified finalizer is deleted from given Ingress.
+func EnsureDeleteFinalizer(ing *v1beta1.Ingress, ingClient client.IngressInterface, finalizerKey string) error {
+	if HasGivenFinalizer(ing.ObjectMeta, finalizerKey) {
 		updated := ing.DeepCopy()
-		updated.ObjectMeta.Finalizers = slice.RemoveString(updated.ObjectMeta.Finalizers, ingKey, nil)
+		updated.ObjectMeta.Finalizers = slice.RemoveString(updated.ObjectMeta.Finalizers, finalizerKey, nil)
 		if _, err := ingClient.Update(updated); err != nil {
 			return fmt.Errorf("error updating Ingress %s/%s: %v", ing.Namespace, ing.Name, err)
 		}
-		klog.V(3).Infof("Removed finalizer %q for Ingress %s/%s", ingKey, ing.Namespace, ing.Name)
+		klog.V(2).Infof("Removed finalizer %q for Ingress %s/%s", finalizerKey, ing.Namespace, ing.Name)
 	}
-
 	return nil
 }

--- a/pkg/utils/namer/frontendnamer.go
+++ b/pkg/utils/namer/frontendnamer.go
@@ -14,13 +14,42 @@ limitations under the License.
 package namer
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-gce/pkg/utils/common"
+	"k8s.io/klog"
 )
 
 const (
+	// V1NamingScheme is v1 frontend naming scheme.
 	V1NamingScheme = Scheme("v1")
+	// V2NamingScheme is v2 frontend naming scheme.
 	V2NamingScheme = Scheme("v2")
+	// schemaVersionV2 is suffix to be appended to resource prefix for v2 naming scheme.
+	schemaVersionV2 = "2"
+	// maximumAllowedCombinedLength is the maximum combined length of namespace and
+	// name portions in the resource name.
+	// This is computed by subtracting: k8s1 - 4, dashes - 5, resource prefix - 2,
+	// clusterUID - 8,  suffix hash- 8.
+	// maximumAllowedCombinedLength = maximum name length of gce resource(63) - 27
+	maximumAllowedCombinedLength = 36
+	// urlMapPrefixV2 is URL map prefix for v2 naming scheme.
+	urlMapPrefixV2 = "um"
+	// forwardingRulePrefixV2 is http forwarding rule prefix for v2 naming scheme.
+	forwardingRulePrefixV2 = "fr"
+	// httpsForwardingRulePrefixV2 is https forwarding rule prefix for v2 naming scheme.
+	httpsForwardingRulePrefixV2 = "fs"
+	// targetHTTPProxyPrefixV2 is target http proxy prefix for v2 naming scheme.
+	targetHTTPProxyPrefixV2 = "tp"
+	// targetHTTPSProxyPrefixV2 is target https proxy prefix for v2 naming scheme.
+	targetHTTPSProxyPrefixV2 = "ts"
+	// sslCertPrefixV2 is ssl certificate prefix for v2 naming scheme.
+	sslCertPrefixV2 = "cr"
+	// clusterUIDLength is length of cluster UID to be included in resource names.
+	clusterUIDLength = 8
 )
 
 // Scheme is ingress frontend name scheme.
@@ -79,25 +108,142 @@ func (ln *V1IngressFrontendNamer) LbName() string {
 	return ln.lbName
 }
 
+// V2IngressFrontendNamer implements IngressFrontendNamer.
+type V2IngressFrontendNamer struct {
+	ing *v1beta1.Ingress
+	// prefix for all resource names (ex.: "k8s").
+	prefix string
+	// Load balancer name to be included in resource name.
+	lbName string
+	// clusterUID is an 8 character hash to be included in resource names.
+	// This is immutable after the cluster is created. Kube-system uid which is
+	// immutable is used as cluster UID for v2 naming scheme.
+	clusterUID string
+}
+
+// newV2IngressFrontendNamer returns a v2 frontend namer for given ingress, cluster uid and prefix.
+// Example:
+// For Ingress - namespace/ingress, clusterUID - uid0123, prefix - k8s
+// The resource names are -
+// LoadBalancer          : uid0123-namespace-ingress-cysix1wq
+// HTTP Forwarding Rule  : k8s2-fr-uid0123-namespace-ingress-cysix1wq
+// HTTPS Forwarding Rule : k8s2-fs-uid0123-namespace-ingress-cysix1wq
+// Target HTTP Proxy     : k8s2-tp-uid0123-namespace-ingress-cysix1wq
+// Target HTTPS Proxy    : k8s2-ts-uid0123-namespace-ingress-cysix1wq
+// URL Map               : k8s2-um-uid0123-namespace-ingress-cysix1wq
+// SSL Certificate       : k8s2-cr-uid0123-<lb-hash>-<secret-hash>
+func newV2IngressFrontendNamer(ing *v1beta1.Ingress, clusterUID string, prefix string) IngressFrontendNamer {
+	namer := &V2IngressFrontendNamer{ing: ing, prefix: prefix, clusterUID: clusterUID}
+	// Initialize LbName.
+	truncFields := TrimFieldsEvenly(maximumAllowedCombinedLength, ing.Namespace, ing.Name)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	suffix := namer.suffix(clusterUID, ing.Namespace, ing.Name)
+	namer.lbName = fmt.Sprintf("%s-%s-%s-%s", clusterUID, truncNamespace, truncName, suffix)
+	return namer
+}
+
+// ForwardingRule returns the name of forwarding rule based on given protocol.
+func (vn *V2IngressFrontendNamer) ForwardingRule(protocol NamerProtocol) string {
+	switch protocol {
+	case HTTPProtocol:
+		return fmt.Sprintf("%s%s-%s-%s", vn.prefix, schemaVersionV2, forwardingRulePrefixV2, vn.lbName)
+	case HTTPSProtocol:
+		return fmt.Sprintf("%s%s-%s-%s", vn.prefix, schemaVersionV2, httpsForwardingRulePrefixV2, vn.lbName)
+	default:
+		klog.Fatalf("invalid ForwardingRule protocol: %q", protocol)
+		return "invalid"
+	}
+}
+
+// TargetProxy returns the name of target proxy based on given protocol.
+func (vn *V2IngressFrontendNamer) TargetProxy(protocol NamerProtocol) string {
+	switch protocol {
+	case HTTPProtocol:
+		return fmt.Sprintf("%s%s-%s-%s", vn.prefix, schemaVersionV2, targetHTTPProxyPrefixV2, vn.lbName)
+	case HTTPSProtocol:
+		return fmt.Sprintf("%s%s-%s-%s", vn.prefix, schemaVersionV2, targetHTTPSProxyPrefixV2, vn.lbName)
+	default:
+		klog.Fatalf("invalid TargetProxy protocol: %q", protocol)
+		return "invalid"
+	}
+}
+
+// UrlMap returns the name of URL map.
+func (vn *V2IngressFrontendNamer) UrlMap() string {
+	return fmt.Sprintf("%s%s-%s-%s", vn.prefix, schemaVersionV2, urlMapPrefixV2, vn.lbName)
+}
+
+// SSLCertName returns the name of the certificate.
+func (vn *V2IngressFrontendNamer) SSLCertName(secretHash string) string {
+	return fmt.Sprintf("%s%s-%s-%s-%s-%s", vn.prefix, schemaVersionV2, sslCertPrefixV2, vn.clusterUID, vn.lbNameToHash(), secretHash)
+}
+
+// IsCertNameForLB returns true if the certName belongs to this cluster's ingress.
+// It checks that the hashed lbName exists.
+func (vn *V2IngressFrontendNamer) IsCertNameForLB(certName string) bool {
+	prefix := fmt.Sprintf("%s%s-%s-%s-%s", vn.prefix, schemaVersionV2, sslCertPrefixV2, vn.clusterUID, vn.lbNameToHash())
+	return strings.HasPrefix(certName, prefix)
+}
+
+// IsLegacySSLCert always return false as v2 naming scheme does not use legacy certs.
+func (vn *V2IngressFrontendNamer) IsLegacySSLCert(certName string) bool {
+	return false
+}
+
+// LbName returns loadbalancer name.
+// Note that this is used for generating GCE resource names.
+func (vn *V2IngressFrontendNamer) LbName() string {
+	return vn.lbName
+}
+
+// setLbName sets loadbalancer name.
+func (vn *V2IngressFrontendNamer) setLbName() {
+	truncFields := TrimFieldsEvenly(maximumAllowedCombinedLength, vn.ing.Namespace, vn.ing.Name)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	suffix := vn.suffix(vn.clusterUID, vn.ing.Namespace, vn.ing.Name)
+	vn.lbName = fmt.Sprintf("%s-%s-%s-%s", vn.clusterUID, truncNamespace, truncName, suffix)
+}
+
+// suffix returns hash string of length 8 of a concatenated string generated from
+// uid (an 8 character hash of kube-system uid), namespace and name.
+// These fields define an ingress/ load-balancer uniquely.
+func (vn *V2IngressFrontendNamer) suffix(uid, namespace, name string) string {
+	lbString := strings.Join([]string{uid, namespace, name}, ";")
+	return common.ContentHash(lbString, 8)
+}
+
+// lbNameToHash returns hash string of length 16 of lbName.
+func (vn *V2IngressFrontendNamer) lbNameToHash() string {
+	return common.ContentHash(vn.lbName, 16)
+}
+
 // FrontendNamerFactory implements IngressFrontendNamerFactory.
 type FrontendNamerFactory struct {
 	namer *Namer
+	// clusterUID is an 8 character hash of kube-system UID that is included
+	// in resource names.
+	// Note that this is used only for V2IngressFrontendNamer.
+	clusterUID string
 }
 
-// NewFrontendNamerFactory returns IngressFrontendNamerFactory given a v1 namer.
-func NewFrontendNamerFactory(namer *Namer) IngressFrontendNamerFactory {
-	return &FrontendNamerFactory{namer: namer}
+// NewFrontendNamerFactory returns IngressFrontendNamerFactory given a v1 namer and uid.
+func NewFrontendNamerFactory(namer *Namer, uid types.UID) IngressFrontendNamerFactory {
+	clusterUID := common.ContentHash(string(uid), clusterUIDLength)
+	return &FrontendNamerFactory{namer: namer, clusterUID: clusterUID}
 }
 
 // Namer implements IngressFrontendNamerFactory.
 func (rn *FrontendNamerFactory) Namer(ing *v1beta1.Ingress) IngressFrontendNamer {
-	switch frontendNamingScheme(ing) {
+	namingScheme := FrontendNamingScheme(ing)
+	switch namingScheme {
 	case V1NamingScheme:
 		return newV1IngressFrontendNamer(ing, rn.namer)
 	case V2NamingScheme:
-		// TODO(smatti): return V2 Namer.
-		return nil
+		return newV2IngressFrontendNamer(ing, rn.clusterUID, rn.namer.prefix)
 	default:
+		klog.Errorf("Unexpected frontend naming scheme %s", namingScheme)
 		return newV1IngressFrontendNamer(ing, rn.namer)
 	}
 }


### PR DESCRIPTION
This part4 of V2 Namer Migration: https://github.com/kubernetes/ingress-gce/issues/858. 
Fixes: https://github.com/kubernetes/ingress-gce/issues/537

This PR introduces a new naming scheme for for the following frontend resources:
- Forwarding Rule
- Target Proxy
- URL Map
- SSL Certificates
- Ingress managed Static IP

This should resolve frontend resource naming collision issues. 

The changes made in v2 naming scheme:
- New naming scheme:
`k8s{version-id}-{resource-prefix}-{kube-system-uid}-{namespace}-{name}-{8-char-hash}`
Example http target proxy: `k8s2-tp-ksuid123-namespace-name-wddys49o`
- Resource names will include an 8 character kube-system uid instead of cluster uid. This makes the new naming policy immune to config map(which tracks cluster uid) changes.

Frontend  GC workflow changes:
- New GC workflow for v2 naming scheme
  - GC will be invoked only on the ingress being synced.
  - GC workflow will not leak any GCE resources.

**GC workflow**
 - If finalizer is disabled
   - GC workflow is untouched i.e, run GC for all ingresses
- If finalizer is enabled
  - If ingress being synced needs cleanup
    - Frontend GC
      - if V1 naming scheme - run frontend GC for all v1 ingresses.
      - if V2 naming scheme - run frontend GC for ingress being synced. 
    - Backend GC - run for all ingresses.
    - Ensure delete finalizers
      - if V1 naming scheme - remove finalizers for all v1 ingresses.
      - if V2 naming scheme - remove finalizer for ingress being synced.
   - If  ingress being synced does not need cleanup
     - Backend GC - run for all ingresses.
