### PR TITLE
Adds annotation kubernetes.io/ingress.reserve-global-static-ip-name to signal GLBC to manage static IP

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -50,6 +50,13 @@ const (
 	// responsibility to create/delete it.
 	RegionalStaticIPNameKey = "kubernetes.io/ingress.regional-static-ip-name"
 
+	// ReserveGlobalStaticIPNameKey tells the Ingress controller to manage a specific
+	// GCE static ip for its forwarding rules. If specified, the Ingress controller
+	// reserves and assigns the static ip by this name to the forwarding rules of the
+	// given ingress. It differs from StaticIPNameKey, since the controller does manage
+	// this ip.
+	ReserveGlobalStaticIPNameKey = "kubernetes.io/ingress.reserve-global-static-ip-name"
+
 	// PreSharedCertKey represents the specific pre-shared SSL
 	// certificate for the Ingress controller to use. The controller *does not*
 	// manage this certificate, it is the users responsibility to create/delete it.
@@ -119,17 +126,12 @@ func FromIngress(ing *v1beta1.Ingress) *Ingress {
 	return &Ingress{ing.Annotations}
 }
 
-// AllowHTTP returns the allowHTTP flag. True by default.
-func (ing *Ingress) AllowHTTP() bool {
-	val, ok := ing.v[AllowHTTPKey]
+func (ing *Ingress) ReserveGlobalStaticIPName() string {
+	val, ok := ing.v[ReserveGlobalStaticIPNameKey]
 	if !ok {
-		return true
+		return ""
 	}
-	v, err := strconv.ParseBool(val)
-	if err != nil {
-		return true
-	}
-	return v
+	return val
 }
 
 // UseNamedTLS returns the name of the GCE SSL certificate. Empty by default.
@@ -175,6 +177,19 @@ func (ing *Ingress) RegionalStaticIPName() string {
 		return ""
 	}
 	return val
+}
+
+// AllowHTTP returns the allowHTTP flag. True by default.
+func (ing *Ingress) AllowHTTP() bool {
+	val, ok := ing.v[AllowHTTPKey]
+	if !ok {
+		return true
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return true
+	}
+	return v
 }
 
 func (ing *Ingress) IngressClass() string {

--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -54,7 +54,7 @@ const (
 	// GCE static ip for its forwarding rules. If specified, the Ingress controller
 	// reserves and assigns the static ip by this name to the forwarding rules of the
 	// given ingress. It differs from StaticIPNameKey, since the controller does manage
-	// this ip.
+	// this ip. Do not use the same value for both this annotation and GlobalStaticIPNameKey.
 	ReserveGlobalStaticIPNameKey = "kubernetes.io/ingress.reserve-global-static-ip-name"
 
 	// PreSharedCertKey represents the specific pre-shared SSL
@@ -126,6 +126,7 @@ func FromIngress(ing *v1beta1.Ingress) *Ingress {
 	return &Ingress{ing.Annotations}
 }
 
+// ReserveGlobalStaticIPName returns the value for the ReserveGlobalStaticIPNameKey annotation.
 func (ing *Ingress) ReserveGlobalStaticIPName() string {
 	val, ok := ing.v[ReserveGlobalStaticIPNameKey]
 	if !ok {

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -26,13 +26,14 @@ import (
 
 func TestIngress(t *testing.T) {
 	for _, tc := range []struct {
-		desc         string
-		ing          *v1beta1.Ingress
-		allowHTTP    bool
-		useNamedTLS  string
-		staticIPName string
-		ingressClass string
-		wantErr      bool
+		desc                      string
+		ing                       *v1beta1.Ingress
+		allowHTTP                 bool
+		useNamedTLS               string
+		staticIPName              string
+		ingressClass              string
+		reserveGlobalStaticIPName string
+		wantErr                   bool
 	}{
 		{
 			desc:      "Empty ingress",
@@ -72,6 +73,17 @@ func TestIngress(t *testing.T) {
 			staticIPName: "1.2.3.4",
 			ingressClass: "gce",
 		},
+		{
+			ing: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ReserveGlobalStaticIPNameKey: "1.2.3.4-managed",
+					},
+				},
+			},
+			allowHTTP:                 true,
+			reserveGlobalStaticIPName: "1.2.3.4-managed",
+		},
 	} {
 		ing := FromIngress(tc.ing)
 
@@ -94,6 +106,9 @@ func TestIngress(t *testing.T) {
 		}
 		if x := ing.IngressClass(); x != tc.ingressClass {
 			t.Errorf("ingress %+v; IngressClass() = %v, want %v", tc.ing, x, tc.ingressClass)
+		}
+		if x := ing.ReserveGlobalStaticIPName(); x != tc.reserveGlobalStaticIPName {
+			t.Errorf("ingress %+v; ReserveGlobalStaticIPName() = %v, want %v", tc.ing, x, tc.reserveGlobalStaticIPName)
 		}
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -685,13 +685,14 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *v1beta1.Ingress, urlMap *u
 	}
 
 	return &loadbalancers.L7RuntimeInfo{
-		TLS:            tls,
-		TLSName:        annotations.UseNamedTLS(),
-		Ingress:        ing,
-		AllowHTTP:      annotations.AllowHTTP(),
-		StaticIPName:   staticIPName,
-		UrlMap:         urlMap,
-		FrontendConfig: feConfig,
+		TLS:                       tls,
+		TLSName:                   annotations.UseNamedTLS(),
+		Ingress:                   ing,
+		AllowHTTP:                 annotations.AllowHTTP(),
+		StaticIPName:              staticIPName,
+		ReserveGlobalStaticIPName: annotations.ReserveGlobalStaticIPName(),
+		UrlMap:                    urlMap,
+		FrontendConfig:            feConfig,
 	}, nil
 }
 

--- a/pkg/loadbalancers/addresses.go
+++ b/pkg/loadbalancers/addresses.go
@@ -35,7 +35,10 @@ func (l *L7) checkStaticIP() (err error) {
 		return fmt.Errorf("will not create static IP without a forwarding rule")
 	}
 	managedStaticIPName := l.namer.ForwardingRule(namer.HTTPProtocol)
-	// Don't manage staticIPs if the user has specified an IP.
+	if l.runtimeInfo.ReserveGlobalStaticIPName != "" && l.ip == nil {
+		managedStaticIPName = l.runtimeInfo.ReserveGlobalStaticIPName
+	}
+	// Don't manage staticIPs if the user has specified an IP and if ReserveGlobalStaticIPName was not provided.
 	address, manageStaticIP, err := l.getEffectiveIP()
 	if err != nil {
 		return err

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -63,6 +63,10 @@ type L7RuntimeInfo struct {
 	StaticIPName string
 	// The name of the static IP subnet, this is only used for L7-ILB Ingress static IPs
 	StaticIPSubnet string
+	// The name of a Global Static IP that the ingress controller should manage.
+	// If specified, the static IP will be reserved with the cloud provider and
+	// the IP associated with this name is used in the Forwarding Rules for this loadbalancer.
+	ReserveGlobalStaticIPName string
 	// UrlMap is our internal representation of a url map.
 	UrlMap *utils.GCEURLMap
 	// FrontendConfig is the type which encapsulates features for the load balancer.

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -1059,6 +1059,107 @@ func TestStaticIP(t *testing.T) {
 	}
 }
 
+// Test ReserveGlobalStaticIPName annotation behavior.
+// When ReserveGlobalStaticIPName is specified, a static IP with its value should be created.
+func TestReserveGlobalStaticIPName(t *testing.T) {
+	j := newTestJig(t)
+	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234, BackendNamer: j.namer}
+	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000, BackendNamer: j.namer}}})
+	ing := newIngress()
+	ing.Annotations = map[string]string{
+		"ReserveGlobalStaticIPNameKey": "testmanagedstaticip",
+	}
+	lbInfo := &L7RuntimeInfo{
+		AllowHTTP:                 true,
+		TLS:                       []*TLSCerts{{Key: "key", Cert: "cert"}},
+		UrlMap:                    gceUrlMap,
+		Ingress:                   ing,
+		ReserveGlobalStaticIPName: "testmanagedstaticip",
+	}
+
+	if _, err := j.pool.Ensure(lbInfo); err != nil {
+		t.Fatalf("expected no error ensuring ingress with non-existent static ip with ReserveGlobalStaticIPName set - %v", err)
+	}
+	// Get the reserved static IP value
+	if _, err := j.fakeGCE.GetGlobalAddress("testmanagedstaticip"); err != nil {
+		t.Fatalf("ip address reservation failed - %v", err)
+	}
+}
+
+// When an existing ReserveGlobalStaticIPName value is specified,
+// the behavior shouldn't be different from not specifying ReserveGlobalStaticIP (ingress creation must pass).
+func TestReserveGlobalStaticIPNameExistingValue(t *testing.T) {
+	j := newTestJig(t)
+	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234, BackendNamer: j.namer}
+	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000, BackendNamer: j.namer}}})
+	ing := newIngress()
+	ing.Annotations = map[string]string{
+		"ReserveGlobalStaticIPNameKey": "testmanagedstaticip",
+	}
+	lbInfo := &L7RuntimeInfo{
+		AllowHTTP:                 true,
+		TLS:                       []*TLSCerts{{Key: "key", Cert: "cert"}},
+		UrlMap:                    gceUrlMap,
+		Ingress:                   ing,
+		ReserveGlobalStaticIPName: "testmanagedstaticip",
+	}
+
+	// The only difference from the default behavior is that, with ReserveGlobalStaticIPName set
+	// and by specifying a non-existent IP, the IP will be managed by GLBC.
+	// Create static IP
+	err := j.fakeGCE.ReserveGlobalAddress(&compute.Address{Name: "testmanagedstaticip", Address: "1.2.3.4"})
+	if err != nil {
+		t.Fatalf("ip address reservation failed - %v", err)
+	}
+	if _, err := j.pool.Ensure(lbInfo); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+// When ReserveGlobalStaticIPName is specified at a later time,
+// the ingress update should fail.
+// This will be simulated by reserving a static IP and going through the same behavior as StaticIPName.
+// That is the same behavior as to when a TLS pre-shared cert is specified and a static IP is reserved.
+func TestReserveGlobalStaticIPNameLateChange(t *testing.T) {
+	j := newTestJig(t)
+	gceUrlMap := utils.NewGCEURLMap()
+	gceUrlMap.DefaultBackend = &utils.ServicePort{NodePort: 31234, BackendNamer: j.namer}
+	gceUrlMap.PutPathRulesForHost("bar.example.com", []utils.PathRule{{Path: "/bar", Backend: utils.ServicePort{NodePort: 30000, BackendNamer: j.namer}}})
+	ing := newIngress()
+	ing.Annotations = map[string]string{
+		"StaticIPNameKey": "teststaticip",
+	}
+	lbInfo := &L7RuntimeInfo{
+		AllowHTTP:    true,
+		TLS:          []*TLSCerts{{Key: "key", Cert: "cert"}},
+		UrlMap:       gceUrlMap,
+		Ingress:      ing,
+		StaticIPName: "teststaticip",
+	}
+	// Create static IP
+	err := j.fakeGCE.ReserveGlobalAddress(&compute.Address{Name: "teststaticip", Address: "1.2.3.4"})
+	if err != nil {
+		t.Fatalf("ip address reservation failed - %v", err)
+	}
+	if _, err := j.pool.Ensure(lbInfo); err != nil {
+		t.Fatalf("expected no error ensuring ingress - %v", err)
+	}
+	ing.Annotations = map[string]string{
+		"ReserveGlobalStaticIPNameKey": "testmanagedstaticip",
+	}
+	lbInfo.ReserveGlobalStaticIPName = "testmanagedstaticip"
+
+	if _, err := j.pool.Ensure(lbInfo); err != nil {
+		t.Fatalf("expected no error ensuring ingress - %v", err)
+	}
+	// static IP shouldn't be created
+	if _, err := j.fakeGCE.GetGlobalAddress("testmanagedstaticip"); err == nil {
+		t.Fatalf("expected error getting a static ip, got no error")
+	}
+}
+
 // Test setting frontendconfig Ssl policy
 func TestFrontendConfigSslPolicy(t *testing.T) {
 	flags.F.EnableFrontendConfig = true

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -1072,7 +1072,7 @@ func TestReserveGlobalStaticIPName(t *testing.T) {
 	}
 	lbInfo := &L7RuntimeInfo{
 		AllowHTTP:                 true,
-		TLS:                       []*TLSCerts{{Key: "key", Cert: "cert"}},
+		TLS:                       []*translator.TLSCerts{{Key: "key", Cert: "cert"}},
 		UrlMap:                    gceUrlMap,
 		Ingress:                   ing,
 		ReserveGlobalStaticIPName: "testmanagedstaticip",
@@ -1100,7 +1100,7 @@ func TestReserveGlobalStaticIPNameExistingValue(t *testing.T) {
 	}
 	lbInfo := &L7RuntimeInfo{
 		AllowHTTP:                 true,
-		TLS:                       []*TLSCerts{{Key: "key", Cert: "cert"}},
+		TLS:                       []*translator.TLSCerts{{Key: "key", Cert: "cert"}},
 		UrlMap:                    gceUrlMap,
 		Ingress:                   ing,
 		ReserveGlobalStaticIPName: "testmanagedstaticip",
@@ -1133,7 +1133,7 @@ func TestReserveGlobalStaticIPNameLateChange(t *testing.T) {
 	}
 	lbInfo := &L7RuntimeInfo{
 		AllowHTTP:    true,
-		TLS:          []*TLSCerts{{Key: "key", Cert: "cert"}},
+		TLS:          []*translator.TLSCerts{{Key: "key", Cert: "cert"}},
 		UrlMap:       gceUrlMap,
 		Ingress:      ing,
 		StaticIPName: "teststaticip",


### PR DESCRIPTION
This PR is a follow-up of #1151 

This PR adds the `kubernetes.io/ingress.reserve-global-static-ip-name` annotation, which is a string that specifies a static IP name and manages it, differing from the behaviour of `kubernetes.io/ingress.global-static-ip-name`.

## Things taken in consideration

The behaviour for `kubernetes.io/ingress.global-static-ip-name` is still the same: if the static IP doesn't exist on GCE, it will fail. However, `kubernetes.io/ingress.reserve-global-static-ip-name` will bypass the failure and reserve the static IP with the name provided.

This is different from the default behaviour seen in #1080: even if `kubernetes.io/ingress.global-static-ip-name` was provided, the static IP was reserved with a namer (that follows the pattern `k8s-resource--uid`) and if the user reserved the static IP with the name provided, GLBC would flip to using that, causing downtime. 

In the approach of this PR, however, if `kubernetes.io/ingress.global-static-ip-name` is provided, we use its value from the beginning. 

To avoid flipping to a managed static IP when already using a static IP, we check if there is already a static IP for an Ingress. If it exists, the `kubernetes.io/ingress.global-static-ip-name` behaviour is ignored. 

## Things not taken in consideration

~If the user supplies `kubernetes.io/ingress.reserve-global-static-ip-name` at a later time, the regression will be triggered, causing the IP flip and downtime.~