### PR TITLE
Allow local zone override for NonGCP NEG

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -164,5 +164,5 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpoints(ep *v1.Endpoints, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
-	return toZoneNetworkEndpointMap(ep, l.zoneGetter, l.servicePortName, l.podLister, l.subsetLabels, "")
+	return toZoneNetworkEndpointMap(ep, l.zoneGetter, l.servicePortName, l.podLister, l.subsetLabels, l.networkEndpointType)
 }

--- a/pkg/neg/types/simple_zone_getter.go
+++ b/pkg/neg/types/simple_zone_getter.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+// simpleZoneGetter implements ZoneGetter interface
+// It always return its one single stored zone
+type simpleZoneGetter struct {
+	zone string
+}
+
+func (s *simpleZoneGetter) GetZoneForNode(string) (string, error) {
+	return s.zone, nil
+}
+
+func (s *simpleZoneGetter) ListZones() ([]string, error) {
+	return []string{s.zone}, nil
+}
+
+func NewSimpleZoneGetter(zone string) ZoneGetter {
+	return &simpleZoneGetter{zone: zone}
+}

--- a/pkg/neg/types/simple_zone_getter_test.go
+++ b/pkg/neg/types/simple_zone_getter_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSimpleZoneGetter(t *testing.T) {
+	zone := "foo"
+	zoneGetter := NewSimpleZoneGetter(zone)
+	ret, err := zoneGetter.ListZones()
+	if err != nil {
+		t.Errorf("expect err = nil, but got %v", err)
+	}
+	expectZones := []string{zone}
+	if !reflect.DeepEqual(expectZones, ret) {
+		t.Errorf("expect list zones = %v, but got %v", expectZones, ret)
+	}
+
+	validateGetZoneForNode := func(node string) {
+		retZone, err := zoneGetter.GetZoneForNode(node)
+		if err != nil {
+			t.Errorf("expect err = nil, but got %v", err)
+		}
+
+		if retZone != zone {
+			t.Errorf("expect zone = %q, but got %q", zone, retZone)
+		}
+	}
+
+	validateGetZoneForNode("foo-node")
+	validateGetZoneForNode("bar-node")
+}


### PR DESCRIPTION
This is for NonGCP where node label of fault domains may not be present.