### PR TITLE
Update CRD client(apiextensions) to v1

### DIFF
--- a/pkg/backendconfig/backendconfig.go
+++ b/pkg/backendconfig/backendconfig.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	apisbackendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	backendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/crd"
 )
 
@@ -38,14 +39,16 @@ var (
 func CRDMeta() *crd.CRDMeta {
 	meta := crd.NewCRDMeta(
 		apisbackendconfig.GroupName,
-		"v1",
 		"BackendConfig",
 		"BackendConfigList",
 		"backendconfig",
 		"backendconfigs",
+		[]*crd.Version{
+			crd.NewVersion("v1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.BackendConfig", backendconfigv1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.BackendConfig", backendconfigv1beta1.GetOpenAPIDefinitions),
+		},
 		"bc",
 	)
-	meta.AddValidationInfo("k8s.io/ingress-gce/pkg/apis/backendconfig/v1.BackendConfig", backendconfigv1.GetOpenAPIDefinitions)
 	return meta
 }
 

--- a/pkg/crd/meta.go
+++ b/pkg/crd/meta.go
@@ -22,8 +22,10 @@ import (
 
 // CRDMeta contains version, validation and API information for a CRD.
 type CRDMeta struct {
-	groupName  string
-	version    string
+	groupName string
+	// versions is a slice of supported API versions for the CRD.
+	// The latest version should be the first element in the slice.
+	versions   []*Version
 	kind       string
 	listKind   string
 	singular   string
@@ -35,10 +37,10 @@ type CRDMeta struct {
 
 // NewCRDMeta creates a CRDMeta type which can be passed to a CRDHandler in
 // order to create/ensure a CRD.
-func NewCRDMeta(groupName, version, kind, listKind, singular, plural string, shortNames ...string) *CRDMeta {
+func NewCRDMeta(groupName, kind, listKind, singular, plural string, versions []*Version, shortNames ...string) *CRDMeta {
 	return &CRDMeta{
 		groupName:  groupName,
-		version:    version,
+		versions:   versions,
 		kind:       kind,
 		listKind:   listKind,
 		singular:   singular,
@@ -47,9 +49,19 @@ func NewCRDMeta(groupName, version, kind, listKind, singular, plural string, sho
 	}
 }
 
-// AddValidationInfo adds information that is needed to ensure validation is
-// properly added to a CRD when CRDHandler.EnsureCRD is called.
-func (m *CRDMeta) AddValidationInfo(typeSource string, fn common.GetOpenAPIDefinitions) {
-	m.typeSource = typeSource
-	m.fn = fn
+// Version specifies the API version and meta information that is needed to
+// generate OpenAPI schema based CRD validation.
+type Version struct {
+	name       string
+	typeSource string
+	fn         common.GetOpenAPIDefinitions
+}
+
+// NewVersion returns a CRD API version with validation metadata.
+func NewVersion(name, typeSource string, fn common.GetOpenAPIDefinitions) *Version {
+	return &Version{
+		name:       name,
+		typeSource: typeSource,
+		fn:         fn,
+	}
 }

--- a/pkg/frontendconfig/frontendconfig.go
+++ b/pkg/frontendconfig/frontendconfig.go
@@ -34,13 +34,14 @@ var (
 func CRDMeta() *crd.CRDMeta {
 	meta := crd.NewCRDMeta(
 		apisfrontendconfig.GroupName,
-		"v1beta1",
 		"FrontendConfig",
 		"FrontendConfigList",
 		"frontendconfig",
 		"frontendconfigs",
+		[]*crd.Version{
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1.FrontendConfig", frontendconfigv1beta1.GetOpenAPIDefinitions),
+		},
 	)
-	meta.AddValidationInfo("k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1.FrontendConfig", frontendconfigv1beta1.GetOpenAPIDefinitions)
 	return meta
 }
 

--- a/pkg/svcneg/svcneg.go
+++ b/pkg/svcneg/svcneg.go
@@ -24,13 +24,14 @@ import (
 func CRDMeta() *crd.CRDMeta {
 	meta := crd.NewCRDMeta(
 		apisneg.GroupName,
-		"v1beta1",
 		"ServiceNetworkEndpointGroup",
 		"ServiceNetworkEndpointGroupList",
 		"servicenetworkendpointgroup",
 		"servicenetworkendpointgroups",
+		[]*crd.Version{
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup", negv1beta1.GetOpenAPIDefinitions),
+		},
 		"svcneg",
 	)
-	meta.AddValidationInfo("k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup", negv1beta1.GetOpenAPIDefinitions)
 	return meta
 }


### PR DESCRIPTION
`apiextensions.k8s.io/v1beta1` is deprecated as of [k8s-v1.16](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning).

So, this works just fine with all 1.16+ GKE versions.