### PR TITLE
Reserve Static IP if a static IP name is provided and it doesn't exist

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -88,6 +88,7 @@ Events:
 
 GCE has a concept of [ephemeral](https://cloud.google.com/compute/docs/instances-and-network#ephemeraladdress) and [static](https://cloud.google.com/compute/docs/instances-and-network#reservedaddress) IPs. A production website would always want a static IP, which ephemeral IPs are cheaper (both in terms of quota and cost), and are therefore better suited for experimentation.
 * Creating a HTTP Ingress (i.e an Ingress without a TLS section) allocates an ephemeral IP, because we don't believe HTTP is the right way to deploy an app.
+* Creating an Ingress with the annotation `kubernetes.io/ingress.global-static-ip-name` provided will reserve the static IP if it doesn't exist.
 * Creating an Ingress with a TLS section allocates a static IP, because GLBC assumes you mean business.
 * Modifying an Ingress and adding a TLS section allocates a static IP, but the IP *will* change.
 * You can [promote](https://cloud.google.com/compute/docs/instances-and-network#promote_ephemeral_ip) an ephemeral to a static IP by hand, if required.

--- a/pkg/loadbalancers/addresses.go
+++ b/pkg/loadbalancers/addresses.go
@@ -34,7 +34,11 @@ func (l *L7) checkStaticIP() (err error) {
 		return fmt.Errorf("will not create static IP without a forwarding rule")
 	}
 	managedStaticIPName := l.namer.ForwardingRule(namer.HTTPProtocol)
-	// Don't manage staticIPs if the user has specified an IP.
+	if l.runtimeInfo.StaticIPName != "" {
+		managedStaticIPName = l.runtimeInfo.StaticIPName
+	}
+
+	// Don't manage staticIPs if the user has specified an IP that already exists.
 	address, manageStaticIP, err := l.getEffectiveIP()
 	if err != nil {
 		return err

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -163,7 +163,7 @@ func (l *L7) getEffectiveIP() (string, bool, error) {
 	// A note on IP management:
 	// User specifies a different IP on startup:
 	//	- We create a forwarding rule with the given IP.
-	//		- If this ip doesn't exist in GCE, an error is thrown which fails ingress creation.
+	//		- If this ip doesn't exist in GCE, return the second param as true, so a static IP can be reserved.
 	//	- In the happy case, no static ip is created or deleted by this controller.
 	// Controller allocates a staticIP/ephemeralIP, but user changes it:
 	//  - We still delete the old static IP, but only when we tear down the
@@ -180,8 +180,7 @@ func (l *L7) getEffectiveIP() (string, bool, error) {
 		// Existing static IPs allocated to forwarding rules will get orphaned
 		// till the Ingress is torn down.
 		if ip, err := l.cloud.GetGlobalAddress(l.runtimeInfo.StaticIPName); err != nil || ip == nil {
-			return "", false, fmt.Errorf("the given static IP name %v doesn't translate to an existing global static IP.",
-				l.runtimeInfo.StaticIPName)
+			return "", true, nil
 		} else {
 			return ip.Address, false, nil
 		}


### PR DESCRIPTION
This PR creates Static IPs if a static IP name is provided but it wasn't reserved by the user. 

Currently, GLBC will check if the provided static IP name translates to an existing reserved static IP. If it doesn't, then it's up to the user to reserve it. 

However, there might be a case where you expect GLBC to reserve it for you with the name provided (e.g. if you are deploying a new Ingress for an app using Kustomize, you may not want to execute extra steps only to reserve the static IP, and you may also want GLBC to manage it if you delete an ingress). 