### PR TITLE
syncer writes neg desc on initialization

### DIFF
--- a/pkg/apis/svcneg/v1beta1/types.go
+++ b/pkg/apis/svcneg/v1beta1/types.go
@@ -50,7 +50,7 @@ type ServiceNetworkEndpointGroupStatus struct {
 
 	// Last time the NEG syncer syncs associated NEGs.
 	// +optional
-	LastSyncTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastSyncTime metav1.Time `json:"lastSyncTime,omitempty"`
 }
 
 // NegObjectReference is the object reference to the NEG resource in GCE

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -131,7 +131,7 @@ func NewController(
 	if enableNegCrd {
 		svcNegInformer = ctx.SvcNegInformer.GetIndexer()
 	}
-	manager := newSyncerManager(namer, recorder, cloud, zoneGetter, ctx.SvcNegClient, ctx.PodInformer.GetIndexer(), ctx.ServiceInformer.GetIndexer(), ctx.EndpointInformer.GetIndexer(), ctx.NodeInformer.GetIndexer(), svcNegInformer)
+	manager := newSyncerManager(namer, recorder, cloud, zoneGetter, ctx.SvcNegClient, ctx.KubeSystemUID, ctx.PodInformer.GetIndexer(), ctx.ServiceInformer.GetIndexer(), ctx.EndpointInformer.GetIndexer(), ctx.NodeInformer.GetIndexer(), svcNegInformer)
 	var reflector readiness.Reflector
 	if enableReadinessReflector {
 		reflector = readiness.NewReadinessReflector(ctx, manager)

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -86,7 +86,7 @@ func NewTestSyncerManagerWithNegClient(kubeClient kubernetes.Interface, svcNegCl
 		ResyncPeriod:          0 * time.Second,
 		DefaultBackendSvcPort: defaultBackend,
 	}
-	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, svcNegClient, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, "" /*kubeSystemUID*/, ctxConfig)
+	context := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, svcNegClient, gce.NewFakeGCECloud(gce.DefaultTestClusterValues()), namer, "kube-system-uid", ctxConfig)
 
 	var svcNegInformer cache.Indexer
 	if svcNegClient != nil {
@@ -99,6 +99,7 @@ func NewTestSyncerManagerWithNegClient(kubeClient kubernetes.Interface, svcNegCl
 		negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network"),
 		negtypes.NewFakeZoneGetter(),
 		svcNegClient,
+		context.KubeSystemUID,
 		context.PodInformer.GetIndexer(),
 		context.ServiceInformer.GetIndexer(),
 		context.EndpointInformer.GetIndexer(),

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -40,6 +40,7 @@ const (
 	testServiceName      = "test-name"
 	testNamedPort        = "named-Port"
 	clusterID            = "clusterid"
+	kubeSystemUID        = "kube-system-id"
 )
 
 var (

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -29,8 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -302,9 +305,9 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 		testServiceNameSpace = "test-ns"
 		testNetwork          = cloud.ResourcePath("network", &meta.Key{Zone: testZone, Name: "test-network"})
 		testSubnetwork       = cloud.ResourcePath("subnetwork", &meta.Key{Zone: testZone, Name: "test-subnetwork"})
+		testKubesystemUID    = "kube-system-uid"
+		testPort             = "80"
 	)
-
-	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
 
 	testCases := []struct {
 		description         string
@@ -313,6 +316,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 		networkEndpointType negtypes.NetworkEndpointType
 		expectedSubnetwork  string
 		apiVersion          meta.Version
+		enableNegCRD        bool
 	}{
 		{
 			description:         "Create NEG of type GCE_VM_IP_PORT",
@@ -338,20 +342,54 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			expectedSubnetwork:  testSubnetwork,
 			apiVersion:          meta.VersionAlpha,
 		},
+		{
+			description:         "Create NEG of type GCE_VM_IP_PORT with Neg CRD",
+			negName:             "gcp-neg",
+			enableNonGCPMode:    false,
+			networkEndpointType: negtypes.VmIpPortEndpointType,
+			expectedSubnetwork:  testSubnetwork,
+			apiVersion:          meta.VersionGA,
+			enableNegCRD:        true,
+		},
+		{
+			description:         "Create NEG of type NON_GCP_PRIVATE_IP_PORT with Neg CRD",
+			negName:             "non-gcp-neg",
+			enableNonGCPMode:    true,
+			networkEndpointType: negtypes.NonGCPPrivateEndpointType,
+			expectedSubnetwork:  "",
+			apiVersion:          meta.VersionGA,
+			enableNegCRD:        true,
+		},
+		{
+			description:         "Create NEG of type GCE_VM_IP with Neg CRD",
+			negName:             "gcp-ip-neg",
+			enableNonGCPMode:    false,
+			networkEndpointType: negtypes.VmIpEndpointType,
+			expectedSubnetwork:  testSubnetwork,
+			apiVersion:          meta.VersionAlpha,
+			enableNegCRD:        true,
+		},
 	}
 	for _, tc := range testCases {
-		ensureNetworkEndpointGroup(
+		fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+		flags.F.EnableNegCrd = tc.enableNegCRD
+		_, err := ensureNetworkEndpointGroup(
 			testServiceNameSpace,
 			testServiceName,
 			tc.negName,
 			testZone,
 			testNamedPort,
+			testKubesystemUID,
+			testPort,
 			tc.networkEndpointType,
 			fakeCloud,
 			nil,
 			nil,
 			tc.apiVersion,
 		)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
 
 		neg, err := fakeCloud.GetNetworkEndpointGroup(tc.negName, testZone, tc.apiVersion)
 		if err != nil {
@@ -366,13 +404,38 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			t.Errorf("Unexpected Subnetwork, expecting %q but got %q", tc.expectedSubnetwork, neg.Subnetwork)
 		}
 
+		if tc.enableNegCRD {
+			expectedNegDesc := utils.NegDescription{
+				ClusterUID:  testKubesystemUID,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
+				Port:        testPort,
+			}
+
+			actualNegDesc, err := utils.NegDescriptionFromString(neg.Description)
+			if err != nil {
+				t.Errorf("Invalid neg description: %s", err)
+			}
+
+			if !reflect.DeepEqual(*actualNegDesc, expectedNegDesc) {
+				t.Errorf("Unexpected neg description: %s, expected %s", neg.Description, expectedNegDesc.String())
+			}
+
+		} else {
+			if neg.Description != "" {
+				t.Errorf("Unexpected neg description. Expecting no description but got %s", neg.Description)
+			}
+		}
+
 		// Call ensureNetworkEndpointGroup with the same NEG.
-		err = ensureNetworkEndpointGroup(
+		_, err = ensureNetworkEndpointGroup(
 			testServiceNameSpace,
 			testServiceName,
 			tc.negName,
 			testZone,
 			testNamedPort,
+			testKubesystemUID,
+			testPort,
 			tc.networkEndpointType,
 			fakeCloud,
 			nil,
@@ -817,7 +880,203 @@ func TestShouldPodBeInNeg(t *testing.T) {
 			t.Errorf("For test case %q, endpointSets output = %+v, but got %+v", tc.desc, tc.expect, ret)
 		}
 	}
+}
 
+func TestNameUniqueness(t *testing.T) {
+	var (
+		testZone             = "test-zone"
+		testNamedPort        = "named-port"
+		testServiceName      = "test-svc"
+		testServiceNameSpace = "test-ns"
+		testNetwork          = cloud.ResourcePath("network", &meta.Key{Zone: testZone, Name: "test-network"})
+		testSubnetwork       = cloud.ResourcePath("subnetwork", &meta.Key{Zone: testZone, Name: "test-subnetwork"})
+		testKubesystemUID    = "cluster-uid"
+		testPort             = "80"
+		testServiceName2     = "test-svc-2"
+		negName              = "test-neg"
+		apiVersion           = meta.VersionGA
+		networkEndpointType  = negtypes.VmIpPortEndpointType
+	)
+
+	for _, tc := range []struct {
+		description      string
+		enableNegInitial bool
+		enableNegFinal   bool
+		expectError      bool
+	}{
+		{
+			description:      "both calls have NEG CRD enabled",
+			enableNegInitial: true,
+			enableNegFinal:   true,
+			expectError:      true,
+		},
+		{
+			description:      "first call has NEG CRD enabled",
+			enableNegInitial: true,
+			enableNegFinal:   false,
+			expectError:      true,
+		},
+		{
+			// This case is unlikely. If neg is created when NEG CRD is not enabled, the name is guaranteed to be unique due to naming convention.
+			description:      "final call have NEG CRD enabled",
+			enableNegInitial: false,
+			enableNegFinal:   true,
+			expectError:      false,
+		},
+		{
+			// This case is unlikely. If neg is created when NEG CRD is not enabled, the name is guaranteed to be unique due to naming convention.
+			description:      "neither call has NEG CRD enabled",
+			enableNegInitial: false,
+			enableNegFinal:   false,
+			expectError:      false,
+		},
+	} {
+		fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+		flags.F.EnableNegCrd = tc.enableNegInitial
+
+		_, err := ensureNetworkEndpointGroup(
+			testServiceNameSpace,
+			testServiceName,
+			negName,
+			testZone,
+			testNamedPort,
+			testKubesystemUID,
+			testPort,
+			networkEndpointType,
+			fakeCloud,
+			nil,
+			nil,
+			apiVersion,
+		)
+		if err != nil {
+			t.Errorf("Errored while ensuring network endpoint groups: %s", err)
+		}
+
+		neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion)
+		if err != nil {
+			t.Errorf("Failed to retrieve NEG %q: %v", negName, err)
+		}
+
+		if neg == nil {
+			t.Errorf("Failed to find neg")
+		}
+
+		// Call ensureNetworkEndpointGroup with the same NEG name and different service name
+		flags.F.EnableNegCrd = tc.enableNegFinal
+		_, err = ensureNetworkEndpointGroup(
+			testServiceNameSpace,
+			testServiceName2,
+			negName,
+			testZone,
+			testNamedPort,
+			testKubesystemUID,
+			testPort,
+			networkEndpointType,
+			fakeCloud,
+			nil,
+			nil,
+			apiVersion,
+		)
+
+		if tc.expectError && err == nil {
+			t.Errorf("Expected error when called with duplicate NEG name")
+		} else if !tc.expectError && err != nil {
+			t.Errorf("Unexpected error when ensuring NEG: %s", err)
+		}
+	}
+}
+
+func TestNegObjectCrd(t *testing.T) {
+
+	var (
+		testZone             = "test-zone"
+		testNamedPort        = "named-port"
+		testServiceName      = "test-svc"
+		testServiceNameSpace = "test-ns"
+		testNetwork          = cloud.ResourcePath("network", &meta.Key{Zone: testZone, Name: "test-network"})
+		testSubnetwork       = cloud.ResourcePath("subnetwork", &meta.Key{Zone: testZone, Name: "test-subnetwork"})
+		testKubesystemUID    = "cluster-uid"
+		testPort             = "80"
+		negName              = "test-neg"
+		apiVersion           = meta.VersionGA
+	)
+
+	for _, networkEndpointType := range []negtypes.NetworkEndpointType{
+		negtypes.VmIpPortEndpointType,
+		negtypes.VmIpEndpointType,
+		negtypes.NonGCPPrivateEndpointType,
+	} {
+		// Ensure that the Neg Object Resource returned does not change based on the enableNegCRD input
+		for _, enableNegCRD := range []bool{true, false} {
+			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+			flags.F.EnableNegCrd = enableNegCRD
+			negObj, err := ensureNetworkEndpointGroup(
+				testServiceNameSpace,
+				testServiceName,
+				negName,
+				testZone,
+				testNamedPort,
+				testKubesystemUID,
+				testPort,
+				networkEndpointType,
+				fakeCloud,
+				nil,
+				nil,
+				apiVersion,
+			)
+			if err != nil {
+				t.Errorf("Errored while ensuring network endpoint groups: %s", err)
+			}
+
+			neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion)
+			if err != nil {
+				t.Errorf("Failed to retrieve NEG %q: %v", negName, err)
+			}
+
+			if neg == nil {
+				t.Errorf("Failed to find neg")
+			}
+
+			var expectedNegObj negv1beta1.NegObjectReference
+			if enableNegCRD {
+				expectedNegObj = negv1beta1.NegObjectReference{
+					Id:                  neg.Id,
+					SelfLink:            neg.SelfLink,
+					NetworkEndpointType: negv1beta1.NetworkEndpointType(networkEndpointType),
+				}
+			} else {
+				expectedNegObj = negv1beta1.NegObjectReference{}
+			}
+
+			if negObj != expectedNegObj {
+				t.Errorf("Expected neg object %+v, but received %+v", expectedNegObj, negObj)
+			}
+
+			// Call ensureNetworkEndpointGroup with the same NEG name and different service name
+			negObj, err = ensureNetworkEndpointGroup(
+				testServiceNameSpace,
+				testServiceName,
+				negName,
+				testZone,
+				testNamedPort,
+				testKubesystemUID,
+				testPort,
+				networkEndpointType,
+				fakeCloud,
+				nil,
+				nil,
+				apiVersion,
+			)
+
+			if err != nil {
+				t.Errorf("Unexpected error when ensuring NEG: %s", err)
+			}
+
+			if negObj != expectedNegObj {
+				t.Errorf("Expected neg object %+v, but received %+v", expectedNegObj, negObj)
+			}
+		}
+	}
 }
 
 // numToIP converts the given number to an IP address.

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -49,6 +49,12 @@ const (
 	NegCRServicePortKey = "networking.gke.io/service-port"
 	// NegCRControllerValue is used as the value for the managed-by label on NEG CRs when enabled.
 	NegCRControllerValue = "neg-controller"
+
+	// NEG CR Condition Reasons
+	NegSyncSuccessful           = "NegSyncSuccessful"
+	NegSyncFailed               = "NegSyncFailed"
+	NegInitializationSuccessful = "NegInitializationSuccessful"
+	NegInitializationFailed     = "NegInitializationFailed"
 )
 
 // SvcPortTuple is the tuple representing one service port

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -173,6 +173,7 @@ func (n *Namer) SetFirewall(name string) {
 }
 
 // UID returns the UID/name of this cluster.
+// WARNING: Use KubeSystemUID instead
 func (n *Namer) UID() string {
 	n.nameLock.Lock()
 	defer n.nameLock.Unlock()

--- a/pkg/utils/negdescription.go
+++ b/pkg/utils/negdescription.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+
+	"k8s.io/klog"
+)
+
+// Description stores the description for a BackendService.
+type NegDescription struct {
+	ClusterUID  string `json:"cluster-uid,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	ServiceName string `json:"service-name,omitempty"`
+	Port        string `json:"port,omitempty"`
+}
+
+// String returns the string representation of a Description.
+func (desc NegDescription) String() string {
+	descJson, err := json.Marshal(desc)
+	if err != nil {
+		klog.Errorf("Failed to generate neg description string: %v, falling back to empty string", err)
+		return ""
+	}
+	return string(descJson)
+}
+
+// DescriptionFromString gets a Description from string,
+func NegDescriptionFromString(descString string) (*NegDescription, error) {
+	var desc NegDescription
+	if err := json.Unmarshal([]byte(descString), &desc); err != nil {
+		klog.Errorf("Failed to parse neg description: %s, falling back to empty list", descString)
+		return &NegDescription{}, err
+	}
+	return &desc, nil
+}

--- a/pkg/utils/negdescription_test.go
+++ b/pkg/utils/negdescription_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNegString(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		description    NegDescription
+		expectedString string
+	}{
+		{
+			desc: "all fields",
+			description: NegDescription{
+				ClusterUID:  "00000000001",
+				Namespace:   "my-namespace",
+				ServiceName: "my-service",
+				Port:        "80",
+			},
+			expectedString: `{"cluster-uid":"00000000001","namespace":"my-namespace","service-name":"my-service","port":"80"}`,
+		},
+		{
+			desc:           "empty",
+			description:    NegDescription{},
+			expectedString: "{}",
+		},
+	}
+
+	for _, tc := range testCases {
+		stringDesc := tc.description.String()
+		if stringDesc != tc.expectedString {
+			t.Errorf("%s: String()=%s, want %s", tc.desc, stringDesc, tc.expectedString)
+		}
+	}
+}
+
+func TestNegDescriptionFromString(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		negDesc      string
+		expectedDesc NegDescription
+		expectError  bool
+	}{
+		{
+			desc:        "empty string",
+			expectError: true,
+		},
+		{
+			desc:        "invalid format",
+			negDesc:     "invalid",
+			expectError: true,
+		},
+		{
+			desc:    "no feature",
+			negDesc: `{"cluster-uid":"00000000001", "namespace":"my-namespace", "service-name":"my-service", "port":"80"}`,
+			expectedDesc: NegDescription{
+				ClusterUID:  "00000000001",
+				Namespace:   "my-namespace",
+				ServiceName: "my-service",
+				Port:        "80",
+			},
+			expectError: false,
+		},
+		{
+			desc:    "missing a field",
+			negDesc: `{"cluster-uid":"00000000001","service-name":"my-service", "port":"80"}`,
+			expectedDesc: NegDescription{
+				ClusterUID:  "00000000001",
+				ServiceName: "my-service",
+				Port:        "80",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		description, err := NegDescriptionFromString(tc.negDesc)
+		if err != nil && !tc.expectError {
+			t.Errorf("%s: NegDescriptionFromString(%s) resulted in error: %s", tc.desc, tc.negDesc, err)
+		}
+		if !reflect.DeepEqual(*description, tc.expectedDesc) {
+			t.Errorf("%s: NegDescriptionFromString(%s)=%s, want %s", tc.desc, tc.negDesc, description, tc.expectedDesc)
+		}
+	}
+}

--- a/pkg/utils/patch_test.go
+++ b/pkg/utils/patch_test.go
@@ -49,3 +49,48 @@ func TestStrategicMergePatchBytes(t *testing.T) {
 		t.Errorf("StrategicMergePatchBytes(%+v, %+v) = %s ; want %s", ing, updated, string(b), expected)
 	}
 }
+
+func TestJSONMergePatchBytes(t *testing.T) {
+	// Patch an Ingress w/ a finalizer
+	ing := &v1beta1.Ingress{}
+	updated := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{"foo"},
+		},
+	}
+	b, err := MergePatchBytes(ing, updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"metadata":{"finalizers":["foo"]}}`
+	if string(b) != expected {
+		t.Errorf("MergePatchBytes(%+v, %+v) = %s ; want %s", ing, updated, string(b), expected)
+	}
+
+	// Patch an Ingress with an additional finalizer
+	ing = updated
+	updated = &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{"foo", "bar"},
+		},
+	}
+	b, err = MergePatchBytes(ing, updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `{"metadata":{"finalizers":["foo","bar"]}}`
+	if string(b) != expected {
+		t.Errorf("MergePatchBytes(%+v, %+v) = %s ; want %s", ing, updated, string(b), expected)
+	}
+	// Patch an Ingress with the finalizer removed
+	ing = updated
+	updated = &v1beta1.Ingress{}
+	b, err = MergePatchBytes(ing, updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `{"metadata":{"finalizers":null}}`
+	if string(b) != expected {
+		t.Errorf("MergePatchBytes(%+v, %+v) = %s ; want %s", ing, updated, string(b), expected)
+	}
+}


### PR DESCRIPTION
  - updates status on NEG CRs when neg crd is enabled
  - errors during sync and initializations are exposed in NEG CR