### PR TITLE
Cleanup L4 ILB IP Reservation in all cases.

### DIFF
--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -133,6 +133,15 @@ func TestEnsureInternalLoadBalancer(t *testing.T) {
 		t.Errorf("Got empty loadBalancer status using handler %v", l)
 	}
 	assertInternalLbResources(t, svc, l, nodeNames)
+	// Simulate a periodic sync
+	status, err = l.EnsureInternalLoadBalancer(nodeNames, svc)
+	if err != nil {
+		t.Errorf("Failed to ensure loadBalancer, err %v", err)
+	}
+	if len(status.Ingress) == 0 {
+		t.Errorf("Got empty loadBalancer status using handler %v", l)
+	}
+	assertInternalLbResources(t, svc, l, nodeNames)
 }
 
 func TestEnsureInternalLoadBalancerTypeChange(t *testing.T) {
@@ -1107,6 +1116,6 @@ func assertInternalLbResourcesDeleted(t *testing.T, apiService *v1.Service, fire
 	}
 	addr, err := l.cloud.GetRegionAddress(resourceName, l.cloud.Region())
 	if err == nil || addr != nil {
-		t.Errorf("Expected error when looking up backend service after deletion")
+		t.Errorf("Expected error when looking up IP address after deletion")
 	}
 }


### PR DESCRIPTION
This is a follow up to https://github.com/kubernetes/ingress-gce/pull/1179, the previous PR cleaned up the reservation in case of new Forwarding rule creation or on updates. But, reservation also happens during periodic syncs which need to be cleaned up.

/assign @freehan @bowei 