### PR TITLE
Handle error when calculating endpoints for NEG.

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -163,6 +163,9 @@ func (s *transactionSyncer) syncInternal() error {
 	s.logStats(currentMap, "after in-progress operations have completed, NEG endpoints")
 
 	targetMap, endpointPodMap, err := s.endpointsCalculator.CalculateEndpoints(ep.(*apiv1.Endpoints), currentMap)
+	if err != nil {
+		return fmt.Errorf("endpoints calculation error in mode %q, err: %v", s.endpointsCalculator.Mode(), err)
+	}
 	s.logStats(targetMap, "desired NEG endpoints")
 
 	// Calculate the endpoints to add and delete to transform the current state to desire state


### PR DESCRIPTION
Without this check, error on endpoints calculation could briefly remove all endpoints in the NEG.

/assign @freehan 