### PR TITLE
Remove unnecessary `update` permissions

### DIFF
--- a/docs/deploy/resources/rbac.yaml
+++ b/docs/deploy/resources/rbac.yaml
@@ -37,34 +37,25 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  verbs: ["get", "list"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch", "update", "create", "patch"]
 - apiGroups: [""]
   resources: ["endpoints", "services", "pods", "nodes", "namespaces"]
   verbs: ["get", "list", "watch"]
-# TODO: switch to patch services/status
-# https://github.com/kubernetes/ingress-gce/blob/4918eb2f0f484f09ac9e5a975907a9b16ed2b344/pkg/neg/controller.go#L339-L342
-# https://github.com/kubernetes/ingress-gce/blob/4918eb2f0f484f09ac9e5a975907a9b16ed2b344/pkg/neg/controller.go#L359-L361
 - apiGroups: [""]
-  resources: ["services", "pods"]
-  verbs: ["update", "patch"]
+  resources: ["services/status"]
+  verbs: ["patch"]
 - apiGroups: ["networking.istio.io"]
   resources: ["destinationrules"]
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
-# For now, GLBC annotates ingress resources with various state and statuses: 
-# https://github.com/kubernetes/ingress-gce/blob/50d49b077d9ab4362a02fae05f94e433cd3f08dc/pkg/controller/controller.go#L579
-# TODO(rramkumar1): Remove unnecessary `update` permission once statuses are propagated through `ingresses/status`
-- apiGroups: ["extensions", "networking.k8s.io"]
-  resources: ["ingresses"]
-  verbs: ["update"]
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses/status"]
-  verbs: ["update"]
+  verbs: ["patch"]
 # GLBC ensures that the `cloud.google.com/backendconfigs` CRD exists in a desired state:
 # https://github.com/kubernetes/ingress-gce/blob/4918eb2f0f484f09ac9e5a975907a9b16ed2b344/cmd/glbc/main.go#L93
 # TODO(rramkumar1): https://github.com/kubernetes/ingress-gce/issues/744


### PR DESCRIPTION
This removes `update` permissions for Pod, Service and Ingress resources.
All the `update` calls are removed in Ingress-GCE in
kubernetes/ingress-gce#1125 and kubernetes/ingress-gce#1127.

/assign @rramkumar1 