### PR TITLE
Refactor affinity test for L7 XLB to use transitions for all test cases

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -39,98 +39,88 @@ const (
 	transitionPollInterval = 30 * time.Second
 )
 
-type affinityTransition struct {
-	affinity string
+type affinity struct {
+	affinityType string
 	ttl      int64
 }
 
 func TestAffinity(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		desc       string
-		ttl        int64
-		expect     string
-		transition affinityTransition
-		beConfig   *backendconfig.BackendConfig
-	}{
+	beConfig := fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build()
+	initial := affinity{
+		affinityType: "None",
+		ttl: 0,
+	}
+	transitions := []affinity{
 		{
-			desc:       "http with no affinity.",
-			beConfig:   fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
-			expect:     "NONE",
-			transition: affinityTransition{"CLIENT_IP", 10},
+			affinityType: "CLIENT_IP",
+			ttl: 10,
 		},
 		{
-			desc: "http with cookie based affinity.",
-			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
-				SetSessionAffinity("GENERATED_COOKIE").
-				Build(),
-			expect:     "GENERATED_COOKIE",
-			transition: affinityTransition{"NONE", 20},
+			affinityType: "GENERATED_COOKIE",
+			ttl: 20,
 		},
 		{
-			desc: "http with cookie based affinity and 60s ttl.",
-			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
-				SetSessionAffinity("GENERATED_COOKIE").
-				SetAffinityCookieTtlSec(60).
-				Build(),
-			expect:     "GENERATED_COOKIE",
-			ttl:        60,
-			transition: affinityTransition{"CLIENT_IP", 30},
+			affinityType: "GENERATED_COOKIE",
+			ttl: 60,
 		},
-	} {
-		tc := tc // Capture tc as we are running this in parallel.
-		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
-			t.Parallel()
+		{
+			affinityType: "NONE",
+			ttl: 20,
+		},
+	}
 
-			ctx := context.Background()
+	Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+		ctx := context.Background()
 
-			backendConfigAnnotation := map[string]string{
-				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
-			}
+		backendConfigAnnotation := map[string]string{
+			annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+		}
 
-			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
-			tc.beConfig.Namespace = s.Namespace
-			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
-				t.Fatalf("error creating BackendConfig: %v", err)
-			}
-			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+		bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		tc.beConfig.Namespace = s.Namespace
+		if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+			t.Fatalf("error creating BackendConfig: %v", err)
+		}
+		t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
 
-			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
-			if err != nil {
-				t.Fatalf("error creating echo service: %v", err)
-			}
-			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+		_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+		if err != nil {
+			t.Fatalf("error creating echo service: %v", err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
-				AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
-				Build()
-			crud := adapter.IngressCRUD{C: Framework.Clientset}
-			if _, err := crud.Create(ing); err != nil {
-				t.Fatalf("error creating Ingress spec: %v", err)
-			}
-			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+		ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			AddPath("test.com", "/", "service-1", intstr.FromInt(80)).
+			Build()
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
 
-			ing, err = e2e.WaitForIngress(s, ing, nil)
-			if err != nil {
-				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
-			}
-			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+		ing, err = e2e.WaitForIngress(s, ing, nil)
+		if err != nil {
+			t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+		}
+		t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
-			vip := ing.Status.LoadBalancer.Ingress[0].IP
-			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+		vip := ing.Status.LoadBalancer.Ingress[0].IP
+		t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
 
-			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
-			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
-			if err != nil {
-				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
-			}
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+		gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+		}
 
-			// Check conformity
-			if err := verifyAffinity(t, gclb, s.Namespace, "service-1", tc.expect, tc.ttl); err != nil {
-				t.Error(err)
-			}
+		// Check initial conformity
+		if err := verifyAffinity(t, gclb, s.Namespace, "service-1", initial); err != nil {
+			t.Error(err)
+		}
 
+		for _, transition := range transitions {
 			// Test modifications
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
@@ -140,8 +130,8 @@ func TestAffinity(t *testing.T) {
 				if bc.Spec.SessionAffinity == nil {
 					bc.Spec.SessionAffinity = &backendconfig.SessionAffinityConfig{}
 				}
-				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
-				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
+				bc.Spec.SessionAffinity.AffinityType = transition.affinityType
+				bc.Spec.SessionAffinity.AffinityCookieTtlSec = transition.ttl
 				_, err = bcCRUD.Update(bc)
 				return err
 			}); err != nil {
@@ -154,28 +144,28 @@ func TestAffinity(t *testing.T) {
 					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 					return false, nil
 				}
-				if err := verifyAffinity(t, gclb, s.Namespace, "service-1", tc.transition.affinity, tc.transition.ttl); err != nil {
+				if err := verifyAffinity(t, gclb, s.Namespace, "service-1", transition.affinityType, transition.ttl); err != nil {
 					return false, nil
 				}
 				return true, nil
 			}); err != nil {
 				t.Errorf("error waiting for BackendConfig affinity transition propagation to GCLB: %v", err)
 			}
+		}
 
-			// Wait for GCLB resources to be deleted.
-			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
-				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
-			}
+		// Wait for GCLB resources to be deleted.
+		if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+			t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+		}
 
-			deleteOptions := &fuzz.GCLBDeleteOptions{
-				SkipDefaultBackend: true,
-			}
-			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
-			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
-				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
-			}
-			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
-		})
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+		if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+		}
+		t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
 	}
 }
 
@@ -188,14 +178,14 @@ func TestILBSA(t *testing.T) {
 		desc       string
 		ttl        int64
 		expect     string
-		transition affinityTransition
+		transition affinity
 		beConfig   *backendconfig.BackendConfig
 	}{
 		{
 			desc:       "http with no affinity.",
 			beConfig:   fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
 			expect:     "NONE",
-			transition: affinityTransition{"CLIENT_IP", 0},
+			transition: affinity{"CLIENT_IP", 0},
 		},
 		{
 			desc: "http with cookie based affinity.",
@@ -203,7 +193,7 @@ func TestILBSA(t *testing.T) {
 				SetSessionAffinity("GENERATED_COOKIE").
 				Build(),
 			expect:     "GENERATED_COOKIE",
-			transition: affinityTransition{"NONE", 0},
+			transition: affinity{"NONE", 0},
 		},
 		{
 			desc: "http with cookie based affinity and 60s ttl.",
@@ -213,7 +203,7 @@ func TestILBSA(t *testing.T) {
 				Build(),
 			expect:     "GENERATED_COOKIE",
 			ttl:        60,
-			transition: affinityTransition{"CLIENT_IP", 0},
+			transition: affinity{"CLIENT_IP", 0},
 		},
 	} {
 		tc := tc // Capture tc as we are running this in parallel.
@@ -279,7 +269,7 @@ func TestILBSA(t *testing.T) {
 				if bc.Spec.SessionAffinity == nil {
 					bc.Spec.SessionAffinity = &backendconfig.SessionAffinityConfig{}
 				}
-				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
+				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinityType
 				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
 				_, err = bcCRUD.Update(bc)
 				return err


### PR DESCRIPTION
Now, instead of creating four load balancers (one per test case) we can reuse the same load balancer and invoke each test case via transitions. Note that there is no loss in test coverage here since we are still applying the same exact settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/1132)
<!-- Reviewable:end -->
