### PR TITLE
Translate HealthCheck in a single function call in healthchecks.go

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -162,7 +162,6 @@ func main() {
 		Namespace:             flags.F.WatchNamespace,
 		ResyncPeriod:          flags.F.ResyncPeriod,
 		DefaultBackendSvcPort: defaultBackendServicePort,
-		HealthCheckPath:       flags.F.HealthCheckPath,
 		FrontendConfigEnabled: flags.F.EnableFrontendConfig,
 		EnableASMConfigMap:    flags.F.EnableASMConfigMapBasedConfig,
 		ASMConfigMapNamespace: flags.F.ASMConfigMapBasedConfigNamespace,

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -42,7 +42,7 @@ type Jig struct {
 }
 
 func newTestJig(fakeGCE *gce.Cloud) *Jig {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, defaultBackendSvc)
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -136,7 +136,7 @@ var (
 )
 
 func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -97,7 +97,6 @@ type ControllerContextConfig struct {
 	ResyncPeriod time.Duration
 	// DefaultBackendSvcPortID is the ServicePort for the system default backend.
 	DefaultBackendSvcPort utils.ServicePort
-	HealthCheckPath       string
 	FrontendConfigEnabled bool
 	EnableASMConfigMap    bool
 	ASMConfigMapNamespace string

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -108,7 +108,7 @@ func NewLoadBalancerController(
 		Interface: ctx.KubeClient.CoreV1().Events(""),
 	})
 
-	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service)
+	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.DefaultBackendSvcPort.ID.Service)
 	instancePool := instances.NewNodePool(ctx.Cloud, ctx.ClusterNamer, ctx)
 	backendPool := backends.NewPool(ctx.Cloud, ctx.ClusterNamer)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -72,7 +72,6 @@ func newLoadBalancerController() *LoadBalancerController {
 		Namespace:             api_v1.NamespaceAll,
 		ResyncPeriod:          1 * time.Minute,
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
-		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -62,7 +62,6 @@ func fakeTranslator() *Translator {
 		Namespace:             apiv1.NamespaceAll,
 		ResyncPeriod:          1 * time.Second,
 		DefaultBackendSvcPort: defaultBackend,
-		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, nil, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	gce := &Translator{

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -57,6 +57,9 @@ func init() {
 	// flag.StringVar(&logLevel, "logLevel", "4", "test")
 	// flag.Lookup("v").Value.Set(logLevel)
 
+	flags.F.DefaultSvcHealthCheckPath = "/healthz"
+	flags.F.HealthCheckPath = "/"
+
 	// Generate many types of ServicePorts.
 	// Example: sps["HTTP-8000-neg-nil"] is a ServicePort for HTTP with NEG-enabled.
 	testSPs = map[string]*utils.ServicePort{}
@@ -109,7 +112,7 @@ func init() {
 
 func TestHealthCheckAdd(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	sp := &utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: testNamer}
 	_, err := healthChecks.SyncServicePort(sp, nil)
@@ -147,7 +150,7 @@ func TestHealthCheckAdd(t *testing.T) {
 
 func TestHealthCheckAddExisting(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	// HTTP
 	// Manually insert a health check
@@ -219,7 +222,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 
 func TestHealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	// Create HTTP HC for 1234
 	hc := translator.DefaultHealthCheck(1234, annotations.ProtocolHTTP)
@@ -249,7 +252,7 @@ func TestHealthCheckDelete(t *testing.T) {
 
 func TestHTTP2HealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	// Create HTTP2 HC for 1234
 	hc := translator.DefaultHealthCheck(1234, annotations.ProtocolHTTP2)
@@ -279,7 +282,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaHealthChecks.UpdateHook = mock.UpdateAlphaHealthCheckHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaHealthChecks.UpdateHook = mock.UpdateBetaHealthCheckHook
 
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	healthChecks := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 	// HTTP
 	// Manually insert a health check
@@ -1160,7 +1163,7 @@ func TestSyncServicePort(t *testing.T) {
 				tc.setup(mock)
 			}
 
-			hcs := NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+			hcs := NewHealthChecker(fakeGCE, defaultBackendSvc)
 
 			gotSelfLink, err := hcs.SyncServicePort(tc.sp, tc.probe)
 			if gotErr := err != nil; gotErr != tc.wantErr {

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -317,3 +317,30 @@ func ApplyProbeSettingsToHC(p *v1.Probe, hc *HealthCheck) {
 
 	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
 }
+
+// formatBackendConfigHC returns a human readable string version of the HealthCheckConfig
+func formatBackendConfigHC(b *backendconfigv1.HealthCheckConfig) string {
+	var ret []string
+
+	for _, e := range []struct {
+		v *int64
+		k string
+	}{
+		{k: "checkIntervalSec", v: b.CheckIntervalSec},
+		{k: "healthyThreshold", v: b.HealthyThreshold},
+		{k: "unhealthyThreshold", v: b.UnhealthyThreshold},
+		{k: "timeoutSec", v: b.TimeoutSec},
+		{k: "port", v: b.Port},
+	} {
+		if e.v != nil {
+			ret = append(ret, fmt.Sprintf("%s=%d", e.k, *e.v))
+		}
+	}
+	if b.Type != nil {
+		ret = append(ret, fmt.Sprintf("type=%s", *b.Type))
+	}
+	if b.RequestPath != nil {
+		ret = append(ret, fmt.Sprintf("requestPath=%q", *b.RequestPath))
+	}
+	return strings.Join(ret, ", ")
+}


### PR DESCRIPTION
This change ensure that HealthChecks are generated from the translator package. Call sites are appropriately updated and care was taken to ensure that syncing logic in healthchecks.go is maintained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/ingress-gce/1170)
<!-- Reviewable:end -->
