### PR TITLE
Update forwarding rule logic for l7-ilb

### DIFF
--- a/pkg/loadbalancers/features/l7ilb.go
+++ b/pkg/loadbalancers/features/l7ilb.go
@@ -65,23 +65,6 @@ func isSameNetwork(l, r string) (bool, error) {
 	return lID.Equal(rID), nil
 }
 
-// IsCustomModeNetwork is a helper for determining if a network is a custom mode network
-// (as opposed to a auto mode network).  This is used for l7-ilb since custom mode networks
-// require an additional field on the forwarding rule
-func IsCustomModeNetwork(c *gce.Cloud, networkURL string) (bool, error) {
-	netID, err := cloud.ParseResourceURL(networkURL)
-	if err != nil {
-		return false, err
-	}
-
-	network, err := c.Compute().Networks().Get(context.Background(), netID.Key)
-	if err != nil {
-		return false, err
-	}
-
-	return !network.AutoCreateSubnetworks, nil
-}
-
 // L7ILBVersion is a helper to get the version of L7-ILB
 func L7ILBVersions() *ResourceVersions {
 	return versionsFromFeatures([]string{FeatureL7ILB})

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -18,10 +18,8 @@ package loadbalancers
 
 import (
 	"fmt"
-	"k8s.io/ingress-gce/pkg/flags"
-	"k8s.io/ingress-gce/pkg/loadbalancers/features"
-
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
@@ -95,13 +93,8 @@ func (l *L7) checkForwardingRule(name, proxyLink, ip, portRange string) (fw *com
 		// Update rule for L7-ILB
 		if flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress) {
 			rule.LoadBalancingScheme = "INTERNAL_MANAGED"
-
-			// Custom mode networks require adding the cluster subnetwork
-			if isCustomMode, err := features.IsCustomModeNetwork(l.cloud, l.cloud.NetworkURL()); err != nil {
-				return nil, err
-			} else if isCustomMode {
-				rule.Subnetwork = l.cloud.SubnetworkURL()
-			}
+			rule.Network = l.cloud.NetworkURL()
+			rule.Subnetwork = l.cloud.SubnetworkURL()
 		}
 
 		if err = composite.CreateForwardingRule(l.cloud, key, rule); err != nil {


### PR DESCRIPTION
Use network and subnetwork fields for l7-ilb all forwarding rules
instead of only custom-mode networks.  It turns out that the GCE API assumes the default network when no network or subnet is provided.

This also saves us from having to do a network lookup from the GCE API. (cc: @bowei)