### PR TITLE
Bump TestAffinity transition timeout from 5 to 10 minutes

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	transitionPollTimeout = 5 * time.Minute
+	transitionPollTimeout = 10 * time.Minute
 	tansitionPollInterval = 30 * time.Second
 )
 


### PR DESCRIPTION
We are sometimes hitting this timeout, bumping it up to avoid flakes

/assign @MrHohn 