### PR TITLE
Use NEG CRs for NEG Garbage Collection

### DIFF
--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -55,6 +55,9 @@ const (
 	NegSyncFailed               = "NegSyncFailed"
 	NegInitializationSuccessful = "NegInitializationSuccessful"
 	NegInitializationFailed     = "NegInitializationFailed"
+
+	// NEG CRD Enabled Garbage Collection Event Reasons
+	NegGCError = "NegCRError"
 )
 
 // SvcPortTuple is the tuple representing one service port

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -41,6 +41,8 @@ const (
 	LegacyILBFinalizer = "gke.networking.io/l4-ilb-v1"
 	// ILBFinalizerV2 is the finalizer used by newer controllers that implement Internal LoadBalancer services.
 	ILBFinalizerV2 = "gke.networking.io/l4-ilb-v2"
+	// NegFinalizerKey is the finalizer used by neg controller to ensure NEG CRs are deleted after corresponding negs are deleted
+	NegFinalizerKey = "networking.gke.io/neg-finalizer"
 )
 
 // IsDeletionCandidate is true if the passed in meta contains an ingress finalizer.


### PR DESCRIPTION
 - Add finalizer to NEG CRs to ensure CR exists until NEG is deleted
 during GC
 - When neg crd is enabled, GC will use neg crs, otherwise will fallback
 to regular GC using the naming to determine which NEGs are to be
 deleted