### PR TITLE
RegionalGCLBForVIP() Fix

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -119,7 +119,7 @@ func TestILB(t *testing.T) {
 				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
 			}
 
-			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
 			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
@@ -265,7 +265,7 @@ func TestILBHttps(t *testing.T) {
 				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
 			}
 
-			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Validators: fuzz.FeatureValidators(features.All)}
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
 			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
@@ -407,7 +407,7 @@ func TestILBUpdate(t *testing.T) {
 				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
 			}
 
-			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Validators: fuzz.FeatureValidators(features.All)}
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
 			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 			if err != nil {
 				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
@@ -604,7 +604,7 @@ func TestILBShared(t *testing.T) {
 					t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
 				}
 
-				params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Validators: fuzz.FeatureValidators(features.All)}
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
 				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 				if err != nil {
 					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)

--- a/cmd/e2e-test/run.sh
+++ b/cmd/e2e-test/run.sh
@@ -72,7 +72,7 @@ for ATTEMPT in $(seq 60); do
   sleep 1
 done
 
-NETWORK = NETWORK_INFO | sed 's+projects/.*/networks/++'
+NETWORK=$(echo ${NETWORK_INFO} | sed 's+projects/.*/networks/++')
 
 if [[ -z "${NETWORK}" ]]; then
   echo "Error: could not parse network from network info"

--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -396,10 +396,8 @@ func GCLBForVIP(ctx context.Context, c cloud.Cloud, params *GCLBForVIPParams) (*
 	gclb := NewGCLB(params.VIP)
 
 	if params.Region != "" {
-		if err := RegionalGCLBForVIP(ctx, c, gclb, params); err != nil {
-			return nil, err
-		}
-		return gclb, nil
+		err := RegionalGCLBForVIP(ctx, c, gclb, params)
+		return gclb, err
 	}
 
 	allGFRs, err := c.GlobalForwardingRules().List(ctx, filter.None)


### PR DESCRIPTION
Fixes a bug where the ilb e2e test helper function may confuse multiple forwarding rules
from different VPCs with the same VIP

Will require another PR first to add the network flag to internal tests
/hold 

Blocked by #971