### PR TITLE
Remove `DefaultBackendHealthCheckPath` as a parameter

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -134,15 +134,14 @@ func main() {
 	cloud := app.NewGCEClient()
 	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)
 	ctxConfig := ingctx.ControllerContextConfig{
-		Namespace:                     flags.F.WatchNamespace,
-		ResyncPeriod:                  flags.F.ResyncPeriod,
-		DefaultBackendSvcPort:         defaultBackendServicePort,
-		HealthCheckPath:               flags.F.HealthCheckPath,
-		DefaultBackendHealthCheckPath: flags.F.DefaultSvcHealthCheckPath,
-		FrontendConfigEnabled:         flags.F.EnableFrontendConfig,
-		EnableASMConfigMap:            flags.F.EnableASMConfigMapBasedConfig,
-		ASMConfigMapNamespace:         flags.F.ASMConfigMapBasedConfigNamespace,
-		ASMConfigMapName:              flags.F.ASMConfigMapBasedConfigCMName,
+		Namespace:             flags.F.WatchNamespace,
+		ResyncPeriod:          flags.F.ResyncPeriod,
+		DefaultBackendSvcPort: defaultBackendServicePort,
+		HealthCheckPath:       flags.F.HealthCheckPath,
+		FrontendConfigEnabled: flags.F.EnableFrontendConfig,
+		EnableASMConfigMap:    flags.F.EnableASMConfigMapBasedConfig,
+		ASMConfigMapNamespace: flags.F.ASMConfigMapBasedConfigNamespace,
+		ASMConfigMapName:      flags.F.ASMConfigMapBasedConfigCMName,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -41,7 +41,7 @@ type Jig struct {
 }
 
 func newTestJig(fakeGCE *gce.Cloud) *Jig {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -131,7 +131,7 @@ var (
 )
 
 func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -91,13 +91,12 @@ type ControllerContextConfig struct {
 	Namespace    string
 	ResyncPeriod time.Duration
 	// DefaultBackendSvcPortID is the ServicePort for the system default backend.
-	DefaultBackendSvcPort         utils.ServicePort
-	HealthCheckPath               string
-	DefaultBackendHealthCheckPath string
-	FrontendConfigEnabled         bool
-	EnableASMConfigMap            bool
-	ASMConfigMapNamespace         string
-	ASMConfigMapName              string
+	DefaultBackendSvcPort utils.ServicePort
+	HealthCheckPath       string
+	FrontendConfigEnabled bool
+	EnableASMConfigMap    bool
+	ASMConfigMapNamespace string
+	ASMConfigMapName      string
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,7 +106,7 @@ func NewLoadBalancerController(
 		Interface: ctx.KubeClient.CoreV1().Events(""),
 	})
 
-	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendHealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service)
+	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service)
 	instancePool := instances.NewNodePool(ctx.Cloud, ctx.ClusterNamer)
 	backendPool := backends.NewPool(ctx.Cloud, ctx.ClusterNamer)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -66,11 +66,10 @@ func newLoadBalancerController() *LoadBalancerController {
 
 	stopCh := make(chan struct{})
 	ctxConfig := context.ControllerContextConfig{
-		Namespace:                     api_v1.NamespaceAll,
-		ResyncPeriod:                  1 * time.Minute,
-		DefaultBackendSvcPort:         test.DefaultBeSvcPort,
-		HealthCheckPath:               "/",
-		DefaultBackendHealthCheckPath: "/healthz",
+		Namespace:             api_v1.NamespaceAll,
+		ResyncPeriod:          1 * time.Minute,
+		DefaultBackendSvcPort: test.DefaultBeSvcPort,
+		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -59,11 +59,10 @@ func fakeTranslator() *Translator {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 
 	ctxConfig := context.ControllerContextConfig{
-		Namespace:                     apiv1.NamespaceAll,
-		ResyncPeriod:                  1 * time.Second,
-		DefaultBackendSvcPort:         defaultBackend,
-		HealthCheckPath:               "/",
-		DefaultBackendHealthCheckPath: "/healthz",
+		Namespace:             apiv1.NamespaceAll,
+		ResyncPeriod:          1 * time.Second,
+		DefaultBackendSvcPort: defaultBackend,
+		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	gce := &Translator{

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
@@ -76,8 +77,6 @@ type HealthChecks struct {
 	cloud HealthCheckProvider
 	// path is the default health check path for backends.
 	path string
-	// defaultBackend is the default health check path for the default backend.
-	defaultBackendPath string
 	// This is a workaround which allows us to not have to maintain
 	// a separate health checker for the default backend.
 	defaultBackendSvc types.NamespacedName
@@ -86,8 +85,8 @@ type HealthChecks struct {
 // NewHealthChecker creates a new health checker.
 // cloud: the cloud object implementing SingleHealthCheck.
 // defaultHealthCheckPath: is the HTTP path to use for health checks.
-func NewHealthChecker(cloud HealthCheckProvider, healthCheckPath string, defaultBackendHealthCheckPath string, defaultBackendSvc types.NamespacedName) HealthChecker {
-	return &HealthChecks{cloud, healthCheckPath, defaultBackendHealthCheckPath, defaultBackendSvc}
+func NewHealthChecker(cloud HealthCheckProvider, healthCheckPath string, defaultBackendSvc types.NamespacedName) HealthChecker {
+	return &HealthChecks{cloud, healthCheckPath, defaultBackendSvc}
 }
 
 // New returns a *HealthCheck with default settings and specified port/protocol
@@ -623,7 +622,7 @@ func betaToAlphaHealthCheck(hc *computebeta.HealthCheck) (*computealpha.HealthCh
 // the passed in ServicePort is associated with the system default backend.
 func (h *HealthChecks) pathFromSvcPort(sp utils.ServicePort) string {
 	if h.defaultBackendSvc == sp.ID.Service {
-		return h.defaultBackendPath
+		return flags.F.DefaultSvcHealthCheckPath
 	}
 	return h.path
 }

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -39,7 +39,7 @@ var (
 
 func TestHealthCheckAdd(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	sp := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: namer}
 	hc := healthChecks.New(sp)
@@ -80,7 +80,7 @@ func TestHealthCheckAdd(t *testing.T) {
 
 func TestHealthCheckAddExisting(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	// HTTP
 	// Manually insert a health check
@@ -155,7 +155,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 
 func TestHealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	// Create HTTP HC for 1234
 	hc := DefaultHealthCheck(1234, annotations.ProtocolHTTP)
@@ -191,7 +191,7 @@ func TestHealthCheckDelete(t *testing.T) {
 
 func TestHTTP2HealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	// Create HTTP2 HC for 1234
 	hc := DefaultHealthCheck(1234, annotations.ProtocolHTTP2)
@@ -221,7 +221,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaHealthChecks.UpdateHook = mock.UpdateAlphaHealthCheckHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaHealthChecks.UpdateHook = mock.UpdateBetaHealthCheckHook
 
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 
 	// HTTP
 	// Manually insert a health check
@@ -322,7 +322,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 
 func TestAlphaHealthCheck(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", "/healthz", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 	sp := utils.ServicePort{NodePort: 8000, Protocol: annotations.ProtocolHTTPS, NEGEnabled: true, BackendNamer: namer}
 	hc := healthChecks.New(sp)
 	_, err := healthChecks.Sync(hc)


### PR DESCRIPTION
All uses of this parameter come from the default flag value.
This reduces the surface area of the health checker.