### PR TITLE
Update FrontendConfig v1beta1 API so that Spec and Status fields are optional

### DIFF
--- a/pkg/apis/frontendconfig/v1beta1/types.go
+++ b/pkg/apis/frontendconfig/v1beta1/types.go
@@ -28,8 +28,8 @@ import (
 type FrontendConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              FrontendConfigSpec   `json:"spec"`
-	Status            FrontendConfigStatus `json:"status"`
+	Spec              FrontendConfigSpec   `json:"spec,omitempty"`
+	Status            FrontendConfigStatus `json:"status,omitempty"`
 }
 
 // FrontendConfigSpec is the spec for a FrontendConfig resource

--- a/pkg/apis/frontendconfig/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/frontendconfig/v1beta1/zz_generated.openapi.go
@@ -70,7 +70,6 @@ func schema_pkg_apis_frontendconfig_v1beta1_FrontendConfig(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"spec", "status"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This matches the same behavior of the BackendConfig CRD

This will also need to be cherry picked into v1.9

/assign @bowei 