### PR TITLE
Fix internal ingress static IP bug

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -84,7 +84,7 @@ func (l *L7) checkForwardingRule(protocol namer.NamerProtocol, name, proxyLink, 
 	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
 	tr := translator.NewTranslator(isL7ILB, l.namer)
 	env := &translator.Env{VIP: ip, Network: l.cloud.NetworkURL(), Subnetwork: l.cloud.SubnetworkURL()}
-	fr := tr.ToCompositeForwardingRule(env, protocol, version, proxyLink, description)
+	fr := tr.ToCompositeForwardingRule(env, protocol, version, proxyLink, description, l.runtimeInfo.StaticIPSubnet)
 
 	existing, _ = composite.GetForwardingRule(l.cloud, key, version)
 	if existing != nil && (fr.IPAddress != "" && existing.IPAddress != fr.IPAddress || existing.PortRange != fr.PortRange) {
@@ -180,6 +180,7 @@ func (l *L7) getEffectiveIP() (string, bool, error) {
 			return "", false, fmt.Errorf("the given static IP name %v doesn't translate to an existing static IP.",
 				l.runtimeInfo.StaticIPName)
 		} else {
+			l.runtimeInfo.StaticIPSubnet = ip.Subnetwork
 			return ip.Address, false, nil
 		}
 	}

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -61,6 +61,8 @@ type L7RuntimeInfo struct {
 	// this name is used in the Forwarding Rules for this loadbalancer.
 	// If this is an l7-ILB ingress, the static IP is assumed to be internal
 	StaticIPName string
+	// The name of the static IP subnet, this is only used for L7-ILB Ingress static IPs
+	StaticIPSubnet string
 	// UrlMap is our internal representation of a url map.
 	UrlMap *utils.GCEURLMap
 	// FrontendConfig is the type which encapsulates features for the load balancer.

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -244,7 +244,7 @@ const (
 )
 
 // ToCompositeForwardingRule returns a composite.ForwardingRule of type HTTP or HTTPS.
-func (t *Translator) ToCompositeForwardingRule(env *Env, protocol namer.NamerProtocol, version meta.Version, proxyLink, description string) *composite.ForwardingRule {
+func (t *Translator) ToCompositeForwardingRule(env *Env, protocol namer.NamerProtocol, version meta.Version, proxyLink, description, fwSubnet string) *composite.ForwardingRule {
 	var portRange string
 	if protocol == namer.HTTPProtocol {
 		portRange = httpDefaultPortRange
@@ -265,7 +265,11 @@ func (t *Translator) ToCompositeForwardingRule(env *Env, protocol namer.NamerPro
 	if t.IsL7ILB {
 		fr.LoadBalancingScheme = "INTERNAL_MANAGED"
 		fr.Network = env.Network
-		fr.Subnetwork = env.Subnetwork
+		if fwSubnet != "" {
+			fr.Subnetwork = fwSubnet
+		} else {
+			fr.Subnetwork = env.Subnetwork
+		}
 	}
 
 	return fr

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -366,6 +366,7 @@ func TestToForwardingRule(t *testing.T) {
 		desc     string
 		isL7ILB  bool
 		protocol namer_util.NamerProtocol
+		ipSubnet string
 		want     *composite.ForwardingRule
 	}{
 		{
@@ -428,13 +429,31 @@ func TestToForwardingRule(t *testing.T) {
 				Subnetwork:          subnetwork,
 			},
 		},
+		{
+			desc:     "http-ilb with different subnet for ip",
+			isL7ILB:  true,
+			protocol: namer_util.HTTPProtocol,
+			ipSubnet: "different-subnet",
+			want: &composite.ForwardingRule{
+				Name:                "foo-fr",
+				IPAddress:           vip,
+				Target:              proxyLink,
+				PortRange:           httpDefaultPortRange,
+				IPProtocol:          "TCP",
+				Description:         description,
+				Version:             version,
+				LoadBalancingScheme: "INTERNAL_MANAGED",
+				Network:             network,
+				Subnetwork:          "different-subnet",
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			tr := NewTranslator(tc.isL7ILB, &testNamer{"foo"})
 			env := &Env{VIP: vip, Network: network, Subnetwork: subnetwork}
-			got := tr.ToCompositeForwardingRule(env, tc.protocol, version, proxyLink, description)
+			got := tr.ToCompositeForwardingRule(env, tc.protocol, version, proxyLink, description, tc.ipSubnet)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatalf("Got diff for ForwardingRule (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
We mistakenly provided the cluster subnet for the forwarding rule, which prevents customers
from being able to use a static ip from any subnet in the same VPC/Region as the cluster