### PR TITLE
Use Patch instead of Update for k8s Service client

### DIFF
--- a/pkg/cmconfig/controller.go
+++ b/pkg/cmconfig/controller.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 )
 
@@ -65,7 +65,7 @@ func (c *ConfigMapConfigController) GetConfig() Config {
 }
 
 func (c *ConfigMapConfigController) updateASMReady(status string) {
-	patchBytes, err := utils.StrategicMergePatchBytes(v1.ConfigMap{Data: map[string]string{}},
+	patchBytes, err := patch.StrategicMergePatchBytes(v1.ConfigMap{Data: map[string]string{}},
 		v1.ConfigMap{Data: map[string]string{asmReady: status}}, v1.ConfigMap{})
 	if err != nil {
 		c.RecordEvent("Warning", "FailedToUpdateASMStatus", fmt.Sprintf("Failed to update ASM Status, failed to create patch for ASM ConfigMap, error: %s", err))

--- a/pkg/experimental/workload/daemon/daemon.go
+++ b/pkg/experimental/workload/daemon/daemon.go
@@ -31,7 +31,7 @@ import (
 	workloadv1a1 "k8s.io/ingress-gce/pkg/experimental/apis/workload/v1alpha1"
 	workloadclient "k8s.io/ingress-gce/pkg/experimental/workload/client/clientset/versioned"
 	daemonutils "k8s.io/ingress-gce/pkg/experimental/workload/daemon/utils"
-	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 )
 
@@ -177,7 +177,7 @@ func OutputCredentials(credentials daemonutils.ClusterCredentials) {
 
 // preparePatchBytesforWorkloadStatus generates patch bytes based on the old and new workload status
 func preparePatchBytesforWorkloadStatus(oldStatus, newStatus workloadv1a1.WorkloadStatus) ([]byte, error) {
-	patchBytes, err := utils.StrategicMergePatchBytes(
+	patchBytes, err := patch.StrategicMergePatchBytes(
 		workloadv1a1.Workload{Status: oldStatus},
 		workloadv1a1.Workload{Status: newStatus},
 		workloadv1a1.Workload{},

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
 	namer2 "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 )
 
@@ -693,7 +694,7 @@ func (c *Controller) syncDestinationRuleNegStatusAnnotation(namespace, destinati
 	newDestinationRule := destinationRule.DeepCopy()
 	newDestinationRule.SetAnnotations(drAnnotations)
 	// Get the diff, we only need the Object meta diff.
-	patchBytes, err := utils.StrategicMergePatchBytes(destinationRule, newDestinationRule, struct {
+	patchBytes, err := patch.StrategicMergePatchBytes(destinationRule, newDestinationRule, struct {
 		metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	}{})
 	if err != nil {

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -625,8 +625,8 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 	if err != nil {
 		return err
 	}
-	svcClient := c.client.CoreV1().Services(namespace)
-	service, err := svcClient.Get(context2.TODO(), name, metav1.GetOptions{})
+	coreClient := c.client.CoreV1()
+	service, err := coreClient.Services(namespace).Get(context2.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -634,11 +634,10 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 	// Remove NEG Status Annotation when no NEG is needed
 	if len(portMap) == 0 {
 		if _, ok := service.Annotations[annotations.NEGStatusKey]; ok {
-			// TODO: use PATCH to remove annotation
-			delete(service.Annotations, annotations.NEGStatusKey)
+			newSvcObjectMeta := service.ObjectMeta.DeepCopy()
+			delete(newSvcObjectMeta.Annotations, annotations.NEGStatusKey)
 			klog.V(2).Infof("Removing NEG status annotation from service: %s/%s", namespace, name)
-			_, err = svcClient.Update(context2.TODO(), service, metav1.UpdateOptions{})
-			return err
+			return patch.PatchServiceObjectMetadata(coreClient, service, *newSvcObjectMeta)
 		}
 		// service doesn't have the expose NEG annotation and doesn't need update
 		return nil
@@ -653,14 +652,14 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 	if ok && existingAnnotation == annotation {
 		return nil
 	}
+	newSvcObjectMeta := service.ObjectMeta.DeepCopy()
 	// If enableCSM=true, it's possible a service having nil Annotations.
-	if service.Annotations == nil {
-		service.Annotations = make(map[string]string)
+	if newSvcObjectMeta.Annotations == nil {
+		newSvcObjectMeta.Annotations = make(map[string]string)
 	}
-	service.Annotations[annotations.NEGStatusKey] = annotation
+	newSvcObjectMeta.Annotations[annotations.NEGStatusKey] = annotation
 	klog.V(2).Infof("Updating NEG visibility annotation %q on service %s/%s.", annotation, namespace, name)
-	_, err = svcClient.Update(context2.TODO(), service, metav1.UpdateOptions{})
-	return err
+	return patch.PatchServiceObjectMetadata(coreClient, service, *newSvcObjectMeta)
 }
 
 // syncDestinationRuleNegStatusAnnotation syncs the destinationrule related neg status annotation

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -44,6 +44,7 @@ import (
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -576,7 +577,7 @@ func deleteSvcNegCR(svcNegClient svcnegclient.Interface, negCR *negv1beta1.Servi
 
 // patchNegStatus patches the specified NegCR status with the provided new status
 func patchNegStatus(svcNegClient svcnegclient.Interface, oldNeg, newNeg negv1beta1.ServiceNetworkEndpointGroup) (*negv1beta1.ServiceNetworkEndpointGroup, error) {
-	patchBytes, err := utils.MergePatchBytes(oldNeg, newNeg)
+	patchBytes, err := patch.MergePatchBytes(oldNeg, newNeg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare patch bytes: %s", err)
 	}

--- a/pkg/neg/readiness/utils.go
+++ b/pkg/neg/readiness/utils.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
-	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 )
 
@@ -113,7 +113,7 @@ func patchPodStatus(c clientset.Interface, namespace, name string, patchBytes []
 
 // preparePatchBytesforPodStatus generates patch bytes based on the old and new pod status
 func preparePatchBytesforPodStatus(oldPodStatus, newPodStatus v1.PodStatus) ([]byte, error) {
-	patchBytes, err := utils.StrategicMergePatchBytes(v1.Pod{Status: oldPodStatus}, v1.Pod{Status: newPodStatus}, v1.Pod{})
+	patchBytes, err := patch.StrategicMergePatchBytes(v1.Pod{Status: oldPodStatus}, v1.Pod{Status: newPodStatus}, v1.Pod{})
 	return patchBytes, err
 }
 

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/readiness"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
-	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/apis/core"
 )
@@ -546,7 +546,7 @@ func getNegFromStore(svcNegLister cache.Indexer, namespace, negName string) (*ne
 
 // patchNegStatus patches the specified NegCR status with the provided new status
 func patchNegStatus(svcNegClient svcnegclient.Interface, oldStatus, newStatus negv1beta1.ServiceNetworkEndpointGroupStatus, namespace, negName string) (*negv1beta1.ServiceNetworkEndpointGroup, error) {
-	patchBytes, err := utils.MergePatchBytes(negv1beta1.ServiceNetworkEndpointGroup{Status: oldStatus}, negv1beta1.ServiceNetworkEndpointGroup{Status: newStatus})
+	patchBytes, err := patch.MergePatchBytes(negv1beta1.ServiceNetworkEndpointGroup{Status: oldStatus}, negv1beta1.ServiceNetworkEndpointGroup{Status: newStatus})
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare patch bytes: %s", err)
 	}

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -17,8 +17,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	svchelpers "k8s.io/cloud-provider/service/helpers"
 )
 
 // StrategicMergePatchBytes returns a patch between the old and new object using a strategic merge patch.
@@ -61,4 +65,22 @@ func MergePatchBytes(old, cur interface{}) ([]byte, error) {
 	}
 
 	return patchBytes, nil
+}
+
+// PatchServiceObjectMetadata patches the given service's metadata based on new
+// service metadata.
+func PatchServiceObjectMetadata(client coreclient.CoreV1Interface, svc *corev1.Service, newObjectMetadata metav1.ObjectMeta) error {
+	newSvc := svc.DeepCopy()
+	newSvc.ObjectMeta = newObjectMetadata
+	_, err := svchelpers.PatchService(client, svc, newSvc)
+	return err
+}
+
+// PatchServiceLoadBalancerStatus patches the given service's LoadBalancerStatus
+// based on new service's load-balancer status.
+func PatchServiceLoadBalancerStatus(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus) error {
+	newSvc := svc.DeepCopy()
+	newSvc.Status.LoadBalancer = newStatus
+	_, err := svchelpers.PatchService(client, svc, newSvc)
+	return err
 }

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package patch
 
 import (
 	"encoding/json"

--- a/pkg/utils/patch/patch_test.go
+++ b/pkg/utils/patch/patch_test.go
@@ -14,10 +14,17 @@ limitations under the License.
 package patch
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 func TestStrategicMergePatchBytes(t *testing.T) {
@@ -92,5 +99,184 @@ func TestJSONMergePatchBytes(t *testing.T) {
 	expected = `{"metadata":{"finalizers":null}}`
 	if string(b) != expected {
 		t.Errorf("MergePatchBytes(%+v, %+v) = %s ; want %s", ing, updated, string(b), expected)
+	}
+}
+
+func TestPatchServiceObjectMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		svc         *apiv1.Service
+		newMetaFunc func(*apiv1.Service) *apiv1.Service
+	}{
+		{
+			desc: "add annotation",
+			svc:  newTestService("ns1", "add-annotation-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Annotations["test-annotation-key3"] = "test-value3"
+				return ret
+			},
+		},
+		{
+			desc: "delete annotation",
+			svc:  newTestService("ns2", "delete-annotation-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				delete(ret.Annotations, testAnnotationKey)
+				return ret
+			},
+		},
+		{
+			desc: "delete all annotations",
+			svc:  newTestService("ns3", "delete-all-annotations-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Annotations = nil
+				return ret
+			},
+		},
+		{
+			desc: "add finalizer",
+			svc:  newTestService("ns4", "add-finalizer-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Finalizers = append(ret.Finalizers, "new-test-finalizer")
+				return ret
+			},
+		},
+		{
+			desc: "delete finalizer",
+			svc:  newTestService("ns5", "delete-finalizer-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Finalizers = slice.RemoveString(ret.Finalizers, testFinalizer, nil)
+				return ret
+			},
+		},
+		{
+			desc: "delete all finalizers",
+			svc:  newTestService("ns6", "delete-all-finalizers-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Finalizers = nil
+				return ret
+			},
+		},
+		{
+			desc: "delete both annotation and finalizer",
+			svc:  newTestService("ns7", "delete-annotation-and-finalizer-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Finalizers = slice.RemoveString(ret.Finalizers, testFinalizer, nil)
+				delete(ret.Annotations, testAnnotationKey)
+				return ret
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			svcKey := fmt.Sprintf("%s/%s", tc.svc.Namespace, tc.svc.Name)
+			coreClient := fake.NewSimpleClientset().CoreV1()
+			if _, err := coreClient.Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
+			}
+			expectSvc := tc.newMetaFunc(tc.svc)
+			err := PatchServiceObjectMetadata(coreClient, tc.svc, expectSvc.ObjectMeta)
+			if err != nil {
+				t.Fatalf("PatchServiceObjectMetadata(%s) = %v, want nil", svcKey, err)
+			}
+
+			gotSvc, err := coreClient.Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get(%s) = %v, want nil", svcKey, err)
+			}
+			if diff := cmp.Diff(expectSvc, gotSvc); diff != "" {
+				t.Errorf("Got mismatch for Service (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPatchServiceLoadBalancerStatus(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		svc         *apiv1.Service
+		newMetaFunc func(*apiv1.Service) *apiv1.Service
+	}{
+		{
+			desc: "update status",
+			svc:  newTestService("ns1", "update-status-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Status = apiv1.ServiceStatus{
+					LoadBalancer: apiv1.LoadBalancerStatus{
+						Ingress: []apiv1.LoadBalancerIngress{
+							{IP: "10.0.0.1"},
+						},
+					},
+				}
+				return ret
+			},
+		},
+		{
+			desc: "delete status",
+			svc:  newTestService("ns2", "delete-status-svc"),
+			newMetaFunc: func(svc *apiv1.Service) *apiv1.Service {
+				ret := svc.DeepCopy()
+				ret.Status = apiv1.ServiceStatus{}
+				return ret
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			svcKey := fmt.Sprintf("%s/%s", tc.svc.Namespace, tc.svc.Name)
+			coreClient := fake.NewSimpleClientset().CoreV1()
+			if _, err := coreClient.Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
+			}
+			expectSvc := tc.newMetaFunc(tc.svc)
+			err := PatchServiceLoadBalancerStatus(coreClient, tc.svc, expectSvc.Status.LoadBalancer)
+			if err != nil {
+				t.Fatalf("PatchServiceLoadBalancerStatus(%s) = %v, want nil", svcKey, err)
+			}
+
+			gotSvc, err := coreClient.Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get(%s) = %v, want nil", svcKey, err)
+			}
+			if diff := cmp.Diff(expectSvc, gotSvc); diff != "" {
+				t.Errorf("Got mismatch for Service (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+const (
+	testAnnotationKey = "test-annotations-key1"
+	testFinalizer     = "test-finalizer"
+)
+
+func newTestService(namespace, name string) *apiv1.Service {
+	return &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				testAnnotationKey:       "test-value1",
+				"test-annotations-key2": "test-value2",
+			},
+			Finalizers: []string{testFinalizer},
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{Name: "http-80"},
+			},
+		},
+		Status: apiv1.ServiceStatus{
+			LoadBalancer: apiv1.LoadBalancerStatus{
+				Ingress: []apiv1.LoadBalancerIngress{
+					{IP: "127.0.0.1"},
+				},
+			},
+		},
 	}
 }

--- a/pkg/utils/patch/patch_test.go
+++ b/pkg/utils/patch/patch_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package patch
 
 import (
 	"testing"


### PR DESCRIPTION
This replaces of all instances of update calls of k8s Service resource from this controller.

Also, this uses k8s service helper function to patch Service.

/assign @freehan @prameshj  