### PR TITLE
Bugfix: Delete unused GCE load-balancer resources on ingress spec change

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -42,7 +42,7 @@ const (
 	StaticIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
 
 	// PreSharedCertKey represents the specific pre-shared SSL
-	// certicate for the Ingress controller to use. The controller *does not*
+	// certificate for the Ingress controller to use. The controller *does not*
 	// manage this certificate, it is the users responsibility to create/delete it.
 	// In GCP, the Ingress controller assigns the SSL certificate with this name
 	// to the target proxies of the Ingress.
@@ -77,6 +77,25 @@ const (
 	// - annotations:
 	//     networking.gke.io/v1beta1.FrontendConfig: 'my-frontendconfig'
 	FrontendConfigKey = "networking.gke.io/v1beta1.FrontendConfig"
+
+	// UrlMapKey is the annotation key used by controller to record GCP URL map.
+	UrlMapKey = StatusPrefix + "/url-map"
+	// HttpForwardingRuleKey is the annotation key used by controller to record
+	// GCP http forwarding rule.
+	HttpForwardingRuleKey = StatusPrefix + "/forwarding-rule"
+	// HttpsForwardingRuleKey is the annotation key used by controller to record
+	// GCP https forwarding rule.
+	HttpsForwardingRuleKey = StatusPrefix + "/https-forwarding-rule"
+	// TargetHttpProxyKey is the annotation key used by controller to record
+	// GCP target http proxy.
+	TargetHttpProxyKey = StatusPrefix + "/target-proxy"
+	// TargetHttpsProxyKey is the annotation key used by controller to record
+	// GCP target https proxy.
+	TargetHttpsProxyKey = StatusPrefix + "/https-target-proxy"
+	// SSLCertKey is the annotation key used by controller to record GCP ssl cert.
+	SSLCertKey = StatusPrefix + "/ssl-cert"
+	// StaticIPKey is the annotation key used by controller to record GCP static ip.
+	StaticIPKey = StatusPrefix + "/static-ip"
 )
 
 // Ingress represents ingress annotations.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -88,6 +88,7 @@ var (
 		ASMConfigMapBasedConfigNamespace string
 		ASMConfigMapBasedConfigCMName    string
 		EnableNonGCPMode                 bool
+		EnableDeleteUnusedFrontends      bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -206,6 +207,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.ASMConfigMapBasedConfigNamespace, "asm-configmap-based-config-namespace", "kube-system,istio-system", "ASM Configmap based config: configmap namespace")
 	flag.StringVar(&F.ASMConfigMapBasedConfigCMName, "asm-configmap-based-config-cmname", "ingress-controller-asm-cm-config", "ASM Configmap based config: configmap name")
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
+	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 }
 
 type RateLimitSpecs struct {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/ingress-gce/issues/32, https://github.com/kubernetes/ingress-gce/issues/465, https://github.com/kubernetes/ingress-gce/issues/764

/assign @bowei @freehan 

The Ensure workflow of Loadbalancer pool is modified in order to delete unused GCE resources.
This looks at user specified ingress options/annotations to determine if we need to delete specific frontend resources. 

- AllowHTTP is set to false:
  if existing ingress annotations has http resources, then those will be deleted.
- SSL is not configured:
  if existing ingress annotations has https resources, then those will be deleted.
- If User specifies an IP:
  We try to delete Ingress managed static IP if exists. This is performed only when both http and https are enabled.

Note that the existing behavior of load-balancer pool does not update frontend resource annotations for the above mentioned cases. This modifies this behavior to update these annotations which will be used for determining whether we need to delete frontend resources.
