### PR TITLE
Fail ingress creation if specified staticIP name does not exist

### DIFF
--- a/pkg/loadbalancers/addresses.go
+++ b/pkg/loadbalancers/addresses.go
@@ -35,7 +35,11 @@ func (l *L7) checkStaticIP() (err error) {
 	}
 	managedStaticIPName := l.namer.ForwardingRule(namer.HTTPProtocol)
 	// Don't manage staticIPs if the user has specified an IP.
-	if address, manageStaticIP := l.getEffectiveIP(); !manageStaticIP {
+	address, manageStaticIP, err := l.getEffectiveIP()
+	if err != nil {
+		return err
+	}
+	if !manageStaticIP {
 		klog.V(3).Infof("Not managing user specified static IP %v", address)
 		if flags.F.EnableDeleteUnusedFrontends {
 			// Delete ingress controller managed static ip if exists.


### PR DESCRIPTION
The current behavior is to create a different staticIP and use that in the forwarding rule. Once the user-specified ip becomes available, the forwarding rule ip will flip to using that, causing some downtime.

With this change, ingress creation will fail and retry until the user-specified IP has been created out of band.

@spencerhance 