### PR TITLE
Make metrics label Snake case compliant 

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	label = "Feature"
+	label = "feature"
 )
 
 var (


### PR DESCRIPTION
prometheus-to-sd requires the labels to named in snake case format.