### PR TITLE
Add missing features to ingress metrics

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -591,7 +591,14 @@ func (lbc *LoadBalancerController) sync(key string) error {
 		lbc.ctx.Recorder(ing.Namespace).Eventf(ing, apiv1.EventTypeWarning, events.SyncIngress, "Error syncing to GCP: %v", syncErr.Error())
 	} else {
 		// Insert/update the ingress state for metrics after successful sync.
-		lbc.metrics.SetIngress(key, metrics.NewIngressState(ing, urlMap.AllServicePorts()))
+		var fc *frontendconfigv1beta1.FrontendConfig
+		if flags.F.EnableFrontendConfig {
+			fc, err = frontendconfig.FrontendConfigForIngress(lbc.ctx.FrontendConfigs().List(), ing)
+			if err != nil {
+				return err
+			}
+		}
+		lbc.metrics.SetIngress(key, metrics.NewIngressState(ing, fc, urlMap.AllServicePorts()))
 	}
 
 	// Garbage collection will occur regardless of an error occurring. If an error occurred,

--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
 )
@@ -44,36 +46,38 @@ const (
 	// certificate for the Ingress controller to use.
 	preSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
 	managedCertKey   = "networking.gke.io/managed-certificates"
-	// StaticIPNameKey tells the Ingress controller to use a specific GCE
+	// StaticGlobalIPNameKey tells the Ingress controller to use a specific GCE
 	// static ip for its forwarding rules. If specified, the Ingress controller
 	// assigns the static ip by this name to the forwarding rules of the given
 	// Ingress. The controller *does not* manage this ip, it is the users
 	// responsibility to create/delete it.
-	StaticIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
+	StaticGlobalIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
 	// staticIPKey is the annotation key used by controller to record GCP static ip.
 	staticIPKey = "ingress.kubernetes.io/static-ip"
 	// SSLCertKey is the annotation key used by controller to record GCP ssl cert.
 	SSLCertKey = "ingress.kubernetes.io/ssl-cert"
 
-	ingress                 = feature("Ingress")
-	externalIngress         = feature("ExternalIngress")
-	internalIngress         = feature("InternalIngress")
-	httpEnabled             = feature("HTTPEnabled")
-	hostBasedRouting        = feature("HostBasedRouting")
-	pathBasedRouting        = feature("PathBasedRouting")
-	tlsTermination          = feature("TLSTermination")
-	secretBasedCertsForTLS  = feature("SecretBasedCertsForTLS")
-	preSharedCertsForTLS    = feature("PreSharedCertsForTLS")
-	managedCertsForTLS      = feature("ManagedCertsForTLS")
-	staticGlobalIP          = feature("StaticGlobalIP")
-	managedStaticGlobalIP   = feature("ManagedStaticGlobalIP")
-	specifiedStaticGlobalIP = feature("SpecifiedStaticGlobalIP")
+	ingress                   = feature("Ingress")
+	externalIngress           = feature("ExternalIngress")
+	internalIngress           = feature("InternalIngress")
+	httpEnabled               = feature("HTTPEnabled")
+	hostBasedRouting          = feature("HostBasedRouting")
+	pathBasedRouting          = feature("PathBasedRouting")
+	tlsTermination            = feature("TLSTermination")
+	secretBasedCertsForTLS    = feature("SecretBasedCertsForTLS")
+	preSharedCertsForTLS      = feature("PreSharedCertsForTLS")
+	managedCertsForTLS        = feature("ManagedCertsForTLS")
+	staticGlobalIP            = feature("StaticGlobalIP")
+	managedStaticGlobalIP     = feature("ManagedStaticGlobalIP")
+	specifiedStaticGlobalIP   = feature("SpecifiedStaticGlobalIP")
+	specifiedStaticRegionalIP = feature("SpecifiedStaticRegionalIP")
 
 	servicePort         = feature("L7LBServicePort")
 	externalServicePort = feature("L7XLBServicePort")
 	internalServicePort = feature("L7ILBServicePort")
 	neg                 = feature("NEG")
 
+	// BackendConfig Features
 	cloudCDN                  = feature("CloudCDN")
 	cloudArmor                = feature("CloudArmor")
 	cloudIAP                  = feature("CloudIAP")
@@ -82,6 +86,10 @@ const (
 	clientIPAffinity          = feature("ClientIPAffinity")
 	cookieAffinity            = feature("CookieAffinity")
 	customRequestHeaders      = feature("CustomRequestHeaders")
+	customHealthChecks        = feature("CustomHealthChecks")
+
+	// FrontendConfig Features
+	sslPolicy = feature("SSLPolicy")
 
 	standaloneNeg  = feature("StandaloneNEG")
 	ingressNeg     = feature("IngressNEG")
@@ -102,7 +110,7 @@ const (
 )
 
 // featuresForIngress returns the list of features for given ingress.
-func featuresForIngress(ing *v1beta1.Ingress) []feature {
+func featuresForIngress(ing *v1beta1.Ingress, fc *frontendconfigv1beta1.FrontendConfig) []feature {
 	features := []feature{ingress}
 
 	ingKey := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
@@ -191,15 +199,27 @@ func featuresForIngress(ing *v1beta1.Ingress) []feature {
 	if val, ok := ingAnnotations[staticIPKey]; ok && val != "" {
 		klog.V(6).Infof("Static IP for ingress %s: %s", ingKey, val)
 		features = append(features, staticGlobalIP)
-
 		// Check if user specified static ip annotation exists.
-		if val, ok = ingAnnotations[StaticIPNameKey]; ok {
+		if val, ok = ingAnnotations[StaticGlobalIPNameKey]; ok {
 			klog.V(6).Infof("User specified static IP for ingress %s: %s", ingKey, val)
 			features = append(features, specifiedStaticGlobalIP)
 		} else {
 			features = append(features, managedStaticGlobalIP)
 		}
 	}
+
+	// Check for regional static IP
+	// We do this separately from the global static IP because Controller does not
+	// populate StaticIPKey annotation when processing Regional static IP.
+	if val, ok := ingAnnotations[annotations.RegionalStaticIPNameKey]; ok && val != "" {
+		features = append(features, specifiedStaticRegionalIP)
+	}
+
+	// FrontendConfig Features
+	if fc != nil && fc.Spec.SslPolicy != nil && *fc.Spec.SslPolicy != "" {
+		features = append(features, sslPolicy)
+	}
+
 	klog.V(4).Infof("Features for ingress %s: %v", ingKey, features)
 	return features
 }
@@ -275,6 +295,11 @@ func featuresForServicePort(sp utils.ServicePort) []feature {
 		klog.V(6).Infof("Custom request headers configured for service port %s: %v", svcPortKey, sp.BackendConfig.Spec.CustomRequestHeaders.Headers)
 		features = append(features, customRequestHeaders)
 	}
+	if sp.BackendConfig.Spec.HealthCheck != nil {
+		klog.V(6).Infof("Custom health check configured for service port %s: %v", svcPortKey, sp.BackendConfig.Spec.HealthCheck)
+		features = append(features, customHealthChecks)
+	}
+
 	klog.V(4).Infof("Features for Service port %s: %v", svcPortKey, features)
 	return features
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -25,7 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
@@ -57,6 +59,7 @@ var (
 					ConnectionDraining: &backendconfigv1.ConnectionDrainingConfig{
 						DrainingTimeoutSec: testTTL,
 					},
+					HealthCheck: &backendconfigv1.HealthCheckConfig{RequestPath: utils.NewStringPointer("/foo")},
 				},
 			},
 		},
@@ -126,6 +129,7 @@ var (
 	ingressStates = []struct {
 		desc             string
 		ing              *v1beta1.Ingress
+		fc               *frontendconfigv1beta1.FrontendConfig
 		frontendFeatures []feature
 		svcPorts         []utils.ServicePort
 		backendFeatures  []feature
@@ -138,6 +142,7 @@ var (
 					Name:      "ingress0",
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled},
 			[]utils.ServicePort{},
 			nil,
@@ -152,6 +157,7 @@ var (
 						allowHTTPKey: "false"},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress},
 			[]utils.ServicePort{},
 			nil,
@@ -171,10 +177,11 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled},
 			[]utils.ServicePort{testServicePorts[0]},
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining},
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks},
 		},
 		{
 			"host rule only",
@@ -191,6 +198,7 @@ var (
 					},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled, hostBasedRouting},
 			[]utils.ServicePort{},
 			nil,
@@ -223,6 +231,7 @@ var (
 					},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				hostBasedRouting, pathBasedRouting},
 			[]utils.ServicePort{testServicePorts[1]},
@@ -261,11 +270,12 @@ var (
 					},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				hostBasedRouting, pathBasedRouting},
 			testServicePorts[:2],
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining, neg, cloudIAP,
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks, neg, cloudIAP,
 				clientIPAffinity, backendTimeout, customRequestHeaders},
 		},
 		{
@@ -287,11 +297,12 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				tlsTermination, preSharedCertsForTLS},
 			[]utils.ServicePort{testServicePorts[0]},
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining},
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks},
 		},
 		{
 			"tls termination with google managed certs",
@@ -312,11 +323,12 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				tlsTermination, managedCertsForTLS},
 			[]utils.ServicePort{testServicePorts[0]},
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining},
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks},
 		},
 		{
 			"tls termination with pre-shared and google managed certs",
@@ -338,11 +350,12 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				tlsTermination, preSharedCertsForTLS, managedCertsForTLS},
 			[]utils.ServicePort{testServicePorts[0]},
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining},
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks},
 		},
 		{
 			"tls termination with pre-shared and secret based certs",
@@ -382,6 +395,7 @@ var (
 					},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled, hostBasedRouting,
 				pathBasedRouting, tlsTermination, preSharedCertsForTLS, secretBasedCertsForTLS},
 			[]utils.ServicePort{testServicePorts[1]},
@@ -408,11 +422,12 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				tlsTermination, preSharedCertsForTLS, staticGlobalIP, managedStaticGlobalIP},
 			[]utils.ServicePort{testServicePorts[0]},
 			[]feature{servicePort, externalServicePort, cloudCDN,
-				cookieAffinity, cloudArmor, backendConnectionDraining},
+				cookieAffinity, cloudArmor, backendConnectionDraining, customHealthChecks},
 		},
 		{
 			"default backend, host rule for internal load-balancer",
@@ -449,6 +464,7 @@ var (
 					},
 				},
 			},
+			nil,
 			[]feature{ingress, internalIngress, httpEnabled,
 				hostBasedRouting, pathBasedRouting},
 			[]utils.ServicePort{testServicePorts[2], testServicePorts[3]},
@@ -473,6 +489,7 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled},
 			[]utils.ServicePort{},
 			nil,
@@ -484,8 +501,8 @@ var (
 					Namespace: defaultNamespace,
 					Name:      "ingress13",
 					Annotations: map[string]string{
-						StaticIPNameKey: "user-spec-static-ip",
-						staticIPKey:     "user-spec-static-ip",
+						StaticGlobalIPNameKey: "user-spec-static-ip",
+						staticIPKey:           "user-spec-static-ip",
 					},
 				},
 				Spec: v1beta1.IngressSpec{
@@ -496,8 +513,92 @@ var (
 					Rules: []v1beta1.IngressRule{},
 				},
 			},
+			nil,
 			[]feature{ingress, externalIngress, httpEnabled,
 				staticGlobalIP, specifiedStaticGlobalIP},
+			[]utils.ServicePort{},
+			nil,
+		},
+		{
+			"sslpolicy and tls termination with pre-shared certs",
+			&v1beta1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      "ingress14",
+					Annotations: map[string]string{
+						preSharedCertKey: "pre-shared-cert1,pre-shared-cert2",
+						SSLCertKey:       "pre-shared-cert1,pre-shared-cert2",
+					},
+				},
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: "dummy-service",
+						ServicePort: intstr.FromInt(80),
+					},
+					Rules: []v1beta1.IngressRule{},
+				},
+			},
+			&frontendconfigv1beta1.FrontendConfig{
+				Spec: frontendconfigv1beta1.FrontendConfigSpec{
+					SslPolicy: utils.NewStringPointer("test-policy"),
+				},
+			},
+			[]feature{ingress, externalIngress, httpEnabled,
+				tlsTermination, preSharedCertsForTLS, sslPolicy},
+			[]utils.ServicePort{},
+			nil,
+		},
+		{
+			"user specified regional static IP",
+			&v1beta1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      "ingress15",
+					Annotations: map[string]string{
+						annotations.RegionalStaticIPNameKey: "user-spec-static-ip",
+						ingressClassKey:                     "gce-internal",
+					},
+				},
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: "dummy-service",
+						ServicePort: intstr.FromInt(80),
+					},
+					Rules: []v1beta1.IngressRule{},
+				},
+			},
+			nil,
+			[]feature{ingress, internalIngress, httpEnabled,
+				specifiedStaticRegionalIP},
+			[]utils.ServicePort{},
+			nil,
+		},
+		{
+			"empty sslpolicy and tls termination with pre-shared certs",
+			&v1beta1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      "ingress16",
+					Annotations: map[string]string{
+						preSharedCertKey: "pre-shared-cert1,pre-shared-cert2",
+						SSLCertKey:       "pre-shared-cert1,pre-shared-cert2",
+					},
+				},
+				Spec: v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: "dummy-service",
+						ServicePort: intstr.FromInt(80),
+					},
+					Rules: []v1beta1.IngressRule{},
+				},
+			},
+			&frontendconfigv1beta1.FrontendConfig{
+				Spec: frontendconfigv1beta1.FrontendConfigSpec{
+					SslPolicy: utils.NewStringPointer(""),
+				},
+			},
+			[]feature{ingress, externalIngress, httpEnabled,
+				tlsTermination, preSharedCertsForTLS},
 			[]utils.ServicePort{},
 			nil,
 		},
@@ -510,7 +611,7 @@ func TestFeaturesForIngress(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			gotFrontendFeatures := featuresForIngress(tc.ing)
+			gotFrontendFeatures := featuresForIngress(tc.ing, tc.fc)
 			if diff := cmp.Diff(tc.frontendFeatures, gotFrontendFeatures); diff != "" {
 				t.Fatalf("Got diff for frontend features (-want +got):\n%s", diff)
 			}
@@ -553,10 +654,11 @@ func TestComputeIngressMetrics(t *testing.T) {
 		{
 			"frontend features only",
 			[]IngressState{
-				NewIngressState(ingressStates[0].ing, ingressStates[0].svcPorts),
-				NewIngressState(ingressStates[1].ing, ingressStates[1].svcPorts),
-				NewIngressState(ingressStates[3].ing, ingressStates[3].svcPorts),
-				NewIngressState(ingressStates[13].ing, ingressStates[13].svcPorts),
+				NewIngressState(ingressStates[0].ing, nil, ingressStates[0].svcPorts),
+				NewIngressState(ingressStates[1].ing, nil, ingressStates[1].svcPorts),
+				NewIngressState(ingressStates[3].ing, nil, ingressStates[3].svcPorts),
+				NewIngressState(ingressStates[13].ing, nil, ingressStates[13].svcPorts),
+				NewIngressState(ingressStates[14].ing, ingressStates[14].fc, ingressStates[14].svcPorts),
 			},
 			map[feature]int{
 				backendConnectionDraining: 0,
@@ -567,20 +669,21 @@ func TestComputeIngressMetrics(t *testing.T) {
 				cloudIAP:                  0,
 				cookieAffinity:            0,
 				customRequestHeaders:      0,
-				externalIngress:           4,
-				httpEnabled:               3,
+				externalIngress:           5,
+				httpEnabled:               4,
 				hostBasedRouting:          1,
-				ingress:                   4,
+				ingress:                   5,
 				internalIngress:           0,
 				managedCertsForTLS:        0,
 				managedStaticGlobalIP:     0,
 				neg:                       0,
 				pathBasedRouting:          0,
-				preSharedCertsForTLS:      0,
+				preSharedCertsForTLS:      1,
 				secretBasedCertsForTLS:    0,
 				specifiedStaticGlobalIP:   1,
 				staticGlobalIP:            1,
-				tlsTermination:            0,
+				tlsTermination:            1,
+				sslPolicy:                 1,
 			},
 			map[feature]int{
 				backendConnectionDraining: 0,
@@ -600,11 +703,11 @@ func TestComputeIngressMetrics(t *testing.T) {
 		{
 			"features for internal and external load-balancers",
 			[]IngressState{
-				NewIngressState(ingressStates[0].ing, ingressStates[0].svcPorts),
-				NewIngressState(ingressStates[1].ing, ingressStates[1].svcPorts),
-				NewIngressState(ingressStates[3].ing, ingressStates[3].svcPorts),
-				NewIngressState(ingressStates[11].ing, ingressStates[11].svcPorts),
-				NewIngressState(ingressStates[13].ing, ingressStates[13].svcPorts),
+				NewIngressState(ingressStates[0].ing, nil, ingressStates[0].svcPorts),
+				NewIngressState(ingressStates[1].ing, nil, ingressStates[1].svcPorts),
+				NewIngressState(ingressStates[3].ing, nil, ingressStates[3].svcPorts),
+				NewIngressState(ingressStates[11].ing, nil, ingressStates[11].svcPorts),
+				NewIngressState(ingressStates[13].ing, nil, ingressStates[13].svcPorts),
 			},
 			map[feature]int{
 				backendConnectionDraining: 1,
@@ -629,6 +732,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				specifiedStaticGlobalIP:   1,
 				staticGlobalIP:            1,
 				tlsTermination:            0,
+				sslPolicy:                 0,
 			},
 			map[feature]int{
 				backendConnectionDraining: 1,
@@ -648,12 +752,12 @@ func TestComputeIngressMetrics(t *testing.T) {
 		{
 			"frontend and backend features",
 			[]IngressState{
-				NewIngressState(ingressStates[2].ing, ingressStates[2].svcPorts),
-				NewIngressState(ingressStates[4].ing, ingressStates[4].svcPorts),
-				NewIngressState(ingressStates[6].ing, ingressStates[6].svcPorts),
-				NewIngressState(ingressStates[8].ing, ingressStates[8].svcPorts),
-				NewIngressState(ingressStates[10].ing, ingressStates[10].svcPorts),
-				NewIngressState(ingressStates[12].ing, ingressStates[12].svcPorts),
+				NewIngressState(ingressStates[2].ing, nil, ingressStates[2].svcPorts),
+				NewIngressState(ingressStates[4].ing, nil, ingressStates[4].svcPorts),
+				NewIngressState(ingressStates[6].ing, nil, ingressStates[6].svcPorts),
+				NewIngressState(ingressStates[8].ing, nil, ingressStates[8].svcPorts),
+				NewIngressState(ingressStates[10].ing, nil, ingressStates[10].svcPorts),
+				NewIngressState(ingressStates[12].ing, nil, ingressStates[12].svcPorts),
 			},
 			map[feature]int{
 				backendConnectionDraining: 4,
@@ -664,6 +768,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				cloudIAP:                  1,
 				cookieAffinity:            4,
 				customRequestHeaders:      1,
+				customHealthChecks:        4,
 				externalIngress:           6,
 				httpEnabled:               6,
 				hostBasedRouting:          1,
@@ -678,6 +783,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				specifiedStaticGlobalIP:   0,
 				staticGlobalIP:            1,
 				tlsTermination:            3,
+				sslPolicy:                 0,
 			},
 			map[feature]int{
 				backendConnectionDraining: 1,
@@ -692,25 +798,28 @@ func TestComputeIngressMetrics(t *testing.T) {
 				servicePort:               2,
 				externalServicePort:       2,
 				neg:                       1,
+				customHealthChecks:        1,
 			},
 		},
 		{
 			"all ingress features",
 			[]IngressState{
-				NewIngressState(ingressStates[0].ing, ingressStates[0].svcPorts),
-				NewIngressState(ingressStates[1].ing, ingressStates[1].svcPorts),
-				NewIngressState(ingressStates[2].ing, ingressStates[2].svcPorts),
-				NewIngressState(ingressStates[3].ing, ingressStates[3].svcPorts),
-				NewIngressState(ingressStates[4].ing, ingressStates[4].svcPorts),
-				NewIngressState(ingressStates[5].ing, ingressStates[5].svcPorts),
-				NewIngressState(ingressStates[6].ing, ingressStates[6].svcPorts),
-				NewIngressState(ingressStates[7].ing, ingressStates[7].svcPorts),
-				NewIngressState(ingressStates[8].ing, ingressStates[8].svcPorts),
-				NewIngressState(ingressStates[9].ing, ingressStates[9].svcPorts),
-				NewIngressState(ingressStates[10].ing, ingressStates[10].svcPorts),
-				NewIngressState(ingressStates[11].ing, ingressStates[11].svcPorts),
-				NewIngressState(ingressStates[12].ing, ingressStates[12].svcPorts),
-				NewIngressState(ingressStates[13].ing, ingressStates[13].svcPorts),
+				NewIngressState(ingressStates[0].ing, nil, ingressStates[0].svcPorts),
+				NewIngressState(ingressStates[1].ing, nil, ingressStates[1].svcPorts),
+				NewIngressState(ingressStates[2].ing, nil, ingressStates[2].svcPorts),
+				NewIngressState(ingressStates[3].ing, nil, ingressStates[3].svcPorts),
+				NewIngressState(ingressStates[4].ing, nil, ingressStates[4].svcPorts),
+				NewIngressState(ingressStates[5].ing, nil, ingressStates[5].svcPorts),
+				NewIngressState(ingressStates[6].ing, nil, ingressStates[6].svcPorts),
+				NewIngressState(ingressStates[7].ing, nil, ingressStates[7].svcPorts),
+				NewIngressState(ingressStates[8].ing, nil, ingressStates[8].svcPorts),
+				NewIngressState(ingressStates[9].ing, nil, ingressStates[9].svcPorts),
+				NewIngressState(ingressStates[10].ing, nil, ingressStates[10].svcPorts),
+				NewIngressState(ingressStates[11].ing, nil, ingressStates[11].svcPorts),
+				NewIngressState(ingressStates[12].ing, nil, ingressStates[12].svcPorts),
+				NewIngressState(ingressStates[13].ing, nil, ingressStates[13].svcPorts),
+				NewIngressState(ingressStates[14].ing, ingressStates[14].fc, ingressStates[14].svcPorts),
+				NewIngressState(ingressStates[15].ing, nil, ingressStates[15].svcPorts),
 			},
 			map[feature]int{
 				backendConnectionDraining: 7,
@@ -721,20 +830,23 @@ func TestComputeIngressMetrics(t *testing.T) {
 				cloudIAP:                  4,
 				cookieAffinity:            7,
 				customRequestHeaders:      3,
-				externalIngress:           13,
-				httpEnabled:               13,
+				customHealthChecks:        6,
+				externalIngress:           14,
+				httpEnabled:               15,
 				hostBasedRouting:          5,
-				ingress:                   14,
-				internalIngress:           1,
+				ingress:                   16,
+				internalIngress:           2,
 				managedCertsForTLS:        2,
 				managedStaticGlobalIP:     1,
 				neg:                       4,
 				pathBasedRouting:          4,
-				preSharedCertsForTLS:      4,
+				preSharedCertsForTLS:      5,
 				secretBasedCertsForTLS:    1,
 				specifiedStaticGlobalIP:   1,
+				specifiedStaticRegionalIP: 1,
 				staticGlobalIP:            2,
-				tlsTermination:            5,
+				tlsTermination:            6,
+				sslPolicy:                 1,
 			},
 			map[feature]int{
 				backendConnectionDraining: 2,
@@ -745,6 +857,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				cloudIAP:                  2,
 				cookieAffinity:            2,
 				customRequestHeaders:      1,
+				customHealthChecks:        1,
 				internalServicePort:       2,
 				servicePort:               4,
 				externalServicePort:       2,

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -18,13 +18,15 @@ package metrics
 
 import (
 	"k8s.io/api/networking/v1beta1"
+	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // IngressState defines an ingress and its associated service ports.
 type IngressState struct {
-	ingress      *v1beta1.Ingress
-	servicePorts []utils.ServicePort
+	ingress        *v1beta1.Ingress
+	frontendconfig *frontendconfigv1beta1.FrontendConfig
+	servicePorts   []utils.ServicePort
 }
 
 // NegServiceState contains all the neg usage associated with one service


### PR DESCRIPTION
These features have been implemented but are currently not included in the metrics
- SSLPolicy
- Regional Static IP
- Custom Health Checks

This PR adds metrics for them
All of them can be cherry-picked to v1.9 + v1.10

HTTPS Redirects will be added in a follow up since it is currently 1.10 only
