### PR TITLE
remove transaction syncer reconciliation

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -146,8 +146,6 @@ func (s *transactionSyncer) syncInternal() error {
 	// Merge the current state from cloud with the transaction table together
 	// The combined state represents the eventual result when all transactions completed
 	mergeTransactionIntoZoneEndpointMap(currentMap, s.transactions)
-	// Find transaction entries that needs to be reconciled
-	reconcileTransactions(targetMap, s.transactions)
 	// Calculate the endpoints to add and delete to transform the current state to desire state
 	addEndpoints, removeEndpoints := calculateNetworkEndpointDifference(targetMap, currentMap)
 	// Calculate Pods that are already in the NEG
@@ -203,9 +201,8 @@ func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints m
 			}
 
 			transEntry := transactionEntry{
-				Operation:     operation,
-				NeedReconcile: false,
-				Zone:          zone,
+				Operation: operation,
+				Zone:      zone,
 			}
 
 			// Insert networkEndpoint into transaction table
@@ -299,15 +296,11 @@ func (s *transactionSyncer) commitTransaction(err error, networkEndpointMap map[
 	}
 
 	for networkEndpoint := range networkEndpointMap {
-		entry, ok := s.transactions.Get(networkEndpoint)
+		_, ok := s.transactions.Get(networkEndpoint)
 		// clear transaction
 		if !ok {
 			klog.Errorf("Endpoint %q was not found in the transaction table.", networkEndpoint)
 			continue
-		}
-		// TODO: Remove NeedReconcile in the transation entry (freehan)
-		if entry.NeedReconcile == true {
-			klog.Errorf("Endpoint %q in NEG %q need to be reconciled.", networkEndpoint, s.NegSyncerKey.String())
 		}
 		s.transactions.Delete(networkEndpoint)
 	}
@@ -376,63 +369,5 @@ func mergeTransactionIntoZoneEndpointMap(endpointMap map[string]negtypes.Network
 			endpointMap[entry.Zone].Delete(endpointKey)
 		}
 	}
-	return
-}
-
-// reconcileTransactions compares the endpoint map with existing transaction entries in transaction table
-// if transaction does not cu
-func reconcileTransactions(endpointMap map[string]negtypes.NetworkEndpointSet, transactions networkEndpointTransactionTable) {
-	// Identify endpoints that should be in NEG but the current transaction does not match the intention
-	for zone, endpointSet := range endpointMap {
-		for _, endpointKey := range endpointSet.List() {
-			entry, ok := transactions.Get(endpointKey)
-			// if transaction does not contain endpoints, it will be handled in this sync
-			if !ok {
-				continue
-			}
-			needReconcile := false
-			// if zone does not match, need to reconcile
-			if entry.Zone != zone {
-				needReconcile = true
-			}
-			// if the endpoint entry is in detach transaction but shows up endpointMap
-			if entry.Operation == detachOp {
-				needReconcile = true
-			}
-
-			if needReconcile {
-				entry.NeedReconcile = true
-				transactions.Put(endpointKey, entry)
-			}
-		}
-	}
-
-	// Identify endpoints that should not to be in NEG but the current transaction does not match the intention
-	for _, endpointKey := range transactions.Keys() {
-		entry, ok := transactions.Get(endpointKey)
-		if !ok {
-			continue
-		}
-		needReconcile := false
-		if entry.Operation == attachOp {
-			endpointSet, ok := endpointMap[entry.Zone]
-			// If zone is not in endpointMap, then the endpoint must not exist in the endpointMap
-			if !ok {
-				needReconcile = true
-			}
-
-			// If the endpoint that is in attach transaction does not exists in the endpointMap,
-			// Then it means the endpoint needs to be reconciled after attach operation completes.
-			if !endpointSet.Has(endpointKey) {
-				needReconcile = true
-			}
-		}
-
-		if needReconcile {
-			entry.NeedReconcile = true
-			transactions.Put(endpointKey, entry)
-		}
-	}
-
 	return
 }

--- a/pkg/neg/syncers/transaction_table.go
+++ b/pkg/neg/syncers/transaction_table.go
@@ -49,8 +49,6 @@ func (op transactionOp) String() string {
 type transactionEntry struct {
 	// Operation represents the operation type associated with each transaction
 	Operation transactionOp
-	// NeedReconcile indicates whether the entry needs to be reconciled.
-	NeedReconcile bool
 	// Zone represents the zone of the transaction
 	Zone string
 }

--- a/pkg/neg/syncers/transaction_table_test.go
+++ b/pkg/neg/syncers/transaction_table_test.go
@@ -49,7 +49,6 @@ func TestTransactionTable(t *testing.T) {
 		key := negtypes.NetworkEndpoint{IP: fmt.Sprintf("%s%d", ipPrefix, i), Port: fmt.Sprintf("%s%d", portPrefix, i), Node: fmt.Sprintf("%s%d", nodePrefix, i)}
 		entry := transactionEntry{
 			attachOp,
-			false,
 			fmt.Sprintf("%s%d", zonePrefix, i),
 		}
 		table.Put(key, entry)
@@ -63,7 +62,6 @@ func TestTransactionTable(t *testing.T) {
 		key := negtypes.NetworkEndpoint{IP: fmt.Sprintf("%s%d", ipPrefix, i), Port: fmt.Sprintf("%s%d", portPrefix, i), Node: fmt.Sprintf("%s%d", nodePrefix, i)}
 		newEntry := transactionEntry{
 			detachOp,
-			true,
 			fmt.Sprintf("%s%d", zonePrefix, i),
 		}
 		table.Put(key, newEntry)

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -231,7 +231,7 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
@@ -245,8 +245,8 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
@@ -260,14 +260,14 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			4,
@@ -280,12 +280,12 @@ func TestCommitTransaction(t *testing.T) {
 			map[negtypes.NetworkEndpoint]*compute.NetworkEndpoint{},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			5,
@@ -298,14 +298,14 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			6,
@@ -318,7 +318,7 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
@@ -332,14 +332,14 @@ func TestCommitTransaction(t *testing.T) {
 			generateEndpointBatch(negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080"))),
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
+				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				return table
 			},
 			8,
@@ -370,261 +370,6 @@ func TestCommitTransaction(t *testing.T) {
 			t.Errorf("For case %q, endpointSets retry count == %v, but got %v", tc.desc, tc.expectRetryCount, testRetryer.RetryCount)
 		}
 
-	}
-}
-
-func TestReconcileTransactions(t *testing.T) {
-	testCases := []struct {
-		desc        string
-		endpointMap map[string]negtypes.NetworkEndpointSet
-		table       func() networkEndpointTransactionTable
-		expect      func() networkEndpointTransactionTable
-	}{
-		{
-			"empty inputs",
-			map[string]negtypes.NetworkEndpointSet{},
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-		},
-		{
-			"1 endpoint, empty transaction table",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 1, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-		},
-		{
-			"10 endpoints, empty transaction table",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			func() networkEndpointTransactionTable { return NewTransactionTable() },
-		},
-		{
-			"10 endpoints and 5 attaching transactions are expected",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints and 10 attaching transactions are expected",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints, 5 attaching transactions are expected",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints, 5 attaching and 10 detaching transactions are expected",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
-				return table
-			},
-		},
-		{
-			"endpointSets 10 endpoints, but unwanted endpoints are being attached",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints and 5 attaching transaction expected, 5 attaching transactions need reconcile",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints expected, 5 detaching transactions need reconcile",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"10 endpoints and 5 attaching transaction expected, 5 detaching transactions need reconcile",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"transaction entry has the wrong zone information",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				return table
-			},
-		},
-		{
-			"complex case 1: multiple zone and instances. No transaction",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				return table
-			},
-		},
-		{
-			"complex case 2: detaching transactions need reconciliation",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				return table
-			},
-		},
-		{
-			"complex case 2: both attaching and detaching transactions need reconciliation",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
-				return table
-			},
-			func() networkEndpointTransactionTable {
-				table := NewTransactionTable()
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: true}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone1, Operation: attachOp, NeedReconcile: false}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: false}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
-				generateTransaction(table, transactionEntry{Zone: testZone2, Operation: detachOp, NeedReconcile: true}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				return table
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		copy := copyMap(tc.endpointMap)
-		table := tc.table()
-		reconcileTransactions(tc.endpointMap, table)
-
-		// Check if endpointMap was modified
-		if !reflect.DeepEqual(copy, tc.endpointMap) {
-			t.Errorf("For test case %q, does not endpointSets endpointMap to change", tc.desc)
-		}
-		// Check if the existing entries are matching expected
-		validateTransactionTableEquality(t, tc.desc, table, tc.expect())
 	}
 }
 
@@ -659,19 +404,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: attachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: true,
-					Zone:          testZone2,
+					Operation: attachOp,
+
+					Zone: testZone2,
 				}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: true,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
@@ -689,19 +434,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: attachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: true,
-					Zone:          testZone2,
+					Operation: attachOp,
+
+					Zone: testZone2,
 				}, net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: true,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
@@ -719,19 +464,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: attachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: true,
-					Zone:          testZone2,
+					Operation: attachOp,
+
+					Zone: testZone2,
 				}, net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: true,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
@@ -749,9 +494,9 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				return table
 			},
@@ -769,14 +514,14 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: true,
-					Zone:          testZone1,
+					Operation: attachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
@@ -814,14 +559,14 @@ func TestFilterEndpointByTransaction(t *testing.T) {
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
-					Operation:     detachOp,
-					NeedReconcile: false,
-					Zone:          testZone1,
+					Operation: detachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				generateTransaction(table, transactionEntry{
-					Operation:     attachOp,
-					NeedReconcile: true,
-					Zone:          testZone1,
+					Operation: attachOp,
+
+					Zone: testZone1,
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},


### PR DESCRIPTION
This PR removes the reconciliation for transactions since it is no longer needed. 

Before, transaction syncer only triggers resync if any transaction requires reconciliation.
However, after some change, transaction syncer ALWAYS triggers resync. Hence, reconciliation handling is no longer needed. https://github.com/kubernetes/ingress-gce/blob/release-1.7/pkg/neg/syncers/transaction.go#L320

