### PR TITLE
Add a flag for Non-GCP mode NEG controller.

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -86,6 +86,7 @@ var (
 		EnableL7Ilb                 bool
 		EnableCSM                   bool
 		CSMServiceNEGSkipNamespaces []string
+		EnableNonGCPMode            bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -202,6 +203,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		`Optional, whether or not to enable L7-ILB.`)
 	flag.BoolVar(&F.EnableCSM, "enable-csm", false, "Enable CSM(Istio) support")
 	flag.StringSliceVar(&F.CSMServiceNEGSkipNamespaces, "csm-service-skip-namespaces", []string{}, "Only for CSM mode, skip the NEG creation for Services in the given namespaces.")
+	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 }
 
 type RateLimitSpecs struct {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -314,19 +314,22 @@ func TestGarbageCollectionNEG(t *testing.T) {
 		t.Fatalf("Failed to ensure syncer: %v", err)
 	}
 
-	negName := manager.namer.NEG("test", "test", 80)
-	manager.cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{
-		Name: negName,
-	}, negtypes.TestZone1)
+	for _, networkEndpointType := range []negtypes.NetworkEndpointType{negtypes.VMNetworkEndpointType, negtypes.NonGCPPrivateEndpointType} {
+		negName := manager.namer.NEG("test", "test", 80)
+		manager.cloud.CreateNetworkEndpointGroup(&compute.NetworkEndpointGroup{
+			Name:                negName,
+			NetworkEndpointType: string(networkEndpointType),
+		}, negtypes.TestZone1)
 
-	if err := manager.GC(); err != nil {
-		t.Fatalf("Failed to GC: %v", err)
-	}
+		if err := manager.GC(); err != nil {
+			t.Fatalf("Failed to GC: %v", err)
+		}
 
-	negs, _ := manager.cloud.ListNetworkEndpointGroup(negtypes.TestZone1)
-	for _, neg := range negs {
-		if neg.Name == negName {
-			t.Errorf("Expect NEG %q to be GCed.", negName)
+		negs, _ := manager.cloud.ListNetworkEndpointGroup(negtypes.TestZone1)
+		for _, neg := range negs {
+			if neg.Name == negName {
+				t.Errorf("Expect NEG %q to be GCed.", negName)
+			}
 		}
 	}
 

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -36,6 +36,8 @@ type transactionSyncer struct {
 	// metadata
 	negtypes.NegSyncerKey
 	negName string
+	// The type of the network endpoints in this NEG.
+	networkEndpointType negtypes.NetworkEndpointType
 
 	// syncer provides syncer life cycle interfaces
 	syncer negtypes.NegSyncer
@@ -65,20 +67,21 @@ type transactionSyncer struct {
 	reflector readiness.Reflector
 }
 
-func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, networkEndpointGroupName string, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, reflector readiness.Reflector) negtypes.NegSyncer {
+func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, networkEndpointGroupName string, networkEndpointType negtypes.NetworkEndpointType, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, reflector readiness.Reflector) negtypes.NegSyncer {
 	// TransactionSyncer implements the syncer core
 	ts := &transactionSyncer{
-		NegSyncerKey:   negSyncerKey,
-		negName:        networkEndpointGroupName,
-		needInit:       true,
-		transactions:   NewTransactionTable(),
-		podLister:      podLister,
-		serviceLister:  serviceLister,
-		endpointLister: endpointLister,
-		recorder:       recorder,
-		cloud:          cloud,
-		zoneGetter:     zoneGetter,
-		reflector:      reflector,
+		NegSyncerKey:        negSyncerKey,
+		negName:             networkEndpointGroupName,
+		networkEndpointType: networkEndpointType,
+		needInit:            true,
+		transactions:        NewTransactionTable(),
+		podLister:           podLister,
+		serviceLister:       serviceLister,
+		endpointLister:      endpointLister,
+		recorder:            recorder,
+		cloud:               cloud,
+		zoneGetter:          zoneGetter,
+		reflector:           reflector,
 	}
 	// Syncer implements life cycle logic
 	syncer := newSyncer(negSyncerKey, networkEndpointGroupName, serviceLister, recorder, ts)
@@ -130,7 +133,7 @@ func (s *transactionSyncer) syncInternal() error {
 		return nil
 	}
 
-	targetMap, endpointPodMap, err := toZoneNetworkEndpointMap(ep.(*apiv1.Endpoints), s.zoneGetter, s.TargetPort, s.podLister, s.NegSyncerKey.SubsetLabels)
+	targetMap, endpointPodMap, err := toZoneNetworkEndpointMap(ep.(*apiv1.Endpoints), s.zoneGetter, s.TargetPort, s.podLister, s.NegSyncerKey.SubsetLabels, s.networkEndpointType)
 	if err != nil {
 		return err
 	}
@@ -178,7 +181,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 
 	var errList []error
 	for _, zone := range zones {
-		if err := ensureNetworkEndpointGroup(s.Namespace, s.Name, s.negName, zone, s.NegSyncerKey.String(), s.cloud, s.serviceLister, s.recorder); err != nil {
+		if err := ensureNetworkEndpointGroup(s.Namespace, s.Name, s.negName, zone, s.NegSyncerKey.String(), s.networkEndpointType, s.cloud, s.serviceLister, s.recorder); err != nil {
 			errList = append(errList, err)
 		}
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1091,6 +1091,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud) (negty
 
 	negsyncer := NewTransactionSyncer(svcPort,
 		testNegName,
+		negtypes.VMNetworkEndpointType,
 		record.NewFakeRecorder(100),
 		fakeGCE,
 		negtypes.NewFakeZoneGetter(),

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -29,6 +29,13 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 )
 
+type NetworkEndpointType string
+
+const (
+	VMNetworkEndpointType     = NetworkEndpointType("GCE_VM_IP_PORT")
+	NonGCPPrivateEndpointType = NetworkEndpointType("NON_GCP_PRIVATE_IP_PORT")
+)
+
 // SvcPortMap is a map of ServicePort:TargetPort
 type SvcPortMap map[int32]string
 


### PR DESCRIPTION
With '--enable-non-gcp-mode', NEG controller will create NEGs of type NON_GCP_PRIVATE_IP_PORT instead of GCE_VM_IP_PORT.