### PR TITLE
Allow modifying protocol in L4 ILB service

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -196,61 +196,27 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	if err != nil {
 		return nil, err
 	}
-	desc := utils.L4ILBResourceDescription{}
 	// version used for creating the existing forwarding rule.
-	existingVersion := meta.VersionGA
-	// version to use for the new forwarding rule
-	newVersion := getAPIVersion(options)
+	version := meta.VersionGA
 
 	// Get the GA version forwarding rule, use the description to identify the version it was created with.
 	existingFwdRule, err := composite.GetForwardingRule(l.cloud, key, meta.VersionGA)
 	if utils.IgnoreHTTPNotFound(err) != nil {
 		return nil, err
 	}
-	if existingFwdRule != nil {
-		if err = desc.Unmarshal(existingFwdRule.Description); err != nil {
-			klog.Warningf("Failed to lookup forwarding rule version from description, err %v. Using GA Version.", err)
-		} else {
-			existingVersion = desc.APIVersion
-		}
-	}
-	// Fetch the right forwarding rule in case it is not using GA
-	if existingVersion != meta.VersionGA {
-		existingFwdRule, err = composite.GetForwardingRule(l.cloud, key, existingVersion)
-		if utils.IgnoreHTTPNotFound(err) != nil {
-			klog.Errorf("Failed to lookup forwarding rule '%s' at version - %s, err %v", key.Name, existingVersion, err)
-			return nil, err
-		}
-	}
-
 	if l.cloud.IsLegacyNetwork() {
 		l.recorder.Event(l.Service, v1.EventTypeWarning, "ILBOptionsIgnored", "Internal LoadBalancer options are not supported with Legacy Networks.")
 		options = gce.ILBOptions{}
 	}
 	subnetworkURL := l.cloud.SubnetworkURL()
 
-	if !l.cloud.AlphaFeatureGate.Enabled(gce.AlphaFeatureILBCustomSubnet) {
-		if options.SubnetName != "" {
-			l.recorder.Event(l.Service, v1.EventTypeWarning, "ILBCustomSubnetOptionIgnored", "Internal LoadBalancer CustomSubnet options ignored as the feature gate is disabled.")
-			options.SubnetName = ""
-		}
-	}
-	if l.cloud.AlphaFeatureGate.Enabled(gce.AlphaFeatureILBCustomSubnet) {
-		// If this feature is enabled, changes to subnet annotation will be
-		// picked up and reflected in the forwarding rule.
-		// Removing the annotation will set the forwarding rule to use the default subnet.
-		if options.SubnetName != "" {
-			subnetKey := *key
-			subnetKey.Name = options.SubnetName
-			subnetworkURL = cloud.SelfLink(meta.VersionGA, l.cloud.ProjectID(), "subnetworks", &subnetKey)
-		}
-	} else {
-		// TODO(84885) remove this once ILBCustomSubnet goes beta.
-		if existingFwdRule != nil && existingFwdRule.Subnetwork != "" {
-			// If the ILB already exists, continue using the subnet that it's already using.
-			// This is to support existing ILBs that were setup using the wrong subnet - https://github.com/kubernetes/kubernetes/pull/57861
-			subnetworkURL = existingFwdRule.Subnetwork
-		}
+	// Custom subnet feature is always enabled when running L4 controller.
+	// Changes to subnet annotation will be picked up and reflected in the forwarding rule.
+	// Removing the annotation will set the forwarding rule to use the default subnet.
+	if options.SubnetName != "" {
+		subnetKey := *key
+		subnetKey.Name = options.SubnetName
+		subnetworkURL = cloud.SelfLink(meta.VersionGA, l.cloud.ProjectID(), "subnetworks", &subnetKey)
 	}
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
 	// or specified in the Service spec, then requestedIP = "".
@@ -279,7 +245,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	ports, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
 	// Create the forwarding rule
 	frDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(l.Service.Namespace, l.Service.Name), ipToUse,
-		newVersion)
+		version)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %v", loadBalancerName,
 			err)
@@ -293,7 +259,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 		LoadBalancingScheme: string(cloud.SchemeInternal),
 		Subnetwork:          subnetworkURL,
 		Network:             l.cloud.NetworkURL(),
-		Version:             newVersion,
+		Version:             version,
 		BackendService:      bsLink,
 		AllowGlobalAccess:   options.AllowGlobalAccess,
 		Description:         frDesc,
@@ -308,7 +274,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 			// If the forwarding rule pointed to a backend service which does not match the controller naming scheme,
 			// that resouce could be leaked. It is not being deleted here because that is a user-managed resource.
 			klog.V(2).Infof("ensureForwardingRule: Deleting existing forwarding rule - %s, will be recreated", fr.Name)
-			if err = utils.IgnoreHTTPNotFound(composite.DeleteForwardingRule(l.cloud, key, existingVersion)); err != nil {
+			if err = utils.IgnoreHTTPNotFound(composite.DeleteForwardingRule(l.cloud, key, version)); err != nil {
 				return nil, err
 			}
 			l.recorder.Eventf(l.Service, corev1.EventTypeNormal, events.SyncIngress, "ForwardingRule %q deleted", key.Name)
@@ -321,13 +287,19 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	return composite.GetForwardingRule(l.cloud, key, fr.Version)
 }
 
+func (l *L4) deleteForwardingRule(name string, version meta.Version) {
+	key, err := l.CreateKey(name)
+	if err != nil {
+		klog.Errorf("Failed to create key for deleting forwarding rule %s, err: %v", name, err)
+		return
+	}
+	if err := utils.IgnoreHTTPNotFound(composite.DeleteForwardingRule(l.cloud, key, version)); err != nil {
+		klog.Errorf("Failed to delete forwarding rule %s, err: %v", name, err)
+	}
+}
+
 func Equal(fr1, fr2 *composite.ForwardingRule) bool {
-	// If one of the IP addresses is empty, do not consider it as an inequality.
-	// If the IP address drops from a valid IP to empty, we do not want to apply
-	// the change if it is the only change in the forwarding rule. Similarly, if
-	// the forwarding rule changes from an empty IP to an allocated IP address, the
-	// subnetwork will change as well.
-	return (fr1.IPAddress == "" || fr2.IPAddress == "" || fr1.IPAddress == fr2.IPAddress) &&
+	return fr1.IPAddress == fr2.IPAddress &&
 		fr1.IPProtocol == fr2.IPProtocol &&
 		fr1.LoadBalancingScheme == fr2.LoadBalancingScheme &&
 		utils.EqualStringSets(fr1.Ports, fr2.Ports) &&
@@ -344,6 +316,11 @@ func ilbIPToUse(svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSub
 		return svc.Spec.LoadBalancerIP
 	}
 	if fwdRule == nil {
+		// Reuse the already assigned IP address for this ILB. This is most likely the case
+		// where ILB protocol changed and the forwarding rule got deleted.
+		if len(svc.Status.LoadBalancer.Ingress) > 0 {
+			return svc.Status.LoadBalancer.Ingress[0].IP
+		}
 		return ""
 	}
 	if requestedSubnet != fwdRule.Subnetwork {
@@ -351,12 +328,4 @@ func ilbIPToUse(svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSub
 		return ""
 	}
 	return fwdRule.IPAddress
-}
-
-// getAPIVersion returns the API version to use for CRUD of Forwarding rules, given the options enabled.
-func getAPIVersion(options gce.ILBOptions) meta.Version {
-	if options.AllowGlobalAccess {
-		return meta.VersionBeta
-	}
-	return meta.VersionGA
 }


### PR DESCRIPTION
Protocol modification requires forwarding rule to be deleted before backend service update. Forwarding rule will also reuses the IP from service
status, to avoid IP address change due to proto change.

Other changes:
Also use GA API for forwarding rule creation always since Global Access is GA.
Remove feature gate logic for Custom Subnet.
Simplified Forwarding Rule Equality Logic. If the IP address in old and new FR do not match,
it is considered to be a change. Special case for empty IP removed.

/assign @freehan @skmatti 