### PR TITLE
Handle health-check not found error gracefully

### DIFF
--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -243,12 +243,6 @@ func TestHealthCheckDelete(t *testing.T) {
 	if !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 		t.Errorf("expected not-found error, actual: %v", err)
 	}
-
-	// Delete only HTTP 1234
-	err = healthChecks.Delete(testNamer.IGBackend(1234), meta.Global)
-	if err == nil {
-		t.Errorf("expected not-found error when deleting health check, err: %v", err)
-	}
 }
 
 func TestHTTP2HealthCheckDelete(t *testing.T) {


### PR DESCRIPTION
Return after deleting regional health-checks and not try to delete global health checks.

Results in the following error and the ILB gets re-queued,
```
I0325 09:31:12.089142       1 healthchecks.go:310] Deleting health check k8s1-0cf92254-test-sandbox-7ca3ebc1bfe2ffbd-svc-1-80-54141625
E0325 09:31:12.308709       1 taskqueue.go:62] Requeuing "test-sandbox-7ca3ebc1bfe2ffbd/ing1-1" due to error: error running backend garbage collection routine: error GCing regional Backends: googleapi: Error 404: The resource 'projects/gke-test-ingress-11/global/healthChecks/k8s1-0cf92254-test-sandbox-7ca3ebc1bfe2ffbd-svc-1-80-54141625' was not found, notFound (ingresses)
```

Also, ignore health-check not found errors.