### PR TITLE
Allow modifying trafficPolicy for L4 ILB services

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -527,7 +527,7 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 	// Update usage metrics.
 	negUsage.VmIpNeg = usage.NewVmIpNegType(onlyLocal)
 
-	return portInfoMap.Merge(negtypes.NewPortInfoMapForVMIPNEG(name.Namespace, name.Name, c.namer, !onlyLocal))
+	return portInfoMap.Merge(negtypes.NewPortInfoMapForVMIPNEG(name.Namespace, name.Name, c.namer, onlyLocal))
 }
 
 // mergeDefaultBackendServicePortInfoMap merge the PortInfoMap for the default backend service into portInfoMap

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -142,8 +142,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 		if !ok {
 			// determine the implementation that calculates NEG endpoints on each sync.
 			epc := negsyncer.GetEndpointsCalculator(manager.nodeLister, manager.podLister, manager.zoneGetter,
-				syncerKey, portInfo.RandomizeEndpoints)
-
+				syncerKey, portInfo.EpCalculatorMode)
 			syncer = negsyncer.NewTransactionSyncer(
 				syncerKey,
 				portInfo.NegName,
@@ -476,20 +475,23 @@ func ensureNegCROwnerRef(negCR *negv1beta1.ServiceNetworkEndpointGroup, expected
 // getSyncerKey encodes a service namespace, name, service port and targetPort into a string key
 func getSyncerKey(namespace, name string, servicePortKey negtypes.PortInfoMapKey, portInfo negtypes.PortInfo) negtypes.NegSyncerKey {
 	networkEndpointType := negtypes.VmIpPortEndpointType
+	calculatorMode := negtypes.L7Mode
 	if flags.F.EnableNonGCPMode {
 		networkEndpointType = negtypes.NonGCPPrivateEndpointType
 	}
 	if portInfo.PortTuple.Empty() {
 		networkEndpointType = negtypes.VmIpEndpointType
+		calculatorMode = portInfo.EpCalculatorMode
 	}
 
 	return negtypes.NegSyncerKey{
-		Namespace:    namespace,
-		Name:         name,
-		PortTuple:    portInfo.PortTuple,
-		Subset:       servicePortKey.Subset,
-		SubsetLabels: portInfo.SubsetLabels,
-		NegType:      networkEndpointType,
+		Namespace:        namespace,
+		Name:             name,
+		PortTuple:        portInfo.PortTuple,
+		Subset:           servicePortKey.Subset,
+		SubsetLabels:     portInfo.SubsetLabels,
+		NegType:          networkEndpointType,
+		EpCalculatorMode: calculatorMode,
 	}
 }
 

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -85,7 +85,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(ep *v1.Endpoints, cur
 		}
 	}
 	if numEndpoints == 0 {
-		// TODO verify the behavior seen by a client when accessing an ILB whose NEGs have no endpoints.
+		// Not having backends will cause clients to see connection timeout instead of an "ICMP ConnectionRefused".
 		return nil, nil, nil
 	}
 	// Compute the networkEndpoints, with total endpoints count <= l.subsetSizeLimit

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -32,7 +32,8 @@ import (
 // The L7 implementation is tested in TestToZoneNetworkEndpointMapUtil.
 func TestLocalGetEndpointSet(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), false)
+	mode := negtypes.L4LocalMode
+	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), mode)
 	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
 	for i := 0; i < len(nodeNames); i++ {
 		err := transactionSyncer.nodeLister.Add(&v1.Node{
@@ -102,7 +103,8 @@ func TestLocalGetEndpointSet(t *testing.T) {
 // TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4ILBEndpointsCalculator.
 func TestClusterGetEndpointSet(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), true)
+	mode := negtypes.L4ClusterMode
+	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), mode)
 	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
 	for i := 0; i < len(nodeNames); i++ {
 		err := transactionSyncer.nodeLister.Add(&v1.Node{

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1202,9 +1202,9 @@ func TestUpdateStatus(t *testing.T) {
 	}
 }
 
-func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, randomize bool) (negtypes.NegSyncer, *transactionSyncer) {
+func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, mode negtypes.EndpointsCalculatorMode) (negtypes.NegSyncer, *transactionSyncer) {
 	negsyncer, ts := newTestTransactionSyncer(fakeGCE, negtypes.VmIpEndpointType)
-	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.zoneGetter, ts.NegSyncerKey, randomize)
+	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.zoneGetter, ts.NegSyncerKey, mode)
 	return negsyncer, ts
 }
 
@@ -1237,10 +1237,12 @@ func newTestTransactionSyncerWithNegClient(fakeGCE negtypes.NetworkEndpointGroup
 		flags.F.EnableNegCrd = true
 	}
 
+	var mode negtypes.EndpointsCalculatorMode
 	if negType == negtypes.VmIpEndpointType {
 		svcPort.PortTuple.Port = 0
 		svcPort.PortTuple.TargetPort = ""
 		svcPort.PortTuple.Name = string(negtypes.VmIpEndpointType)
+		mode = negtypes.L4LocalMode
 	}
 
 	// TODO(freehan): use real readiness reflector
@@ -1263,7 +1265,7 @@ func newTestTransactionSyncerWithNegClient(fakeGCE negtypes.NetworkEndpointGroup
 		svcNegLister,
 		reflector,
 		GetEndpointsCalculator(context.NodeInformer.GetIndexer(), context.PodInformer.GetIndexer(), negtypes.NewFakeZoneGetter(),
-			svcPort, false),
+			svcPort, mode),
 		string(kubeSystemUID),
 		context.SvcNegClient,
 	)


### PR DESCRIPTION
Switching from Local to Cluster trafficPolicy (or vice versa) should change the endpoints calculator mode.

Also added logic to pick a random subset of upto 3 nodes in case of Local mode, with no endpoints. With this change, accessing the VIP will return "Connection refused" immediately, instead of timing out after a few seconds.
The behavior is unchanged for cases where there are endpoints.

/assign @freehan 