### PR TITLE
Validation generation

### DIFF
--- a/pkg/apis/svcneg/v1beta1/types.go
+++ b/pkg/apis/svcneg/v1beta1/types.go
@@ -24,7 +24,6 @@ import (
 // ServiceNetworkEndpointGroup represents a group of Network Endpoint Groups associated with a service.
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 //
 // +k8s:openapi-gen=true
@@ -37,15 +36,19 @@ type ServiceNetworkEndpointGroup struct {
 }
 
 // ServiceNetworkEndpointGroupSpec is the spec for a ServiceNetworkEndpointGroup resource
-// +k8s:openapi-gen=true
 type ServiceNetworkEndpointGroupSpec struct{}
 
 // ServiceNetworkEndpointGroupStatus is the status for a ServiceNetworkEndpointGroup resource
+// +k8s:openapi-gen=true
 type ServiceNetworkEndpointGroupStatus struct {
+	// +listType=map
+	// +listMapKey=id
 	NetworkEndpointGroups []NegObjectReference `json:"networkEndpointGroups,omitempty"`
 
 	// Last time the NEG syncer syncs associated NEGs.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty"`
 
 	// Last time the NEG syncer syncs associated NEGs.
@@ -54,9 +57,10 @@ type ServiceNetworkEndpointGroupStatus struct {
 }
 
 // NegObjectReference is the object reference to the NEG resource in GCE
+// +k8s:openapi-gen=true
 type NegObjectReference struct {
 	// The unique identifier for the NEG resource in GCE API.
-	Id uint64 `json:"id,omitempty,string"`
+	Id string `json:"id,omitempty"`
 
 	// SelfLink is the GCE Server-defined fully-qualified URL for the GCE NEG resource
 	SelfLink string `json:"selfLink,omitempty"`
@@ -66,6 +70,7 @@ type NegObjectReference struct {
 	NetworkEndpointType NetworkEndpointType `json:"networkEndpointType,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 type NetworkEndpointType string
 
 const (
@@ -76,6 +81,7 @@ const (
 
 // TODO: Replace Condition with standard Condition
 // NegCondition contains details for the current condition of this NEG.
+// +k8s:openapi-gen=true
 type Condition struct {
 	// Type is the type of the condition.
 	// +required

--- a/pkg/apis/svcneg/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/svcneg/v1beta1/zz_generated.openapi.go
@@ -29,8 +29,101 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup":     schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroup(ref),
-		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroupSpec": schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroupSpec(ref),
+		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.Condition":                         schema_pkg_apis_svcneg_v1beta1_Condition(ref),
+		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.NegObjectReference":                schema_pkg_apis_svcneg_v1beta1_NegObjectReference(ref),
+		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup":       schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroup(ref),
+		"k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroupStatus": schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroupStatus(ref),
+	}
+}
+
+func schema_pkg_apis_svcneg_v1beta1_Condition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "NegCondition contains details for the current condition of this NEG.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type is the type of the condition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration will not be set for ServiceNetworkEndpointGroup as the spec is empty.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition transitioned from one status to another.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reason for the condition's last transition",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human readable message indicating details about the transition. This field may be empty.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status", "reason", "message"},
+			},
+		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+	}
+}
+
+func schema_pkg_apis_svcneg_v1beta1_NegObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "NegObjectReference is the object reference to the NEG resource in GCE",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The unique identifier for the NEG resource in GCE API.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"selfLink": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SelfLink is the GCE Server-defined fully-qualified URL for the GCE NEG resource",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"networkEndpointType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkEndpointType: Type of network endpoints in this network endpoint group.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -77,13 +170,64 @@ func schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroup(ref common.Refer
 	}
 }
 
-func schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroupSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_svcneg_v1beta1_ServiceNetworkEndpointGroupStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ServiceNetworkEndpointGroupSpec is the spec for a ServiceNetworkEndpointGroup resource",
+				Description: "ServiceNetworkEndpointGroupStatus is the status for a ServiceNetworkEndpointGroup resource",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"networkEndpointGroups": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"id",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.NegObjectReference"),
+									},
+								},
+							},
+						},
+					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the NEG syncer syncs associated NEGs.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.Condition"),
+									},
+								},
+							},
+						},
+					},
+					"lastSyncTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the NEG syncer syncs associated NEGs.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time", "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.Condition", "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.NegObjectReference"},
 	}
 }

--- a/pkg/crd/validation_test.go
+++ b/pkg/crd/validation_test.go
@@ -40,6 +40,23 @@ var (
 								Ref: spec.MustCreateRef("Baz"),
 							},
 						},
+						"quuxs": {
+							SchemaProps: spec.SchemaProps{
+								Type: []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: spec.MustCreateRef("Quux"),
+										},
+									},
+								},
+							},
+						},
+						"ts": {
+							SchemaProps: spec.SchemaProps{
+								Ref: spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							},
+						},
 					},
 				},
 			},
@@ -88,6 +105,20 @@ var (
 				},
 			},
 		},
+		"Quux": {
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Description: "Quux",
+					Properties: map[string]spec.Schema{
+						"qux": {
+							SchemaProps: spec.SchemaProps{
+								Ref: spec.MustCreateRef("Qux"),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 )
 
@@ -104,5 +135,24 @@ func TestCondenseSchema(t *testing.T) {
 	condensedBarSchema := condensedFooSchema.SchemaProps.Properties["bar"]
 	if condensedBarSchema.SchemaProps.Properties["qux"].SchemaProps.Description != "Qux" {
 		t.Errorf("Expected Foo's schema for Bar to contain the Description for Qux.")
+	}
+	if condensedFooSchema.SchemaProps.Properties["quuxs"].SchemaProps.Items.Schema.SchemaProps.Description != "Quux" {
+		t.Errorf("Expected Foo's schema to contain the Description for Quux.")
+	}
+
+	condensedQuuxSchema := condensedFooSchema.SchemaProps.Properties["quuxs"].SchemaProps.Items.Schema
+	if condensedQuuxSchema.SchemaProps.Properties["qux"].Description != "Qux" {
+		t.Errorf("Expected Foo's schema to contain the Description for Qux.")
+	}
+
+	tsProp := condensedFooSchema.SchemaProps.Properties["ts"]
+	if !tsProp.SchemaProps.Type.Contains("string") {
+		t.Errorf("Expected Foo's ts property to have type string")
+	}
+	if tsProp.SchemaProps.Format != "date-time" {
+		t.Errorf("Expected Foo's ts property to have format 'date-time'")
+	}
+	if !tsProp.SchemaProps.Nullable {
+		t.Errorf("Expected Foo's ts property to be Nullable")
 	}
 }

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1261,7 +1261,7 @@ func getNegObjectRefs(t *testing.T, cloud negtypes.NetworkEndpointGroupCloud, zo
 			continue
 		}
 		negRefs = append(negRefs, negv1beta1.NegObjectReference{
-			Id:                  neg.Id,
+			Id:                  fmt.Sprint(neg.Id),
 			SelfLink:            neg.SelfLink,
 			NetworkEndpointType: negv1beta1.NetworkEndpointType(neg.NetworkEndpointType),
 		})

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1078,12 +1078,12 @@ func TestUpdateStatus(t *testing.T) {
 	testNegType := negtypes.VmIpPortEndpointType
 	testNegRefs := []negv1beta1.NegObjectReference{
 		negv1beta1.NegObjectReference{
-			Id:                  0,
+			Id:                  "0",
 			SelfLink:            "self-link-0",
 			NetworkEndpointType: "neg-type-0",
 		},
 		negv1beta1.NegObjectReference{
-			Id:                  1,
+			Id:                  "1",
 			SelfLink:            "self-link-1",
 			NetworkEndpointType: "neg-type-1",
 		},
@@ -1406,7 +1406,7 @@ func negObjectReferences(negs map[*meta.Key]*composite.NetworkEndpointGroup) map
 	negObjs := make(map[string]negv1beta1.NegObjectReference)
 	for _, neg := range negs {
 		negObjs[neg.SelfLink] = negv1beta1.NegObjectReference{
-			Id:                  neg.Id,
+			Id:                  fmt.Sprint(neg.Id),
 			SelfLink:            neg.SelfLink,
 			NetworkEndpointType: negv1beta1.NetworkEndpointType(neg.NetworkEndpointType),
 		}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -207,7 +207,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 		}
 
 		negRef = negv1beta1.NegObjectReference{
-			Id:                  neg.Id,
+			Id:                  fmt.Sprint(neg.Id),
 			SelfLink:            neg.SelfLink,
 			NetworkEndpointType: negv1beta1.NetworkEndpointType(neg.NetworkEndpointType),
 		}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1040,7 +1040,7 @@ func TestNegObjectCrd(t *testing.T) {
 			var expectedNegObj negv1beta1.NegObjectReference
 			if enableNegCRD {
 				expectedNegObj = negv1beta1.NegObjectReference{
-					Id:                  neg.Id,
+					Id:                  fmt.Sprint(neg.Id),
 					SelfLink:            neg.SelfLink,
 					NetworkEndpointType: negv1beta1.NetworkEndpointType(networkEndpointType),
 				}

--- a/pkg/svcneg/client/clientset/versioned/typed/svcneg/v1beta1/fake/fake_servicenetworkendpointgroup.go
+++ b/pkg/svcneg/client/clientset/versioned/typed/svcneg/v1beta1/fake/fake_servicenetworkendpointgroup.go
@@ -102,6 +102,18 @@ func (c *FakeServiceNetworkEndpointGroups) Update(ctx context.Context, serviceNe
 	return obj.(*v1beta1.ServiceNetworkEndpointGroup), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeServiceNetworkEndpointGroups) UpdateStatus(ctx context.Context, serviceNetworkEndpointGroup *v1beta1.ServiceNetworkEndpointGroup, opts v1.UpdateOptions) (*v1beta1.ServiceNetworkEndpointGroup, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(servicenetworkendpointgroupsResource, "status", c.ns, serviceNetworkEndpointGroup), &v1beta1.ServiceNetworkEndpointGroup{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ServiceNetworkEndpointGroup), err
+}
+
 // Delete takes name of the serviceNetworkEndpointGroup and deletes it. Returns an error if one occurs.
 func (c *FakeServiceNetworkEndpointGroups) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/svcneg/client/clientset/versioned/typed/svcneg/v1beta1/servicenetworkendpointgroup.go
+++ b/pkg/svcneg/client/clientset/versioned/typed/svcneg/v1beta1/servicenetworkendpointgroup.go
@@ -40,6 +40,7 @@ type ServiceNetworkEndpointGroupsGetter interface {
 type ServiceNetworkEndpointGroupInterface interface {
 	Create(ctx context.Context, serviceNetworkEndpointGroup *v1beta1.ServiceNetworkEndpointGroup, opts v1.CreateOptions) (*v1beta1.ServiceNetworkEndpointGroup, error)
 	Update(ctx context.Context, serviceNetworkEndpointGroup *v1beta1.ServiceNetworkEndpointGroup, opts v1.UpdateOptions) (*v1beta1.ServiceNetworkEndpointGroup, error)
+	UpdateStatus(ctx context.Context, serviceNetworkEndpointGroup *v1beta1.ServiceNetworkEndpointGroup, opts v1.UpdateOptions) (*v1beta1.ServiceNetworkEndpointGroup, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.ServiceNetworkEndpointGroup, error)
@@ -128,6 +129,22 @@ func (c *serviceNetworkEndpointGroups) Update(ctx context.Context, serviceNetwor
 		Namespace(c.ns).
 		Resource("servicenetworkendpointgroups").
 		Name(serviceNetworkEndpointGroup.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(serviceNetworkEndpointGroup).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *serviceNetworkEndpointGroups) UpdateStatus(ctx context.Context, serviceNetworkEndpointGroup *v1beta1.ServiceNetworkEndpointGroup, opts v1.UpdateOptions) (result *v1beta1.ServiceNetworkEndpointGroup, err error) {
+	result = &v1beta1.ServiceNetworkEndpointGroup{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("servicenetworkendpointgroups").
+		Name(serviceNetworkEndpointGroup.Name).
+		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(serviceNetworkEndpointGroup).
 		Do(ctx).


### PR DESCRIPTION
Update validation generation to allow for flattening array properties and outside types.

Regenerate Neg CRD code generation for open api definitions for missing types and change NegObjectReference.Id to string to generate proper validation