### PR TITLE
Add NEG mocks for alpha API and a new transactions test

### DIFF
--- a/pkg/composite/gen.go
+++ b/pkg/composite/gen.go
@@ -1185,6 +1185,14 @@ type HealthCheckReference struct {
 
 // HealthStatusForNetworkEndpoint is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
 type HealthStatusForNetworkEndpoint struct {
+	// Version keeps track of the intended compute version for this HealthStatusForNetworkEndpoint.
+	// Note that the compute API's do not contain this field. It is for our
+	// own bookkeeping purposes.
+	Version meta.Version `json:"-"`
+	// Scope keeps track of the intended type of the service (e.g. Global)
+	// This is also an internal field purely for bookkeeping purposes
+	Scope meta.KeyType `json:"-"`
+
 	// URL of the backend service associated with the health state of the
 	// network endpoint.
 	BackendService *BackendServiceReference `json:"backendService,omitempty"`
@@ -1702,6 +1710,14 @@ type MutualTls struct {
 
 // NetworkEndpoint is a composite type wrapping the Alpha, Beta, and GA methods for its GCE equivalent
 type NetworkEndpoint struct {
+	// Version keeps track of the intended compute version for this NetworkEndpoint.
+	// Note that the compute API's do not contain this field. It is for our
+	// own bookkeeping purposes.
+	Version meta.Version `json:"-"`
+	// Scope keeps track of the intended type of the service (e.g. Global)
+	// This is also an internal field purely for bookkeeping purposes
+	Scope meta.KeyType `json:"-"`
+
 	// Metadata defined as annotations on the network endpoint.
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// Optional fully qualified domain name of network endpoint. This can
@@ -3502,6 +3518,126 @@ func (healthCheck *HealthCheck) ToGA() (*compute.HealthCheck, error) {
 	err := copyViaJSON(ga, healthCheck)
 	if err != nil {
 		return nil, fmt.Errorf("error converting %T to compute ga type via JSON: %v", healthCheck, err)
+	}
+
+	return ga, nil
+}
+
+// ToHealthStatusForNetworkEndpointList converts a list of compute alpha, beta or GA
+// HealthStatusForNetworkEndpoint into a list of our composite type.
+func ToHealthStatusForNetworkEndpointList(objs interface{}) ([]*HealthStatusForNetworkEndpoint, error) {
+	result := []*HealthStatusForNetworkEndpoint{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to %T via JSON: %v", objs, result, err)
+	}
+	return result, nil
+}
+
+// ToHealthStatusForNetworkEndpoint converts a compute alpha, beta or GA
+// HealthStatusForNetworkEndpoint into our composite type.
+func ToHealthStatusForNetworkEndpoint(obj interface{}) (*HealthStatusForNetworkEndpoint, error) {
+	healthStatusForNetworkEndpoint := &HealthStatusForNetworkEndpoint{}
+	err := copyViaJSON(healthStatusForNetworkEndpoint, obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %+v to %T via JSON: %v", obj, healthStatusForNetworkEndpoint, err)
+	}
+
+	return healthStatusForNetworkEndpoint, nil
+}
+
+// ToAlpha converts our composite type into an alpha type.
+// This alpha type can be used in GCE API calls.
+func (healthStatusForNetworkEndpoint *HealthStatusForNetworkEndpoint) ToAlpha() (*computealpha.HealthStatusForNetworkEndpoint, error) {
+	alpha := &computealpha.HealthStatusForNetworkEndpoint{}
+	err := copyViaJSON(alpha, healthStatusForNetworkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute alpha type via JSON: %v", healthStatusForNetworkEndpoint, err)
+	}
+
+	return alpha, nil
+}
+
+// ToBeta converts our composite type into an beta type.
+// This beta type can be used in GCE API calls.
+func (healthStatusForNetworkEndpoint *HealthStatusForNetworkEndpoint) ToBeta() (*computebeta.HealthStatusForNetworkEndpoint, error) {
+	beta := &computebeta.HealthStatusForNetworkEndpoint{}
+	err := copyViaJSON(beta, healthStatusForNetworkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute beta type via JSON: %v", healthStatusForNetworkEndpoint, err)
+	}
+
+	return beta, nil
+}
+
+// ToGA converts our composite type into an ga type.
+// This ga type can be used in GCE API calls.
+func (healthStatusForNetworkEndpoint *HealthStatusForNetworkEndpoint) ToGA() (*compute.HealthStatusForNetworkEndpoint, error) {
+	ga := &compute.HealthStatusForNetworkEndpoint{}
+	err := copyViaJSON(ga, healthStatusForNetworkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute ga type via JSON: %v", healthStatusForNetworkEndpoint, err)
+	}
+
+	return ga, nil
+}
+
+// ToNetworkEndpointList converts a list of compute alpha, beta or GA
+// NetworkEndpoint into a list of our composite type.
+func ToNetworkEndpointList(objs interface{}) ([]*NetworkEndpoint, error) {
+	result := []*NetworkEndpoint{}
+
+	err := copyViaJSON(&result, objs)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %v to %T via JSON: %v", objs, result, err)
+	}
+	return result, nil
+}
+
+// ToNetworkEndpoint converts a compute alpha, beta or GA
+// NetworkEndpoint into our composite type.
+func ToNetworkEndpoint(obj interface{}) (*NetworkEndpoint, error) {
+	networkEndpoint := &NetworkEndpoint{}
+	err := copyViaJSON(networkEndpoint, obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not copy object %+v to %T via JSON: %v", obj, networkEndpoint, err)
+	}
+
+	return networkEndpoint, nil
+}
+
+// ToAlpha converts our composite type into an alpha type.
+// This alpha type can be used in GCE API calls.
+func (networkEndpoint *NetworkEndpoint) ToAlpha() (*computealpha.NetworkEndpoint, error) {
+	alpha := &computealpha.NetworkEndpoint{}
+	err := copyViaJSON(alpha, networkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute alpha type via JSON: %v", networkEndpoint, err)
+	}
+
+	return alpha, nil
+}
+
+// ToBeta converts our composite type into an beta type.
+// This beta type can be used in GCE API calls.
+func (networkEndpoint *NetworkEndpoint) ToBeta() (*computebeta.NetworkEndpoint, error) {
+	beta := &computebeta.NetworkEndpoint{}
+	err := copyViaJSON(beta, networkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute beta type via JSON: %v", networkEndpoint, err)
+	}
+
+	return beta, nil
+}
+
+// ToGA converts our composite type into an ga type.
+// This ga type can be used in GCE API calls.
+func (networkEndpoint *NetworkEndpoint) ToGA() (*compute.NetworkEndpoint, error) {
+	ga := &compute.NetworkEndpoint{}
+	err := copyViaJSON(ga, networkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %T to compute ga type via JSON: %v", networkEndpoint, err)
 	}
 
 	return ga, nil

--- a/pkg/composite/gen_test.go
+++ b/pkg/composite/gen_test.go
@@ -541,12 +541,103 @@ func TestHealthCheckReference(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
 func TestHealthStatusForNetworkEndpoint(t *testing.T) {
+	// Use reflection to verify that our composite type contains all the
+	// same fields as the alpha type.
 	compositeType := reflect.TypeOf(HealthStatusForNetworkEndpoint{})
 	alphaType := reflect.TypeOf(computealpha.HealthStatusForNetworkEndpoint{})
-	if err := typeEquality(compositeType, alphaType, true); err != nil {
+	betaType := reflect.TypeOf(computebeta.HealthStatusForNetworkEndpoint{})
+	gaType := reflect.TypeOf(compute.HealthStatusForNetworkEndpoint{})
+
+	// For the composite type, remove the Version field from consideration
+	compositeTypeNumFields := compositeType.NumField() - 2
+	if compositeTypeNumFields != alphaType.NumField() {
+		t.Fatalf("%v should contain %v fields. Got %v", alphaType.Name(), alphaType.NumField(), compositeTypeNumFields)
+	}
+
+	// Compare all the fields by doing a lookup since we can't guarantee that they'll be in the same order
+	// Make sure that composite type is strictly alpha fields + internal bookkeeping
+	for i := 2; i < compositeType.NumField(); i++ {
+		lookupField, found := alphaType.FieldByName(compositeType.Field(i).Name)
+		if !found {
+			t.Fatal(fmt.Errorf("Field %v not present in alpha type %v", compositeType.Field(i), alphaType))
+		}
+		if err := compareFields(compositeType.Field(i), lookupField); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify that all beta fields are in composite type
+	if err := typeEquality(betaType, compositeType, false); err != nil {
 		t.Fatal(err)
+	}
+
+	// Verify that all GA fields are in composite type
+	if err := typeEquality(gaType, compositeType, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToHealthStatusForNetworkEndpoint(t *testing.T) {
+	testCases := []struct {
+		input    interface{}
+		expected *HealthStatusForNetworkEndpoint
+	}{
+		{
+			computealpha.HealthStatusForNetworkEndpoint{},
+			&HealthStatusForNetworkEndpoint{},
+		},
+		{
+			computebeta.HealthStatusForNetworkEndpoint{},
+			&HealthStatusForNetworkEndpoint{},
+		},
+		{
+			compute.HealthStatusForNetworkEndpoint{},
+			&HealthStatusForNetworkEndpoint{},
+		},
+	}
+	for _, testCase := range testCases {
+		result, _ := ToHealthStatusForNetworkEndpoint(testCase.input)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Fatalf("ToHealthStatusForNetworkEndpoint(input) = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(testCase.input), pretty.Sprint(result), pretty.Sprint(testCase.expected))
+		}
+	}
+}
+
+func TestHealthStatusForNetworkEndpointToAlpha(t *testing.T) {
+	composite := HealthStatusForNetworkEndpoint{}
+	expected := &computealpha.HealthStatusForNetworkEndpoint{}
+	result, err := composite.ToAlpha()
+	if err != nil {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToAlpha() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToAlpha() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestHealthStatusForNetworkEndpointToBeta(t *testing.T) {
+	composite := HealthStatusForNetworkEndpoint{}
+	expected := &computebeta.HealthStatusForNetworkEndpoint{}
+	result, err := composite.ToBeta()
+	if err != nil {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToBeta() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToBeta() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestHealthStatusForNetworkEndpointToGA(t *testing.T) {
+	composite := HealthStatusForNetworkEndpoint{}
+	expected := &compute.HealthStatusForNetworkEndpoint{}
+	result, err := composite.ToGA()
+	if err != nil {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToGA() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("HealthStatusForNetworkEndpoint.ToGA() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
 	}
 }
 
@@ -709,12 +800,103 @@ func TestMutualTls(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
 func TestNetworkEndpoint(t *testing.T) {
+	// Use reflection to verify that our composite type contains all the
+	// same fields as the alpha type.
 	compositeType := reflect.TypeOf(NetworkEndpoint{})
 	alphaType := reflect.TypeOf(computealpha.NetworkEndpoint{})
-	if err := typeEquality(compositeType, alphaType, true); err != nil {
+	betaType := reflect.TypeOf(computebeta.NetworkEndpoint{})
+	gaType := reflect.TypeOf(compute.NetworkEndpoint{})
+
+	// For the composite type, remove the Version field from consideration
+	compositeTypeNumFields := compositeType.NumField() - 2
+	if compositeTypeNumFields != alphaType.NumField() {
+		t.Fatalf("%v should contain %v fields. Got %v", alphaType.Name(), alphaType.NumField(), compositeTypeNumFields)
+	}
+
+	// Compare all the fields by doing a lookup since we can't guarantee that they'll be in the same order
+	// Make sure that composite type is strictly alpha fields + internal bookkeeping
+	for i := 2; i < compositeType.NumField(); i++ {
+		lookupField, found := alphaType.FieldByName(compositeType.Field(i).Name)
+		if !found {
+			t.Fatal(fmt.Errorf("Field %v not present in alpha type %v", compositeType.Field(i), alphaType))
+		}
+		if err := compareFields(compositeType.Field(i), lookupField); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify that all beta fields are in composite type
+	if err := typeEquality(betaType, compositeType, false); err != nil {
 		t.Fatal(err)
+	}
+
+	// Verify that all GA fields are in composite type
+	if err := typeEquality(gaType, compositeType, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToNetworkEndpoint(t *testing.T) {
+	testCases := []struct {
+		input    interface{}
+		expected *NetworkEndpoint
+	}{
+		{
+			computealpha.NetworkEndpoint{},
+			&NetworkEndpoint{},
+		},
+		{
+			computebeta.NetworkEndpoint{},
+			&NetworkEndpoint{},
+		},
+		{
+			compute.NetworkEndpoint{},
+			&NetworkEndpoint{},
+		},
+	}
+	for _, testCase := range testCases {
+		result, _ := ToNetworkEndpoint(testCase.input)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Fatalf("ToNetworkEndpoint(input) = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(testCase.input), pretty.Sprint(result), pretty.Sprint(testCase.expected))
+		}
+	}
+}
+
+func TestNetworkEndpointToAlpha(t *testing.T) {
+	composite := NetworkEndpoint{}
+	expected := &computealpha.NetworkEndpoint{}
+	result, err := composite.ToAlpha()
+	if err != nil {
+		t.Fatalf("NetworkEndpoint.ToAlpha() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("NetworkEndpoint.ToAlpha() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestNetworkEndpointToBeta(t *testing.T) {
+	composite := NetworkEndpoint{}
+	expected := &computebeta.NetworkEndpoint{}
+	result, err := composite.ToBeta()
+	if err != nil {
+		t.Fatalf("NetworkEndpoint.ToBeta() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("NetworkEndpoint.ToBeta() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
+	}
+}
+func TestNetworkEndpointToGA(t *testing.T) {
+	composite := NetworkEndpoint{}
+	expected := &compute.NetworkEndpoint{}
+	result, err := composite.ToGA()
+	if err != nil {
+		t.Fatalf("NetworkEndpoint.ToGA() error: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("NetworkEndpoint.ToGA() = \ninput = %s\n%s\nwant = \n%s", pretty.Sprint(composite), pretty.Sprint(result), pretty.Sprint(expected))
 	}
 }
 func TestNetworkEndpointGroup(t *testing.T) {

--- a/pkg/composite/meta/meta.go
+++ b/pkg/composite/meta/meta.go
@@ -39,11 +39,13 @@ var MainServices = map[string]string{
 	"BackendService":                  "BackendServices",
 	"ForwardingRule":                  "ForwardingRules",
 	"HealthCheck":                     "HealthChecks",
+	"HealthStatusForNetworkEndpoint":  "HealthStatusForNetworkEndpoints",
 	"UrlMap":                          "UrlMaps",
 	"TargetHttpProxy":                 "TargetHttpProxies",
 	"TargetHttpsProxy":                "TargetHttpsProxies",
 	"SslCertificate":                  "SslCertificates",
 	"NetworkEndpointGroup":            "NetworkEndpointGroups",
+	"NetworkEndpoint":                 "NetworkEndpoints",
 	"NetworkEndpointWithHealthStatus": "NetworkEndpointsWithHealthStatus",
 	"NetworkEndpointGroupsAttachEndpointsRequest": "NetworkEndpointGroupsAttachEndpointsRequests",
 	"NetworkEndpointGroupsDetachEndpointsRequest": "NetworkEndpointGroupsDetachEndpointsRequests",
@@ -54,18 +56,22 @@ var MainServices = map[string]string{
 // Services in NoUpdate will not have an Update() method generated for them
 var NoUpdate = sets.NewString(
 	"ForwardingRule",
+	"HealthStatusForNetworkEndpoint",
 	"TargetHttpProxy",
 	"TargetHttpsProxy",
 	"SslCertificate",
 	"NetworkEndpointGroup",
+	"NetworkEndpoint",
 	"NetworkEndpointWithHealthStatus",
 )
 
 // Services in NoCRUD will not have Create, Get, Delete, Update, methods generated for them
 var NoCRUD = sets.NewString(
+	"HealthStatusForNetworkEndpoint",
 	"NetworkEndpointGroupsAttachEndpointsRequest",
 	"NetworkEndpointGroupsDetachEndpointsRequest",
 	"NetworkEndpointGroupsListEndpointsRequest",
+	"NetworkEndpoint",
 	"NetworkEndpointWithHealthStatus",
 )
 var Versions = map[string]string{

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -17,17 +17,15 @@ limitations under the License.
 package readiness
 
 import (
+	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"testing"
 
-	"k8s.io/ingress-gce/pkg/composite"
-
-	"fmt"
-	"reflect"
-
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/ingress-gce/pkg/composite"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
 )

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -17,18 +17,19 @@ limitations under the License.
 package readiness
 
 import (
-	"k8s.io/ingress-gce/pkg/composite"
 	"net"
 	"strconv"
 	"testing"
 
+	"k8s.io/ingress-gce/pkg/composite"
+
 	"fmt"
+	"reflect"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/types"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
-	"reflect"
 )
 
 type testPatcher struct {
@@ -364,14 +365,14 @@ func TestPoll(t *testing.T) {
 	port := int64(80)
 	instance := "k8s-node-xxxxxx"
 	irrelevantEntry := negtypes.NetworkEndpointEntry{
-		NetworkEndpoint: &compute.NetworkEndpoint{
+		NetworkEndpoint: &composite.NetworkEndpoint{
 			IpAddress: ip,
 			Port:      port,
 			Instance:  "foo-instance",
 		},
-		Healths: []*compute.HealthStatusForNetworkEndpoint{
+		Healths: []*composite.HealthStatusForNetworkEndpoint{
 			{
-				BackendService: &compute.BackendServiceReference{
+				BackendService: &composite.BackendServiceReference{
 					BackendService: negName,
 				},
 				HealthState: "HEALTHY",
@@ -417,22 +418,18 @@ func TestPoll(t *testing.T) {
 	pollAndValidate(step, false, true, 0)
 
 	step = "NE added to the NEG, but NE health status is empty"
-	ne := &compute.NetworkEndpoint{
+	ne := &composite.NetworkEndpoint{
 		IpAddress: ip,
 		Port:      port,
 		Instance:  instance,
 	}
 
-	negCloud.AttachNetworkEndpoints(negName, zone, []*composite.NetworkEndpoint{{
-		IpAddress: ip,
-		Port:      port,
-		Instance:  instance,
-	}}, meta.VersionGA)
+	negCloud.AttachNetworkEndpoints(negName, zone, []*composite.NetworkEndpoint{ne}, meta.VersionGA)
 	// add NE with empty healthy status
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
 		{
 			NetworkEndpoint: ne,
-			Healths:         []*compute.HealthStatusForNetworkEndpoint{},
+			Healths:         []*composite.HealthStatusForNetworkEndpoint{},
 		},
 	})
 
@@ -445,7 +442,7 @@ func TestPoll(t *testing.T) {
 		irrelevantEntry,
 		{
 			NetworkEndpoint: ne,
-			Healths:         []*compute.HealthStatusForNetworkEndpoint{},
+			Healths:         []*composite.HealthStatusForNetworkEndpoint{},
 		},
 	})
 	pollAndValidate(step, false, true, 2)
@@ -455,9 +452,9 @@ func TestPoll(t *testing.T) {
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
 		{
 			NetworkEndpoint: ne,
-			Healths: []*compute.HealthStatusForNetworkEndpoint{
+			Healths: []*composite.HealthStatusForNetworkEndpoint{
 				{
-					BackendService: &compute.BackendServiceReference{
+					BackendService: &composite.BackendServiceReference{
 						BackendService: negName,
 					},
 					HealthState: "UNKNOWN",
@@ -473,9 +470,9 @@ func TestPoll(t *testing.T) {
 		irrelevantEntry,
 		{
 			NetworkEndpoint: ne,
-			Healths: []*compute.HealthStatusForNetworkEndpoint{
+			Healths: []*composite.HealthStatusForNetworkEndpoint{
 				{
-					BackendService: &compute.BackendServiceReference{
+					BackendService: &composite.BackendServiceReference{
 						BackendService: negName,
 					},
 					HealthState: "UNKNOWN",
@@ -492,9 +489,9 @@ func TestPoll(t *testing.T) {
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
 		{
 			NetworkEndpoint: ne,
-			Healths: []*compute.HealthStatusForNetworkEndpoint{
+			Healths: []*composite.HealthStatusForNetworkEndpoint{
 				{
-					BackendService: &compute.BackendServiceReference{
+					BackendService: &composite.BackendServiceReference{
 						BackendService: backendServiceUrl,
 					},
 					HealthState: healthyState,

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -178,17 +178,17 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 		for _, tc := range testCases {
 			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints)
 			if err != nil {
-				t.Errorf("For case %q, endpointSets error == nil, but got %v", tc.desc, err)
+				t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
 
 			if err := waitForTransactions(transactionSyncer); err != nil {
-				t.Errorf("For case %q, endpointSets error == nil, but got %v", tc.desc, err)
+				t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 			}
 
 			for zone, endpoints := range tc.expectEndpoints {
 				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.negName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion())
 				if err != nil {
-					t.Errorf("For case %q,, endpointSets error == nil, but got %v", tc.desc, err)
+					t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 				}
 
 				endpointSet := negtypes.NewNetworkEndpointSet()

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -387,7 +387,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())))
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
 	podLister := transactionSyncer.podLister
 
 	// add all pods in default endpoint into podLister
@@ -744,7 +744,7 @@ func TestMakeEndpointBatch(t *testing.T) {
 func TestShouldPodBeInNeg(t *testing.T) {
 	t.Parallel()
 
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())))
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
 
 	podLister := transactionSyncer.podLister
 

--- a/pkg/neg/types/mock.go
+++ b/pkg/neg/types/mock.go
@@ -134,14 +134,18 @@ func MockAttachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 	newList := m.X.(NetworkEndpointStore)[*key]
 	for _, newEp := range obj.NetworkEndpoints {
 		found := false
+		newComposite, err := composite.ToNetworkEndpoint(newEp)
+		if err != nil {
+			return err
+		}
 		for _, oldEp := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, toComposite(newEp)) {
+			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, newComposite) {
 				found = true
 				break
 			}
 		}
 		if !found {
-			newList = append(newList, generateNetworkEndpointEntry(toComposite(newEp)))
+			newList = append(newList, generateNetworkEndpointEntry(newComposite))
 		}
 	}
 	m.X.(NetworkEndpointStore)[*key] = newList
@@ -166,8 +170,12 @@ func MockDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 
 	for _, left := range obj.NetworkEndpoints {
 		found := false
+		leftComposite, err := composite.ToNetworkEndpoint(left)
+		if err != nil {
+			return err
+		}
 		for _, right := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(toComposite(left), right.NetworkEndpoint) {
+			if isNetworkEndpointsEqual(leftComposite, right.NetworkEndpoint) {
 				found = true
 				break
 			}
@@ -185,7 +193,11 @@ func MockDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 	for _, ep := range m.X.(NetworkEndpointStore)[*key] {
 		found := false
 		for _, del := range obj.NetworkEndpoints {
-			if isNetworkEndpointsEqual(ep.NetworkEndpoint, toComposite(del)) {
+			delComposite, err := composite.ToNetworkEndpoint(del)
+			if err != nil {
+				return err
+			}
+			if isNetworkEndpointsEqual(ep.NetworkEndpoint, delComposite) {
 				found = true
 				break
 			}
@@ -266,14 +278,18 @@ func MockAlphaAttachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj
 	newList := m.X.(NetworkEndpointStore)[*key]
 	for _, newEp := range obj.NetworkEndpoints {
 		found := false
+		newComposite, err := composite.ToNetworkEndpoint(newEp)
+		if err != nil {
+			return err
+		}
 		for _, oldEp := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, toComposite(newEp)) {
+			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, newComposite) {
 				found = true
 				break
 			}
 		}
 		if !found {
-			newList = append(newList, generateNetworkEndpointEntry(toComposite(newEp)))
+			newList = append(newList, generateNetworkEndpointEntry(newComposite))
 		}
 	}
 	m.X.(NetworkEndpointStore)[*key] = newList
@@ -298,8 +314,12 @@ func MockAlphaDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj
 
 	for _, left := range obj.NetworkEndpoints {
 		found := false
+		leftComposite, err := composite.ToNetworkEndpoint(left)
+		if err != nil {
+			return err
+		}
 		for _, right := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(toComposite(left), right.NetworkEndpoint) {
+			if isNetworkEndpointsEqual(leftComposite, right.NetworkEndpoint) {
 				found = true
 				break
 			}
@@ -317,7 +337,11 @@ func MockAlphaDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj
 	for _, ep := range m.X.(NetworkEndpointStore)[*key] {
 		found := false
 		for _, del := range obj.NetworkEndpoints {
-			if isNetworkEndpointsEqual(ep.NetworkEndpoint, toComposite(del)) {
+			delComposite, err := composite.ToNetworkEndpoint(del)
+			if err != nil {
+				return err
+			}
+			if isNetworkEndpointsEqual(ep.NetworkEndpoint, delComposite) {
 				found = true
 				break
 			}
@@ -330,11 +354,6 @@ func MockAlphaDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj
 
 	m.X.(NetworkEndpointStore)[*key] = generateNetworkEndpointEntryList(newList)
 	return nil
-}
-
-func toComposite(input interface{}) *composite.NetworkEndpoint {
-	out, _ := composite.ToNetworkEndpoint(input)
-	return out
 }
 
 func isNetworkEndpointsEqual(left, right *composite.NetworkEndpoint) bool {

--- a/pkg/neg/types/mock.go
+++ b/pkg/neg/types/mock.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"context"
+	"k8s.io/ingress-gce/pkg/composite"
 
 	"fmt"
 	"net/http"
@@ -25,14 +26,15 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
 type NetworkEndpointEntry struct {
-	NetworkEndpoint *compute.NetworkEndpoint
-	Healths         []*compute.HealthStatusForNetworkEndpoint
+	NetworkEndpoint *composite.NetworkEndpoint
+	Healths         []*composite.HealthStatusForNetworkEndpoint
 }
 
 type NetworkEndpointStore map[meta.Key][]NetworkEndpointEntry
@@ -56,6 +58,12 @@ func MockNetworkEndpointAPIs(fakeGCE *gce.Cloud) {
 	m.MockNetworkEndpointGroups.DetachNetworkEndpointsHook = MockDetachNetworkEndpointsHook
 	m.MockNetworkEndpointGroups.ListNetworkEndpointsHook = MockListNetworkEndpointsHook
 	m.MockNetworkEndpointGroups.AggregatedListHook = MockAggregatedListNetworkEndpointGroupHook
+
+	m.MockAlphaNetworkEndpointGroups.X = NetworkEndpointStore{}
+	m.MockAlphaNetworkEndpointGroups.AttachNetworkEndpointsHook = MockAlphaAttachNetworkEndpointsHook
+	m.MockAlphaNetworkEndpointGroups.DetachNetworkEndpointsHook = MockAlphaDetachNetworkEndpointsHook
+	m.MockAlphaNetworkEndpointGroups.ListNetworkEndpointsHook = MockAlphaListNetworkEndpointsHook
+	m.MockAlphaNetworkEndpointGroups.AggregatedListHook = MockAlphaAggregatedListNetworkEndpointGroupHook
 }
 
 // TODO: move this logic into code gen
@@ -127,13 +135,13 @@ func MockAttachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 	for _, newEp := range obj.NetworkEndpoints {
 		found := false
 		for _, oldEp := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, newEp) {
+			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, toComposite(newEp)) {
 				found = true
 				break
 			}
 		}
 		if !found {
-			newList = append(newList, generateNetworkEndpointEntry(newEp))
+			newList = append(newList, generateNetworkEndpointEntry(toComposite(newEp)))
 		}
 	}
 	m.X.(NetworkEndpointStore)[*key] = newList
@@ -159,7 +167,7 @@ func MockDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 	for _, left := range obj.NetworkEndpoints {
 		found := false
 		for _, right := range m.X.(NetworkEndpointStore)[*key] {
-			if isNetworkEndpointsEqual(left, right.NetworkEndpoint) {
+			if isNetworkEndpointsEqual(toComposite(left), right.NetworkEndpoint) {
 				found = true
 				break
 			}
@@ -173,11 +181,11 @@ func MockDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 		}
 	}
 
-	newList := []*compute.NetworkEndpoint{}
+	newList := []*composite.NetworkEndpoint{}
 	for _, ep := range m.X.(NetworkEndpointStore)[*key] {
 		found := false
 		for _, del := range obj.NetworkEndpoints {
-			if isNetworkEndpointsEqual(ep.NetworkEndpoint, del) {
+			if isNetworkEndpointsEqual(ep.NetworkEndpoint, toComposite(del)) {
 				found = true
 				break
 			}
@@ -192,21 +200,158 @@ func MockDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *com
 	return nil
 }
 
-func isNetworkEndpointsEqual(left, right *compute.NetworkEndpoint) bool {
+func MockAlphaAggregatedListNetworkEndpointGroupHook(ctx context.Context, fl *filter.F, m *cloud.MockAlphaNetworkEndpointGroups) (bool, map[string][]*computealpha.NetworkEndpointGroup, error) {
+	objs := map[string][]*computealpha.NetworkEndpointGroup{}
+	for _, obj := range m.Objects {
+		res, err := cloud.ParseResourceURL(obj.ToAlpha().SelfLink)
+		if err != nil {
+			return false, nil, err
+		}
+		if !fl.Match(obj.ToAlpha()) {
+			continue
+		}
+		var location string
+		switch res.Key.Type() {
+		case meta.Regional:
+			location = fmt.Sprintf("regions/%s", res.Key.Region)
+			break
+		case meta.Zonal:
+			location = fmt.Sprintf("zones/%s", res.Key.Zone)
+			break
+		case meta.Global:
+			location = string(meta.Global)
+		}
+		objs[location] = append(objs[location], obj.ToAlpha())
+	}
+	// Always return global
+	if _, ok := objs[meta.Global]; !ok {
+		objs[meta.Global] = []*computealpha.NetworkEndpointGroup{}
+	}
+	return true, objs, nil
+}
+
+func MockAlphaListNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *computealpha.NetworkEndpointGroupsListEndpointsRequest, filter *filter.F, m *cloud.MockAlphaNetworkEndpointGroups) ([]*computealpha.NetworkEndpointWithHealthStatus, error) {
+	_, err := m.Get(ctx, key)
+	if err != nil {
+		return nil, &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in NetworkEndpointGroup", key.String()),
+		}
+	}
+
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+	if _, ok := m.X.(NetworkEndpointStore)[*key]; !ok {
+		m.X.(NetworkEndpointStore)[*key] = []NetworkEndpointEntry{}
+	}
+	return generateAlphaNetworkEndpointWithHealthStatusList(m.X.(NetworkEndpointStore)[*key]), nil
+}
+
+func MockAlphaAttachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *computealpha.NetworkEndpointGroupsAttachEndpointsRequest, m *cloud.MockAlphaNetworkEndpointGroups) error {
+	_, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in NetworkEndpointGroup", key.String()),
+		}
+	}
+
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
+	if _, ok := m.X.(NetworkEndpointStore)[*key]; !ok {
+		m.X.(NetworkEndpointStore)[*key] = []NetworkEndpointEntry{}
+	}
+
+	newList := m.X.(NetworkEndpointStore)[*key]
+	for _, newEp := range obj.NetworkEndpoints {
+		found := false
+		for _, oldEp := range m.X.(NetworkEndpointStore)[*key] {
+			if isNetworkEndpointsEqual(oldEp.NetworkEndpoint, toComposite(newEp)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newList = append(newList, generateNetworkEndpointEntry(toComposite(newEp)))
+		}
+	}
+	m.X.(NetworkEndpointStore)[*key] = newList
+	return nil
+}
+
+func MockAlphaDetachNetworkEndpointsHook(ctx context.Context, key *meta.Key, obj *computealpha.NetworkEndpointGroupsDetachEndpointsRequest, m *cloud.MockAlphaNetworkEndpointGroups) error {
+	_, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in NetworkEndpointGroup", key.String()),
+		}
+	}
+
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
+	if _, ok := m.X.(NetworkEndpointStore)[*key]; !ok {
+		m.X.(NetworkEndpointStore)[*key] = []NetworkEndpointEntry{}
+	}
+
+	for _, left := range obj.NetworkEndpoints {
+		found := false
+		for _, right := range m.X.(NetworkEndpointStore)[*key] {
+			if isNetworkEndpointsEqual(toComposite(left), right.NetworkEndpoint) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return &googleapi.Error{
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("Endpoint %v was not found in NetworkEndpointGroup %q", left, key.String()),
+			}
+		}
+	}
+
+	newList := []*composite.NetworkEndpoint{}
+	for _, ep := range m.X.(NetworkEndpointStore)[*key] {
+		found := false
+		for _, del := range obj.NetworkEndpoints {
+			if isNetworkEndpointsEqual(ep.NetworkEndpoint, toComposite(del)) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			newList = append(newList, ep.NetworkEndpoint)
+		}
+	}
+
+	m.X.(NetworkEndpointStore)[*key] = generateNetworkEndpointEntryList(newList)
+	return nil
+}
+
+func toComposite(input interface{}) *composite.NetworkEndpoint {
+	out, _ := composite.ToNetworkEndpoint(input)
+	return out
+}
+
+func isNetworkEndpointsEqual(left, right *composite.NetworkEndpoint) bool {
 	if left.IpAddress == right.IpAddress && left.Port == right.Port && left.Instance == right.Instance {
 		return true
 	}
 	return false
 }
 
-func generateNetworkEndpointEntry(networkEndpoint *compute.NetworkEndpoint) NetworkEndpointEntry {
+func generateNetworkEndpointEntry(networkEndpoint *composite.NetworkEndpoint) NetworkEndpointEntry {
 	return NetworkEndpointEntry{
 		NetworkEndpoint: networkEndpoint,
-		Healths:         []*compute.HealthStatusForNetworkEndpoint{},
+		Healths:         []*composite.HealthStatusForNetworkEndpoint{},
 	}
 }
 
-func generateNetworkEndpointEntryList(networkEndpoints []*compute.NetworkEndpoint) []NetworkEndpointEntry {
+func generateNetworkEndpointEntryList(networkEndpoints []*composite.NetworkEndpoint) []NetworkEndpointEntry {
 	ret := []NetworkEndpointEntry{}
 	for _, ne := range networkEndpoints {
 		ret = append(ret, generateNetworkEndpointEntry(ne))
@@ -215,16 +360,39 @@ func generateNetworkEndpointEntryList(networkEndpoints []*compute.NetworkEndpoin
 }
 
 func generateNetworkEndpointWithHealthStatus(networkEndpointEntry NetworkEndpointEntry) *compute.NetworkEndpointWithHealthStatus {
-	return &compute.NetworkEndpointWithHealthStatus{
-		NetworkEndpoint: networkEndpointEntry.NetworkEndpoint,
-		Healths:         networkEndpointEntry.Healths,
+	ret := &compute.NetworkEndpointWithHealthStatus{}
+	ret.NetworkEndpoint, _ = networkEndpointEntry.NetworkEndpoint.ToGA()
+
+	for _, health := range networkEndpointEntry.Healths {
+		h, _ := health.ToGA()
+		ret.Healths = append(ret.Healths, h)
 	}
+	return ret
+}
+
+func generateAlphaNetworkEndpointWithHealthStatus(networkEndpointEntry NetworkEndpointEntry) *computealpha.NetworkEndpointWithHealthStatus {
+	ret := &computealpha.NetworkEndpointWithHealthStatus{}
+	ret.NetworkEndpoint, _ = networkEndpointEntry.NetworkEndpoint.ToAlpha()
+
+	for _, health := range networkEndpointEntry.Healths {
+		h, _ := health.ToAlpha()
+		ret.Healths = append(ret.Healths, h)
+	}
+	return ret
 }
 
 func generateNetworkEndpointWithHealthStatusList(networkEndpointEntryList []NetworkEndpointEntry) []*compute.NetworkEndpointWithHealthStatus {
 	ret := []*compute.NetworkEndpointWithHealthStatus{}
 	for _, ne := range networkEndpointEntryList {
 		ret = append(ret, generateNetworkEndpointWithHealthStatus(ne))
+	}
+	return ret
+}
+
+func generateAlphaNetworkEndpointWithHealthStatusList(networkEndpointEntryList []NetworkEndpointEntry) []*computealpha.NetworkEndpointWithHealthStatus {
+	ret := []*computealpha.NetworkEndpointWithHealthStatus{}
+	for _, ne := range networkEndpointEntryList {
+		ret = append(ret, generateAlphaNetworkEndpointWithHealthStatus(ne))
 	}
 	return ret
 }


### PR DESCRIPTION
This enables creation of NEGs in unit tests using Alpha or GA api. The transactions test has been modified to create both VM_IP_PORT as well as PRIMARY_VM_IP negs.