### PR TITLE
Fix timestamp of legacy-cloud-providers dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ replace (
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.0.0-20190620085909-5dfb14b3a101
 	k8s.io/kubelet => k8s.io/kubelet v0.0.0-20190620085837-98477dc0c87c
 	k8s.io/kubernetes => k8s.io/kubernetes v1.15.0
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.0.0-20191114112650-b5fed2ccee23
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.0.0-20191210234026-b5fed2ccee23
 	k8s.io/metrics => k8s.io/metrics v0.0.0-20190620085627-5b02f62e9559
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.0.0-20190620085357-8191e314a1f7
 )

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ k8s.io/legacy-cloud-providers v0.0.0-20190620090159-a9e4f3cb5bf3 h1:M7/X/e8icd2q
 k8s.io/legacy-cloud-providers v0.0.0-20190620090159-a9e4f3cb5bf3/go.mod h1:vN4qQ5sBl+8105txtOVlFFNAXTc8lYvM41krV0K7xXc=
 k8s.io/legacy-cloud-providers v0.0.0-20191114112650-b5fed2ccee23 h1:bTJRQQAdp8b4KQ7Km30l7JjQbgPsjeEaRWbrQhmOFVs=
 k8s.io/legacy-cloud-providers v0.0.0-20191114112650-b5fed2ccee23/go.mod h1:DdzaepJ3RtRy+e5YhNtrCYwlgyK87j/5+Yfp0L9Syp8=
+k8s.io/legacy-cloud-providers v0.0.0-20191210234026-b5fed2ccee23 h1:OGjiUCSaoiv+WWO35dN2txDvwX8htOCyb8MAkd5vuQU=
+k8s.io/legacy-cloud-providers v0.0.0-20191210234026-b5fed2ccee23/go.mod h1:DdzaepJ3RtRy+e5YhNtrCYwlgyK87j/5+Yfp0L9Syp8=
 k8s.io/metrics v0.0.0-20190620085627-5b02f62e9559/go.mod h1:f5M7Wu7aoJPaYxys9OpQdzhfOVWhuS/WE20voRy8KEY=
 k8s.io/repo-infra v0.0.0-20181204233714-00fe14e3d1a3/go.mod h1:+G1xBfZDfVFsm1Tj/HNCvg4QqWx8rJ2Fxpqr1rqp/gQ=
 k8s.io/sample-apiserver v0.0.0-20190620085357-8191e314a1f7/go.mod h1:RVMdQ03C5ZqPz82uV82L72wju27+zFFnyzKje9DVBZI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -513,7 +513,7 @@ k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/kubernetes v1.15.0 => k8s.io/kubernetes v1.15.0
 k8s.io/kubernetes/pkg/client/leaderelectionconfig
 k8s.io/kubernetes/pkg/util/slice
-# k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.0.0-20191114112650-b5fed2ccee23
+# k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.0.0-20191210234026-b5fed2ccee23
 k8s.io/legacy-cloud-providers/gce
 # k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 k8s.io/utils/net


### PR DESCRIPTION
The change in https://github.com/kubernetes/ingress-gce/pull/975/commits/7550fb74e5efb00d05c6041556b3c34ea50c770c updated the dependency version, but did not update the timestamp.

The correct version was pulled in and build succeeded, but subsequent "go mod vendor" fails with timestamp mismatch error. This change fixes that error.