### PR TITLE
Revert #849[Use protobufs for communication with apiserver] in v1.6

### DIFF
--- a/cmd/glbc/app/clients.go
+++ b/cmd/glbc/app/clients.go
@@ -46,16 +46,6 @@ const (
 
 // NewKubeConfig returns a Kubernetes client config given the command line settings.
 func NewKubeConfig() (*rest.Config, error) {
-	config, err := newKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-	// Use protobufs for communication with apiserver
-	config.ContentType = "application/vnd.kubernetes.protobuf"
-	return config, nil
-}
-
-func newKubeConfig() (*rest.Config, error) {
 	if flags.F.InCluster {
 		klog.V(0).Infof("Using in cluster configuration")
 		return rest.InClusterConfig()


### PR DESCRIPTION
Fixes https://github.com/kubernetes/ingress-gce/issues/1049