### PR TITLE
Fix ensure logging workflow for nil/empty sampling rate

### DIFF
--- a/pkg/composite/gen.go
+++ b/pkg/composite/gen.go
@@ -4030,6 +4030,9 @@ func (backendService *BackendService) ToAlpha() (*computealpha.BackendService, e
 	}
 	if alpha.LogConfig != nil {
 		alpha.LogConfig.ForceSendFields = []string{"Enable"}
+		if alpha.LogConfig.Enable {
+			alpha.LogConfig.ForceSendFields = []string{"Enable", "SampleRate"}
+		}
 	}
 
 	return alpha, nil
@@ -4052,6 +4055,9 @@ func (backendService *BackendService) ToBeta() (*computebeta.BackendService, err
 	}
 	if beta.LogConfig != nil {
 		beta.LogConfig.ForceSendFields = []string{"Enable"}
+		if beta.LogConfig.Enable {
+			beta.LogConfig.ForceSendFields = []string{"Enable", "SampleRate"}
+		}
 	}
 
 	return beta, nil
@@ -4074,6 +4080,9 @@ func (backendService *BackendService) ToGA() (*compute.BackendService, error) {
 	}
 	if ga.LogConfig != nil {
 		ga.LogConfig.ForceSendFields = []string{"Enable"}
+		if ga.LogConfig.Enable {
+			ga.LogConfig.ForceSendFields = []string{"Enable", "SampleRate"}
+		}
 	}
 
 	return ga, nil

--- a/pkg/composite/gen/main.go
+++ b/pkg/composite/gen/main.go
@@ -826,6 +826,9 @@ func ({{$type.VarName}} *{{$type.Name}}) To{{$version}}() (*compute{{$extension}
 	}
 	if {{$lower}}.LogConfig != nil {
 		{{$lower}}.LogConfig.ForceSendFields = []string{"Enable"}
+		if {{$lower}}.LogConfig.Enable {
+			{{$lower}}.LogConfig.ForceSendFields = []string{"Enable", "SampleRate"}
+		}
 	}
 	{{- end}}
 


### PR DESCRIPTION
This fixes an edge case where logging is enabled and sampling rate is set to 0.0

Currently, the value is treated as empty value and not sent to the server in which case the existing sampling rate is retained.