### PR TITLE
Set healthcheck from BackendConfig

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,7 @@ k8s.io/component-base v0.17.0 h1:BnDFcmBDq+RPpxXjmuYnZXb59XNN9CaFrX8ba9+3xrA=
 k8s.io/component-base v0.17.0/go.mod h1:rKuRAokNMY2nn2A6LP/MiwpoaMRHpfRnrPaUJJj1Yoc=
 k8s.io/cri-api v0.0.0-20190531030430-6117653b35f1/go.mod h1:K6Ux7uDbzKhacgqW0OJg3rjXk/SR9kprCPfSUDXGB5A=
 k8s.io/csi-translation-lib v0.0.0-20190620090114-816aa063c73d/go.mod h1:q5k0Vv3qsOTu2PUrTh+4mRAj+Pt+1BRyWiiwr5LBFOM=
+k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af h1:SwjZbO0u5ZuaV6TRMWOGB40iaycX8sbdMQHtjNZ19dk=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=

--- a/pkg/apis/backendconfig/v1/types.go
+++ b/pkg/apis/backendconfig/v1/types.go
@@ -137,11 +137,23 @@ type CustomRequestHeadersConfig struct {
 // HealthCheckConfig contains configuration for the health check.
 // +k8s:openapi-gen=true
 type HealthCheckConfig struct {
-	CheckIntervalSec   *int64  `json:"checkIntervalSec,omitempty"`
-	TimeoutSec         *int64  `json:"timeoutSec,omitempty"`
-	HealthyThreshold   *int64  `json:"healthyThreshold,omitempty"`
-	UnhealthyThreshold *int64  `json:"unhealthyThreshold,omitempty"`
-	Type               *string `json:"type,omitempty"`
-	Port               *int64  `json:"port,omitempty"`
-	RequestPath        *string `json:"requestPath,omitempty"`
+	// CheckIntervalSec is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	CheckIntervalSec *int64 `json:"checkIntervalSec,omitempty"`
+	// TimeoutSec is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
+	// HealthyThreshold is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	HealthyThreshold *int64 `json:"healthyThreshold,omitempty"`
+	// UnhealthyThreshold is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	UnhealthyThreshold *int64 `json:"unhealthyThreshold,omitempty"`
+	// Type is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	Type *string `json:"type,omitempty"`
+	Port *int64  `json:"port,omitempty"`
+	// RequestPath is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	RequestPath *string `json:"requestPath,omitempty"`
 }

--- a/pkg/apis/backendconfig/v1/zz_generated.openapi.go
+++ b/pkg/apis/backendconfig/v1/zz_generated.openapi.go
@@ -35,6 +35,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CacheKeyPolicy":             schema_pkg_apis_backendconfig_v1_CacheKeyPolicy(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.ConnectionDrainingConfig":   schema_pkg_apis_backendconfig_v1_ConnectionDrainingConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CustomRequestHeadersConfig": schema_pkg_apis_backendconfig_v1_CustomRequestHeadersConfig(ref),
+		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.HealthCheckConfig":          schema_pkg_apis_backendconfig_v1_HealthCheckConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.IAPConfig":                  schema_pkg_apis_backendconfig_v1_IAPConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.OAuthClientCredentials":     schema_pkg_apis_backendconfig_v1_OAuthClientCredentials(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.SessionAffinityConfig":      schema_pkg_apis_backendconfig_v1_SessionAffinityConfig(ref),
@@ -127,11 +128,16 @@ func schema_pkg_apis_backendconfig_v1_BackendConfigSpec(ref common.ReferenceCall
 							Ref: ref("k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CustomRequestHeadersConfig"),
 						},
 					},
+					"healthCheck": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/ingress-gce/pkg/apis/backendconfig/v1.HealthCheckConfig"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CDNConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.ConnectionDrainingConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CustomRequestHeadersConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.IAPConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.SecurityPolicyConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.SessionAffinityConfig"},
+			"k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CDNConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.ConnectionDrainingConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.CustomRequestHeadersConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.HealthCheckConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.IAPConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.SecurityPolicyConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.SessionAffinityConfig"},
 	}
 }
 
@@ -262,6 +268,67 @@ func schema_pkg_apis_backendconfig_v1_CustomRequestHeadersConfig(ref common.Refe
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_backendconfig_v1_HealthCheckConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "HealthCheckConfig contains configuration for the health check.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"checkIntervalSec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CheckIntervalSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"timeoutSec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TimeoutSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"healthyThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"unhealthyThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UnhealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+					"requestPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequestPath is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/backendconfig/v1beta1/types.go
+++ b/pkg/apis/backendconfig/v1beta1/types.go
@@ -137,11 +137,23 @@ type CustomRequestHeadersConfig struct {
 // HealthCheckConfig contains configuration for the health check.
 // +k8s:openapi-gen=true
 type HealthCheckConfig struct {
-	CheckIntervalSec   *int64  `json:"checkIntervalSec,omitempty"`
-	TimeoutSec         *int64  `json:"timeoutSec,omitempty"`
-	HealthyThreshold   *int64  `json:"healthyThreshold,omitempty"`
-	UnhealthyThreshold *int64  `json:"unhealthyThreshold,omitempty"`
-	Type               *string `json:"type,omitempty"`
-	Port               *int64  `json:"port,omitempty"`
-	RequestPath        *string `json:"requestPath,omitempty"`
+	// CheckIntervalSec is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	CheckIntervalSec *int64 `json:"checkIntervalSec,omitempty"`
+	// TimeoutSec is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
+	// HealthyThreshold is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	HealthyThreshold *int64 `json:"healthyThreshold,omitempty"`
+	// UnhealthyThreshold is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	UnhealthyThreshold *int64 `json:"unhealthyThreshold,omitempty"`
+	// Type is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	Type *string `json:"type,omitempty"`
+	Port *int64  `json:"port,omitempty"`
+	// RequestPath is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	RequestPath *string `json:"requestPath,omitempty"`
 }

--- a/pkg/apis/backendconfig/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/backendconfig/v1beta1/zz_generated.openapi.go
@@ -35,6 +35,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CacheKeyPolicy":             schema_pkg_apis_backendconfig_v1beta1_CacheKeyPolicy(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.ConnectionDrainingConfig":   schema_pkg_apis_backendconfig_v1beta1_ConnectionDrainingConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CustomRequestHeadersConfig": schema_pkg_apis_backendconfig_v1beta1_CustomRequestHeadersConfig(ref),
+		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.HealthCheckConfig":          schema_pkg_apis_backendconfig_v1beta1_HealthCheckConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.IAPConfig":                  schema_pkg_apis_backendconfig_v1beta1_IAPConfig(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.OAuthClientCredentials":     schema_pkg_apis_backendconfig_v1beta1_OAuthClientCredentials(ref),
 		"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.SessionAffinityConfig":      schema_pkg_apis_backendconfig_v1beta1_SessionAffinityConfig(ref),
@@ -127,11 +128,16 @@ func schema_pkg_apis_backendconfig_v1beta1_BackendConfigSpec(ref common.Referenc
 							Ref: ref("k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CustomRequestHeadersConfig"),
 						},
 					},
+					"healthCheck": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.HealthCheckConfig"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CDNConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.ConnectionDrainingConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CustomRequestHeadersConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.IAPConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.SecurityPolicyConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.SessionAffinityConfig"},
+			"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CDNConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.ConnectionDrainingConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.CustomRequestHeadersConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.HealthCheckConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.IAPConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.SecurityPolicyConfig", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.SessionAffinityConfig"},
 	}
 }
 
@@ -262,6 +268,67 @@ func schema_pkg_apis_backendconfig_v1beta1_CustomRequestHeadersConfig(ref common
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_pkg_apis_backendconfig_v1beta1_HealthCheckConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "HealthCheckConfig contains configuration for the health check.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"checkIntervalSec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CheckIntervalSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"timeoutSec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TimeoutSec is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"healthyThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"unhealthyThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UnhealthyThreshold is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+					"requestPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequestPath is a health check parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -111,6 +111,9 @@ func FakeGoogleAPINotFoundErr() *googleapi.Error {
 // IsHTTPErrorCode checks if the given error matches the given HTTP Error code.
 // For this to work the error must be a googleapi Error.
 func IsHTTPErrorCode(err error, code int) bool {
+	if err == nil {
+		return false
+	}
 	apiErr, ok := err.(*googleapi.Error)
 	return ok && apiErr.Code == code
 }


### PR DESCRIPTION
```
    Take healthcheck configuration overrides from the backendconfig

    This enables taking the healthcheck configuration from a backendconfig
    associated with the given Service.

    As part of this PR, we also clean up the override handling to be easier
    to understand where the settings come from.

    For a given ServicePort `sp` and its associated healthcheck `hc`:

    1. `sp` has some default settings depending on its type (e.g. IG, NEG, ILB).
    2. SyncServicePort() will override those settings if the Probe exists.
         Path, Host, TimeoutSec, CheckIntervalSec.
    3. We then sync with what exists in GCE:
        3.1 If the healthcheck is does not exist, it will be CREATED.
            3.1.1 If it has a backendconfig, then the following settings are used:
                    CheckIntervalSec, TimeoutSec, HealthyThreshold,
                    UnhealthyThreshold, Type, RequestPath
                  We have `Port` in the struct, but it does not seem to be a valid
                  field to use so it is currently ignored.
        3.2 Otherwise the healthcheck will need to be UPDATED. The criteria
            for update can be found in `calculateDiff()`:
            3.2.1 Services w/out backendconfig will only update when `Protocol`,
                  `PortSpecification` changes.
            3.2.2 Services w/ backendconfig will also consider any fields
                  covered by the backendconfig (see above)
            3.2.3 We merge in the settings from the existing healthcheck. As
                  users have (in the past) done edits to their HCs directly, we
                  do not want to break any previous behavior. Thus we merge in
                  all of the settings on HTTPHealthCheck as well as any fields on
                  HealthCheck itself, with the exception of: `Port`, `PortSpecification`
            3.2.2 We now consider the backendconfig to be a final override.
                  See list above for settings from the backendconfig.

    Several situations do not seem to be handled currently:

    * There is no way to change HC based on probe after it is created.
      This is because there is no way to tell if the difference is due
      to a user changing the setting directly in GCE or the HC should
      be updated.
    * Changing types to/from NEG, ILB will leak the old healthcheck.
      User healthchecksettings will not propagate to the new healthcheck.
    * backendconfig seems to be missing `Host`
```

```
TestSyncServicePort does the following:

1. Setup any preexisting objects (tc.setup) that should exist in the
   mocked GCE.
2. Run one sync given a ServicePort.
3. Attempt to re-run the sync with the same ServicePort, checking that
   no update will be needed.
```