### PR TITLE
Plumb region to neg validator for e2e testing

### DIFF
--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -101,7 +101,9 @@ func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitForIngressOpt
 		if err != nil {
 			return true, err
 		}
-		validator, err := fuzz.NewIngressValidator(s.ValidatorEnv, ing, features.All, []fuzz.WhiteboxTest{}, nil)
+		attrs := fuzz.DefaultAttributes()
+		attrs.Region = s.f.Region
+		validator, err := fuzz.NewIngressValidator(s.ValidatorEnv, ing, features.All, []fuzz.WhiteboxTest{}, attrs)
 		if err != nil {
 			return true, err
 		}

--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -81,6 +81,7 @@ type IngressValidatorAttributes struct {
 	CheckHTTPS          bool
 	RejectInsecureCerts bool
 	RequestTimeout      time.Duration
+	Region              string
 	// HTTPPort and HTTPSPort are used only for unit testing.
 	HTTPPort  int
 	HTTPSPort int
@@ -154,8 +155,8 @@ type PathResult struct {
 	Err    error
 }
 
-// defaultAttributes are the base attributes for validation.
-func defaultAttributes() *IngressValidatorAttributes {
+// DefaultAttributes are the base attributes for validation.
+func DefaultAttributes() *IngressValidatorAttributes {
 	return &IngressValidatorAttributes{
 		CheckHTTP:      true,
 		CheckHTTPS:     false,
@@ -175,7 +176,7 @@ func NewIngressValidator(env ValidatorEnv, ing *v1beta1.Ingress, features []Feat
 	}
 
 	if attribs == nil {
-		attribs = defaultAttributes()
+		attribs = DefaultAttributes()
 	}
 	attribs.baseAttributes(ing)
 	if err := attribs.applyFeatures(env, ing, fvs); err != nil {

--- a/pkg/fuzz/validator_test.go
+++ b/pkg/fuzz/validator_test.go
@@ -306,7 +306,7 @@ func TestValidatorCheck(t *testing.T) {
 				ms.serve()
 			}
 
-			attribs := defaultAttributes()
+			attribs := DefaultAttributes()
 			attribs.HTTPPort = ms.l.Addr().(*net.TCPAddr).Port
 			attribs.HTTPSPort = ms.ls.Addr().(*net.TCPAddr).Port
 			validator, err := NewIngressValidator(&MockValidatorEnv{}, tc.ing, []Feature{}, []WhiteboxTest{}, attribs)
@@ -380,7 +380,7 @@ func TestValidatorCheckFeature(t *testing.T) {
 			}
 			ms.serve()
 
-			attribs := defaultAttributes()
+			attribs := DefaultAttributes()
 			attribs.HTTPPort = ms.l.Addr().(*net.TCPAddr).Port
 			attribs.HTTPSPort = ms.ls.Addr().(*net.TCPAddr).Port
 
@@ -412,13 +412,13 @@ func TestPortStr(t *testing.T) {
 		{
 			desc:   "http, default port",
 			scheme: "http",
-			a:      *defaultAttributes(),
+			a:      *DefaultAttributes(),
 			want:   "",
 		},
 		{
 			desc:   "https, default port",
 			scheme: "https",
-			a:      *defaultAttributes(),
+			a:      *DefaultAttributes(),
 			want:   "",
 		},
 		{


### PR DESCRIPTION
Previously, region was hardcoded to us-central1