### PR TITLE
Update BackendConfig LoadBalancingScheme for L7-ILB to INTERNAL_MANAGED

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -87,7 +87,8 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string) (*composite.Backe
 	}
 
 	if sp.L7ILBEnabled {
-		be.LoadBalancingScheme = "INTERNAL"
+		// This enables l7-ILB and advanced traffic management features
+		be.LoadBalancingScheme = "INTERNAL_MANAGED"
 	}
 
 	ensureDescription(be, &sp)


### PR DESCRIPTION
Both options work for basic routing, but we should migrate to INTERNAL_MANAGED to support advanced routing rules (https://github.com/kubernetes/ingress-gce/issues/1059)