### PR TITLE
Revert to individual secret get

### DIFF
--- a/docs/deploy/resources/rbac.yaml
+++ b/docs/deploy/resources/rbac.yaml
@@ -37,7 +37,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list"]
+  verbs: ["get"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch", "update", "create", "patch"]

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -281,6 +281,10 @@ func TestSecrets(t *testing.T) {
 
 			env, err := NewEnv(tc.ing, kubeClient, "", "", "")
 			if err != nil {
+				if tc.wantErr {
+					// we look up secrets in NewEnv, so an error here is ok
+					return
+				}
 				t.Fatalf("NewEnv(): %v", err)
 			}
 


### PR DESCRIPTION
This PR:
* reverts the mechanism for fetching TLS secrets to a Get() (away from listing all secrets in a namespace in https://github.com/kubernetes/ingress-gce/pull/1101/files#r456811105)
* removes the secret list permission added in https://github.com/kubernetes/ingress-gce/pull/1134/files#r456812266
* resolves the test failure reported in https://github.com/kubernetes/kubernetes/pull/93031

/assign @bowei @rramkumar1 