### PR TITLE
Add rbac permissions for networking.gke.io/frontendconfigs

### DIFF
--- a/docs/deploy/resources/rbac.yaml
+++ b/docs/deploy/resources/rbac.yaml
@@ -74,6 +74,11 @@ rules:
 - apiGroups: ["cloud.google.com"]
   resources: ["backendconfigs"]
   verbs: ["get", "list", "watch", "update", "create", "patch"]
+# GLBC ensures that the `networking.gke.io/frontendconfigs` CRD exists and reconciles the configuration
+# https://github.com/kubernetes/ingress-gce/blob/v1.9.4/cmd/glbc/main.go#L118
+- apiGroups: ["networking.gke.io"]
+  resources: ["frontendconfigs"]
+  verbs: ["get", "list", "watch", "update", "create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# **NOTE** When adding new CRDs. Make sure to include the new rbac permissions in docs/deploy/resources/rbac.yaml
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
This will need to be cherry-picked into release-1.9 asap

Tested the rbac config in a sandbox