### PR TITLE
Fix VM_IP_NEG creation and updates

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
+	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/backends/features"
@@ -261,7 +262,9 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 		HealthChecks:        []string{hcLink},
 		SessionAffinity:     utils.TranslateAffinityType(sessionAffinity),
 		LoadBalancingScheme: string(scheme),
-		ConnectionDraining:  &composite.ConnectionDraining{DrainingTimeoutSec: DefaultConnectionDrainingTimeoutSeconds},
+	}
+	if protocol == string(api_v1.ProtocolTCP) {
+		expectedBS.ConnectionDraining = &composite.ConnectionDraining{DrainingTimeoutSec: DefaultConnectionDrainingTimeoutSeconds}
 	}
 
 	// Create backend service if none was found

--- a/pkg/backends/neg_linker_test.go
+++ b/pkg/backends/neg_linker_test.go
@@ -14,15 +14,16 @@ limitations under the License.
 package backends
 
 import (
-	"k8s.io/ingress-gce/pkg/composite"
 	"strings"
 	"testing"
 
+	"k8s.io/ingress-gce/pkg/annotations"
+	befeatures "k8s.io/ingress-gce/pkg/backends/features"
+	"k8s.io/ingress-gce/pkg/composite"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/ingress-gce/pkg/annotations"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
@@ -35,7 +36,9 @@ func newTestNEGLinker(fakeNEG negtypes.NetworkEndpointGroupCloud, fakeGCE *gce.C
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaBackendServices.UpdateHook = mock.UpdateAlphaBackendServiceHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaBackendServices.UpdateHook = mock.UpdateBetaBackendServiceHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBackendServices.UpdateHook = mock.UpdateBackendServiceHook
-
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaRegionBackendServices.UpdateHook = mock.UpdateAlphaRegionBackendServiceHook
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaRegionBackendServices.UpdateHook = mock.UpdateBetaRegionBackendServiceHook
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 	return &negLinker{fakeBackendPool, fakeNEG, fakeGCE}
 }
 
@@ -46,52 +49,73 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 
 	zones := []GroupKey{{Zone: "zone1"}, {Zone: "zone2"}}
 	namespace, name, port := "ns", "name", "port"
+	svc := types.NamespacedName{Namespace: namespace, Name: name}
 
-	svcPort := utils.ServicePort{
-		ID: utils.ServicePortID{
-			Service: types.NamespacedName{
-				Namespace: namespace,
-				Name:      name,
-			},
-		},
-		Port:         80,
-		NodePort:     30001,
-		Protocol:     annotations.ProtocolHTTP,
-		TargetPort:   port,
-		NEGEnabled:   true,
-		BackendNamer: defaultNamer,
-	}
-
-	// Mimic how the syncer would create the backend.
-	linker.backendPool.Create(svcPort, "fake-healthcheck-link")
-
-	for _, key := range zones {
-		err := fakeNEG.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
-			Name:    defaultNamer.NEG(namespace, name, svcPort.Port),
-			Version: meta.VersionGA,
-		}, key.Zone)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+	for _, svcPort := range []utils.ServicePort{
+		utils.ServicePort{
+			ID:             utils.ServicePortID{Service: svc},
+			BackendNamer:   defaultNamer,
+			VMIPNEGEnabled: true},
+		utils.ServicePort{
+			ID:           utils.ServicePortID{Service: svc},
+			Port:         80,
+			NodePort:     30001,
+			Protocol:     annotations.ProtocolHTTP,
+			TargetPort:   port,
+			NEGEnabled:   true,
+			BackendNamer: defaultNamer},
+	} {
+		// Mimic how the syncer would create the backend.
+		if _, err := linker.backendPool.Create(svcPort, "fake-healthcheck-link"); err != nil {
+			t.Fatalf("Failed to create backend service to NEG for svcPort %v: %v", svcPort, err)
 		}
-	}
 
-	if err := linker.Link(svcPort, zones); err != nil {
-		t.Fatalf("Failed to link backend service to NEG: %v", err)
-	}
+		version := befeatures.VersionFromServicePort(&svcPort)
 
-	beName := svcPort.BackendName()
-	bs, err := fakeGCE.GetGlobalBackendService(beName)
-	if err != nil {
-		t.Fatalf("Failed to retrieve backend service: %v", err)
-	}
-	if len(bs.Backends) != len(zones) {
-		t.Errorf("Expect %v backends, but got %v.", len(zones), len(bs.Backends))
-	}
+		for _, key := range zones {
+			neg := &composite.NetworkEndpointGroup{
+				Name:    svcPort.BackendName(),
+				Version: version,
+			}
+			if svcPort.VMIPNEGEnabled {
+				neg.NetworkEndpointType = string(negtypes.VmIpEndpointType)
+			}
+			err := fakeNEG.CreateNetworkEndpointGroup(neg, key.Zone)
+			if err != nil {
+				t.Fatalf("unexpected error creating NEG for svcPort %v: %v", svcPort, err)
+			}
+		}
 
-	for _, be := range bs.Backends {
-		neg := "networkEndpointGroups"
-		if !strings.Contains(be.Group, neg) {
-			t.Errorf("Got backend link %q, want containing %q", be.Group, neg)
+		if err := linker.Link(svcPort, zones); err != nil {
+			t.Fatalf("Failed to link backend service to NEG for svcPort %v: %v", svcPort, err)
+		}
+
+		beName := svcPort.BackendName()
+		scope := befeatures.ScopeFromServicePort(&svcPort)
+
+		key, err := composite.CreateKey(fakeGCE, beName, scope)
+		if err != nil {
+			t.Fatalf("Failed to create composite key - %v", err)
+		}
+		bs, err := composite.GetBackendService(fakeGCE, key, version)
+		if err != nil {
+			t.Fatalf("Failed to retrieve backend service using key %+v for svcPort %v: %v", key, svcPort, err)
+		}
+		if len(bs.Backends) != len(zones) {
+			t.Errorf("Expect %v backends in backend service %s, but got %v.key %+v %+v", len(zones), beName, len(bs.Backends), key, bs)
+		}
+
+		for _, be := range bs.Backends {
+			neg := "networkEndpointGroups"
+			if !strings.Contains(be.Group, neg) {
+				t.Errorf("Got backend link %q, want containing %q", be.Group, neg)
+			}
+			if svcPort.VMIPNEGEnabled {
+				// Balancing mode should be connection, rate should be unset
+				if be.BalancingMode != string(Connections) || be.MaxRatePerEndpoint != 0 {
+					t.Errorf("Only 'Connection' balancing mode is supported with VM_IP NEGs, Got %q with max rate %v", be.BalancingMode, be.MaxRatePerEndpoint)
+				}
+			}
 		}
 	}
 }

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -410,7 +410,7 @@ func (c *Controller) processService(key string) error {
 		return fmt.Errorf("failed to merge CSM service PortInfoMap: %v, error: %v", csmSVCPortInfoMap, err)
 	}
 	if c.runL4 {
-		if err := c.mergeVmIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, negUsage); err != nil {
+		if err := c.mergeVmIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, &negUsage); err != nil {
 			return err
 		}
 	}
@@ -495,7 +495,7 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 }
 
 // mergeVmIpNEGsPortInfo merges the PortInfo for ILB services using GCE_VM_IP NEGs into portInfoMap
-func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage usage.NegServiceState) error {
+func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usage.NegServiceState) error {
 	if wantsILB, _ := annotations.WantsL4ILB(service); !wantsILB {
 		return nil
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -69,6 +69,10 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
+		var targetPort string
+		if testNegType == negtypes.VmIpPortEndpointType {
+			targetPort = "8080"
+		}
 
 		// Verify the NEGs are created as expected
 		ret, _ := transactionSyncer.cloud.AggregatedListNetworkEndpointGroup(transactionSyncer.NegSyncerKey.GetAPIVersion())
@@ -108,71 +112,71 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 			{
 				"add some endpoints",
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"remove some endpoints",
 				map[string]negtypes.NetworkEndpointSet{},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"add duplicate endpoints",
 				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"add and remove endpoints",
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
 			},
 			{
 				"add more endpoints",
 				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 			},
 			{
 				"add and remove endpoints in both zones",
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")),
+					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 		}
@@ -195,7 +199,11 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 
 				endpointSet := negtypes.NewNetworkEndpointSet()
 				for _, ep := range list {
-					endpointSet.Insert(negtypes.NetworkEndpoint{IP: ep.NetworkEndpoint.IpAddress, Node: ep.NetworkEndpoint.Instance, Port: strconv.FormatInt(ep.NetworkEndpoint.Port, 10)})
+					tmp := negtypes.NetworkEndpoint{IP: ep.NetworkEndpoint.IpAddress, Node: ep.NetworkEndpoint.Instance}
+					if testNegType == negtypes.VmIpPortEndpointType {
+						tmp.Port = strconv.FormatInt(ep.NetworkEndpoint.Port, 10)
+					}
+					endpointSet.Insert(tmp)
 				}
 
 				if !endpoints.Equal(endpointSet) {
@@ -923,7 +931,7 @@ func unionEndpointMap(m1, m2 negtypes.EndpointPodMap) negtypes.EndpointPodMap {
 }
 
 func generateEndpointBatch(endpointSet negtypes.NetworkEndpointSet) map[negtypes.NetworkEndpoint]*composite.NetworkEndpoint {
-	ret, _ := makeEndpointBatch(endpointSet)
+	ret, _ := makeEndpointBatch(endpointSet, negtypes.VmIpPortEndpointType)
 	return ret
 }
 


### PR DESCRIPTION
This PR fixes issues identified by testing the VM_IP_NEG implementation. Fixes are:

1) Do not set "Port" field for VM_IP_NEGs, when listing existing endpoints as well as for new.
2) Skip invoking "commitPods" for VM_IP_NEGs since that prints several non-relevant warning messages for this mode.
3) Fix metrics export for VM_IP_NEGs
3) Set Balancing Mode as Connection for L4 ILB Backends.
4) Set ConnectionDrainingTimeout only for UDP

All these changes were verified in a dev setup.

/assign @freehan 