### PR TITLE
Cherry-Pick #1092 [Add support for Port to BackendConfig HealthCheckConfig] to release-1.9

### DIFF
--- a/pkg/apis/backendconfig/v1/types.go
+++ b/pkg/apis/backendconfig/v1/types.go
@@ -154,7 +154,10 @@ type HealthCheckConfig struct {
 	// Type is a health check parameter. See
 	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
 	Type *string `json:"type,omitempty"`
-	Port *int64  `json:"port,omitempty"`
+	// Port is a health check parameter. See
+	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
+	// If Port is used, the controller updates portSpecification as well
+	Port *int64 `json:"port,omitempty"`
 	// RequestPath is a health check parameter. See
 	// https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks.
 	RequestPath *string `json:"requestPath,omitempty"`

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -402,6 +402,7 @@ func (h *HealthChecks) pathFromSvcPort(sp utils.ServicePort) string {
 	return h.path
 }
 
+// formatBackendConfigHC returns a human readable string version of the HealthCheckConfig
 func formatBackendConfigHC(b *backendconfigv1.HealthCheckConfig) string {
 	var ret []string
 
@@ -413,6 +414,7 @@ func formatBackendConfigHC(b *backendconfigv1.HealthCheckConfig) string {
 		{k: "healthyThreshold", v: b.HealthyThreshold},
 		{k: "unhealthyThreshold", v: b.UnhealthyThreshold},
 		{k: "timeoutSec", v: b.TimeoutSec},
+		{k: "port", v: b.Port},
 	} {
 		if e.v != nil {
 			ret = append(ret, fmt.Sprintf("%s=%d", e.k, *e.v))


### PR DESCRIPTION

#1092 
[Wire in support to override the Port of a HealthCheck via BackendConfig.
This also forces the PortSpecification to be "USE_FIXED_PORT" regardless
of what type the health check is (e.g. neg, ilb etc.)]