### PR TITLE
Support creation of GCE_VM_PRIMARY_IP NEGs for L4 ILB Services.

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -219,7 +219,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 	fwc := firewalls.NewFirewallController(ctx, flags.F.NodePortRanges.Values())
 
 	// TODO: Refactor NEG to use cloud mocks so ctx.Cloud can be referenced within NewController.
-	negController := neg.NewController(negtypes.NewAdapter(ctx.Cloud), ctx, lbc.Translator, ctx.ClusterNamer, flags.F.ResyncPeriod, flags.F.NegGCPeriod, flags.F.EnableReadinessReflector)
+	negController := neg.NewController(negtypes.NewAdapter(ctx.Cloud), ctx, lbc.Translator, ctx.ClusterNamer, flags.F.ResyncPeriod, flags.F.NegGCPeriod, flags.F.EnableReadinessReflector, flags.F.RunIngressController, flags.F.RunL4Controller)
 
 	go negController.Run(stopCh)
 	klog.V(0).Infof("negController started")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -90,6 +90,8 @@ var (
 		EnableNonGCPMode                 bool
 		EnableDeleteUnusedFrontends      bool
 		EnableV2FrontendNamer            bool
+		RunIngressController             bool
+		RunL4Controller                  bool
 
 		LeaderElection LeaderElectionConfiguration
 	}{}
@@ -210,6 +212,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
+	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
+	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 }
 
 type RateLimitSpecs struct {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -114,6 +114,7 @@ func newTestController(kubeClient kubernetes.Interface) *Controller {
 		// TODO(freehan): enable readiness reflector for unit tests
 		false,
 		true,
+		false,
 	)
 	return controller
 }
@@ -277,6 +278,31 @@ func TestEnableNEGServiceWithIngress(t *testing.T) {
 		t.Fatalf("Service was not created successfully, err: %v", err)
 	}
 	validateServiceStateAnnotation(t, svc, svcPorts, controller.namer)
+}
+
+//TestEnableNEGSeviceWithL4ILB tests L4 ILB service with NEGs enabled.
+func TestEnableNEGServiceWithL4ILB(t *testing.T) {
+	controller := newTestController(fake.NewSimpleClientset())
+	controller.runL4 = true
+	defer controller.stop()
+	for _, randomize := range []bool{false, true} {
+		controller.serviceLister.Add(newTestILBService(controller, !randomize, 80))
+		svcClient := controller.client.CoreV1().Services(testServiceNamespace)
+		svcKey := utils.ServiceKeyFunc(testServiceNamespace, testServiceName)
+		err := controller.processService(svcKey)
+		if err != nil {
+			t.Fatalf("Failed to process service: %v", err)
+		}
+		svc, err := svcClient.Get(testServiceName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Service was not created.(*apiv1.Service) successfully, err: %v", err)
+		}
+		validateSyncers(t, controller, 1, false)
+		expectedPortInfoMap := negtypes.NewPortInfoMapForPrimaryIPNEG(testServiceNamespace, testServiceName,
+			controller.namer, randomize)
+		validateSyncerManagerWithPortInfoMap(t, controller, testServiceNamespace, testServiceName, expectedPortInfoMap)
+		validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap)
+	}
 }
 
 // TestEnableNEGServiceWithILBIngress tests ILB service with NEG enabled
@@ -1068,6 +1094,28 @@ func getTestSvcPortTuple(svcPort int32) negtypes.SvcPortTuple {
 		}
 	}
 	return negtypes.SvcPortTuple{}
+}
+
+func newTestILBService(c *Controller, onlyLocal bool, port int) *apiv1.Service {
+	svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testServiceName,
+			Namespace:   testServiceNamespace,
+			Annotations: map[string]string{gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal)},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeLoadBalancer,
+			Ports: []apiv1.ServicePort{
+				{Name: "testport", Port: int32(port)},
+			},
+		},
+	}
+	if onlyLocal {
+		svc.Spec.ExternalTrafficPolicy = apiv1.ServiceExternalTrafficPolicyTypeLocal
+	}
+
+	c.client.CoreV1().Services(testServiceNamespace).Create(svc)
+	return svc
 }
 
 func newTestService(c *Controller, negIngress bool, negSvcPorts []int32) *apiv1.Service {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -113,6 +113,7 @@ func newTestController(kubeClient kubernetes.Interface) *Controller {
 		1*time.Second,
 		// TODO(freehan): enable readiness reflector for unit tests
 		false,
+		true,
 	)
 	return controller
 }

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -84,6 +84,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) *syncerManager {
 		context.PodInformer.GetIndexer(),
 		context.ServiceInformer.GetIndexer(),
 		context.EndpointInformer.GetIndexer(),
+		context.NodeInformer.GetIndexer(),
 	)
 	manager.reflector = readiness.NewReadinessReflector(context, manager)
 	return manager

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	listers "k8s.io/client-go/listers/core/v1"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+// TestLocalGetEndpointSet verifies the GetEndpointSet method implemented by the LocalL4ILBEndpointsCalculator.
+// The L7 implementation is tested in TestToZoneNetworkEndpointMapUtil.
+func TestLocalGetEndpointSet(t *testing.T) {
+	t.Parallel()
+	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), false)
+	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
+	for i := 0; i < len(nodeNames); i++ {
+		err := transactionSyncer.nodeLister.Add(&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				//Namespace: testServiceNamespace,
+				Name: nodeNames[i],
+			},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeInternalIP,
+						Address: fmt.Sprintf("1.2.3.%d", i+1),
+					},
+				},
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to add node %s to syncer's nodeLister, err %v", nodeNames[i], err)
+		}
+	}
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	nodeLister := listers.NewNodeLister(transactionSyncer.nodeLister)
+
+	testCases := []struct {
+		desc                string
+		endpoints           *v1.Endpoints
+		endpointSets        map[string]negtypes.NetworkEndpointSet
+		networkEndpointType negtypes.NetworkEndpointType
+	}{
+		{
+			desc:      "default endpoints",
+			endpoints: getDefaultEndpoint(),
+			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
+			endpointSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+		},
+		{
+			desc:      "no endpoints",
+			endpoints: &v1.Endpoints{},
+			// No nodes are picked as there are no service endpoints.
+			endpointSets:        nil,
+			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+		},
+	}
+	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
+	ec := NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey)
+	for _, tc := range testCases {
+		retSet, _, err := ec.CalculateEndpoints(tc.endpoints, nil)
+		if err != nil {
+			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
+		}
+		if !reflect.DeepEqual(retSet, tc.endpointSets) {
+			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
+		}
+	}
+}
+
+// TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4ILBEndpointsCalculator.
+func TestClusterGetEndpointSet(t *testing.T) {
+	t.Parallel()
+	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), true)
+	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
+	for i := 0; i < len(nodeNames); i++ {
+		err := transactionSyncer.nodeLister.Add(&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeNames[i],
+			},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeInternalIP,
+						Address: fmt.Sprintf("1.2.3.%d", i+1),
+					},
+				},
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to add node %s to syncer's nodeLister, err %v", nodeNames[i], err)
+		}
+	}
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	nodeLister := listers.NewNodeLister(transactionSyncer.nodeLister)
+	testCases := []struct {
+		desc                string
+		endpoints           *v1.Endpoints
+		endpointSets        map[string]negtypes.NetworkEndpointSet
+		networkEndpointType negtypes.NetworkEndpointType
+	}{
+		{
+			desc:      "default endpoints",
+			endpoints: getDefaultEndpoint(),
+			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
+			endpointSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
+			},
+			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+		},
+		{
+			desc: "no endpoints",
+			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
+			// Even when there are no service endpoints, nodes are selected at random.
+			endpoints: &v1.Endpoints{},
+			endpointSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
+			},
+			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+		},
+	}
+	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
+	ec := NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey)
+	for _, tc := range testCases {
+		retSet, _, err := ec.CalculateEndpoints(tc.endpoints, nil)
+		if err != nil {
+			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
+		}
+		if !reflect.DeepEqual(retSet, tc.endpointSets) {
+			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
+		}
+	}
+}
+
+// TestGetPerZoneSubsetCount verifies the perZoneSubsetCount method.
+func TestGetPerZoneSubsetCount(t *testing.T) {
+	t.Parallel()
+	zoneCount := 3
+	result := 0
+	tcs := []struct {
+		desc          string
+		randomize     bool
+		startCount    int
+		endCount      int
+		expectedCount int
+	}{
+		{desc: "start with endpoints, drop to none, ExternalTrafficPolicy:Local", startCount: 5, endCount: 0, expectedCount: 0},
+		{desc: "no endpoints, ExternalTrafficPolicy:Local", startCount: 0, endCount: 0, expectedCount: 0},
+		{desc: "valid endpoints increase, ExternalTrafficPolicy:Local", startCount: 5, endCount: 10, expectedCount: 10 / zoneCount},
+		// If total number of nodes is less than the number of zones, per zone count will be 1.
+		{desc: "valid endpoints decrease, ExternalTrafficPolicy:Local", startCount: 5, endCount: 2, expectedCount: 1},
+		{desc: "valid endpoints > limit, ExternalTrafficPolicy:Local", startCount: 5, endCount: 258, expectedCount: maxSubsetSizeLocal / zoneCount},
+		{desc: "start with endpoints, drop to none, ExternalTrafficPolicy:Cluster", randomize: true, startCount: 5, endCount: 0, expectedCount: maxSubsetSizeDefault / zoneCount},
+		{desc: "no endpoints, random true, ExternalTrafficPolicy:Cluster", randomize: true, startCount: 0, endCount: 0, expectedCount: maxSubsetSizeDefault / zoneCount},
+		{desc: "valid endpoints increase, ExternalTrafficPolicy:Cluster", randomize: true, startCount: 5, endCount: 10, expectedCount: maxSubsetSizeDefault / zoneCount},
+		{desc: "valid endpoints decrease, ExternalTrafficPolicy:Cluster", randomize: true, startCount: 5, endCount: 2, expectedCount: maxSubsetSizeDefault / zoneCount},
+	}
+	for _, tc := range tcs {
+		if tc.randomize {
+			result = NewClusterL4ILBEndpointsCalculator(nil, nil, "test").getPerZoneSubsetCount(zoneCount, tc.endCount)
+		} else {
+			result = NewLocalL4ILBEndpointsCalculator(nil, nil, "test").getPerZoneSubsetCount(zoneCount, tc.endCount)
+		}
+		if result != tc.expectedCount {
+			t.Errorf("For test case '%s', expected subsetCount of %d, but got %d", tc.desc, tc.expectedCount, result)
+		}
+	}
+}

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+
+	"k8s.io/api/core/v1"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	// Max number of subsets in ExternalTrafficPolicy:Local
+	maxSubsetSizeLocal = 250
+	// Max number of subsets in ExternalTrafficPolicy:Cluster, which is the default mode.
+	maxSubsetSizeDefault = 25
+)
+
+// NodeInfo stores node metadata used to sort nodes and pick a subset.
+type NodeInfo struct {
+	// index stores the index of the given node in the input node list. This is useful to
+	// identify the node in the list after sorting.
+	index int
+	// hashedName is the sha256 hash of the given node name along with a salt.
+	hashedName string
+	// skip indicates if this node has already been selected in the subset and hence needs
+	// to be skipped.
+	skip bool
+}
+
+func getHashedName(nodeName, salt string) string {
+	hashSum := sha256.Sum256([]byte(nodeName + ":" + salt))
+	return hex.EncodeToString(hashSum[:])
+}
+
+// pickSubsetsMinRemovals ensures that there are no node removals from current subset unless the node no longer exists
+// or the subset size has reduced. Subset size can reduce if a new zone got added in the cluster and the per-zone limit
+// now reduces.
+// This function takes a list of nodes, hash salt, count, current set and returns a subset of size - 'count'.
+// If the input list is smaller than the desired subset count, the entire list is returned. The hash salt
+// is used so that a different subset is returned even when the same node list is passed in, for a different salt value.
+// It also keeps the subset relatively stable for the same service.
+// Example 1 - Recalculate subset, subset size increase.
+// nodes = [node1 node2 node3 node4 node5], Current subset - [node3, node2, node5], count 4
+// sorted list is [node3 node2 node5 node4 node1]
+// Output [node3, node2, node5, node4] - No removals in existing subset.
+// ---------------------------------------------------------------------------------------------------------
+// Example 2 - Recalculate subset, new node got added.
+// nodes = [node1 node2 node3 node4 node5, node6], Current subset - [node3, node2, node5, node4], count 4
+// sorted list is [node3 node6 node2 node5 node4 node1]
+// Output [node3, node2, node5, node4] - No removals in existing subset even though node6 shows up at a lower index
+// in the sorted list.
+// ---------------------------------------------------------------------------------------------------------
+// Example 2 - Recalculate subset, node3 got removed.
+// nodes = [node1 node2 node4 node5, node6], Current subset - [node3, node2, node5, node4], count 4
+// sorted list is [node6 node2 node5 node4 node1]
+// Output [node2, node5, node4 node6]
+func pickSubsetsMinRemovals(nodes []*v1.Node, salt string, count int, current []negtypes.NetworkEndpoint) []*v1.Node {
+	if len(nodes) < count {
+		return nodes
+	}
+	subset := make([]*v1.Node, 0, count)
+	info := make([]*NodeInfo, len(nodes))
+	// Generate hashed names for all cluster nodes and sort them alphabetically, based on the hashed string.
+	for i, node := range nodes {
+		info[i] = &NodeInfo{i, getHashedName(node.Name, salt), false}
+	}
+	sort.Slice(info, func(i, j int) bool {
+		return info[i].hashedName < info[j].hashedName
+	})
+	// Pick all nodes from existing subset if still available.
+	for _, ep := range current {
+		curHashName := getHashedName(ep.Node, salt)
+		for _, nodeInfo := range info {
+			if nodeInfo.hashedName == curHashName {
+				subset = append(subset, nodes[nodeInfo.index])
+				nodeInfo.skip = true
+			} else if nodeInfo.hashedName > curHashName {
+				break
+			}
+		}
+	}
+	if len(subset) >= count {
+		// trim the subset to the given subset size, remove extra nodes.
+		subset = subset[:count]
+		return subset
+	}
+	for _, val := range info {
+		if val.skip {
+			// This node was already picked as it is part of the current subset.
+			continue
+		}
+		subset = append(subset, nodes[val.index])
+		if len(subset) == count {
+			break
+		}
+	}
+	return subset
+}
+
+// getSubsetPerZone creates a subset of nodes from the given list of nodes, for each zone provided.
+// The output is a map of zone string to NEG subset.
+func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, perZoneCount int, svcID string, currentMap map[string]negtypes.NetworkEndpointSet) (map[string]negtypes.NetworkEndpointSet, error) {
+	result := make(map[string]negtypes.NetworkEndpointSet)
+	var currentList []negtypes.NetworkEndpoint
+
+	for zone, nodes := range nodesPerZone {
+		result[zone] = negtypes.NewNetworkEndpointSet()
+		if currentMap != nil {
+			if zset, ok := currentMap[zone]; ok && zset != nil {
+				currentList = zset.List()
+			} else {
+				currentList = nil
+			}
+		}
+		subset := pickSubsetsMinRemovals(nodes, svcID, perZoneCount, currentList)
+		for _, node := range subset {
+			result[zone].Insert(negtypes.NetworkEndpoint{Node: node.Name, IP: utils.GetNodePrimaryIP(node)})
+		}
+	}
+	return result, nil
+}

--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"k8s.io/ingress-gce/pkg/neg/types"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBasicSubset(t *testing.T) {
+	t.Parallel()
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node73"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node986"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node25"}},
+	}
+	count := 3
+	subset1 := PickSubsetsNoRemovals(nodes, "svc123", count, nil)
+	if len(subset1) < 3 {
+		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset1), subset1)
+	}
+	if !validateSubset(subset1, nodes) {
+		t.Errorf("Invalid subset list %v from %v", subset1, nodes)
+	}
+	subset2 := PickSubsetsNoRemovals(nodes, "svc345", count, nil)
+	subset3 := PickSubsetsNoRemovals(nodes, "svc56", count, nil)
+	t.Logf("Subset2 is %s", nodeNames(subset2))
+	t.Logf("Subset3 is %s", nodeNames(subset3))
+	if isIdentical(subset1, subset2) || isIdentical(subset3, subset2) || isIdentical(subset1, subset3) {
+		t.Errorf("2 out of 3 subsets are identical")
+	}
+}
+
+func TestEmptyNodes(t *testing.T) {
+	t.Parallel()
+	count := 3
+	subset1 := PickSubsetsNoRemovals(nil, "svc123", count, nil)
+	if len(subset1) != 0 {
+		t.Errorf("Expected empty subset, got - %s", nodeNames(subset1))
+	}
+}
+
+// Tests the case where there are fewer nodes than subsets
+func TestFewerNodes(t *testing.T) {
+	t.Parallel()
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node73"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node986"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node25"}},
+	}
+	count := 10
+	subset1 := PickSubsetsNoRemovals(nodes, "svc123", count, nil)
+	if len(subset1) != len(nodes) {
+		t.Errorf("Expected subset of length %d, got %d, subsets - %s", len(nodes), len(subset1), nodeNames(subset1))
+	}
+	if !isIdentical(nodes, subset1) {
+		t.Errorf("Subset list is different from list of nodes, subsets - %s", nodeNames(subset1))
+	}
+}
+
+func TestNoRemovals(t *testing.T) {
+	t.Parallel()
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node0"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node73"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node986"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node25"}},
+	}
+	count := 5
+	subset1 := PickSubsetsNoRemovals(nodes, "svc123", count, nil)
+	if len(subset1) < 5 {
+		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset1), subset1)
+	}
+	// nodeName abcd shows up 2nd in the sorted list for the given salt. So picking a subset of 5 will remove one of the
+	// existing nodes.
+	nodes = append(nodes, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node:abcd"}})
+	subset2 := PickSubsetsNoRemovals(nodes, "svc123", count, nil)
+	if len(subset2) < 5 {
+		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset2), subset2)
+	}
+	if isIdentical(subset1, subset2) {
+		t.Errorf("Got identical subsets %+v", subset1)
+	}
+	existingEp := []types.NetworkEndpoint{}
+	for _, node := range subset1 {
+		existingEp = append(existingEp, types.NetworkEndpoint{Node: node.Name})
+	}
+	subset3 := PickSubsetsNoRemovals(nodes, "svc123", count, existingEp)
+	if len(subset3) < 5 {
+		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset3), subset3)
+	}
+	if !isIdentical(subset1, subset3) {
+		t.Errorf("Got subsets %+v and %+v, expected identical subsets %+v", subset1, subset3, subset1)
+	}
+}
+
+func TestGetSubsetCount(t *testing.T) {
+	t.Parallel()
+	zoneCount := 3
+	tcs := []struct {
+		desc          string
+		randomize     bool
+		startCount    int
+		endCount      int
+		expectedCount int
+	}{
+		{desc: "start with endpoints, drop to none", startCount: 5, endCount: 0, expectedCount: zoneCount},
+		{desc: "no endpoints", startCount: 0, endCount: 0, expectedCount: zoneCount},
+		{desc: "valid endpoints increase", startCount: 5, endCount: 10, expectedCount: 10},
+		{desc: "valid endpoints decrease", startCount: 5, endCount: 2, expectedCount: 2},
+		{desc: "start with endpoints, drop to none, random true", randomize: true, startCount: 5, endCount: 0, expectedCount: 5},
+		{desc: "no endpoints, random true", randomize: true, startCount: 0, endCount: 0, expectedCount: zoneCount},
+		{desc: "valid endpoints increase, random true", randomize: true, startCount: 5, endCount: 10, expectedCount: 10},
+		{desc: "valid endpoints decrease, random true", randomize: true, startCount: 5, endCount: 2, expectedCount: 5},
+	}
+	for _, tc := range tcs {
+		result := getSubsetCount(tc.startCount, tc.endCount, zoneCount, tc.randomize)
+		if result != tc.expectedCount {
+			t.Errorf("For test case '%s', expected subsetCount of %d, but got %d", tc.desc, tc.expectedCount, result)
+		}
+	}
+}
+
+func validateSubset(subset []*v1.Node, nodes []*v1.Node) bool {
+	for _, val := range subset {
+		found := false
+		for _, node := range nodes {
+			if val == node {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func nodeNames(subset []*v1.Node) string {
+	names := []string{}
+	for _, n := range subset {
+		names = append(names, n.Name)
+	}
+	return strings.Join(names, " ")
+}
+
+func isIdentical(subset1, subset2 []*v1.Node) bool {
+	foundCount := 0
+	if len(subset1) != len(subset2) {
+		return false
+	}
+	for _, node1 := range subset1 {
+		found := false
+		for _, node2 := range subset2 {
+			if node1 == node2 {
+				found = true
+				break
+			}
+		}
+		if found {
+			foundCount = foundCount + 1
+		}
+	}
+	return foundCount == len(subset1)
+}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -861,7 +861,9 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 		context.PodInformer.GetIndexer(),
 		context.ServiceInformer.GetIndexer(),
 		context.EndpointInformer.GetIndexer(),
-		reflector)
+		context.NodeInformer.GetIndexer(),
+		reflector,
+		false)
 	transactionSyncer := negsyncer.(*syncer).core.(*transactionSyncer)
 	return negsyncer, transactionSyncer
 }

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -34,6 +34,8 @@ const (
 	TestInstance2 = "instance2"
 	TestInstance3 = "instance3"
 	TestInstance4 = "instance4"
+	TestInstance5 = "instance5"
+	TestInstance6 = "instance6"
 )
 
 type fakeZoneGetter struct {
@@ -44,7 +46,7 @@ func NewFakeZoneGetter() *fakeZoneGetter {
 	return &fakeZoneGetter{
 		zoneInstanceMap: map[string]sets.String{
 			TestZone1: sets.NewString(TestInstance1, TestInstance2),
-			TestZone2: sets.NewString(TestInstance3, TestInstance4),
+			TestZone2: sets.NewString(TestInstance3, TestInstance4, TestInstance5, TestInstance6),
 		},
 	}
 }

--- a/pkg/neg/types/network_endpoint.go
+++ b/pkg/neg/types/network_endpoint.go
@@ -96,6 +96,9 @@ func (s NetworkEndpointSet) HasAny(items ...NetworkEndpoint) bool {
 // s1.Difference(s2) = {a3}
 // s2.Difference(s1) = {a4, a5}
 func (s NetworkEndpointSet) Difference(s2 NetworkEndpointSet) NetworkEndpointSet {
+	if s2 == nil {
+		return s
+	}
 	result := NewNetworkEndpointSet()
 	for key := range s {
 		if !s2.Has(key) {
@@ -130,6 +133,9 @@ func (s1 NetworkEndpointSet) Union(s2 NetworkEndpointSet) NetworkEndpointSet {
 func (s1 NetworkEndpointSet) Intersection(s2 NetworkEndpointSet) NetworkEndpointSet {
 	var walk, other NetworkEndpointSet
 	result := NewNetworkEndpointSet()
+	if s2 == nil {
+		return result
+	}
 	if s1.Len() < s2.Len() {
 		walk = s1
 		other = s2

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -32,6 +32,10 @@ func (*negNamer) NEG(namespace, name string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v", namespace, name, svcPort)
 }
 
+func (*negNamer) PrimaryIPNEG(namespace, name string) string {
+	return fmt.Sprintf("%v-%v", namespace, name)
+}
+
 func (*negNamer) NEGWithSubset(namespace, name, subset string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, subset, svcPort)
 }

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -29,6 +29,11 @@ const (
 	// FinalizerKeyV2 is the string representing the Ingress finalizer version.
 	// Ingress with V2 finalizer uses V2 frontend naming scheme.
 	FinalizerKeyV2 = "networking.gke.io/ingress-finalizer-V2"
+	// FinalizerKeyL4 is the string representing the L4 ILB controller finalizer in this repo.
+	FinalizerKeyL4 = "networking.gke.io/l4-ilb-v2"
+	// FinalizerKeyL4V1 is the string representing the service controller finalizer. A service with this finalizer
+	// is managed by k/k service controller.
+	FinalizerKeyL4V1 = "networking.gke.io/l4-ilb-v1"
 )
 
 // IsDeletionCandidate is true if the passed in meta contains an ingress finalizer.

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -59,7 +59,7 @@ type ServicePort struct {
 // for creating NEGs associated with the given ServicePort.
 func GetAPIVersionFromServicePort(sp *ServicePort) meta.Version {
 	if sp == nil {
-		// this uses VM_PRIMARY_IP_NEGS which requires alpha API
+		// this uses GCE_VM_PRIMARY_IP NEGS which requires alpha API
 		return meta.VersionAlpha
 	}
 	return meta.VersionGA

--- a/vendor/k8s.io/kubernetes/pkg/util/node/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/node/BUILD
@@ -1,0 +1,45 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["node.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/node",
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["node_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/util/node/node.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/node/node.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/klog"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	// NodeUnreachablePodReason is the reason on a pod when its state cannot be confirmed as kubelet is unresponsive
+	// on the node it is (was) running.
+	NodeUnreachablePodReason = "NodeLost"
+	// NodeUnreachablePodMessage is the message on a pod when its state cannot be confirmed as kubelet is unresponsive
+	// on the node it is (was) running.
+	NodeUnreachablePodMessage = "Node %v which was running pod %v is unresponsive"
+)
+
+// GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'.
+func GetHostname(hostnameOverride string) (string, error) {
+	hostName := hostnameOverride
+	if len(hostName) == 0 {
+		nodeName, err := os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf("couldn't determine hostname: %v", err)
+		}
+		hostName = nodeName
+	}
+
+	// Trim whitespaces first to avoid getting an empty hostname
+	// For linux, the hostname is read from file /proc/sys/kernel/hostname directly
+	hostName = strings.TrimSpace(hostName)
+	if len(hostName) == 0 {
+		return "", fmt.Errorf("empty hostname is invalid")
+	}
+	return strings.ToLower(hostName), nil
+}
+
+// NoMatchError is a typed implementation of the error interface. It indicates a failure to get a matching Node.
+type NoMatchError struct {
+	addresses []v1.NodeAddress
+}
+
+// Error is the implementation of the conventional interface for
+// representing an error condition, with the nil value representing no error.
+func (e *NoMatchError) Error() string {
+	return fmt.Sprintf("no preferred addresses found; known addresses: %v", e.addresses)
+}
+
+// GetPreferredNodeAddress returns the address of the provided node, using the provided preference order.
+// If none of the preferred address types are found, an error is returned.
+func GetPreferredNodeAddress(node *v1.Node, preferredAddressTypes []v1.NodeAddressType) (string, error) {
+	for _, addressType := range preferredAddressTypes {
+		for _, address := range node.Status.Addresses {
+			if address.Type == addressType {
+				return address.Address, nil
+			}
+		}
+	}
+	return "", &NoMatchError{addresses: node.Status.Addresses}
+}
+
+// GetNodeHostIP returns the provided node's IP, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+func GetNodeHostIP(node *v1.Node) (net.IP, error) {
+	addresses := node.Status.Addresses
+	addressMap := make(map[v1.NodeAddressType][]v1.NodeAddress)
+	for i := range addresses {
+		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	}
+	if addresses, ok := addressMap[v1.NodeInternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[v1.NodeExternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
+}
+
+// GetNodeIP returns the ip of node with the provided hostname
+func GetNodeIP(client clientset.Interface, hostname string) net.IP {
+	var nodeIP net.IP
+	node, err := client.CoreV1().Nodes().Get(hostname, metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to retrieve node info: %v", err)
+		return nil
+	}
+	nodeIP, err = GetNodeHostIP(node)
+	if err != nil {
+		klog.Warningf("Failed to retrieve node IP: %v", err)
+		return nil
+	}
+	return nodeIP
+}
+
+// GetZoneKey is a helper function that builds a string identifier that is unique per failure-zone;
+// it returns empty-string for no zone.
+func GetZoneKey(node *v1.Node) string {
+	labels := node.Labels
+	if labels == nil {
+		return ""
+	}
+
+	region, _ := labels[v1.LabelZoneRegion]
+	failureDomain, _ := labels[v1.LabelZoneFailureDomain]
+
+	if region == "" && failureDomain == "" {
+		return ""
+	}
+
+	// We include the null character just in case region or failureDomain has a colon
+	// (We do assume there's no null characters in a region or failureDomain)
+	// As a nice side-benefit, the null character is not printed by fmt.Print or glog
+	return region + ":\x00:" + failureDomain
+}
+
+// SetNodeCondition updates specific node condition with patch operation.
+func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+	generatePatch := func(condition v1.NodeCondition) ([]byte, error) {
+		raw, err := json.Marshal(&[]v1.NodeCondition{condition})
+		if err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw)), nil
+	}
+	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+	patch, err := generatePatch(condition)
+	if err != nil {
+		return nil
+	}
+	_, err = c.CoreV1().Nodes().PatchStatus(string(node), patch)
+	return err
+}
+
+// PatchNodeCIDR patches the specified node's CIDR to the given value.
+func PatchNodeCIDR(c clientset.Interface, node types.NodeName, cidr string) error {
+	raw, err := json.Marshal(cidr)
+	if err != nil {
+		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
+	}
+
+	patchBytes := []byte(fmt.Sprintf(`{"spec":{"podCIDR":%s}}`, raw))
+
+	if _, err := c.CoreV1().Nodes().Patch(string(node), types.StrategicMergePatchType, patchBytes); err != nil {
+		return fmt.Errorf("failed to patch node CIDR: %v", err)
+	}
+	return nil
+}
+
+// PatchNodeStatus patches node status.
+func PatchNodeStatus(c v1core.CoreV1Interface, nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) (*v1.Node, []byte, error) {
+	patchBytes, err := preparePatchBytesforNodeStatus(nodeName, oldNode, newNode)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updatedNode, err := c.Nodes().Patch(string(nodeName), types.StrategicMergePatchType, patchBytes, "status")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to patch status %q for node %q: %v", patchBytes, nodeName, err)
+	}
+	return updatedNode, patchBytes, nil
+}
+
+func preparePatchBytesforNodeStatus(nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) ([]byte, error) {
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal oldData for node %q: %v", nodeName, err)
+	}
+
+	// Reset spec to make sure only patch for Status or ObjectMeta is generated.
+	// Note that we don't reset ObjectMeta here, because:
+	// 1. This aligns with Nodes().UpdateStatus().
+	// 2. Some component does use this to update node annotations.
+	newNode.Spec = oldNode.Spec
+	newData, err := json.Marshal(newNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal newData for node %q: %v", nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateTwoWayMergePatch for node %q: %v", nodeName, err)
+	}
+	return patchBytes, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -519,6 +519,7 @@ k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/kubernetes v1.15.0 => k8s.io/kubernetes v1.15.0
 k8s.io/kubernetes/pkg/client/leaderelectionconfig
+k8s.io/kubernetes/pkg/util/node
 k8s.io/kubernetes/pkg/util/slice
 # k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.0.0-20191210234026-b5fed2ccee23
 k8s.io/legacy-cloud-providers/gce


### PR DESCRIPTION
This change adds support in transaction syncer to create GCE_VM_PRIMARY_IP NEGs.

The neg controller has 2 new flags - one for  watching ingress and one for services.
LoadBalancer services will be processed only if the second flag is enabled. This is disabled by default and can be enabled by adding "ILBSubsets" Alpha feature gate.

/assign @freehan @bowei 