### PR TITLE
Ignore deletion timestamp when ensuring NEG CR

### DIFF
--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -842,7 +842,7 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 			svc:               svc1,
 			svcTuple:          svcTuple1,
 			markedForDeletion: true,
-			expectErr:         true,
+			expectErr:         false,
 			crExists:          true,
 		},
 		{desc: "same service, different port configuration, original cr is not marked for deletion",


### PR DESCRIPTION
 - svcPortMap is the source of truth, so continue neg creation and
 syncing even if corresponding NEG CR has a deletion timestamp