### PR TITLE
Add createIlbSubnet flag to ilb e2e tests

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -85,9 +85,10 @@ func TestILB(t *testing.T) {
 			t.Parallel()
 			t.Logf("Ingress = %s", tc.ing.String())
 
-			// Create Subnet if it doesn't already exist
-			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
-				t.Fatalf("error ensuring regional subnet for ILB: %v", err)
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
 			}
 
 			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
@@ -208,9 +209,10 @@ func TestILBHttps(t *testing.T) {
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			t.Parallel()
 
-			// Create Subnet if it doesn't already exist
-			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
-				t.Fatalf("error ensuring regional subnet for ILB: %v", err)
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
 			}
 
 			for i, h := range tc.hosts {
@@ -370,9 +372,10 @@ func TestILBUpdate(t *testing.T) {
 
 			t.Logf("Ingress = %s", tc.ing.String())
 
-			// Create Subnet if it doesn't already exist
-			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
-				t.Fatalf("error ensuring regional subnet for ILB: %v", err)
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
 			}
 
 			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
@@ -477,9 +480,10 @@ func TestILBError(t *testing.T) {
 
 			t.Logf("Ingress = %s", tc.ing.String())
 
-			// Create Subnet if it doesn't already exist
-			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
-				t.Fatalf("error ensuring regional subnet for ILB: %v", err)
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
 			}
 
 			_, err := e2e.CreateEchoService(s, serviceName, tc.svcAnnotations)
@@ -561,9 +565,10 @@ func TestILBShared(t *testing.T) {
 		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
 			t.Parallel()
 
-			// Create Subnet if it doesn't already exist
-			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
-				t.Fatalf("error ensuring regional subnet for ILB: %v", err)
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
 			}
 
 			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)

--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -48,6 +48,7 @@ var (
 		destroySandboxes    bool
 		handleSIGINT        bool
 		gceEndpointOverride string
+		createILBSubnet     bool
 	}
 
 	Framework *e2e.Framework
@@ -64,11 +65,12 @@ func init() {
 	flag.BoolVar(&flags.inCluster, "inCluster", false, "set to true if running in the cluster")
 	flag.StringVar(&flags.project, "project", "", "GCP project")
 	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
-	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default) to use for ilb subnet")
+	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default)")
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
 	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/")
+	flag.BoolVar(&flags.createILBSubnet, "createILBSubnet", false, "If set, creates a proxy subnet for the L7 ILB")
 }
 
 // TestMain is the entrypoint for the end-to-end test suite. This is where
@@ -89,9 +91,9 @@ func TestMain(m *testing.M) {
 		fmt.Println("-region must be set to the region of the cluster")
 		os.Exit(1)
 	}
-
 	if flags.network == "" {
-		klog.Info("No network provided, will not create ILB Subnet")
+		// TODO(shance): Make this a required flag, error out here
+		fmt.Println("-network must be set to the network of the cluster")
 	}
 
 	fmt.Printf("Version: %q, Commit: %q\n", version.Version, version.GitCommit)
@@ -123,6 +125,7 @@ func TestMain(m *testing.M) {
 		Seed:                flags.seed,
 		DestroySandboxes:    flags.destroySandboxes,
 		GceEndpointOverride: flags.gceEndpointOverride,
+		CreateILBSubnet:     flags.createILBSubnet,
 	})
 	if flags.handleSIGINT {
 		Framework.CatchSIGINT()

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -264,11 +264,11 @@ func DeleteGCPAddress(s *Sandbox, name string) error {
 
 // CreateILBSubnet creates the ILB subnet
 func CreateILBSubnet(s *Sandbox) error {
-	klog.V(3).Info("CreateILBSubnet()")
+	klog.V(2).Info("CreateILBSubnet()")
 
 	// If no network is provided, we don't try to create the subnet
 	if s.f.Network == "" {
-		return ErrSubnetExists
+		return fmt.Errorf("error no network provided, cannot create ILB Subnet")
 	}
 
 	name := "ilb-subnet-ingress-e2e"

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -47,6 +47,7 @@ type Options struct {
 	Seed                int64
 	DestroySandboxes    bool
 	GceEndpointOverride string
+	CreateILBSubnet     bool
 }
 
 // NewFramework returns a new test framework to run.
@@ -69,6 +70,7 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 		Cloud:               theCloud,
 		Rand:                rand.New(rand.NewSource(options.Seed)),
 		destroySandboxes:    options.DestroySandboxes,
+		CreateILBSubnet:     options.CreateILBSubnet,
 	}
 	f.statusManager = NewStatusManager(f)
 	return f
@@ -87,6 +89,7 @@ type Framework struct {
 	statusManager       *StatusManager
 
 	destroySandboxes bool
+	CreateILBSubnet  bool
 
 	lock      sync.Mutex
 	sandboxes []*Sandbox


### PR DESCRIPTION
Now used in addition to -network since all ilb tests will need -network
for GCLBForVIP()