### PR TITLE
Fix naming scheme on creation

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -25,7 +25,6 @@ import (
 
 	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
 	"k8s.io/klog"
 
@@ -125,15 +124,12 @@ func main() {
 		klog.V(0).Infof("Cluster name: %+v", namer.UID())
 	}
 
-	var kubeSystemUID types.UID
-	if flags.F.EnableV2FrontendNamer {
-		// Get kube-system UID that will be used for v2 frontend naming scheme.
-		kubeSystemNS, err := kubeClient.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
-		if err != nil {
-			klog.Fatalf("Error getting kube-system namespace: %v", err)
-		}
-		kubeSystemUID = kubeSystemNS.GetUID()
+	// Get kube-system UID that will be used for v2 frontend naming scheme.
+	kubeSystemNS, err := kubeClient.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
+	if err != nil {
+		klog.Fatalf("Error getting kube-system namespace: %v", err)
 	}
+	kubeSystemUID := kubeSystemNS.GetUID()
 
 	cloud := app.NewGCEClient()
 	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)


### PR DESCRIPTION
This fixes the following two things

- Naming scheme on Ingress Creation
 When controller ensures a finalizer for a new ingress being created, the load-balancer pool requires ingress latest finalizer annotation for creating ingress frontend resources based on corresponding naming scheme. This fix makes sure that finalizer annotation is updated before passing the ingress for sync.
- Kube-system UID needs to populated for all cases
 Imagine a case where an ingress is created using v2 naming scheme and ingress controller is restarted with `--enable-v2-frontend-namer` disabled. We expect the ingress controller handle existing ingresses with v2 namer properly. We need kube-system uid to retrieve/delete load-balancer frontend resources in this case.

/assign @MrHohn  
