### PR TITLE
Add e2e tests for frontend resource leak fix

### DIFF
--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -222,7 +222,7 @@ func DeleteSecret(s *Sandbox, name string) error {
 	if err := s.f.Clientset.CoreV1().Secrets(s.Namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
 		return err
 	}
-	klog.V(2).Infof("Secret %q:%q created", s.Namespace, name)
+	klog.V(2).Infof("Secret %q:%q deleted", s.Namespace, name)
 
 	return nil
 }

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -201,6 +201,26 @@ func WaitForGCLBDeletion(ctx context.Context, c cloud.Cloud, g *fuzz.GCLB, optio
 	})
 }
 
+// WaitForFrontendResourceDeletion waits for frontend resources associated with the GLBC to be
+// deleted for given protocol.
+func WaitForFrontendResourceDeletion(ctx context.Context, c cloud.Cloud, g *fuzz.GCLB, options *fuzz.GCLBDeleteOptions) error {
+	return wait.Poll(gclbDeletionInterval, gclbDeletionTimeout, func() (bool, error) {
+		if options.CheckHttpFrontendResources {
+			if err := g.CheckResourceDeletionByProtocol(ctx, c, options, fuzz.HttpProtocol); err != nil {
+				klog.Infof("WaitForGCLBDeletionByProtocol(..., %q, %q) = %v", g.VIP, fuzz.HttpsProtocol, err)
+				return false, nil
+			}
+		}
+		if options.CheckHttpsFrontendResources {
+			if err := g.CheckResourceDeletionByProtocol(ctx, c, options, fuzz.HttpsProtocol); err != nil {
+				klog.Infof("WaitForGCLBDeletionByProtocol(..., %q, %q) = %v", g.VIP, fuzz.HttpsProtocol, err)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
 // WaitForNEGDeletion waits for all NEGs associated with a GCLB to be deleted via GC
 func WaitForNEGDeletion(ctx context.Context, c cloud.Cloud, g *fuzz.GCLB, options *fuzz.GCLBDeleteOptions) error {
 	return wait.Poll(negPollInterval, gclbDeletionTimeout, func() (bool, error) {

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -230,6 +230,12 @@ func (i *IngressBuilder) Path(host, path, service string, port intstr.IntOrStrin
 	return &h.HTTP.Paths[len(h.HTTP.Paths)-1]
 }
 
+// SetTLS sets TLS certs to given list.
+func (i *IngressBuilder) SetTLS(tlsCerts []v1beta1.IngressTLS) *IngressBuilder {
+	i.ing.Spec.TLS = tlsCerts
+	return i
+}
+
 // AddTLS adds a TLS secret reference.
 func (i *IngressBuilder) AddTLS(hosts []string, secretName string) *IngressBuilder {
 	i.ing.Spec.TLS = append(i.ing.Spec.TLS, v1beta1.IngressTLS{

--- a/pkg/fuzz/whitebox/num_target_proxies.go
+++ b/pkg/fuzz/whitebox/num_target_proxies.go
@@ -24,30 +24,33 @@ import (
 	"k8s.io/ingress-gce/pkg/fuzz"
 )
 
-// Implements a whitebox test to check that the GCLB has the expected number of ForwardingRule's.
-type numForwardingRulesTest struct {
+// Implements a whitebox test to check that the GCLB has the expected number of TargetHTTPSProxy's.
+type numTargetProxiesTest struct {
 }
 
 // Name implements WhiteboxTest.
-func (t *numForwardingRulesTest) Name() string {
-	return "NumForwardingRulesTest"
+func (t *numTargetProxiesTest) Name() string {
+	return "NumTargetProxiesTest"
 
 }
 
 // Test implements WhiteboxTest.
-func (t *numForwardingRulesTest) Test(ing *v1beta1.Ingress, gclb *fuzz.GCLB) error {
-	expectedForwardingRules := 0
+func (t *numTargetProxiesTest) Test(ing *v1beta1.Ingress, gclb *fuzz.GCLB) error {
+	expectedHTTPTargetProxies, expectedHTTPSTargetProxies := 0, 0
 
 	an := annotations.FromIngress(ing)
 	if an.AllowHTTP() {
-		expectedForwardingRules += 1
+		expectedHTTPTargetProxies = 1
 	}
 	if len(ing.Spec.TLS) > 0 || an.UseNamedTLS() != "" {
-		expectedForwardingRules += 1
+		expectedHTTPSTargetProxies = 1
 	}
 
-	if len(gclb.ForwardingRule) != expectedForwardingRules {
-		return fmt.Errorf("expected %d ForwardingRule's but got %d", expectedForwardingRules, len(gclb.ForwardingRule))
+	if l := len(gclb.TargetHTTPProxy); l != expectedHTTPTargetProxies {
+		return fmt.Errorf("expected %d TargetHTTPProxy's but got %d", expectedHTTPTargetProxies, l)
+	}
+	if l := len(gclb.TargetHTTPSProxy); l != expectedHTTPSTargetProxies {
+		return fmt.Errorf("expected %d TargetHTTPSProxy's but got %d", expectedHTTPSTargetProxies, l)
 	}
 
 	return nil

--- a/pkg/fuzz/whitebox/whitebox_tests.go
+++ b/pkg/fuzz/whitebox/whitebox_tests.go
@@ -22,4 +22,5 @@ import "k8s.io/ingress-gce/pkg/fuzz"
 var AllTests = []fuzz.WhiteboxTest{
 	&numBackendServicesTest{},
 	&numForwardingRulesTest{},
+	&numTargetProxiesTest{},
 }


### PR DESCRIPTION
This adds tests for https://github.com/kubernetes/ingress-gce/pull/894. This test asserts that frontend resources existence is in agreement with user specified ingress configuration. 