### PR TITLE
Update finalizer tests to validate against an ingress finalizer

### DIFF
--- a/cmd/e2e-test/finalizer_test.go
+++ b/cmd/e2e-test/finalizer_test.go
@@ -58,9 +58,8 @@ func TestFinalizer(t *testing.T) {
 			t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
 		}
 
-		ingFinalizers := ing.GetFinalizers()
-		if len(ingFinalizers) != 1 || ingFinalizers[0] != common.FinalizerKey {
-			t.Fatalf("GetFinalizers() = %+v, want [%q]", ingFinalizers, common.FinalizerKey)
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
 		}
 
 		// Perform whitebox testing.
@@ -109,9 +108,8 @@ func TestFinalizerIngressClassChange(t *testing.T) {
 			t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
 		}
 
-		ingFinalizers := ing.GetFinalizers()
-		if len(ingFinalizers) != 1 || ingFinalizers[0] != common.FinalizerKey {
-			t.Fatalf("GetFinalizers() = %+v, want [%q]", ingFinalizers, common.FinalizerKey)
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
 		}
 
 		// Perform whitebox testing.
@@ -184,13 +182,11 @@ func TestFinalizerIngressesWithSharedResources(t *testing.T) {
 			t.Fatalf("error waiting for Ingress %s to stabilize: %v", otherIngKey, err)
 		}
 
-		ingFinalizers := ing.GetFinalizers()
-		if len(ingFinalizers) != 1 || ingFinalizers[0] != common.FinalizerKey {
-			t.Fatalf("GetFinalizers() = %+v, want [%q]", ingFinalizers, common.FinalizerKey)
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
 		}
-		otherIngFinalizers := otherIng.GetFinalizers()
-		if len(otherIngFinalizers) != 1 || otherIngFinalizers[0] != common.FinalizerKey {
-			t.Fatalf("GetFinalizers() = %+v, want [%q]", otherIngFinalizers, common.FinalizerKey)
+		if err := e2e.CheckForAnyFinalizer(otherIng); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", otherIngKey, err)
 		}
 
 		// Perform whitebox testing.

--- a/cmd/e2e-test/upgrade/finalizer.go
+++ b/cmd/e2e-test/upgrade/finalizer.go
@@ -103,10 +103,14 @@ func (fr *Finalizer) PostUpgrade() error {
 	// Ingress status is updated to unstable, which would be set back to stable
 	// after WaitForFinalizer below finishes successfully.
 	fr.s.PutStatus(e2e.Unstable)
-	// Wait for finalizer to be added and verify that correct finalizer is added to the ingress after the upgrade.
+	// Wait for an ingress finalizer to be added on the ingress after the upgrade.
 	ing, err := e2e.WaitForFinalizer(fr.s, fr.ing)
 	if err != nil {
 		fr.t.Fatalf("e2e.WaitForFinalizer(_, %q) = _, %v, want nil", ingKey, err)
+	}
+	// Assert that v1 finalizer is added.
+	if err := e2e.CheckV1Finalizer(ing); err != nil {
+		fr.t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
 	}
 	gclb, err := e2e.WhiteboxTest(ing, fr.s, fr.framework.Cloud, "")
 	if err != nil {


### PR DESCRIPTION
After adding new finalizer (V2 Finalizer), update finalizer upgrade tests to validate against either of v1 or v2 finalizers.