### PR TITLE
Fix a bug in NEG controller namedport handling

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -18,7 +18,6 @@ package neg
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	istioV1alpha3 "istio.io/api/networking/v1alpha3"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
@@ -647,46 +647,26 @@ func (c *Controller) gc() {
 // gatherPortMappingUsedByIngress returns a map containing port:targetport
 // of all service ports of the service that are referenced by ingresses
 func gatherPortMappingUsedByIngress(ings []v1beta1.Ingress, svc *apiv1.Service) negtypes.SvcPortTupleSet {
-	servicePorts := sets.NewString()
 	ingressSvcPortTuples := make(negtypes.SvcPortTupleSet)
 	for _, ing := range ings {
 		if utils.IsGLBCIngress(&ing) {
 			utils.TraverseIngressBackends(&ing, func(id utils.ServicePortID) bool {
-				if id.Service.Name == svc.Name {
-					servicePorts.Insert(id.Port.String())
+				if id.Service.Name == svc.Name && id.Service.Namespace == svc.Namespace {
+					servicePort := translator.ServicePort(*svc, id.Port)
+					if servicePort == nil {
+						klog.Warningf("Port %+v in Service %q not found", id.Port, id.Service.String())
+						return false
+					}
+					ingressSvcPortTuples.Insert(negtypes.SvcPortTuple{
+						Port:       servicePort.Port,
+						Name:       servicePort.Name,
+						TargetPort: servicePort.TargetPort.String(),
+					})
 				}
 				return false
 			})
 		}
 	}
-
-	for _, svcPort := range svc.Spec.Ports {
-		found := false
-		for _, refSvcPort := range servicePorts.List() {
-			port, err := strconv.Atoi(refSvcPort)
-			if err != nil {
-				// port name matches
-				if refSvcPort == svcPort.Name {
-					found = true
-					break
-				}
-			} else {
-				// service port matches
-				if port == int(svcPort.Port) {
-					found = true
-					break
-				}
-			}
-		}
-		if found {
-			ingressSvcPortTuples.Insert(negtypes.SvcPortTuple{
-				Port:       svcPort.Port,
-				Name:       svcPort.Name,
-				TargetPort: svcPort.TargetPort.String(),
-			})
-		}
-	}
-
 	return ingressSvcPortTuples
 }
 

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -48,10 +48,10 @@ import (
 )
 
 const (
-	testServiceNamespace = "test-ns"
-	testServiceName      = "test-Name"
-	testNamedPort        = "named-Port"
-	testNamePort2        = "http"
+	testServiceNamespace    = "test-ns"
+	testServiceName         = "test-Name"
+	testNamedPort           = "named-Port"
+	testNamedPortWithNumber = "80"
 )
 
 var (
@@ -400,6 +400,35 @@ func TestGatherPortMappingUsedByIngress(t *testing.T) {
 			[]v1beta1.Ingress{*newTestIngress(testServiceName)},
 			[]int32{80, 443, 8081},
 			"one ingress with multiple different references to service",
+		},
+		{
+			[]v1beta1.Ingress{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testServiceName,
+					Namespace: testServiceNamespace,
+				},
+				Spec: v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
+						{
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
+										{
+											Path: "/path1",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: testServiceName,
+												ServicePort: intstr.FromString(testNamedPortWithNumber),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+			[]int32{8881},
+			"ingress reference service with service port name with number",
 		},
 	}
 
@@ -998,6 +1027,11 @@ var ports = []apiv1.ServicePort{
 	{
 		Port:       8888,
 		TargetPort: intstr.FromInt(8888),
+	},
+	{
+		Name:       testNamedPortWithNumber,
+		Port:       8881,
+		TargetPort: intstr.FromInt(8882),
 	},
 }
 


### PR DESCRIPTION
This bus would be triggered in the following scenario:

Service A has the following 2 ports:
Port1 has name="80" and port=9999
Port2 has name="foo" and port=80

Ingress B references Service A with port name "80". Ingress controller picks port 9999, while NEG controller pickes port 80.

This PR makes NEG controller follow the same processing util for service references.
