### PR TITLE
Lookup forwarding rule before deletion on L4 ILB protocol change.

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -191,7 +191,7 @@ func (l *L7) getEffectiveIP() (string, bool, error) {
 
 // ensureForwardingRule creates a forwarding rule with the given name, if it does not exist. It updates the existing
 // forwarding rule if needed.
-func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.ILBOptions, existingFwdRule *composite.ForwardingRule) (*composite.ForwardingRule, error) {
 	key, err := l.CreateKey(loadBalancerName)
 	if err != nil {
 		return nil, err
@@ -199,11 +199,6 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	// version used for creating the existing forwarding rule.
 	version := meta.VersionGA
 
-	// Get the GA version forwarding rule, use the description to identify the version it was created with.
-	existingFwdRule, err := composite.GetForwardingRule(l.cloud, key, meta.VersionGA)
-	if utils.IgnoreHTTPNotFound(err) != nil {
-		return nil, err
-	}
 	if l.cloud.IsLegacyNetwork() {
 		l.recorder.Event(l.Service, v1.EventTypeWarning, "ILBOptionsIgnored", "Internal LoadBalancer options are not supported with Legacy Networks.")
 		options = gce.ILBOptions{}
@@ -287,6 +282,20 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	return composite.GetForwardingRule(l.cloud, key, fr.Version)
 }
 
+func (l *L4) getForwardingRule(name string, version meta.Version) *composite.ForwardingRule {
+	key, err := l.CreateKey(name)
+	if err != nil {
+		klog.Errorf("Failed to create key for fetching existing forwarding rule %s, err: %v", name, err)
+		return nil
+	}
+	fr, err := composite.GetForwardingRule(l.cloud, key, version)
+	if utils.IgnoreHTTPNotFound(err) != nil {
+		klog.Errorf("Failed to lookup existing forwarding rule %s, err: %v", name, err)
+		return nil
+	}
+	return fr
+}
+
 func (l *L4) deleteForwardingRule(name string, version meta.Version) {
 	key, err := l.CreateKey(name)
 	if err != nil {
@@ -316,11 +325,6 @@ func ilbIPToUse(svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSub
 		return svc.Spec.LoadBalancerIP
 	}
 	if fwdRule == nil {
-		// Reuse the already assigned IP address for this ILB. This is most likely the case
-		// where ILB protocol changed and the forwarding rule got deleted.
-		if len(svc.Status.LoadBalancer.Ingress) > 0 {
-			return svc.Status.LoadBalancer.Ingress[0].IP
-		}
 		return ""
 	}
 	if requestedSubnet != fwdRule.Subnetwork {

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -226,9 +226,11 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service,
 	if err != nil {
 		klog.Errorf("Failed to lookup existing backend service, ignoring err: %v", err)
 	}
+	existingFR := l.getForwardingRule(l.GetFRName(), meta.VersionGA)
 	if existingBS != nil && existingBS.Protocol != string(protocol) {
 		klog.Infof("Protocol changed from %q to %q for service %s", existingBS.Protocol, string(protocol), l.NamespacedName)
 		// Delete forwarding rule if it exists
+		existingFR = l.getForwardingRule(l.getFRNameWithProtocol(existingBS.Protocol), meta.VersionGA)
 		l.deleteForwardingRule(l.getFRNameWithProtocol(existingBS.Protocol), meta.VersionGA)
 	}
 
@@ -240,7 +242,7 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service,
 	}
 
 	// create fr rule
-	fr, err := l.ensureForwardingRule(l.GetFRName(), bs.SelfLink, options)
+	fr, err := l.ensureForwardingRule(l.GetFRName(), bs.SelfLink, options, existingFR)
 	if err != nil {
 		klog.Errorf("EnsureInternalLoadBalancer: Failed to create forwarding rule - %v", err)
 		return nil, err


### PR DESCRIPTION
This change will preserve the same ILB IP in case protocol changes. The previous approach to lookup the previous IP from status section is less-preferred.

/assign @freehan 