### PR TITLE
Add support for GCE path prefix rewrites

### DIFF
--- a/cmd/e2e-test/path_prefix_rewrite_test.go
+++ b/cmd/e2e-test/path_prefix_rewrite_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestPathPrefixRewrite(t *testing.T) {
+	t.Parallel()
+
+	port80 := intstr.FromInt(80)
+	Framework.RunWithSandbox("with path prefix rewrite", t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		_, err := e2e.CreateEchoServiceWithOS(s, "service-1", nil, e2e.Linux)
+		if err != nil {
+			t.Fatalf("error creating echo service: %v", err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+		testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			AddPath("test.com", "/foo", "service-1", port80).
+			AddPath("test.com", "/bar", "service-1", port80).
+			SetPathPrefixRewrite("/").
+			Build()
+
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		if _, err = crud.Create(testIng); err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress created (%s/%s)", s.Namespace, testIng.Name)
+
+		ing, err := e2e.WaitForIngress(s, testIng, nil)
+		if err != nil {
+			t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+		}
+		t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+		vip := ing.Status.LoadBalancer.Ingress[0].IP
+		t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+		gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+		}
+		if err := verifyRewrite(gclb, "/"); err != nil {
+			t.Fatal(err)
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+func verifyRewrite(gclb *fuzz.GCLB, want string) error {
+	for _, um := range gclb.URLMap {
+		for _, pm := range um.GA.PathMatchers {
+			for _, rule := range pm.PathRules {
+				actual := rule.RouteAction.UrlRewrite.PathPrefixRewrite
+				if actual != want {
+					return fmt.Errorf("PathPrefixRewrite = %s, want %s", actual, want)
+				}
+			}
+		}
+	}
+}

--- a/cmd/e2e-test/path_prefix_rewrite_test.go
+++ b/cmd/e2e-test/path_prefix_rewrite_test.go
@@ -93,4 +93,5 @@ func verifyRewrite(gclb *fuzz.GCLB, want string) error {
 			}
 		}
 	}
+	return nil
 }

--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -87,6 +87,10 @@ const (
 	//     networking.gke.io/v1beta1.FrontendConfig: 'my-frontendconfig'
 	FrontendConfigKey = "networking.gke.io/v1beta1.FrontendConfig"
 
+	// PathPrefixRewriteKey is the annotation key used by controller to
+	// configure an URL rewrite rule used by the load balancer.
+	PathPrefixRewriteKey = "ingress.gcp.kubernetes.io/path-prefix-rewrite"
+
 	// UrlMapKey is the annotation key used by controller to record GCP URL map.
 	UrlMapKey = StatusPrefix + "/url-map"
 	// HttpForwardingRuleKey is the annotation key used by controller to record
@@ -199,6 +203,14 @@ func (ing *Ingress) SuppressFirewallXPNError() bool {
 
 func (ing *Ingress) FrontendConfig() string {
 	val, ok := ing.v[FrontendConfigKey]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+func (ing *Ingress) PathPrefixRewrite() string {
+	val, ok := ing.v[PathPrefixRewriteKey]
 	if !ok {
 		return ""
 	}

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -65,7 +65,7 @@ func TestIngress(t *testing.T) {
 						IngressClassKey:       "gce",
 						PreSharedCertKey:      "shared-cert-key",
 						GlobalStaticIPNameKey: "1.2.3.4",
-						PathPrefixRewriteKey: "/api/v1",
+						PathPrefixRewriteKey:  "/api/v1",
 					},
 				},
 			},

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -33,6 +33,7 @@ func TestIngress(t *testing.T) {
 		staticIPName string
 		ingressClass string
 		wantErr      bool
+		urlRewrite   string
 	}{
 		{
 			desc:      "Empty ingress",
@@ -64,6 +65,7 @@ func TestIngress(t *testing.T) {
 						IngressClassKey:       "gce",
 						PreSharedCertKey:      "shared-cert-key",
 						GlobalStaticIPNameKey: "1.2.3.4",
+						PathPrefixRewriteKey: "/api/v1",
 					},
 				},
 			},
@@ -71,6 +73,7 @@ func TestIngress(t *testing.T) {
 			useNamedTLS:  "shared-cert-key",
 			staticIPName: "1.2.3.4",
 			ingressClass: "gce",
+			urlRewrite:   "/api/v1",
 		},
 	} {
 		ing := FromIngress(tc.ing)
@@ -94,6 +97,9 @@ func TestIngress(t *testing.T) {
 		}
 		if x := ing.IngressClass(); x != tc.ingressClass {
 			t.Errorf("ingress %+v; IngressClass() = %v, want %v", tc.ing, x, tc.ingressClass)
+		}
+		if x := ing.PathPrefixRewrite(); x != tc.urlRewrite {
+			t.Errorf("ingress %+v; PathPrefixRewrite() = %v, want %v", tc.ing, x, tc.urlRewrite)
 		}
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -681,7 +681,7 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *v1beta1.Ingress, urlMap *u
 	if err != nil {
 		return nil, err
 	}
-	
+
 	urlMap.PathPrefixRewrite = annotations.PathPrefixRewrite()
 
 	return &loadbalancers.L7RuntimeInfo{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -681,6 +681,8 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *v1beta1.Ingress, urlMap *u
 	if err != nil {
 		return nil, err
 	}
+	
+	urlMap.PathPrefixRewrite = annotations.PathPrefixRewrite()
 
 	return &loadbalancers.L7RuntimeInfo{
 		TLS:            tls,

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -302,6 +302,15 @@ func (i *IngressBuilder) SetFrontendConfig(name string) *IngressBuilder {
 	return i
 }
 
+// SetPathPrefixRewrite sets the PathPrefixRewrite annotation on the ingress
+func (i *IngressBuilder) SetPathPrefixRewrite(val string) *IngressBuilder {
+	if i.ing.Annotations == nil {
+		i.ing.Annotations = make(map[string]string)
+	}
+	i.ing.Annotations[annotations.PathPrefixRewriteKey] = val
+	return i
+}
+
 // BackendConfigBuilder is syntactic sugar for creating BackendConfig specs for testing
 // purposes.
 //

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -187,6 +187,11 @@ func ToCompositeURLMap(g *utils.GCEURLMap, namer namer.IngressFrontendNamer, key
 			pathMatcher.PathRules = append(pathMatcher.PathRules, &composite.PathRule{
 				Paths:   []string{rule.Path},
 				Service: beLink,
+				RouteAction: &composite.HttpRouteAction{
+					UrlRewrite: &composite.UrlRewrite{
+						PathPrefixRewrite: g.PathPrefixRewrite,
+					},
+				},
 			})
 		}
 		m.PathMatchers = append(m.PathMatchers, pathMatcher)

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -72,7 +72,8 @@ func TestToComputeURLMap(t *testing.T) {
 	wantComputeMap := testCompositeURLMap()
 	namer := namer_util.NewNamer("uid1", "fw1")
 	gceURLMap := &utils.GCEURLMap{
-		DefaultBackend: &utils.ServicePort{NodePort: 30000, BackendNamer: namer},
+		DefaultBackend:    &utils.ServicePort{NodePort: 30000, BackendNamer: namer},
+		PathPrefixRewrite: "/",
 		HostRules: []utils.HostRule{
 			{
 				Hostname: "abc.com",
@@ -133,10 +134,20 @@ func testCompositeURLMap() *composite.UrlMap {
 					{
 						Paths:   []string{"/web"},
 						Service: "global/backendServices/k8s-be-32000--uid1",
+						RouteAction: &composite.HttpRouteAction{
+							UrlRewrite: &composite.UrlRewrite{
+								PathPrefixRewrite: "/",
+							},
+						},
 					},
 					{
 						Paths:   []string{"/other"},
 						Service: "global/backendServices/k8s-be-32500--uid1",
+						RouteAction: &composite.HttpRouteAction{
+							UrlRewrite: &composite.UrlRewrite{
+								PathPrefixRewrite: "/",
+							},
+						},
 					},
 				},
 			},
@@ -147,10 +158,20 @@ func testCompositeURLMap() *composite.UrlMap {
 					{
 						Paths:   []string{"/"},
 						Service: "global/backendServices/k8s-be-33000--uid1",
+						RouteAction: &composite.HttpRouteAction{
+							UrlRewrite: &composite.UrlRewrite{
+								PathPrefixRewrite: "/",
+							},
+						},
 					},
 					{
 						Paths:   []string{"/*"},
 						Service: "global/backendServices/k8s-be-33500--uid1",
+						RouteAction: &composite.HttpRouteAction{
+							UrlRewrite: &composite.UrlRewrite{
+								PathPrefixRewrite: "/",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/utils/gceurlmap.go
+++ b/pkg/utils/gceurlmap.go
@@ -30,6 +30,8 @@ type GCEURLMap struct {
 	DefaultBackend *ServicePort
 	// HostRules is an ordered list of hostnames, path rule tuples.
 	HostRules []HostRule
+	// PathPrefixRewrite is a global rewrite rule that is added to all path rules in the URL map
+	PathPrefixRewrite string
 	// hosts is a map of existing hosts.
 	hosts map[string]bool
 }
@@ -58,6 +60,10 @@ func EqualMapping(a, b *GCEURLMap) bool {
 		return false
 	}
 	if a.DefaultBackend != nil && a.DefaultBackend.ID != b.DefaultBackend.ID {
+		return false
+	}
+
+	if a.PathPrefixRewrite != b.PathPrefixRewrite {
 		return false
 	}
 
@@ -188,5 +194,6 @@ func (g *GCEURLMap) String() string {
 		}
 	}
 	b.WriteString(fmt.Sprintf("Default Backend: %+v", g.DefaultBackend))
+	b.WriteString(fmt.Sprintf("Path Prefix Rewrite: %+v", g.PathPrefixRewrite))
 	return b.String()
 }


### PR DESCRIPTION
This adds support for setting up a GCE path prefix rewrite as described in [Setting up URL rewrite for external HTTP(S) load balancers](https://cloud.google.com/load-balancing/docs/https/setting-up-url-rewrite). It introduces a new annotation `ingress.gcp.kubernetes.io/path-prefix-rewrite` that is set on the underlying URL map for all paths configured through the Ingress.

Usage is similar to the NGINX Controller. For example, the following configuration will route requests from `/foo` to `http://foo:80/` and from `/bar` to `http://bar:80/`:

```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: test-ingress
  annotations:
    ingress.gcp.kubernetes.io/path-prefix-rewrite: /
spec:
  rules:
  - http:
      paths:
      - path: /foo
        backend:
          serviceName: foo
          servicePort: 80
      - path: /bar
        backend:
          serviceName: bar
          servicePort: 80
```

This should fix #109 