### PR TITLE
Enable Access Logs by default

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -73,6 +73,10 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 		Port:         namedPort.Port,
 		PortName:     namedPort.Name,
 		HealthChecks: []string{hcLink},
+		// LogConfig is using GA API so this is not considered for computing API version.
+		LogConfig: &composite.BackendServiceLogConfig{
+			Enable: true,
+		},
 	}
 
 	if sp.L7ILBEnabled {


### PR DESCRIPTION
GCE API is updated to a version with `LogConfig` field available in https://github.com/kubernetes/ingress-gce/pull/1033. The change will be in a different PR.