### PR TITLE
Cherrypick #1225[Bugfix http forwarding rule create workflow] into release-10

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -109,7 +109,7 @@ func (l *L7) checkForwardingRule(protocol namer.NamerProtocol, name, proxyLink, 
 				currentIP, _ := l.cloud.GetGlobalAddress(managedStaticIPName)
 				if currentIP != nil {
 					klog.V(3).Infof("Ingress managed static IP %s(%s) exists, using it to create forwarding rule %s", currentIPName, currentIP.Address, name)
-					ip = currentIP.Address
+					fr.IPAddress = currentIP.Address
 				}
 			}
 		}


### PR DESCRIPTION
Forwarding rule address needs to be reused when
an ingress controller managed static IP address
exists for the ingress.