### PR TITLE
e2e test run.sh add network

### DIFF
--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -92,8 +92,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	if flags.network == "" {
-		// TODO(shance): Make this a required flag, error out here
-		fmt.Println("-network must be set to the network of the cluster")
+		fmt.Fprintln(os.Stderr, "-network must be set to the network of the cluster")
+		os.Exit(1)
 	}
 
 	fmt.Printf("Version: %q, Commit: %q\n", version.Version, version.GitCommit)


### PR DESCRIPTION
Parse the network name from the metadata server and pass it along to e2e tests

blocked by #970 
/hold