### PR TITLE
Move APIs to work with health checks into translator package to prepare for future refactoring

### DIFF
--- a/pkg/healthchecks/healthcheck.go
+++ b/pkg/healthchecks/healthcheck.go
@@ -17,234 +17,13 @@ limitations under the License.
 package healthchecks
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	computealpha "google.golang.org/api/compute/v0.alpha"
-	computebeta "google.golang.org/api/compute/v0.beta"
-	"google.golang.org/api/compute/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
-	"k8s.io/ingress-gce/pkg/loadbalancers/features"
-	"k8s.io/klog"
+	"k8s.io/ingress-gce/pkg/translator"
 )
-
-// DefaultHealthCheck simply returns the default health check.
-func DefaultHealthCheck(port int64, protocol annotations.AppProtocol) *HealthCheck {
-	klog.V(3).Infof("DefaultHealthCheck(%v, %v)", port, protocol)
-	httpSettings := computealpha.HTTPHealthCheck{Port: port}
-
-	hcSettings := computealpha.HealthCheck{
-		// How often to health check.
-		CheckIntervalSec: int64(DefaultHealthCheckInterval.Seconds()),
-		// How long to wait before claiming failure of a health check.
-		TimeoutSec: int64(DefaultTimeout.Seconds()),
-		// Number of healthchecks to pass for a vm to be deemed healthy.
-		HealthyThreshold: DefaultHealthyThreshold,
-		// Number of healthchecks to fail before the vm is deemed unhealthy.
-		UnhealthyThreshold: DefaultUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check.",
-		Type:               string(protocol),
-	}
-
-	return &HealthCheck{
-		HTTPHealthCheck: httpSettings,
-		HealthCheck:     hcSettings,
-		forNEG:          false,
-	}
-}
-
-// DefaultNEGHealthCheck simply returns the default health check.
-func DefaultNEGHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
-	httpSettings := computealpha.HTTPHealthCheck{PortSpecification: UseServingPortSpecification}
-	klog.V(3).Infof("DefaultNEGHealthCheck(%v)", protocol)
-
-	hcSettings := computealpha.HealthCheck{
-		// How often to health check.
-		CheckIntervalSec: int64(DefaultNEGHealthCheckInterval.Seconds()),
-		// How long to wait before claiming failure of a health check.
-		TimeoutSec: int64(DefaultNEGTimeout.Seconds()),
-		// Number of healthchecks to pass for a vm to be deemed healthy.
-		HealthyThreshold: DefaultHealthyThreshold,
-		// Number of healthchecks to fail before the vm is deemed unhealthy.
-		UnhealthyThreshold: DefaultNEGUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check for NEG.",
-		Type:               string(protocol),
-	}
-
-	return &HealthCheck{
-		HTTPHealthCheck: httpSettings,
-		HealthCheck:     hcSettings,
-		forNEG:          true,
-	}
-}
-
-func defaultILBHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
-	httpSettings := computealpha.HTTPHealthCheck{PortSpecification: UseServingPortSpecification}
-	klog.V(3).Infof("DefaultILBHealthCheck(%v)", protocol)
-
-	hcSettings := computealpha.HealthCheck{
-		// How often to health check.
-		CheckIntervalSec: int64(DefaultNEGHealthCheckInterval.Seconds()),
-		// How long to wait before claiming failure of a health check.
-		TimeoutSec: int64(DefaultNEGTimeout.Seconds()),
-		// Number of healthchecks to pass for a vm to be deemed healthy.
-		HealthyThreshold: DefaultHealthyThreshold,
-		// Number of healthchecks to fail before the vm is deemed unhealthy.
-		UnhealthyThreshold: DefaultNEGUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check for ILB.",
-		Type:               string(protocol),
-	}
-
-	return &HealthCheck{
-		HTTPHealthCheck: httpSettings,
-		HealthCheck:     hcSettings,
-		forILB:          true,
-		forNEG:          true,
-	}
-}
-
-// HealthCheck is a wrapper for different versions of the compute struct.
-// TODO(bowei): replace inner workings with composite.
-type HealthCheck struct {
-	// As the {HTTP, HTTPS, HTTP2} settings are identical, we mantain the
-	// settings at the outer-level and copy into the appropriate struct
-	// in the HealthCheck embedded struct (see `merge()`) when getting the
-	// compute struct back.
-	computealpha.HTTPHealthCheck
-	computealpha.HealthCheck
-
-	forNEG bool
-	forILB bool
-}
-
-// NewHealthCheck creates a HealthCheck which abstracts nested structs away
-func NewHealthCheck(hc *computealpha.HealthCheck) (*HealthCheck, error) {
-	// TODO(bowei): should never handle nil like this.
-	if hc == nil {
-		return nil, errors.New("nil hc to NewHealthCheck")
-	}
-
-	v := &HealthCheck{HealthCheck: *hc}
-	switch annotations.AppProtocol(hc.Type) {
-	case annotations.ProtocolHTTP:
-		if hc.HttpHealthCheck == nil {
-			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTP, hc.Name)
-		}
-		v.HTTPHealthCheck = *hc.HttpHealthCheck
-	case annotations.ProtocolHTTPS:
-		if hc.HttpsHealthCheck == nil {
-			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTPS, hc.Name)
-		}
-		v.HTTPHealthCheck = computealpha.HTTPHealthCheck(*hc.HttpsHealthCheck)
-	case annotations.ProtocolHTTP2:
-		if hc.Http2HealthCheck == nil {
-			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTP2, hc.Name)
-		}
-		v.HTTPHealthCheck = computealpha.HTTPHealthCheck(*hc.Http2HealthCheck)
-	}
-
-	// Users should be modifying HTTP(S) specific settings on the embedded
-	// HTTPHealthCheck. Setting these to nil for preventing confusion.
-	v.HealthCheck.HttpHealthCheck = nil
-	v.HealthCheck.HttpsHealthCheck = nil
-	v.HealthCheck.Http2HealthCheck = nil
-
-	return v, nil
-}
-
-// Protocol returns the type cased to AppProtocol
-func (hc *HealthCheck) Protocol() annotations.AppProtocol {
-	return annotations.AppProtocol(hc.Type)
-}
-
-// ToComputeHealthCheck returns a valid compute.HealthCheck object
-func (hc *HealthCheck) ToComputeHealthCheck() (*compute.HealthCheck, error) {
-	hc.merge()
-	return toV1HealthCheck(&hc.HealthCheck)
-}
-
-// ToBetaComputeHealthCheck returns a valid computebeta.HealthCheck object
-func (hc *HealthCheck) ToBetaComputeHealthCheck() (*computebeta.HealthCheck, error) {
-	hc.merge()
-	return toBetaHealthCheck(&hc.HealthCheck)
-}
-
-// ToAlphaComputeHealthCheck returns a valid computealpha.HealthCheck object
-func (hc *HealthCheck) ToAlphaComputeHealthCheck() *computealpha.HealthCheck {
-	hc.merge()
-	x := hc.HealthCheck // Make a copy to ensure no aliasing.
-	return &x
-}
-
-func (hc *HealthCheck) merge() {
-	// Cannot specify both portSpecification and port field unless fixed port is specified.
-	// This can happen if the user overrides the port using backendconfig
-	if hc.PortSpecification != "" && hc.PortSpecification != "USE_FIXED_PORT" {
-		hc.Port = 0
-	}
-
-	// Zeroing out child settings as a precaution. GoogleAPI throws an error
-	// if the wrong child struct is set.
-	hc.HealthCheck.Http2HealthCheck = nil
-	hc.HealthCheck.HttpsHealthCheck = nil
-	hc.HealthCheck.HttpHealthCheck = nil
-
-	switch hc.Protocol() {
-	case annotations.ProtocolHTTP:
-		x := hc.HTTPHealthCheck // Make a copy to ensure no aliasing.
-		hc.HealthCheck.HttpHealthCheck = &x
-	case annotations.ProtocolHTTPS:
-		https := computealpha.HTTPSHealthCheck(hc.HTTPHealthCheck)
-		hc.HealthCheck.HttpsHealthCheck = &https
-	case annotations.ProtocolHTTP2:
-		http2 := computealpha.HTTP2HealthCheck(hc.HTTPHealthCheck)
-		hc.HealthCheck.Http2HealthCheck = &http2
-	}
-}
-
-// Version returns the appropriate API version to handle the health check
-// Use Beta API for NEG as PORT_SPECIFICATION is required, and HTTP2
-func (hc *HealthCheck) Version() meta.Version {
-	if hc.forILB {
-		return features.L7ILBVersions().HealthCheck
-	}
-	if hc.Protocol() == annotations.ProtocolHTTP2 || hc.forNEG {
-		return meta.VersionBeta
-	}
-	return meta.VersionGA
-}
-
-func (hc *HealthCheck) updateFromBackendConfig(c *backendconfigv1.HealthCheckConfig) {
-	if c.CheckIntervalSec != nil {
-		hc.CheckIntervalSec = *c.CheckIntervalSec
-	}
-	if c.TimeoutSec != nil {
-		hc.TimeoutSec = *c.TimeoutSec
-	}
-	if c.HealthyThreshold != nil {
-		hc.HealthyThreshold = *c.HealthyThreshold
-	}
-	if c.UnhealthyThreshold != nil {
-		hc.UnhealthyThreshold = *c.UnhealthyThreshold
-	}
-	if c.Type != nil {
-		hc.Type = *c.Type
-	}
-	if c.RequestPath != nil {
-		hc.RequestPath = *c.RequestPath
-	}
-	if c.Port != nil {
-		hc.Port = *c.Port
-		// This override is necessary regardless of type
-		hc.PortSpecification = "USE_FIXED_PORT"
-	}
-}
 
 // fieldDiffs encapsulate which fields are different between health checks.
 type fieldDiffs struct {
@@ -257,7 +36,7 @@ func (c *fieldDiffs) add(field, oldv, newv string) {
 func (c *fieldDiffs) String() string { return strings.Join(c.f, ", ") }
 func (c *fieldDiffs) hasDiff() bool  { return len(c.f) > 0 }
 
-func calculateDiff(old, new *HealthCheck, c *backendconfigv1.HealthCheckConfig) *fieldDiffs {
+func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCheckConfig) *fieldDiffs {
 	var changes fieldDiffs
 
 	if old.Protocol() != new.Protocol() {
@@ -311,7 +90,7 @@ func calculateDiff(old, new *HealthCheck, c *backendconfigv1.HealthCheckConfig) 
 // TODO(bowei): this is very unstable in combination with Probe, we do not
 // have a clear signal as to where the settings are coming from. Once a
 // healthcheck is created, it will basically not change.
-func mergeUserSettings(existing, newHC *HealthCheck) *HealthCheck {
+func mergeUserSettings(existing, newHC *translator.HealthCheck) *translator.HealthCheck {
 	hc := *newHC // return a copy
 
 	hc.HTTPHealthCheck = existing.HTTPHealthCheck
@@ -326,7 +105,7 @@ func mergeUserSettings(existing, newHC *HealthCheck) *HealthCheck {
 	}
 
 	// Cannot specify both portSpecification and port field.
-	if hc.forNEG {
+	if hc.ForNEG {
 		hc.HTTPHealthCheck.Port = 0
 		hc.PortSpecification = newHC.PortSpecification
 	} else {
@@ -334,88 +113,4 @@ func mergeUserSettings(existing, newHC *HealthCheck) *HealthCheck {
 		hc.Port = newHC.Port
 	}
 	return &hc
-}
-
-type jsonConvertable interface {
-	MarshalJSON() ([]byte, error)
-}
-
-func copyViaJSON(dest interface{}, src jsonConvertable) error {
-	var err error
-	bytes, err := src.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(bytes, dest)
-}
-
-// applyProbeSettingsToHC takes the Pod healthcheck settings and applies it
-// to the healthcheck.
-//
-// TODO: what if the port changes?
-// TODO: does not handle protocol?
-func applyProbeSettingsToHC(p *v1.Probe, hc *HealthCheck) {
-	if p.Handler.HTTPGet == nil {
-		return
-	}
-
-	healthPath := p.Handler.HTTPGet.Path
-	// GCE requires a leading "/" for health check urls.
-	if !strings.HasPrefix(healthPath, "/") {
-		healthPath = "/" + healthPath
-	}
-	hc.RequestPath = healthPath
-
-	// Extract host from HTTP headers
-	host := p.Handler.HTTPGet.Host
-	for _, header := range p.Handler.HTTPGet.HTTPHeaders {
-		if header.Name == "Host" {
-			host = header.Value
-			break
-		}
-	}
-	hc.Host = host
-
-	hc.TimeoutSec = int64(p.TimeoutSeconds)
-	if hc.forNEG {
-		// For NEG mode, we can support more aggressive healthcheck interval.
-		hc.CheckIntervalSec = int64(p.PeriodSeconds)
-	} else {
-		// For IG mode, short healthcheck interval may health check flooding problem.
-		hc.CheckIntervalSec = int64(p.PeriodSeconds) + int64(DefaultHealthCheckInterval.Seconds())
-	}
-
-	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
-}
-
-// toV1HealthCheck converts alpha health check to v1 health check.
-// WARNING: alpha health check has a additional PORT_SPECIFICATION field.
-// This field will be omitted after conversion.
-func toV1HealthCheck(hc *computealpha.HealthCheck) (*compute.HealthCheck, error) {
-	ret := &compute.HealthCheck{}
-	err := copyViaJSON(ret, hc)
-	return ret, err
-}
-
-// toBetaHealthCheck converts alpha health check to beta health check.
-func toBetaHealthCheck(hc *computealpha.HealthCheck) (*computebeta.HealthCheck, error) {
-	ret := &computebeta.HealthCheck{}
-	err := copyViaJSON(ret, hc)
-	return ret, err
-}
-
-// v1ToAlphaHealthCheck converts v1 health check to alpha health check.
-// There should be no information lost after conversion.
-func v1ToAlphaHealthCheck(hc *compute.HealthCheck) (*computealpha.HealthCheck, error) {
-	ret := &computealpha.HealthCheck{}
-	err := copyViaJSON(ret, hc)
-	return ret, err
-}
-
-// betaToAlphaHealthCheck converts beta health check to alpha health check.
-// There should be no information lost after conversion.
-func betaToAlphaHealthCheck(hc *computebeta.HealthCheck) (*computealpha.HealthCheck, error) {
-	ret := &computealpha.HealthCheck{}
-	err := copyViaJSON(ret, hc)
-	return ret, err
 }

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -21,6 +21,7 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -54,5 +55,5 @@ type HealthChecker interface {
 	// `probe` can be nil if no probe exists.
 	SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (string, error)
 	Delete(name string, scope meta.KeyType) error
-	Get(name string, version meta.Version, scope meta.KeyType) (*HealthCheck, error)
+	Get(name string, version meta.Version, scope meta.KeyType) (*translator.HealthCheck, error)
 }

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/loadbalancers/features"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog"
+)
+
+const (
+	// These values set a low health threshold and a high failure threshold.
+	// We're just trying to detect if the node networking is
+	// borked, service level outages will get detected sooner
+	// by kube-proxy.
+
+	// defaultHealthCheckInterval defines how frequently a probe runs with IG backends
+	defaultHealthCheckInterval = 60 * time.Second
+	// defaultNEGHealthCheckInterval defines how frequently a probe runs with NEG backends
+	defaultNEGHealthCheckInterval = 15 * time.Second
+	// defaultHealthyThreshold defines the threshold of success probes that declare a backend "healthy"
+	defaultHealthyThreshold = 1
+	// defaultUnhealthyThreshold defines the threshold of failure probes that declare a instance "unhealthy"
+	defaultUnhealthyThreshold = 10
+	// defaultNEGUnhealthyThreshold defines the threshold of failure probes that declare a network endpoint "unhealthy"
+	// In NEG mode, cloud loadbalancer health check request will no longer be loadbalanced by kube-proxy(iptables).
+	// Instead, health checks can reach endpoints directly. Hence the loadbalancer health check can get a clear signal
+	// of endpoint health status. As a result, we are able to tune down the unhealthy threshold to 2.
+	defaultNEGUnhealthyThreshold = 2
+	// defaultTimeout defines the timeout of each probe for IG
+	defaultTimeout = 60 * time.Second
+	// defaultNEGTimeout defines the timeout of each probe for NEG
+	defaultNEGTimeout = 15 * time.Second
+
+	// useServingPortSpecification is a constant for GCE API.
+	// USE_SERVING_PORT: For NetworkEndpointGroup, the port specified for
+	// each network endpoint is used for health checking. For other
+	// backends, the port or named port specified in the Backend Service is
+	// used for health checking.
+	useServingPortSpecification = "USE_SERVING_PORT"
+
+	// TODO: revendor the GCE API go client so that this error will not be hit.
+	newHealthCheckErrorMessageTemplate = "the %v health check configuration on the existing health check %v is nil. " +
+		"This is usually caused by an application protocol change on the k8s service spec. " +
+		"Please revert the change on application protocol to avoid this error message."
+)
+
+// HealthCheck is a wrapper for different versions of the compute struct.
+// TODO(bowei): replace inner workings with composite.
+type HealthCheck struct {
+	ForNEG bool
+	ForILB bool
+
+	// As the {HTTP, HTTPS, HTTP2} settings are identical, we mantain the
+	// settings at the outer-level and copy into the appropriate struct
+	// in the HealthCheck embedded struct (see `merge()`) when getting the
+	// compute struct back.
+	computealpha.HTTPHealthCheck
+	computealpha.HealthCheck
+}
+
+// NewHealthCheck creates a HealthCheck which abstracts nested structs away
+func NewHealthCheck(hc *computealpha.HealthCheck) (*HealthCheck, error) {
+	// TODO(bowei): should never handle nil like this.
+	if hc == nil {
+		return nil, errors.New("nil hc to NewHealthCheck")
+	}
+
+	v := &HealthCheck{HealthCheck: *hc}
+	switch annotations.AppProtocol(hc.Type) {
+	case annotations.ProtocolHTTP:
+		if hc.HttpHealthCheck == nil {
+			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTP, hc.Name)
+		}
+		v.HTTPHealthCheck = *hc.HttpHealthCheck
+	case annotations.ProtocolHTTPS:
+		if hc.HttpsHealthCheck == nil {
+			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTPS, hc.Name)
+		}
+		v.HTTPHealthCheck = computealpha.HTTPHealthCheck(*hc.HttpsHealthCheck)
+	case annotations.ProtocolHTTP2:
+		if hc.Http2HealthCheck == nil {
+			return nil, fmt.Errorf(newHealthCheckErrorMessageTemplate, annotations.ProtocolHTTP2, hc.Name)
+		}
+		v.HTTPHealthCheck = computealpha.HTTPHealthCheck(*hc.Http2HealthCheck)
+	}
+
+	// Users should be modifying HTTP(S) specific settings on the embedded
+	// HTTPHealthCheck. Setting these to nil for preventing confusion.
+	v.HealthCheck.HttpHealthCheck = nil
+	v.HealthCheck.HttpsHealthCheck = nil
+	v.HealthCheck.Http2HealthCheck = nil
+
+	return v, nil
+}
+
+// Protocol returns the type cased to AppProtocol
+func (hc *HealthCheck) Protocol() annotations.AppProtocol {
+	return annotations.AppProtocol(hc.Type)
+}
+
+// ToComputeHealthCheck returns a valid compute.HealthCheck object
+func (hc *HealthCheck) ToComputeHealthCheck() (*compute.HealthCheck, error) {
+	hc.merge()
+	return utils.ToV1HealthCheck(&hc.HealthCheck)
+}
+
+// ToBetaComputeHealthCheck returns a valid computebeta.HealthCheck object
+func (hc *HealthCheck) ToBetaComputeHealthCheck() (*computebeta.HealthCheck, error) {
+	hc.merge()
+	return utils.ToBetaHealthCheck(&hc.HealthCheck)
+}
+
+// ToAlphaComputeHealthCheck returns a valid computealpha.HealthCheck object
+func (hc *HealthCheck) ToAlphaComputeHealthCheck() *computealpha.HealthCheck {
+	hc.merge()
+	x := hc.HealthCheck // Make a copy to ensure no aliasing.
+	return &x
+}
+
+func (hc *HealthCheck) merge() {
+	// Cannot specify both portSpecification and port field unless fixed port is specified.
+	// This can happen if the user overrides the port using backendconfig
+	if hc.PortSpecification != "" && hc.PortSpecification != "USE_FIXED_PORT" {
+		hc.Port = 0
+	}
+
+	// Zeroing out child settings as a precaution. GoogleAPI throws an error
+	// if the wrong child struct is set.
+	hc.HealthCheck.Http2HealthCheck = nil
+	hc.HealthCheck.HttpsHealthCheck = nil
+	hc.HealthCheck.HttpHealthCheck = nil
+
+	switch hc.Protocol() {
+	case annotations.ProtocolHTTP:
+		x := hc.HTTPHealthCheck // Make a copy to ensure no aliasing.
+		hc.HealthCheck.HttpHealthCheck = &x
+	case annotations.ProtocolHTTPS:
+		https := computealpha.HTTPSHealthCheck(hc.HTTPHealthCheck)
+		hc.HealthCheck.HttpsHealthCheck = &https
+	case annotations.ProtocolHTTP2:
+		http2 := computealpha.HTTP2HealthCheck(hc.HTTPHealthCheck)
+		hc.HealthCheck.Http2HealthCheck = &http2
+	}
+}
+
+// Version returns the appropriate API version to handle the health check
+// Use Beta API for NEG as PORT_SPECIFICATION is required, and HTTP2
+func (hc *HealthCheck) Version() meta.Version {
+	if hc.ForILB {
+		return features.L7ILBVersions().HealthCheck
+	}
+	if hc.Protocol() == annotations.ProtocolHTTP2 || hc.ForNEG {
+		return meta.VersionBeta
+	}
+	return meta.VersionGA
+}
+
+func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckConfig) {
+	if c.CheckIntervalSec != nil {
+		hc.CheckIntervalSec = *c.CheckIntervalSec
+	}
+	if c.TimeoutSec != nil {
+		hc.TimeoutSec = *c.TimeoutSec
+	}
+	if c.HealthyThreshold != nil {
+		hc.HealthyThreshold = *c.HealthyThreshold
+	}
+	if c.UnhealthyThreshold != nil {
+		hc.UnhealthyThreshold = *c.UnhealthyThreshold
+	}
+	if c.Type != nil {
+		hc.Type = *c.Type
+	}
+	if c.RequestPath != nil {
+		hc.RequestPath = *c.RequestPath
+	}
+	if c.Port != nil {
+		hc.Port = *c.Port
+		// This override is necessary regardless of type
+		hc.PortSpecification = "USE_FIXED_PORT"
+	}
+}
+
+// DefaultHealthCheck simply returns the default health check.
+func DefaultHealthCheck(port int64, protocol annotations.AppProtocol) *HealthCheck {
+	httpSettings := computealpha.HTTPHealthCheck{Port: port}
+	hcSettings := computealpha.HealthCheck{
+		// How often to health check.
+		CheckIntervalSec: int64(defaultHealthCheckInterval.Seconds()),
+		// How long to wait before claiming failure of a health check.
+		TimeoutSec: int64(defaultTimeout.Seconds()),
+		// Number of healthchecks to pass for a vm to be deemed healthy.
+		HealthyThreshold: defaultHealthyThreshold,
+		// Number of healthchecks to fail before the vm is deemed unhealthy.
+		UnhealthyThreshold: defaultUnhealthyThreshold,
+		Description:        "Default kubernetes L7 Loadbalancing health check.",
+		Type:               string(protocol),
+	}
+	return &HealthCheck{
+		HTTPHealthCheck: httpSettings,
+		HealthCheck:     hcSettings,
+		ForNEG:          false,
+	}
+}
+
+// DefaultNEGHealthCheck simply returns the default health check.
+func DefaultNEGHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
+	httpSettings := computealpha.HTTPHealthCheck{PortSpecification: useServingPortSpecification}
+	klog.V(3).Infof("DefaultNEGHealthCheck(%v)", protocol)
+
+	hcSettings := computealpha.HealthCheck{
+		// How often to health check.
+		CheckIntervalSec: int64(defaultNEGHealthCheckInterval.Seconds()),
+		// How long to wait before claiming failure of a health check.
+		TimeoutSec: int64(defaultNEGTimeout.Seconds()),
+		// Number of healthchecks to pass for a vm to be deemed healthy.
+		HealthyThreshold: defaultHealthyThreshold,
+		// Number of healthchecks to fail before the vm is deemed unhealthy.
+		UnhealthyThreshold: defaultNEGUnhealthyThreshold,
+		Description:        "Default kubernetes L7 Loadbalancing health check for NEG.",
+		Type:               string(protocol),
+	}
+	return &HealthCheck{
+		HTTPHealthCheck: httpSettings,
+		HealthCheck:     hcSettings,
+		ForNEG:          true,
+	}
+}
+
+func DefaultILBHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
+	httpSettings := computealpha.HTTPHealthCheck{PortSpecification: useServingPortSpecification}
+	klog.V(3).Infof("DefaultILBHealthCheck(%v)", protocol)
+
+	hcSettings := computealpha.HealthCheck{
+		// How often to health check.
+		CheckIntervalSec: int64(defaultNEGHealthCheckInterval.Seconds()),
+		// How long to wait before claiming failure of a health check.
+		TimeoutSec: int64(defaultNEGTimeout.Seconds()),
+		// Number of healthchecks to pass for a vm to be deemed healthy.
+		HealthyThreshold: defaultHealthyThreshold,
+		// Number of healthchecks to fail before the vm is deemed unhealthy.
+		UnhealthyThreshold: defaultNEGUnhealthyThreshold,
+		Description:        "Default kubernetes L7 Loadbalancing health check for ILB.",
+		Type:               string(protocol),
+	}
+
+	return &HealthCheck{
+		HTTPHealthCheck: httpSettings,
+		HealthCheck:     hcSettings,
+		ForILB:          true,
+		ForNEG:          true,
+	}
+}
+
+// ApplyProbeSettingsToHC takes the Pod healthcheck settings and applies it
+// to the healthcheck.
+//
+// TODO: what if the port changes?
+// TODO: does not handle protocol?
+func ApplyProbeSettingsToHC(p *v1.Probe, hc *HealthCheck) {
+	if p.Handler.HTTPGet == nil {
+		return
+	}
+
+	healthPath := p.Handler.HTTPGet.Path
+	// GCE requires a leading "/" for health check urls.
+	if !strings.HasPrefix(healthPath, "/") {
+		healthPath = "/" + healthPath
+	}
+	hc.RequestPath = healthPath
+
+	// Extract host from HTTP headers
+	host := p.Handler.HTTPGet.Host
+	for _, header := range p.Handler.HTTPGet.HTTPHeaders {
+		if header.Name == "Host" {
+			host = header.Value
+			break
+		}
+	}
+	hc.Host = host
+
+	hc.TimeoutSec = int64(p.TimeoutSeconds)
+	if hc.ForNEG {
+		// For NEG mode, we can support more aggressive healthcheck interval.
+		hc.CheckIntervalSec = int64(p.PeriodSeconds)
+	} else {
+		// For IG mode, short healthcheck interval may health check flooding problem.
+		hc.CheckIntervalSec = int64(p.PeriodSeconds) + int64(defaultHealthCheckInterval.Seconds())
+	}
+
+	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
+}

--- a/pkg/utils/healthchecks.go
+++ b/pkg/utils/healthchecks.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
+)
+
+// ToV1HealthCheck converts alpha health check to v1 health check.
+// WARNING: alpha health check has a additional PORT_SPECIFICATION field.
+// This field will be omitted after conversion.
+func ToV1HealthCheck(hc *computealpha.HealthCheck) (*compute.HealthCheck, error) {
+	ret := &compute.HealthCheck{}
+	err := copyViaJSON(ret, hc)
+	return ret, err
+}
+
+// ToBetaHealthCheck converts alpha health check to beta health check.
+func ToBetaHealthCheck(hc *computealpha.HealthCheck) (*computebeta.HealthCheck, error) {
+	ret := &computebeta.HealthCheck{}
+	err := copyViaJSON(ret, hc)
+	return ret, err
+}
+
+// V1ToAlphaHealthCheck converts v1 health check to alpha health check.
+// There should be no information lost after conversion.
+func V1ToAlphaHealthCheck(hc *compute.HealthCheck) (*computealpha.HealthCheck, error) {
+	ret := &computealpha.HealthCheck{}
+	err := copyViaJSON(ret, hc)
+	return ret, err
+}
+
+// BetaToAlphaHealthCheck converts beta health check to alpha health check.
+// There should be no information lost after conversion.
+func BetaToAlphaHealthCheck(hc *computebeta.HealthCheck) (*computealpha.HealthCheck, error) {
+	ret := &computealpha.HealthCheck{}
+	err := copyViaJSON(ret, hc)
+	return ret, err
+}
+
+type jsonConvertable interface {
+	MarshalJSON() ([]byte, error)
+}
+
+func copyViaJSON(dest interface{}, src jsonConvertable) error {
+	var err error
+	bytes, err := src.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bytes, dest)
+}


### PR DESCRIPTION
Note that this PR does not introduce any semantic changes.

Some considerations:

1. We eventually want to start using composite.HealthCheck to represent HealthChecks rather than the existing structure. Moving it to the translator package makes it easier to slowly start chipping away at removing the legacy code.

2. Some of the methods exported in pkg/translator/healthchecks.go will eventually become internal implementation details. For example, DefaultHealthCheck, ApplyProbeSettingstoHC, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/1167)
<!-- Reviewable:end -->
