### PR TITLE
Use backendconfig v1 for e2e tests

### DIFF
--- a/cmd/e2e-test/affinity_beta_test.go
+++ b/cmd/e2e-test/affinity_beta_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfigbeta "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestAffinityBeta(t *testing.T) {
+	t.Parallel()
+
+	affinityTransitions := []affinityTransition{
+		// "http with cookie based affinity."
+		{affinity: "GENERATED_COOKIE"},
+		// no affinity
+		{affinity: "NONE"},
+		// http with cookie based affinity and 60s ttl.
+		{affinity: "GENERATED_COOKIE", ttl: 60},
+		// client ip affinity.
+		{affinity: "CLIENT_IP"},
+	}
+
+	Framework.RunWithSandbox("affinity-v1beta1", t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+		ctx := context.Background()
+
+		backendConfigAnnotation := map[string]string{
+			annotations.BetaBackendConfigKey: `{"default":"backendconfigbeta"}`,
+		}
+		affinityType := "CLIENT_IP"
+		beConfig := &backendconfigbeta.BackendConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "backendconfigbeta",
+			},
+			Spec: backendconfigbeta.BackendConfigSpec{
+				SessionAffinity: &backendconfigbeta.SessionAffinityConfig{
+					AffinityType: affinityType,
+				},
+			},
+		}
+		if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(beConfig); err != nil {
+			t.Fatalf("CloudV1beta1().BackendConfigs(%q).Create(%#v) = %v, want nil", s.Namespace, beConfig, err)
+		}
+		t.Logf("BackendConfig created (%s/%s) ", s.Namespace, beConfig.Name)
+
+		svcName := "service-1"
+		_, err := e2e.CreateEchoService(s, svcName, backendConfigAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(_, %q, %q) = %v, want nil", svcName, backendConfigAnnotation, err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+		ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			AddPath("test.com", "/", svcName, intstr.FromInt(80)).
+			Build()
+		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("crud.Create(%#v) = %v, want nil", ing, err)
+		}
+		ingKey := fmt.Sprintf("%s/%s", s.Namespace, ing.Name)
+		t.Logf("Ingress created (%s)", ingKey)
+
+		ing, err = e2e.WaitForIngress(s, ing, nil)
+		if err != nil {
+			t.Fatalf("e2e.WaitForIngress(_, %q, nil) = %v, want nil", ingKey, err)
+		}
+		t.Logf("GCLB resources created (%s)", ingKey)
+
+		vip := ing.Status.LoadBalancer.Ingress[0].IP
+		t.Logf("Ingress %s VIP = %s", ingKey, vip)
+
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+		gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("fuzz.GCLBForVIP(_, _, %q) = %v, want nil; fail to get GCP resources for LB with IP(%q)", vip, err, vip)
+		}
+
+		// Check conformity.
+		if err := verifyAffinity(t, gclb, s.Namespace, svcName, affinityType, 0); err != nil {
+			t.Error(err)
+		}
+
+		for _, transition := range affinityTransitions {
+			// Test modifications.
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Get(beConfig.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if bc.Spec.SessionAffinity == nil {
+					bc.Spec.SessionAffinity = &backendconfigbeta.SessionAffinityConfig{}
+				}
+				bc.Spec.SessionAffinity.AffinityType = transition.affinity
+				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &transition.ttl
+				_, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("CloudV1beta1().BackendConfigs(%q).Update(%#v) = %v, want nil", s.Namespace, transition, err)
+			}
+
+			if waitErr := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("Error getting GCP resources for LB with IP(%q): %v", vip, err)
+					return false, nil
+				}
+				if err := verifyAffinity(t, gclb, s.Namespace, svcName, transition.affinity, transition.ttl); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); waitErr != nil {
+				t.Errorf("Error waiting for BackendConfig affinity transition propagation to GCLB, last seen error: %v", err)
+			}
+		}
+
+		// Wait for GCLB resources to be deleted.
+		if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+			t.Errorf("crud.Delete(%q) = %v, want nil", ingKey, err)
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		t.Logf("Waiting for GCLB resources to be deleted (%s)", ingKey)
+		if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForGCLBDeletion(_, _, %q, %#v) = %v, want nil", gclb.VIP, deleteOptions, err)
+		}
+		t.Logf("GCLB resources deleted (%s)", ingKey)
+	})
+}

--- a/cmd/e2e-test/affinity_beta_test.go
+++ b/cmd/e2e-test/affinity_beta_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigbeta "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 )
@@ -79,7 +80,7 @@ func TestAffinityBeta(t *testing.T) {
 		ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 			AddPath("test.com", "/", svcName, intstr.FromInt(80)).
 			Build()
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		if _, err := crud.Create(ing); err != nil {
 			t.Fatalf("crud.Create(%#v) = %v, want nil", ing, err)
 		}

--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -89,7 +89,7 @@ func TestAffinity(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
@@ -227,7 +227,7 @@ func TestILBSA(t *testing.T) {
 				annotations.NEGAnnotationKey:     negVal.String(),
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)

--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -105,7 +105,7 @@ func TestAffinity(t *testing.T) {
 			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
@@ -244,7 +244,7 @@ func TestILBSA(t *testing.T) {
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				ConfigureForILB().
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -22,21 +22,21 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
 const (
-	transitionPollTimeout = 10 * time.Minute
-	tansitionPollInterval = 30 * time.Second
+	transitionPollTimeout  = 10 * time.Minute
+	transitionPollInterval = 30 * time.Second
 )
 
 type affinityTransition struct {
@@ -89,7 +89,9 @@ func TestAffinity(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
@@ -131,7 +133,7 @@ func TestAffinity(t *testing.T) {
 
 			// Test modifications
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				bc, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Get(tc.beConfig.Name, metav1.GetOptions{})
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
 				if err != nil {
 					return err
 				}
@@ -140,13 +142,13 @@ func TestAffinity(t *testing.T) {
 				}
 				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
 				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
-				_, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(bc)
+				_, err = bcCRUD.Update(bc)
 				return err
 			}); err != nil {
 				t.Errorf("Failed to update BackendConfig affinity settings for %s: %v", t.Name(), err)
 			}
 
-			if err := wait.Poll(tansitionPollInterval, transitionPollTimeout, func() (bool, error) {
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
 				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
@@ -225,7 +227,9 @@ func TestILBSA(t *testing.T) {
 				annotations.NEGAnnotationKey:     negVal.String(),
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
@@ -268,7 +272,7 @@ func TestILBSA(t *testing.T) {
 
 			// Test modifications
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				bc, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Get(tc.beConfig.Name, metav1.GetOptions{})
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
 				if err != nil {
 					return err
 				}
@@ -277,13 +281,13 @@ func TestILBSA(t *testing.T) {
 				}
 				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
 				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
-				_, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(bc)
+				_, err = bcCRUD.Update(bc)
 				return err
 			}); err != nil {
 				t.Errorf("Failed to update BackendConfig affinity settings for %s: %v", t.Name(), err)
 			}
 
-			if err := wait.Poll(tansitionPollInterval, transitionPollTimeout, func() (bool, error) {
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
 				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
 				if err != nil {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)

--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 )
@@ -62,7 +63,7 @@ func TestAppProtocol(t *testing.T) {
 				DefaultBackend("service-1", intstr.FromString("https-port")).
 				AddPath("test.com", "/", "service-1", intstr.FromString("https-port")).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
@@ -132,7 +133,7 @@ func TestAppProtocolTransition(t *testing.T) {
 				DefaultBackend("service-1", intstr.FromString("https-port")).
 				AddPath("test.com", "/", "service-1", intstr.FromString("https-port")).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
@@ -82,7 +82,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 
 			if tc.backendConfig != nil {
 				tc.backendConfig.Namespace = s.Namespace
-				bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+				bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 				if _, err := bcCRUD.Create(tc.backendConfig); err != nil {
 					t.Fatalf("Error creating backend config: %v", err)
 				}

--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -107,7 +107,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 			testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", port80).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			testIng, err := crud.Create(testIng)
 			if err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)

--- a/cmd/e2e-test/backend_config_test.go
+++ b/cmd/e2e-test/backend_config_test.go
@@ -26,9 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )
@@ -44,7 +45,7 @@ func TestBackendConfigNegatives(t *testing.T) {
 	for _, tc := range []struct {
 		desc           string
 		svcAnnotations map[string]string
-		backendConfig  *backendconfigv1beta1.BackendConfig
+		backendConfig  *backendconfigv1.BackendConfig
 		secretName     string
 		expectedMsg    string
 	}{
@@ -80,7 +81,9 @@ func TestBackendConfigNegatives(t *testing.T) {
 			t.Parallel()
 
 			if tc.backendConfig != nil {
-				if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.backendConfig); err != nil {
+				tc.backendConfig.Namespace = s.Namespace
+				bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+				if _, err := bcCRUD.Create(tc.backendConfig); err != nil {
 					t.Fatalf("Error creating backend config: %v", err)
 				}
 				t.Logf("Backend config %s/%s created", s.Namespace, tc.backendConfig.Name)

--- a/cmd/e2e-test/basic_https_test.go
+++ b/cmd/e2e-test/basic_https_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 )
 
@@ -98,7 +99,7 @@ func TestBasicHTTPS(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -78,7 +79,7 @@ func testBasicOS(t *testing.T, os e2e.OS) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
 			if _, err = crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
@@ -128,7 +129,7 @@ func TestBasicStaticIP(t *testing.T) {
 			DefaultBackend("service-1", intstr.FromInt(80)).
 			AddStaticIP(addrName).
 			Build()
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		testIng, err = crud.Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
@@ -189,7 +190,7 @@ func TestEdge(t *testing.T) {
 				t.Fatalf("error creating echo service: %v", err)
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
 			if _, err = crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
@@ -264,7 +265,7 @@ func TestFrontendResourceDeletion(t *testing.T) {
 				AddPath(host, "/", svcName, port80).AddTLS([]string{}, cert.Name).Build()
 			ingKey := common.NamespacedName(ing)
 
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("crud.Create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
 			}

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -92,7 +92,7 @@ func TestCDN(t *testing.T) {
 			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -24,8 +24,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -74,7 +75,10 @@ func TestCDN(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)

--- a/cmd/e2e-test/cdn_test.go
+++ b/cmd/e2e-test/cdn_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -75,7 +75,7 @@ func TestCDN(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {

--- a/cmd/e2e-test/customrequestheaders_test.go
+++ b/cmd/e2e-test/customrequestheaders_test.go
@@ -25,8 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -60,7 +61,9 @@ func TestCustomRequestHeaders(t *testing.T) {
 			backendConfigAnnotation := map[string]string{
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)

--- a/cmd/e2e-test/customrequestheaders_test.go
+++ b/cmd/e2e-test/customrequestheaders_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -61,7 +61,7 @@ func TestCustomRequestHeaders(t *testing.T) {
 			backendConfigAnnotation := map[string]string{
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -71,7 +71,9 @@ func TestDraining(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
@@ -118,7 +120,7 @@ func TestDraining(t *testing.T) {
 
 			// Test modifications/transitions
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				bc, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Get(tc.beConfig.Name, metav1.GetOptions{})
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
 				if err != nil {
 					return err
 				}
@@ -126,7 +128,7 @@ func TestDraining(t *testing.T) {
 					bc.Spec.ConnectionDraining = &backendconfig.ConnectionDrainingConfig{}
 				}
 				bc.Spec.ConnectionDraining.DrainingTimeoutSec = tc.transitionTo
-				_, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(bc)
+				_, err = bcCRUD.Update(bc)
 				return err
 			}); err != nil {
 				t.Errorf("Failed to update BackendConfig ConnectionDraining settings for %s: %v", t.Name(), err)

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -87,7 +87,7 @@ func TestDraining(t *testing.T) {
 			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -71,7 +71,7 @@ func TestDraining(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)

--- a/cmd/e2e-test/finalizer_test.go
+++ b/cmd/e2e-test/finalizer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
@@ -45,7 +46,7 @@ func TestFinalizer(t *testing.T) {
 		}
 		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
 
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		ing.Namespace = s.Namespace
 		ingKey := common.NamespacedName(ing)
 		if _, err := crud.Create(ing); err != nil {
@@ -96,7 +97,7 @@ func TestFinalizerIngressClassChange(t *testing.T) {
 		}
 		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
 
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		ing.Namespace = s.Namespace
 		ingKey := common.NamespacedName(ing)
 		if _, err := crud.Create(ing); err != nil {
@@ -160,7 +161,7 @@ func TestFinalizerIngressesWithSharedResources(t *testing.T) {
 		}
 		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
 
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		ing.Namespace = s.Namespace
 		ingKey := common.NamespacedName(ing)
 		if _, err := crud.Create(ing); err != nil {

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -22,8 +22,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 )
@@ -56,7 +57,9 @@ func TestIAP(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -73,7 +73,7 @@ func TestIAP(t *testing.T) {
 			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/iap_test.go
+++ b/cmd/e2e-test/iap_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 )
@@ -57,7 +57,7 @@ func TestIAP(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	computebeta "google.golang.org/api/compute/v0.beta"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -98,8 +99,9 @@ func TestSecurityPolicyEnable(t *testing.T) {
 			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
 		}
 
-		testBackendConfig := fuzz.NewBackendConfigBuilder("", "backendconfig-1").SetSecurityPolicy(testSecurityPolicy.Name).Build()
-		testBackendConfig, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(testBackendConfig)
+		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicy.Name).Build()
+		bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
 		if err != nil {
 			t.Fatalf("Error creating test backend config: %v", err)
 		}
@@ -175,8 +177,9 @@ func TestSecurityPolicyTransition(t *testing.T) {
 			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
 		}
 
-		testBackendConfig := fuzz.NewBackendConfigBuilder("", "backendconfig-1").SetSecurityPolicy(testSecurityPolicyAllow.Name).Build()
-		testBackendConfig, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(testBackendConfig)
+		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicyAllow.Name).Build()
+		bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
 		if err != nil {
 			t.Fatalf("Error creating test backend config: %v", err)
 		}
@@ -224,7 +227,8 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 		for _, step := range steps {
 			testBackendConfig.Spec.SecurityPolicy.Name = step.securityPolicyToSet
-			testBackendConfig, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(testBackendConfig)
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			testBackendConfig, err = bcCRUD.Update(testBackendConfig)
 			if err != nil {
 				t.Fatalf("Error updating test backend config: %v", err)
 			}

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -112,7 +112,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 			DefaultBackend("service-1", port80).
 			AddPath("test.com", "/", "service-1", port80).
 			Build()
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		testIng, err = crud.Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)
@@ -190,7 +190,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 			DefaultBackend("service-1", port80).
 			AddPath("test.com", "/", "service-1", port80).
 			Build()
-		crud := e2e.IngressCRUD{C: Framework.Clientset}
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
 		testIng, err = crud.Create(testIng)
 		if err != nil {
 			t.Fatalf("error creating Ingress spec: %v", err)

--- a/cmd/e2e-test/security_policy_test.go
+++ b/cmd/e2e-test/security_policy_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	computebeta "google.golang.org/api/compute/v0.beta"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -100,7 +100,7 @@ func TestSecurityPolicyEnable(t *testing.T) {
 		}
 
 		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicy.Name).Build()
-		bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
 		if err != nil {
 			t.Fatalf("Error creating test backend config: %v", err)
@@ -178,7 +178,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 		}
 
 		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicyAllow.Name).Build()
-		bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
 		if err != nil {
 			t.Fatalf("Error creating test backend config: %v", err)
@@ -227,7 +227,7 @@ func TestSecurityPolicyTransition(t *testing.T) {
 
 		for _, step := range steps {
 			testBackendConfig.Spec.SecurityPolicy.Name = step.securityPolicyToSet
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			testBackendConfig, err = bcCRUD.Update(testBackendConfig)
 			if err != nil {
 				t.Fatalf("Error updating test backend config: %v", err)

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -78,7 +78,7 @@ func TestTimeout(t *testing.T) {
 			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}
@@ -169,7 +169,7 @@ func TestILBCT(t *testing.T) {
 				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
 				ConfigureForILB().
 				Build()
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -23,8 +23,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -61,7 +62,9 @@ func TestTimeout(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
@@ -149,7 +152,9 @@ func TestILBCT(t *testing.T) {
 				annotations.NEGAnnotationKey:     negVal.String(),
 			}
 
-			if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(tc.beConfig); err != nil {
+			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
 			}
 			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)

--- a/cmd/e2e-test/timeout_test.go
+++ b/cmd/e2e-test/timeout_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/e2e"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -62,7 +62,7 @@ func TestTimeout(t *testing.T) {
 				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)
@@ -152,7 +152,7 @@ func TestILBCT(t *testing.T) {
 				annotations.NEGAnnotationKey:     negVal.String(),
 			}
 
-			bcCRUD := legacy.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
 			tc.beConfig.Namespace = s.Namespace
 			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
 				t.Fatalf("error creating BackendConfig: %v", err)

--- a/cmd/e2e-test/upgrade/basic_http.go
+++ b/cmd/e2e-test/upgrade/basic_http.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
@@ -37,7 +38,7 @@ type BasicHTTP struct {
 	t         *testing.T
 	s         *e2e.Sandbox
 	framework *e2e.Framework
-	crud      e2e.IngressCRUD
+	crud      adapter.IngressCRUD
 	ing       *v1beta1.Ingress
 }
 
@@ -72,7 +73,7 @@ func (bh *BasicHTTP) PreUpgrade() error {
 		AddPath("foo.com", "/", svcName, port80).
 		Build()
 	ingKey := common.NamespacedName(bh.ing)
-	bh.crud = e2e.IngressCRUD{C: bh.framework.Clientset}
+	bh.crud = adapter.IngressCRUD{C: bh.framework.Clientset}
 	if _, err := bh.crud.Create(bh.ing); err != nil {
 		bh.t.Fatalf("error creating Ingress %s: %v", ingKey, err)
 	}

--- a/cmd/e2e-test/upgrade/finalizer.go
+++ b/cmd/e2e-test/upgrade/finalizer.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
@@ -31,7 +32,7 @@ type Finalizer struct {
 	t         *testing.T
 	s         *e2e.Sandbox
 	framework *e2e.Framework
-	crud      e2e.IngressCRUD
+	crud      adapter.IngressCRUD
 	ing       *v1beta1.Ingress
 }
 
@@ -67,7 +68,7 @@ func (fr *Finalizer) PreUpgrade() error {
 		AddPath("foo.com", "/", svcName, port80).
 		Build()
 	ingKey := common.NamespacedName(ing)
-	fr.crud = e2e.IngressCRUD{C: fr.framework.Clientset}
+	fr.crud = adapter.IngressCRUD{C: fr.framework.Clientset}
 	if _, err := fr.crud.Create(ing); err != nil {
 		fr.t.Fatalf("error creating Ingress %s: %v", ingKey, err)
 	}

--- a/cmd/e2e-test/upgrade/v2frontendnamer.go
+++ b/cmd/e2e-test/upgrade/v2frontendnamer.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
@@ -31,7 +32,7 @@ type V2FrontendNamer struct {
 	t         *testing.T
 	s         *e2e.Sandbox
 	framework *e2e.Framework
-	crud      e2e.IngressCRUD
+	crud      adapter.IngressCRUD
 	ing       *v1beta1.Ingress
 }
 
@@ -67,7 +68,7 @@ func (vf *V2FrontendNamer) PreUpgrade() error {
 		SetIngressClass("gce").
 		Build()
 	ingKey := common.NamespacedName(vf.ing)
-	vf.crud = e2e.IngressCRUD{C: vf.framework.Clientset}
+	vf.crud = adapter.IngressCRUD{C: vf.framework.Clientset}
 
 	if _, err := vf.crud.Create(vf.ing); err != nil {
 		vf.t.Fatalf("Create(%s) = %v, want nil; Ingress: %v", ingKey, err, vf.ing)

--- a/cmd/e2e-test/v2frontendnamer_test.go
+++ b/cmd/e2e-test/v2frontendnamer_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
@@ -69,7 +70,7 @@ func TestV2FrontendNamer(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
 
-			crud := e2e.IngressCRUD{C: Framework.Clientset}
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			var gclbs []*fuzz.GCLB
 			var updatedIngs []*v1beta1.Ingress
 

--- a/pkg/e2e/adapter/beconfig.go
+++ b/pkg/e2e/adapter/beconfig.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	client "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
+	"k8s.io/klog"
+)
+
+// BackendConfigCRUD wraps basic CRUD to allow use of v1beta and v1 APIs.
+type BackendConfigCRUD struct {
+	C *client.Clientset
+}
+
+// Get BackendConfig resource.
+func (crud *BackendConfigCRUD) Get(ns, name string) (*v1.BackendConfig, error) {
+	isV1, err := crud.supportsV1()
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("Get BackendConfig %s/%s", ns, name)
+	if isV1 {
+		return crud.C.CloudV1().BackendConfigs(ns).Get(name, metav1.GetOptions{})
+	}
+	klog.V(2).Info("Using BackendConfig V1beta1 API")
+	bc, err := crud.C.CloudV1beta1().BackendConfigs(ns).Get(name, metav1.GetOptions{})
+	return toV1(bc), err
+}
+
+// Create BackendConfig resource.
+func (crud *BackendConfigCRUD) Create(bc *v1.BackendConfig) (*v1.BackendConfig, error) {
+	isV1, err := crud.supportsV1()
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("Create BackendConfig %s/%s", bc.Namespace, bc.Name)
+	if isV1 {
+		return crud.C.CloudV1().BackendConfigs(bc.Namespace).Create(bc)
+	}
+	klog.V(2).Info("Using BackendConfig V1beta1 API")
+	legacyBc := toV1beta1(bc)
+	legacyBc, err = crud.C.CloudV1beta1().BackendConfigs(bc.Namespace).Create(legacyBc)
+	return toV1(legacyBc), err
+}
+
+// Update BackendConfig resource.
+func (crud *BackendConfigCRUD) Update(bc *v1.BackendConfig) (*v1.BackendConfig, error) {
+	isV1, err := crud.supportsV1()
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("Update %s/%s", bc.Namespace, bc.Name)
+	if isV1 {
+		return crud.C.CloudV1().BackendConfigs(bc.Namespace).Update(bc)
+	}
+	klog.V(2).Infof("Using BackendConfig V1beta1 API")
+	legacyBC := toV1beta1(bc)
+	legacyBC, err = crud.C.CloudV1beta1().BackendConfigs(bc.Namespace).Update(legacyBC)
+	return toV1(legacyBC), err
+}
+
+// Delete BackendConfig resource.
+func (crud *BackendConfigCRUD) Delete(ns, name string) error {
+	isV1, err := crud.supportsV1()
+	if err != nil {
+		return err
+	}
+	klog.V(2).Infof("Delete BackendConfig %s/%s", ns, name)
+	if isV1 {
+		return crud.C.CloudV1().BackendConfigs(ns).Delete(name, &metav1.DeleteOptions{})
+	}
+	klog.V(2).Info("Using BackendConfig V1beta1 API")
+	return crud.C.CloudV1beta1().BackendConfigs(ns).Delete(name, &metav1.DeleteOptions{})
+}
+
+// List BackendConfig resources in given namespace.
+func (crud *BackendConfigCRUD) List(ns string) (*v1.BackendConfigList, error) {
+	isV1, err := crud.supportsV1()
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("List BackendConfigs in namespace(%s)", ns)
+	if isV1 {
+		return crud.C.CloudV1().BackendConfigs(ns).List(metav1.ListOptions{})
+	}
+	klog.V(2).Info("Using BackendConfig V1beta1 API")
+	bcl, err := crud.C.CloudV1beta1().BackendConfigs(ns).List(metav1.ListOptions{})
+	return toV1List(bcl), err
+}
+
+func (crud *BackendConfigCRUD) supportsV1() (bool, error) {
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion("cloud.google.com/v1"); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == "BackendConfig" {
+				return true, nil
+			}
+		}
+	}
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion("cloud.google.com/v1beta1"); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == "BackendConfig" {
+				return false, nil
+			}
+		}
+	}
+	return false, errors.New("no BackendConfig resource found")
+}
+
+func toV1(bc *v1beta1.BackendConfig) *v1.BackendConfig {
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	// This is used by test cases from test data, so we assume no issues with
+	// conversion.
+	if err := e.Encode(bc); err != nil {
+		panic(err)
+	}
+
+	ret := &v1.BackendConfig{}
+	d := json.NewDecoder(b)
+	if err := d.Decode(ret); err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
+func toV1beta1(bc *v1.BackendConfig) *v1beta1.BackendConfig {
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	// This is used by test cases from test data, so we assume no issues with
+	// conversion.
+	if err := e.Encode(bc); err != nil {
+		panic(err)
+	}
+
+	ret := &v1beta1.BackendConfig{}
+	d := json.NewDecoder(b)
+	if err := d.Decode(ret); err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
+func toV1List(bcl *v1beta1.BackendConfigList) *v1.BackendConfigList {
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	// This is used by test cases from test data, so we assume no issues with
+	// conversion.
+	if err := e.Encode(bcl); err != nil {
+		panic(err)
+	}
+
+	ret := &v1.BackendConfigList{}
+	d := json.NewDecoder(b)
+	if err := d.Decode(ret); err != nil {
+		panic(err)
+	}
+
+	return ret
+}

--- a/pkg/e2e/adapter/beconfig_test.go
+++ b/pkg/e2e/adapter/beconfig_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	testutils "k8s.io/ingress-gce/pkg/test"
+)
+
+func TestBackendConfigAPIConversions(t *testing.T) {
+	for _, tc := range []struct {
+		bcV1beta1 *v1beta1.BackendConfig
+		bc        *v1.BackendConfig
+	}{
+		{
+			bcV1beta1: &v1beta1.BackendConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "backendconfig",
+				},
+				Spec: v1beta1.BackendConfigSpec{
+					SessionAffinity: &v1beta1.SessionAffinityConfig{
+						AffinityType: "CLIENT_IP",
+					},
+				},
+			},
+			bc: &v1.BackendConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "backendconfig",
+				},
+				Spec: v1.BackendConfigSpec{
+					SessionAffinity: &v1.SessionAffinityConfig{
+						AffinityType: "CLIENT_IP",
+					},
+				},
+			},
+		},
+	} {
+		gotBC := toV1(tc.bcV1beta1)
+		gotV1beta1BC := toV1beta1(tc.bc)
+
+		if diff := cmp.Diff(tc.bc, gotBC); diff != "" {
+			t.Errorf("Got diff BackendConfig V1 (-want +got):\n%s", diff)
+		}
+
+		if diff := cmp.Diff(tc.bcV1beta1, gotV1beta1BC); diff != "" {
+			t.Errorf("Got diff BackendConfig V1beta1 (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func TestBackendConfigListConversion(t *testing.T) {
+	for _, tc := range []struct {
+		bclV1beta1 *v1beta1.BackendConfigList
+		bcl        *v1.BackendConfigList
+	}{
+		{
+			bclV1beta1: &v1beta1.BackendConfigList{
+				Items: []v1beta1.BackendConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backendconfig1",
+						},
+						Spec: v1beta1.BackendConfigSpec{
+							SessionAffinity: &v1beta1.SessionAffinityConfig{
+								AffinityType: "CLIENT_IP",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backendconfig2",
+						},
+						Spec: v1beta1.BackendConfigSpec{
+							Cdn: &v1beta1.CDNConfig{
+								Enabled: true,
+								CachePolicy: &v1beta1.CacheKeyPolicy{
+									IncludeHost:        true,
+									IncludeProtocol:    false,
+									IncludeQueryString: true,
+								},
+							},
+							SessionAffinity: &v1beta1.SessionAffinityConfig{
+								AffinityType:         "GENERATED_COOKIE",
+								AffinityCookieTtlSec: testutils.Int64ToPtr(60),
+							},
+						},
+					},
+				},
+			},
+			bcl: &v1.BackendConfigList{
+				Items: []v1.BackendConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backendconfig1",
+						},
+						Spec: v1.BackendConfigSpec{
+							SessionAffinity: &v1.SessionAffinityConfig{
+								AffinityType: "CLIENT_IP",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "backendconfig2",
+						},
+						Spec: v1.BackendConfigSpec{
+							Cdn: &v1.CDNConfig{
+								Enabled: true,
+								CachePolicy: &v1.CacheKeyPolicy{
+									IncludeHost:        true,
+									IncludeProtocol:    false,
+									IncludeQueryString: true,
+								},
+							},
+							SessionAffinity: &v1.SessionAffinityConfig{
+								AffinityType:         "GENERATED_COOKIE",
+								AffinityCookieTtlSec: testutils.Int64ToPtr(60),
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		gotBC := toV1List(tc.bclV1beta1)
+
+		if diff := cmp.Diff(tc.bcl, gotBC); diff != "" {
+			t.Errorf("Got diff BackendConfig V1 List (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/pkg/e2e/adapter/ingress.go
+++ b/pkg/e2e/adapter/ingress.go
@@ -1,4 +1,4 @@
-package e2e
+package adapter
 
 // Legacy conversion code for the old extensions v1beta1 API group.
 

--- a/pkg/e2e/adapter/ingress_test.go
+++ b/pkg/e2e/adapter/ingress_test.go
@@ -1,4 +1,4 @@
-package e2e
+package adapter
 
 import (
 	"reflect"

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -265,7 +266,7 @@ func DeleteSecret(s *Sandbox, name string) error {
 
 // EnsureIngress creates a new Ingress or updates an existing one.
 func EnsureIngress(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error) {
-	crud := &IngressCRUD{s.f.Clientset}
+	crud := &adapter.IngressCRUD{C: s.f.Clientset}
 	currentIng, err := crud.Get(ing.ObjectMeta.Namespace, ing.ObjectMeta.Name)
 	if currentIng == nil || err != nil {
 		return crud.Create(ing)

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -293,7 +293,7 @@ func WaitForFrontendResourceDeletion(ctx context.Context, c cloud.Cloud, g *fuzz
 	return wait.Poll(gclbDeletionInterval, gclbDeletionTimeout, func() (bool, error) {
 		if options.CheckHttpFrontendResources {
 			if err := g.CheckResourceDeletionByProtocol(ctx, c, options, fuzz.HttpProtocol); err != nil {
-				klog.Infof("WaitForGCLBDeletionByProtocol(..., %q, %q) = %v", g.VIP, fuzz.HttpsProtocol, err)
+				klog.Infof("WaitForGCLBDeletionByProtocol(..., %q, %q) = %v", g.VIP, fuzz.HttpProtocol, err)
 				return false, nil
 			}
 		}

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/ingress-gce/cmd/echo/app"
 	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
 	"k8s.io/ingress-gce/pkg/fuzz/features"
 	"k8s.io/ingress-gce/pkg/fuzz/whitebox"
@@ -121,7 +122,7 @@ func UpgradeTestWaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitFo
 func WaitForIngress(s *Sandbox, ing *v1beta1.Ingress, options *WaitForIngressOptions) (*v1beta1.Ingress, error) {
 	err := wait.Poll(ingressPollInterval, ingressPollTimeout, func() (bool, error) {
 		var err error
-		crud := IngressCRUD{s.f.Clientset}
+		crud := adapter.IngressCRUD{C: s.f.Clientset}
 		ing, err = crud.Get(s.Namespace, ing.Name)
 		if err != nil {
 			return true, err
@@ -157,7 +158,7 @@ func WaitForHTTPResourceAnnotations(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.
 	klog.V(3).Infof("Waiting for HTTP annotations to be added on Ingress %s", ingKey)
 	err := wait.Poll(updateIngressPollInterval, updateIngressPollTimeout, func() (bool, error) {
 		var err error
-		crud := IngressCRUD{s.f.Clientset}
+		crud := adapter.IngressCRUD{C: s.f.Clientset}
 		if ing, err = crud.Get(s.Namespace, ing.Name); err != nil {
 			return true, err
 		}
@@ -178,7 +179,7 @@ func WaitForFinalizer(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error
 	klog.Infof("Waiting for Finalizer to be added for Ingress %s", ingKey)
 	err := wait.Poll(k8sApiPoolInterval, k8sApiPollTimeout, func() (bool, error) {
 		var err error
-		crud := IngressCRUD{s.f.Clientset}
+		crud := adapter.IngressCRUD{C: s.f.Clientset}
 		if ing, err = crud.Get(s.Namespace, ing.Name); err != nil {
 			klog.Infof("WaitForFinalizer(%s) = %v, error retrieving Ingress", ingKey, err)
 			return false, nil
@@ -238,7 +239,7 @@ func performWhiteboxTests(s *Sandbox, ing *v1beta1.Ingress, gclb *fuzz.GCLB) err
 // WaitForIngressDeletion deletes the given ingress and waits for the
 // resources associated with it to be deleted.
 func WaitForIngressDeletion(ctx context.Context, g *fuzz.GCLB, s *Sandbox, ing *v1beta1.Ingress, options *fuzz.GCLBDeleteOptions) error {
-	crud := IngressCRUD{s.f.Clientset}
+	crud := adapter.IngressCRUD{C: s.f.Clientset}
 	if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
 		return fmt.Errorf("delete(%q) = %v, want nil", ing.Name, err)
 	}
@@ -259,7 +260,7 @@ func WaitForFinalizerDeletion(ctx context.Context, g *fuzz.GCLB, s *Sandbox, ing
 	}
 	klog.Infof("GCLB resources deleted (%s/%s)", s.Namespace, ingName)
 
-	crud := IngressCRUD{s.f.Clientset}
+	crud := adapter.IngressCRUD{C: s.f.Clientset}
 	klog.Infof("Waiting for Finalizer to be removed for Ingress %s/%s", s.Namespace, ingName)
 	return wait.Poll(k8sApiPoolInterval, k8sApiPollTimeout, func() (bool, error) {
 		ing, err := crud.Get(s.Namespace, ingName)

--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/ingress-gce/cmd/glbc/app"
 	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	bcclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
-	"k8s.io/ingress-gce/pkg/e2e/legacy"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
@@ -66,7 +66,7 @@ func NewDefaultValidatorEnv(config *rest.Config, ns string, gce cloud.Cloud) (Va
 
 // BackendConfigs implements ValidatorEnv.
 func (e *DefaultValidatorEnv) BackendConfigs() (map[string]*backendconfig.BackendConfig, error) {
-	bcCRUD := legacy.BackendConfigCRUD{C: e.bc}
+	bcCRUD := adapter.BackendConfigCRUD{C: e.bc}
 	bcl, err := bcCRUD.List(e.ns)
 	if err != nil {
 		return nil, err

--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -23,8 +23,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/ingress-gce/cmd/glbc/app"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	bcclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/e2e/legacy"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
@@ -65,7 +66,8 @@ func NewDefaultValidatorEnv(config *rest.Config, ns string, gce cloud.Cloud) (Va
 
 // BackendConfigs implements ValidatorEnv.
 func (e *DefaultValidatorEnv) BackendConfigs() (map[string]*backendconfig.BackendConfig, error) {
-	bcl, err := e.bc.CloudV1beta1().BackendConfigs(e.ns).List(metav1.ListOptions{})
+	bcCRUD := legacy.BackendConfigCRUD{C: e.bc}
+	bcl, err := bcCRUD.List(e.ns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	backendconfigutil "k8s.io/ingress-gce/pkg/backendconfig"
 	translatorutil "k8s.io/ingress-gce/pkg/controller/translator"
 )

--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
-	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -241,3 +241,8 @@ func CheckEvent(recorder *record.FakeRecorder, expected string, shouldMatch bool
 func Float64ToPtr(val float64) *float64 {
 	return &val
 }
+
+// Int64ToPtr returns int ptr for given int.
+func Int64ToPtr(val int64) *int64 {
+	return &val
+}


### PR DESCRIPTION
- Existing e2e tests are migrated to use backendconfig v1
- one e2e test for backendconfig v1beta1 API is added 