### PR TITLE
Script to run local e2e test

### DIFF
--- a/hack/run-local-glbc.sh
+++ b/hack/run-local-glbc.sh
@@ -1,0 +1,46 @@
+#/bin/bash
+
+# Run glbc. First run `run-local.sh` to set things up.
+#
+# Files touched: /tmp/kubectl-proxy.log /tmp/glbc.log
+
+GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.config/gcloud/application_default_credentials.json"
+
+if [ ! -r ${GOOGLE_APPLICATION_CREDENTIALS} ]; then
+    echo "You must login your application default credentials"
+    echo "$ gcloud auth application-default login"
+    exit 1
+fi
+
+GCECONF=${GCECONF:-/tmp/gce.conf}
+GLBC=${GLBC:-./glbc}
+PORT=${PORT:-7127}
+V=${V:-3}
+
+echo "GCECONF=${GCECONF} GLBC=${GLBC} PORT=${PORT} V=${V}"
+
+if [ ! -x "${GLBC}" ]; then
+    echo "ERROR: No ${GLBC} executable found" >&2
+    exit 1
+fi
+
+echo "$(date) start" >> /tmp/kubectl-proxy.log
+kubectl proxy --port="${PORT}" \
+    >> /tmp/kubectl-proxy.log &
+
+PROXY_PID=$!
+cleanup() {
+    echo "Killing proxy (pid=${PROXY_PID})"
+    kill ${PROXY_PID}
+}
+trap cleanup EXIT
+
+kubectl apply -f docs/deploy/resources/default-http-backend.yaml
+
+sleep 2 # Wait for proxy to start up
+${GLBC} \
+    --apiserver-host=http://localhost:${PORT} \
+    --running-in-cluster=false \
+    --logtostderr --v=${V} \
+    --config-file-path=${GCECONF} \
+    | tee -a /tmp/glbc.log

--- a/hack/setup-local.sh
+++ b/hack/setup-local.sh
@@ -1,0 +1,72 @@
+#/bin/bash
+
+# Setup the environment for running the e2e tests from your
+# desktop.
+
+set -e
+
+parseCluster() {
+    # These are all globals.
+    net=$1
+    subnet=$2
+    zone=$3
+    selfLink=$4
+    net=$(echo ${net} | sed 's+.*networks/\([-a-z]*\).*$+\1+')
+    subnet=$(echo ${subnet} | sed 's+.*subnetworks/\([-a-z]*\)$+\1+')
+    project=$(echo ${selfLink} | sed 's+.*/projects/\([-a-z]*\)/.*+\1+')
+}
+
+parseInstance() {
+    local name=$1
+    local zone=$2
+    # Globals.
+    nodeTag=$(gcloud compute instances describe ${name} --zone ${zone} --format='value(tags.items[0])')
+}
+
+clusterName="$1"
+clusterLocation="$2"
+
+if [ -z "${clusterName}" ]; then
+    echo "Usage: $0 CLUSTER_NAME [LOCATION]"
+    echo
+    echo "LOCATION is optional if there is only one cluster with CLUSTER_NAME"
+    exit 1
+fi
+
+fmt='value(networkConfig.network,networkConfig.subnetwork,zone,selfLink,name)'
+if [ -z "$clusterLocation" ]; then
+    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name=${clusterName}")
+else
+    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name=${clusterName} location=${clusterLocation}")
+fi
+if [ $(echo "${cluster}" | wc -l) -gt 1 ]; then
+    echo "ERROR: more than one cluster matches '${clusterName}'"
+fi
+parseCluster ${clusters}
+if [ -z  "${clusters}" ]; then
+    echo "ERROR: No cluster '${clusterName}' found"
+    exit 1
+fi
+
+instance=$(gcloud compute instances list --format='value(name,zone)' | grep ${clusterName} | tail -n 1)
+parseInstance ${instance}
+if [ -z  "${instance}" ]; then
+    echo "ERROR: No nodes matching '${clusterName}' found"
+    exit 1
+fi
+
+gceConf="/tmp/gce.conf"
+echo "Writing ${gceConf}"
+echo "----"
+cat <<EOF |  tee ${gceConf}
+[global]
+token-url = nil
+project-id = ${project}
+network-name = ${net}
+subnetwork-name = ${subnet}
+node-instance-prefix = ${clusterName}
+node-tags = ${nodeTag}
+local-zone = ${zone}
+EOF
+
+echo "Run glbc with hack/run-glbc.sh"


### PR DESCRIPTION
hack/run-local-e2e.sh will setup your environment and
write some scripts to help run e2e tests from a locally built
binary.

Usage

$ ./hack/run-local-e2e.sh my-cluster
...
$ bash /tmp/run-glbc.sh # run proxy and controller