### PR TITLE
Skip garbage collection for invalid frontend resource names

### DIFF
--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -1382,7 +1382,7 @@ func TestClusterNameChange(t *testing.T) {
 	verifyHTTPSForwardingRuleAndProxyLinks(t, j, l7)
 	verifyHTTPForwardingRuleAndProxyLinks(t, j, l7, "")
 
-	newName := "newName"
+	newName := "new-name"
 	j.namer.SetUID(newName)
 
 	// Now the components should get renamed with the next suffix.

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -70,6 +70,10 @@ func (n *testNamer) LoadBalancer() namer_util.LoadBalancerName {
 	panic("Unimplemented")
 }
 
+func (n *testNamer) IsValidLoadBalancer() bool {
+	panic("Unimplemented")
+}
+
 func TestToComputeURLMap(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/utils/namer/frontendnamer.go
+++ b/pkg/utils/namer/frontendnamer.go
@@ -115,6 +115,12 @@ func (ln *V1IngressFrontendNamer) LoadBalancer() LoadBalancerName {
 	return ln.lbName
 }
 
+// IsValidLoadBalancer implements IngressFrontendNamer.
+func (ln *V1IngressFrontendNamer) IsValidLoadBalancer() bool {
+	// Verify if URL Map is a valid GCE resource name.
+	return isValidGCEResourceName(ln.UrlMap())
+}
+
 // V2IngressFrontendNamer implements IngressFrontendNamer.
 type V2IngressFrontendNamer struct {
 	ing *v1beta1.Ingress
@@ -208,6 +214,12 @@ func (vn *V2IngressFrontendNamer) IsLegacySSLCert(certName string) bool {
 // Note that this is used for generating GCE resource names.
 func (vn *V2IngressFrontendNamer) LoadBalancer() LoadBalancerName {
 	return vn.lbName
+}
+
+// IsValidLoadBalancer implements IngressFrontendNamer.
+func (vn *V2IngressFrontendNamer) IsValidLoadBalancer() bool {
+	// Verify if URL Map is a valid GCE resource name.
+	return isValidGCEResourceName(vn.UrlMap())
 }
 
 // suffix returns hash string of length 8 of a concatenated string generated from

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -37,6 +37,8 @@ type IngressFrontendNamer interface {
 	IsLegacySSLCert(certName string) bool
 	// LoadBalancer returns load-balancer name for the ingress.
 	LoadBalancer() LoadBalancerName
+	// IsValidLoadBalancer returns if the derived loadbalancer is valid.
+	IsValidLoadBalancer() bool
 }
 
 // IngressFrontendNamerFactory is an interface to create a front namer for an Ingress

--- a/pkg/utils/namer/utils.go
+++ b/pkg/utils/namer/utils.go
@@ -15,11 +15,14 @@ package namer
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/klog"
 )
+
+const gceResourceNamePattern = "(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)"
 
 // TrimFieldsEvenly trims the fields evenly and keeps the total length
 // <= max. Truncation is spread in ratio with their original length,
@@ -81,4 +84,14 @@ func FinalizerForNamingScheme(scheme Scheme) (string, error) {
 	default:
 		return "", fmt.Errorf("unexpected naming scheme: %s", scheme)
 	}
+}
+
+// isValidGCEResourceName returns if given name is a valid GCE resource name.
+func isValidGCEResourceName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	matchedString := regexp.MustCompile(gceResourceNamePattern).FindString(name)
+	// Return true only if the entire string is a match.
+	return matchedString == name
 }

--- a/pkg/utils/namer/utils_test.go
+++ b/pkg/utils/namer/utils_test.go
@@ -118,3 +118,44 @@ func TestFrontendNamingScheme(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidGCEResourceName(t *testing.T) {
+	for _, tc := range []struct {
+		desc          string
+		name          string
+		expectIsValid bool
+	}{
+		{
+			desc: "nil string",
+		},
+		{
+			desc: "invalid name starts with numeric",
+			name: "2testname",
+		},
+		{
+			desc: "invalid name with dot character",
+			name: "test.name",
+		},
+		{
+			desc: "invalid name with capitals",
+			name: "testName",
+		},
+		{
+			desc: "invalid name with trailing -",
+			name: "test-name-",
+		},
+		{
+			desc: "invalid name with all numerics",
+			name: "123243",
+		},
+		{
+			desc:          "valid name",
+			name:          "test-name-123243",
+			expectIsValid: true,
+		},
+	} {
+		if got := isValidGCEResourceName(tc.name); got != tc.expectIsValid {
+			t.Errorf("isValidGCEResourceName(%s) = %t, want %t", tc.name, got, tc.expectIsValid)
+		}
+	}
+}


### PR DESCRIPTION
This fixes a bug where an ingress with name that has dot character in it. Since, dot is an invalid character for GCE resource name, the load balancer will not configured. But the ingress failed to get deleted as we proactively try to delete the GCE resources when they were not created.

This ensures that those ingresses with invalid names are deleted and not re-queued by controller.