### PR TITLE
Shorten all ILB e2e ingress test names again since we actually only have 10 characters

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -37,9 +37,8 @@ func TestILB(t *testing.T) {
 	t.Parallel()
 
 	// These names are useful when reading the debug logs
-	testName := "test-ilb-basic"
-	ingressPrefix := testName + "-i-"
-	serviceName := testName + "-s-"
+	ingressPrefix := "ing1-"
+	serviceName := "svc-1"
 
 	port80 := intstr.FromInt(80)
 
@@ -128,9 +127,8 @@ func TestILBHttps(t *testing.T) {
 	t.Parallel()
 
 	// These names are useful when reading the debug logs
-	testName := "test-ilb-s"
-	ingressPrefix := testName + "-i-"
-	serviceName := testName + "-s-"
+	ingressPrefix := "ing2-"
+	serviceName := "svc-2"
 
 	port80 := intstr.FromInt(80)
 
@@ -259,9 +257,8 @@ func TestILBUpdate(t *testing.T) {
 	t.Parallel()
 
 	// These names are useful when reading the debug logs
-	testName := "test-ilb-up"
-	ingressPrefix := testName + "-i-"
-	serviceName := testName + "-s-"
+	ingressPrefix := "ing3-"
+	serviceName := "svc-3"
 
 	port80 := intstr.FromInt(80)
 
@@ -407,9 +404,8 @@ func TestILBError(t *testing.T) {
 	t.Parallel()
 
 	// These names are useful when reading the debug logs
-	testName := "test-ilb-err"
-	ingressPrefix := testName + "-i-"
-	serviceName := testName + "-s-"
+	ingressPrefix := "ing4-"
+	serviceName := "svc-4"
 
 	port80 := intstr.FromInt(80)
 
@@ -464,9 +460,8 @@ func TestILBShared(t *testing.T) {
 	t.Parallel()
 
 	// These names are useful when reading the debug logs
-	testName := "test-ilb-share"
-	ingressPrefix := testName + "-i-"
-	serviceName := testName + "-s-"
+	ingressPrefix := "ing5-"
+	serviceName := "svc-5"
 
 	port80 := intstr.FromInt(80)
 


### PR DESCRIPTION
Turns out our beautifully crafted names are still too long.  We have a total of 40 characters for namespace + name and the sandbox takes up 30 of those.  Now I understand why everything else is called "ingress-1" 

:grin: 

/assign @MrHohn 