### PR TITLE
Cherrypick PR 1090 to release-1.9

### DIFF
--- a/pkg/backends/features/features.go
+++ b/pkg/backends/features/features.go
@@ -36,8 +36,8 @@ const (
 	// FeatureL7ILB defines the feature name of L7 Internal Load Balancer
 	// L7-ILB Resources are currently alpha and regional
 	FeatureL7ILB = "L7ILB"
-	//FeaturePrimaryVMIPNEG defines the feature name of GCE_PRIMARY_VM_IP NEGs which are used for L4 ILB.
-	FeaturePrimaryVMIPNEG = "PrimaryVMIPNEG"
+	//FeatureVMIPNEG defines the feature name of GCE_VM_IP NEGs which are used for L4 ILB.
+	FeatureVMIPNEG = "VMIPNEG"
 )
 
 var (
@@ -48,7 +48,7 @@ var (
 	}
 	// TODO: (shance) refactor all scope to be above the serviceport level
 	scopeToFeatures = map[meta.KeyType][]string{
-		meta.Regional: []string{FeatureL7ILB, FeaturePrimaryVMIPNEG},
+		meta.Regional: []string{FeatureL7ILB, FeatureVMIPNEG},
 	}
 )
 
@@ -70,8 +70,8 @@ func featuresFromServicePort(sp *utils.ServicePort) []string {
 	if sp.NEGEnabled {
 		features = append(features, FeatureNEG)
 	}
-	if sp.PrimaryIPNEGEnabled {
-		features = append(features, FeaturePrimaryVMIPNEG)
+	if sp.VMIPNEGEnabled {
+		features = append(features, FeatureVMIPNEG)
 	}
 	if sp.L7ILBEnabled {
 		features = append(features, FeatureL7ILB)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -107,7 +107,7 @@ func (p *portset) check(fakeGCE *gce.Cloud) error {
 		} else {
 			bs, err := composite.GetBackendService(fakeGCE, key, features.VersionFromServicePort(&sp))
 			if err == nil || !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
-				if sp.PrimaryIPNEGEnabled {
+				if sp.VMIPNEGEnabled {
 					// It is expected that these Backends should not get cleaned up in the GC loop.
 					continue
 				}
@@ -350,7 +350,7 @@ func TestGCMixed(t *testing.T) {
 		{NodePort: 84, Protocol: annotations.ProtocolHTTP, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
 		{NodePort: 85, Protocol: annotations.ProtocolHTTPS, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
 		{NodePort: 86, Protocol: annotations.ProtocolHTTP, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
-		{ID: utils.ServicePortID{Service: types.NamespacedName{Name: "testsvc"}}, PrimaryIPNEGEnabled: true, BackendNamer: defaultNamer},
+		{ID: utils.ServicePortID{Service: types.NamespacedName{Name: "testsvc"}}, VMIPNEGEnabled: true, BackendNamer: defaultNamer},
 	}
 	ps := newPortset(svcNodePorts)
 	if err := ps.add(svcNodePorts); err != nil {

--- a/pkg/l4/l4controller_test.go
+++ b/pkg/l4/l4controller_test.go
@@ -78,7 +78,7 @@ func deleteILBService(l4c *L4Controller, svc *api_v1.Service) {
 
 func addNEG(l4c *L4Controller, svc *api_v1.Service) {
 	// Also create a fake NEG for this service since the sync code will try to link the backend service to NEG
-	negName := l4c.ctx.ClusterNamer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	negName := l4c.ctx.ClusterNamer.VMIPNEG(svc.Namespace, svc.Name)
 	neg := &composite.NetworkEndpointGroup{Name: negName}
 	key := meta.ZonalKey(negName, types.TestZone1)
 	composite.CreateNetworkEndpointGroup(l4c.ctx.Cloud, key, neg)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -61,7 +61,7 @@ func NewL4Handler(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType,
 	l.NamespacedName = types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
 	l.backendPool = backends.NewPool(l.cloud, l.namer)
 	l.ServicePort = utils.ServicePort{ID: utils.ServicePortID{Service: l.NamespacedName}, BackendNamer: l.namer,
-		PrimaryIPNEGEnabled: true}
+		VMIPNEGEnabled: true}
 	return l
 }
 
@@ -81,7 +81,7 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) error {
 	klog.V(2).Infof("EnsureInternalLoadBalancerDeleted(%s): attempting delete of load balancer resources", l.NamespacedName.String())
 	sharedHC := !helpers.RequestsOnlyLocalTraffic(svc)
 	// All resources use the NEG Name, except forwarding rule.
-	name := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	name := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	frName := l.GetFRName()
 	key, err := l.CreateKey(frName)
 	if err != nil {
@@ -158,7 +158,7 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) error {
 // service.
 func (l *L4) GetFRName() string {
 	_, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
-	lbName := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	lbName := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	return lbName + "-" + strings.ToLower(string(protocol))
 }
 
@@ -167,7 +167,7 @@ func (l *L4) GetFRName() string {
 func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service) (*corev1.LoadBalancerStatus, error) {
 	// Use the same resource name for NEG, BackendService as well as FR, FWRule.
 	l.Service = svc
-	name := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	name := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	options := getILBOptions(l.Service)
 
 	// create healthcheck

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -70,7 +70,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewNamer(clusterUID, "")
 	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{}, fakeMetricsCollector)
-	bsName := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	bsName := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	_, err := l.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l.NamespacedName, meta.VersionGA)
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
@@ -181,7 +181,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	lbName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 
 	// Create the expected resources necessary for an Internal Load Balancer
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(svc)
@@ -223,7 +223,7 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	lbName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	frName := l.GetFRName()
 	key, err := composite.CreateKey(l.cloud, frName, meta.Regional)
 	if err != nil {
@@ -333,7 +333,7 @@ func TestUpdateResourceLinks(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	lbName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Regional)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -409,7 +409,7 @@ func TestEnsureInternalLoadBalancerHealthCheckConfigurable(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
-	lbName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	lbName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Regional)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -529,7 +529,7 @@ func TestEnsureInternalLoadBalancerWithSpecialHealthCheck(t *testing.T) {
 	}
 	assertInternalLbResources(t, svc, l, nodeNames)
 
-	lbName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	lbName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Global)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -615,7 +615,7 @@ func TestEnsureInternalLoadBalancerErrors(t *testing.T) {
 			}
 			namer := namer_util.NewNamer(clusterUID, "")
 			l := NewL4Handler(params.service, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{}, fakeMetricsCollector)
-			//lbName := l.namer.PrimaryIPNEG(params.service.Namespace, params.service.Name)
+			//lbName := l.namer.VMIPNEG(params.service.Namespace, params.service.Name)
 			frName := l.GetFRName()
 			key, err := composite.CreateKey(l.cloud, frName, meta.Regional)
 			if err != nil {
@@ -661,7 +661,7 @@ func TestEnsureLoadBalancerDeletedSucceedsOnXPN(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
-	fwName := l.namer.PrimaryIPNEG(svc.Namespace, svc.Name)
+	fwName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
 	status, err := l.EnsureInternalLoadBalancer(nodeNames, svc)
 	if err != nil {
 		t.Errorf("Failed to ensure loadBalancer, err %v", err)
@@ -936,7 +936,7 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewNamer(clusterUID, "")
 	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{}, fakeMetricsCollector)
-	fwName := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	fwName := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	tc := struct {
 		Input  []int
 		Result []string
@@ -981,7 +981,7 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, nodeNames []string) {
 	// Check that Firewalls are created for the LoadBalancer and the HealthCheck
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(apiService)
-	resourceName := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	resourceName := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	resourceDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA)
 	if err != nil {
 		t.Errorf("Failed to create description for resources, err %v", err)
@@ -1067,7 +1067,7 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 func assertInternalLbResourcesDeleted(t *testing.T, apiService *v1.Service, firewallsDeleted bool, l *L4) {
 	frName := l.GetFRName()
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(apiService)
-	resourceName := l.namer.PrimaryIPNEG(l.Service.Namespace, l.Service.Name)
+	resourceName := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
 	hcName, hcFwName := healthchecks.HealthCheckName(sharedHC, l.namer.UID(), resourceName)
 
 	if firewallsDeleted {

--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -83,12 +83,12 @@ const (
 	cookieAffinity            = feature("CookieAffinity")
 	customRequestHeaders      = feature("CustomRequestHeaders")
 
-	standaloneNeg         = feature("StandaloneNEG")
-	ingressNeg            = feature("IngressNEG")
-	asmNeg                = feature("AsmNEG")
-	vmPrimaryIpNeg        = feature("VmPrimaryIpNEG")
-	vmPrimaryIpNegLocal   = feature("VmPrimaryIpNegLocal")
-	vmPrimaryIpNegCluster = feature("VmPrimaryIpNegCluster")
+	standaloneNeg  = feature("StandaloneNEG")
+	ingressNeg     = feature("IngressNEG")
+	asmNeg         = feature("AsmNEG")
+	vmIpNeg        = feature("VmIpNEG")
+	vmIpNegLocal   = feature("VmIpNegLocal")
+	vmIpNegCluster = feature("VmIpNegCluster")
 
 	l4ILBService      = feature("L4ILBService")
 	l4IlbGlobalAccess = feature("L4ILBGlobalAccess")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -279,29 +279,29 @@ func (im *ControllerMetrics) computeNegMetrics() map[feature]int {
 	klog.V(4).Infof("Computing NEG usage metrics from neg state map: %#v", im.negMap)
 
 	counts := map[feature]int{
-		standaloneNeg:         0,
-		ingressNeg:            0,
-		asmNeg:                0,
-		neg:                   0,
-		vmPrimaryIpNeg:        0,
-		vmPrimaryIpNegLocal:   0,
-		vmPrimaryIpNegCluster: 0,
+		standaloneNeg:  0,
+		ingressNeg:     0,
+		asmNeg:         0,
+		neg:            0,
+		vmIpNeg:        0,
+		vmIpNegLocal:   0,
+		vmIpNegCluster: 0,
 	}
 
 	for key, negState := range im.negMap {
 		klog.V(6).Infof("For service %s, it has standaloneNegs:%d, ingressNegs:%d, asmNeg:%d and vmPrimaryNeg:%v",
-			key, negState.StandaloneNeg, negState.IngressNeg, negState.AsmNeg, negState.VmPrimaryIpNeg)
+			key, negState.StandaloneNeg, negState.IngressNeg, negState.AsmNeg, negState.VmIpNeg)
 		counts[standaloneNeg] += negState.StandaloneNeg
 		counts[ingressNeg] += negState.IngressNeg
 		counts[asmNeg] += negState.AsmNeg
 		counts[neg] += negState.AsmNeg + negState.StandaloneNeg + negState.IngressNeg
-		if negState.VmPrimaryIpNeg != nil {
+		if negState.VmIpNeg != nil {
 			counts[neg] += 1
-			counts[vmPrimaryIpNeg] += 1
-			if negState.VmPrimaryIpNeg.trafficPolicyLocal {
-				counts[vmPrimaryIpNegLocal] += 1
+			counts[vmIpNeg] += 1
+			if negState.VmIpNeg.trafficPolicyLocal {
+				counts[vmIpNegLocal] += 1
 			} else {
-				counts[vmPrimaryIpNegCluster] += 1
+				counts[vmIpNegCluster] += 1
 			}
 		}
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -782,13 +782,13 @@ func TestComputeNegMetrics(t *testing.T) {
 			"empty input",
 			[]NegServiceState{},
 			map[feature]int{
-				standaloneNeg:         0,
-				ingressNeg:            0,
-				asmNeg:                0,
-				neg:                   0,
-				vmPrimaryIpNeg:        0,
-				vmPrimaryIpNegLocal:   0,
-				vmPrimaryIpNegCluster: 0,
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         0,
+				neg:            0,
+				vmIpNeg:        0,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 0,
 			},
 		},
 		{
@@ -797,46 +797,46 @@ func TestComputeNegMetrics(t *testing.T) {
 				newNegState(0, 0, 1, nil),
 			},
 			map[feature]int{
-				standaloneNeg:         0,
-				ingressNeg:            0,
-				asmNeg:                1,
-				neg:                   1,
-				vmPrimaryIpNeg:        0,
-				vmPrimaryIpNegLocal:   0,
-				vmPrimaryIpNegCluster: 0,
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         1,
+				neg:            1,
+				vmIpNeg:        0,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 0,
 			},
 		},
 		{
 			"vm primary ip neg in traffic policy cluster mode",
 			[]NegServiceState{
-				newNegState(0, 0, 1, &VmPrimaryIpNegType{trafficPolicyLocal: false}),
+				newNegState(0, 0, 1, &VmIpNegType{trafficPolicyLocal: false}),
 			},
 			map[feature]int{
-				standaloneNeg:         0,
-				ingressNeg:            0,
-				asmNeg:                1,
-				neg:                   2,
-				vmPrimaryIpNeg:        1,
-				vmPrimaryIpNegLocal:   0,
-				vmPrimaryIpNegCluster: 1,
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         1,
+				neg:            2,
+				vmIpNeg:        1,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 1,
 			},
 		},
 		{
 			"many neg services",
 			[]NegServiceState{
 				newNegState(0, 0, 1, nil),
-				newNegState(0, 1, 0, &VmPrimaryIpNegType{trafficPolicyLocal: false}),
-				newNegState(5, 0, 0, &VmPrimaryIpNegType{trafficPolicyLocal: true}),
+				newNegState(0, 1, 0, &VmIpNegType{trafficPolicyLocal: false}),
+				newNegState(5, 0, 0, &VmIpNegType{trafficPolicyLocal: true}),
 				newNegState(5, 3, 2, nil),
 			},
 			map[feature]int{
-				standaloneNeg:         10,
-				ingressNeg:            4,
-				asmNeg:                3,
-				neg:                   19,
-				vmPrimaryIpNeg:        2,
-				vmPrimaryIpNegLocal:   1,
-				vmPrimaryIpNegCluster: 1,
+				standaloneNeg:  10,
+				ingressNeg:     4,
+				asmNeg:         3,
+				neg:            19,
+				vmIpNeg:        2,
+				vmIpNegLocal:   1,
+				vmIpNegCluster: 1,
 			},
 		},
 	} {
@@ -856,12 +856,12 @@ func TestComputeNegMetrics(t *testing.T) {
 	}
 }
 
-func newNegState(standalone, ingress, asm int, negType *VmPrimaryIpNegType) NegServiceState {
+func newNegState(standalone, ingress, asm int, negType *VmIpNegType) NegServiceState {
 	return NegServiceState{
-		IngressNeg:     ingress,
-		StandaloneNeg:  standalone,
-		AsmNeg:         asm,
-		VmPrimaryIpNeg: negType,
+		IngressNeg:    ingress,
+		StandaloneNeg: standalone,
+		AsmNeg:        asm,
+		VmIpNeg:       negType,
 	}
 }
 

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -35,19 +35,19 @@ type NegServiceState struct {
 	IngressNeg int
 	// asmNeg is the count of NEGs created for ASM
 	AsmNeg int
-	// VmPrimaryIpNeg specifies if a service uses GCE_VM_PRIMARY_IP NEG.
-	VmPrimaryIpNeg *VmPrimaryIpNegType
+	// VmIpNeg specifies if a service uses GCE_VM_IP NEG.
+	VmIpNeg *VmIpNegType
 }
 
-// VmPrimaryIpNegType contains whether a GCE_VM_PRIMARY_IP NEG is requesting for
+// VmIpNegType contains whether a GCE_VM_IP NEG is requesting for
 // local traffic (or service external policy set to local).
-type VmPrimaryIpNegType struct {
+type VmIpNegType struct {
 	trafficPolicyLocal bool
 }
 
-// NewVmPrimaryIpNegType returns a new VmPrimaryIpNegType.
-func NewVmPrimaryIpNegType(trafficPolicyLocal bool) *VmPrimaryIpNegType {
-	return &VmPrimaryIpNegType{trafficPolicyLocal: trafficPolicyLocal}
+// NewVmIpNegType returns a new VmIpNegType.
+func NewVmIpNegType(trafficPolicyLocal bool) *VmIpNegType {
+	return &VmIpNegType{trafficPolicyLocal: trafficPolicyLocal}
 }
 
 // L4ILBServiceState defines if global access and subnet features are enabled

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -409,7 +409,7 @@ func (c *Controller) processService(key string) error {
 		return fmt.Errorf("failed to merge CSM service PortInfoMap: %v, error: %v", csmSVCPortInfoMap, err)
 	}
 	if c.runL4 {
-		if err := c.mergeVmPrimaryIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, negUsage); err != nil {
+		if err := c.mergeVmIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, negUsage); err != nil {
 			return err
 		}
 	}
@@ -493,8 +493,8 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 	return nil
 }
 
-// mergeVmPrimaryIpNEGsPortInfo merges the PortInfo for ILB services using GCE_VM_PRIMARY_IP NEGs into portInfoMap
-func (c *Controller) mergeVmPrimaryIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage usage.NegServiceState) error {
+// mergeVmIpNEGsPortInfo merges the PortInfo for ILB services using GCE_VM_IP NEGs into portInfoMap
+func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage usage.NegServiceState) error {
 	if wantsILB, _ := annotations.WantsL4ILB(service); !wantsILB {
 		return nil
 	}
@@ -507,9 +507,9 @@ func (c *Controller) mergeVmPrimaryIpNEGsPortInfo(service *apiv1.Service, name t
 
 	onlyLocal := helpers.RequestsOnlyLocalTraffic(service)
 	// Update usage metrics.
-	negUsage.VmPrimaryIpNeg = usage.NewVmPrimaryIpNegType(onlyLocal)
+	negUsage.VmIpNeg = usage.NewVmIpNegType(onlyLocal)
 
-	return portInfoMap.Merge(negtypes.NewPortInfoMapForPrimaryIPNEG(name.Namespace, name.Name, c.namer, !onlyLocal))
+	return portInfoMap.Merge(negtypes.NewPortInfoMapForVMIPNEG(name.Namespace, name.Name, c.namer, !onlyLocal))
 }
 
 // mergeDefaultBackendServicePortInfoMap merge the PortInfoMap for the default backend service into portInfoMap

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -298,7 +298,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 			t.Fatalf("Service was not created.(*apiv1.Service) successfully, err: %v", err)
 		}
 		validateSyncers(t, controller, 1, false)
-		expectedPortInfoMap := negtypes.NewPortInfoMapForPrimaryIPNEG(testServiceNamespace, testServiceName,
+		expectedPortInfoMap := negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName,
 			controller.namer, randomize)
 		validateSyncerManagerWithPortInfoMap(t, controller, testServiceNamespace, testServiceName, expectedPortInfoMap)
 		validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap)

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -178,13 +178,13 @@ func (manager *syncerManager) Sync(namespace, name string) {
 	}
 }
 
-// SyncNodes signals all GCE_VM_PRIMARY_IP syncers to sync.
+// SyncNodes signals all GCE_VM_IP syncers to sync.
 // Only these use nodes selected at random as endpoints and hence need to sync upon node updates.
 func (manager *syncerManager) SyncNodes() {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	for key, syncer := range manager.syncerMap {
-		if key.NegType == negtypes.VmPrimaryIpEndpointType && !syncer.IsStopped() {
+		if key.NegType == negtypes.VmIpEndpointType && !syncer.IsStopped() {
 			syncer.Sync()
 		}
 	}
@@ -336,7 +336,7 @@ func getSyncerKey(namespace, name string, servicePortKey negtypes.PortInfoMapKey
 		networkEndpointType = negtypes.NonGCPPrivateEndpointType
 	}
 	if portInfo.PortTuple.Empty() {
-		networkEndpointType = negtypes.VmPrimaryIpEndpointType
+		networkEndpointType = negtypes.VmIpEndpointType
 	}
 
 	return negtypes.NegSyncerKey{

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -222,12 +222,12 @@ func TestEnsureAndStopSyncer(t *testing.T) {
 			namespace:   svcNamespace1,
 			name:        svcName,
 			stop:        false,
-			portInfoMap: negtypes.NewPortInfoMap(svcNamespace1, svcName, types.NewSvcPortTupleSet(negtypes.SvcPortTuple{Name: portName2, Port: 3000, TargetPort: "80"}, negtypes.SvcPortTuple{Name: portName0, Port: 4000, TargetPort: "bar"}, negtypes.SvcPortTuple{Name: string(negtypes.VmPrimaryIpEndpointType), Port: 0}), namer, true),
+			portInfoMap: negtypes.NewPortInfoMap(svcNamespace1, svcName, types.NewSvcPortTupleSet(negtypes.SvcPortTuple{Name: portName2, Port: 3000, TargetPort: "80"}, negtypes.SvcPortTuple{Name: portName0, Port: 4000, TargetPort: "bar"}, negtypes.SvcPortTuple{Name: string(negtypes.VmIpEndpointType), Port: 0}), namer, true),
 			expectInternals: map[negtypes.NegSyncerKey]bool{
-				getSyncerKey(svcNamespace2, svcName, negtypes.PortInfoMapKey{ServicePort: 3000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Port: 3000, TargetPort: "80"}}):                         false,
-				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 3000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: portName2, Port: 3000, TargetPort: "80"}}):        true,
-				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 4000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: portName0, Port: 4000, TargetPort: "bar"}}):       true,
-				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 0, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: string(negtypes.VmPrimaryIpEndpointType), Port: 0}}): true,
+				getSyncerKey(svcNamespace2, svcName, negtypes.PortInfoMapKey{ServicePort: 3000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Port: 3000, TargetPort: "80"}}):                   false,
+				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 3000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: portName2, Port: 3000, TargetPort: "80"}}):  true,
+				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 4000, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: portName0, Port: 4000, TargetPort: "bar"}}): true,
+				getSyncerKey(svcNamespace1, svcName, negtypes.PortInfoMapKey{ServicePort: 0, Subset: ""}, negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Name: string(negtypes.VmIpEndpointType), Port: 0}}):  true,
 			},
 			expectEnsureError: false,
 		},
@@ -365,8 +365,8 @@ func TestGarbageCollectionNEG(t *testing.T) {
 	}
 
 	version := meta.VersionGA
-	for _, networkEndpointType := range []negtypes.NetworkEndpointType{negtypes.VmIpPortEndpointType, negtypes.NonGCPPrivateEndpointType, negtypes.VmPrimaryIpEndpointType} {
-		if networkEndpointType == negtypes.VmPrimaryIpEndpointType {
+	for _, networkEndpointType := range []negtypes.NetworkEndpointType{negtypes.VmIpPortEndpointType, negtypes.NonGCPPrivateEndpointType, negtypes.VmIpEndpointType} {
+		if networkEndpointType == negtypes.VmIpEndpointType {
 			version = meta.VersionAlpha
 		}
 		negName := manager.namer.NEG("test", "test", 80)

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -27,7 +27,7 @@ import (
 )
 
 // LocalL4ILBEndpointGetter implements the NetworkEndpointsCalculator interface.
-// It exposes methods to calculate Network endpoints for VM_PRIMARY_IP NEGs when the service
+// It exposes methods to calculate Network endpoints for GCE_VM_IP NEGs when the service
 // uses "ExternalTrafficPolicy: Local" mode.
 // In this mode, the endpoints of the NEG are calculated by listing the nodes that host the service endpoints(pods)
 // for the given service. These candidate nodes picked as is, if the count is less than the subset size limit(250).
@@ -94,7 +94,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(ep *v1.Endpoints, cur
 }
 
 // ClusterL4ILBEndpointGetter implements the NetworkEndpointsCalculator interface.
-// It exposes methods to calculate Network endpoints for VM_PRIMARY_IP NEGs when the service
+// It exposes methods to calculate Network endpoints for GCE_VM_IP NEGs when the service
 // uses "ExternalTrafficPolicy: Cluster" mode This is the default mode.
 // In this mode, the endpoints of the NEG are calculated by selecting nodes at random. Upto 25(subset size limit in this
 // mode) are selected.

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -76,14 +76,14 @@ func TestLocalGetEndpointSet(t *testing.T) {
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
-			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+			networkEndpointType: negtypes.VmIpEndpointType,
 		},
 		{
 			desc:      "no endpoints",
 			endpoints: &v1.Endpoints{},
 			// No nodes are picked as there are no service endpoints.
 			endpointSets:        nil,
-			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+			networkEndpointType: negtypes.VmIpEndpointType,
 		},
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
@@ -145,7 +145,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
 			},
-			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+			networkEndpointType: negtypes.VmIpEndpointType,
 		},
 		{
 			desc: "no endpoints",
@@ -157,7 +157,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
 			},
-			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+			networkEndpointType: negtypes.VmIpEndpointType,
 		},
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -60,7 +60,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 	negtypes.MockNetworkEndpointAPIs(fakeGCE)
 	fakeCloud := negtypes.NewAdapter(fakeGCE)
 	testNegTypes := []negtypes.NetworkEndpointType{
-		negtypes.VmPrimaryIpEndpointType,
+		negtypes.VmIpEndpointType,
 		negtypes.VmIpPortEndpointType,
 	}
 
@@ -829,7 +829,7 @@ func TestCommitPods(t *testing.T) {
 }
 
 func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, randomize bool) (negtypes.NegSyncer, *transactionSyncer) {
-	negsyncer, ts := newTestTransactionSyncer(fakeGCE, negtypes.VmPrimaryIpEndpointType)
+	negsyncer, ts := newTestTransactionSyncer(fakeGCE, negtypes.VmIpEndpointType)
 	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.zoneGetter, ts.NegSyncerKey, randomize)
 	return negsyncer, ts
 }
@@ -853,10 +853,10 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 			TargetPort: "8080",
 		},
 	}
-	if negType == negtypes.VmPrimaryIpEndpointType {
+	if negType == negtypes.VmIpEndpointType {
 		svcPort.PortTuple.Port = 0
 		svcPort.PortTuple.TargetPort = ""
-		svcPort.PortTuple.Name = string(negtypes.VmPrimaryIpEndpointType)
+		svcPort.PortTuple.Name = string(negtypes.VmIpEndpointType)
 	}
 
 	// TODO(freehan): use real readiness reflector

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -330,10 +330,10 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			apiVersion:          meta.VersionGA,
 		},
 		{
-			description:         "Create NEG of type GCE_VM_PRIMARY_IP",
+			description:         "Create NEG of type GCE_VM_IP",
 			negName:             "gcp-ip-neg",
 			enableNonGCPMode:    false,
-			networkEndpointType: negtypes.VmPrimaryIpEndpointType,
+			networkEndpointType: negtypes.VmIpEndpointType,
 			expectedSubnetwork:  testSubnetwork,
 			apiVersion:          meta.VersionAlpha,
 		},

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -45,7 +45,7 @@ type NetworkEndpointGroupCloud interface {
 // NetworkEndpointGroupNamer is an interface for generating network endpoint group name.
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
-	PrimaryIPNEG(namespace, name string) string
+	VMIPNEG(namespace, name string) string
 	NEGWithSubset(namespace, name, subset string, port int32) string
 	IsNEG(name string) bool
 }

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -32,7 +32,7 @@ func (*negNamer) NEG(namespace, name string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v", namespace, name, svcPort)
 }
 
-func (*negNamer) PrimaryIPNEG(namespace, name string) string {
+func (*negNamer) VMIPNEG(namespace, name string) string {
 	return fmt.Sprintf("%v-%v", namespace, name)
 }
 

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -55,8 +55,8 @@ type BackendNamer interface {
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
-	// PrimaryIPNEG returns the gce neg name based on the service namespace and name
-	PrimaryIPNEG(namespace, name string) string
+	// VMIPNEG returns the gce neg name based on the service namespace and name
+	VMIPNEG(namespace, name string) string
 	// InstanceGroup constructs the name for an Instance Group.
 	InstanceGroup() string
 	// NamedPort returns the name for a named port.

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -465,7 +465,7 @@ func (n *Namer) NEGWithSubset(namespace, name, subset string, port int32) string
 	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, truncSubset, negSuffix(n.shortUID(), namespace, name, portStr, subset))
 }
 
-// PrimaryIPNEG returns the gce neg name based on the service namespace and name
+// VMIPNEG returns the gce neg name based on the service namespace and name
 // NEG naming convention:
 //
 //   {prefix}{version}-{clusterid}-{namespace}-{name}-{hash}
@@ -476,13 +476,13 @@ func (n *Namer) NEGWithSubset(namespace, name, subset string, port int32) string
 // WARNING: Controllers depend on the naming pattern to get the list
 // of all NEGs associated with the current cluster. Any modifications
 // must be backward compatible.
-func (n *Namer) PrimaryIPNEG(namespace, name string) string {
+func (n *Namer) VMIPNEG(namespace, name string) string {
 	truncFields := TrimFieldsEvenly(maxNEGDescriptiveLabel, namespace, name)
 	truncNamespace := truncFields[0]
 	truncName := truncFields[1]
 	// Use the full cluster UID in the suffix to reduce chance of collision.
 	return fmt.Sprintf("%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName,
-		primaryIPNegSuffix(n.UID(), namespace, name))
+		vmIPNegSuffix(n.UID(), namespace, name))
 }
 
 // IsNEG returns true if the name is a NEG owned by this cluster.
@@ -497,8 +497,8 @@ func (n *Namer) negPrefix() string {
 	return fmt.Sprintf("%s%s-%s", n.prefix, schemaVersionV1, n.shortUID())
 }
 
-// primaryIPNegSuffix returns an 8 character hash code to be used as suffix in GCE_PRIMARY_VM_IP NEG.
-func primaryIPNegSuffix(uid, namespace, name string) string {
+// vmIPNegSuffix returns an 8 character hash code to be used as suffix in GCE_VM_IP NEG.
+func vmIPNegSuffix(uid, namespace, name string) string {
 	return common.ContentHash(strings.Join([]string{uid, namespace, name}, ";"), 8)
 }
 

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -46,21 +46,21 @@ type ServicePort struct {
 
 	NodePort int64
 	// Numerical port of the Service, retrieved from the Service
-	Port                int32
-	Protocol            annotations.AppProtocol
-	TargetPort          string
-	NEGEnabled          bool
-	PrimaryIPNEGEnabled bool
-	L7ILBEnabled        bool
-	BackendConfig       *backendconfigv1.BackendConfig
-	BackendNamer        namer.BackendNamer
+	Port           int32
+	Protocol       annotations.AppProtocol
+	TargetPort     string
+	NEGEnabled     bool
+	VMIPNEGEnabled bool
+	L7ILBEnabled   bool
+	BackendConfig  *backendconfigv1.BackendConfig
+	BackendNamer   namer.BackendNamer
 }
 
 // GetAPIVersionFromServicePort returns the compute API version to be used
 // for creating NEGs associated with the given ServicePort.
 func GetAPIVersionFromServicePort(sp *ServicePort) meta.Version {
-	if sp.PrimaryIPNEGEnabled {
-		// this uses VM_PRIMARY_IP_NEGS which requires alpha API
+	if sp.VMIPNEGEnabled {
+		// this uses VM_IP NEGS which requires alpha API
 		return meta.VersionAlpha
 	}
 	return meta.VersionGA
@@ -78,8 +78,8 @@ func (sp ServicePort) GetDescription() Description {
 func (sp ServicePort) BackendName() string {
 	if sp.NEGEnabled {
 		return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
-	} else if sp.PrimaryIPNEGEnabled {
-		return sp.BackendNamer.PrimaryIPNEG(sp.ID.Service.Namespace, sp.ID.Service.Name)
+	} else if sp.VMIPNEGEnabled {
+		return sp.BackendNamer.VMIPNEG(sp.ID.Service.Namespace, sp.ID.Service.Name)
 	}
 	return sp.BackendNamer.IGBackend(sp.NodePort)
 }


### PR DESCRIPTION
Cherrypick of https://github.com/kubernetes/ingress-gce/pull/1090

This replaces GCE_PRIMARY_VM_IP to GCE_VM_IP NEG.
That is the new name for the L4 ILB NEG.

/assign @freehan 