### PR TITLE
Fix a couple bugs in the redirects e2e test

### DIFF
--- a/cmd/e2e-test/basic_https_test.go
+++ b/cmd/e2e-test/basic_https_test.go
@@ -112,7 +112,7 @@ func TestBasicHTTPS(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
 			}

--- a/cmd/e2e-test/basic_test.go
+++ b/cmd/e2e-test/basic_test.go
@@ -93,7 +93,7 @@ func testBasicOS(t *testing.T, os e2e.OS) {
 			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, tc.ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
 			}
@@ -204,7 +204,7 @@ func TestEdge(t *testing.T) {
 			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, tc.ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
 			}
@@ -273,7 +273,7 @@ func TestFrontendResourceDeletion(t *testing.T) {
 			if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
 				t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
 			}
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s, ...)= %v, want nil", ingKey, err)
 			}
@@ -305,7 +305,7 @@ func TestFrontendResourceDeletion(t *testing.T) {
 			if err := e2e.WaitForFrontendResourceDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
 				t.Errorf("e2e.WaitForFrontendResourceDeletion(..., %q, _) = %v, want nil", ingKey, err)
 			}
-			if gclb, err = e2e.WhiteboxTest(ing, s, Framework.Cloud, ""); err != nil {
+			if gclb, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s); err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 			}
 
@@ -338,7 +338,7 @@ func TestFrontendResourceDeletion(t *testing.T) {
 				t.Fatalf("error waiting for http annotations on Ingress %s: %v", ingKey, err)
 			}
 
-			gclb, err = e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s, ...)= %v, want nil", ingKey, err)
 			}

--- a/cmd/e2e-test/finalizer_test.go
+++ b/cmd/e2e-test/finalizer_test.go
@@ -64,7 +64,7 @@ func TestFinalizer(t *testing.T) {
 		}
 
 		// Perform whitebox testing.
-		gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 		if err != nil {
 			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 		}
@@ -114,7 +114,7 @@ func TestFinalizerIngressClassChange(t *testing.T) {
 		}
 
 		// Perform whitebox testing.
-		gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 		if err != nil {
 			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 		}
@@ -191,11 +191,11 @@ func TestFinalizerIngressesWithSharedResources(t *testing.T) {
 		}
 
 		// Perform whitebox testing.
-		gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 		if err != nil {
 			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 		}
-		otherGclb, err := e2e.WhiteboxTest(otherIng, s, Framework.Cloud, "")
+		otherGclb, err := e2e.WhiteboxTest(otherIng, nil, Framework.Cloud, "", s)
 		if err != nil {
 			t.Fatalf("e2e.WhiteboxTest(%s)", otherIngKey)
 		}

--- a/cmd/e2e-test/neg_test.go
+++ b/cmd/e2e-test/neg_test.go
@@ -116,7 +116,7 @@ func TestNEG(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
 			}
@@ -208,7 +208,7 @@ func TestNEGTransition(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...)", ing.Namespace, ing.Name)
 			}

--- a/cmd/e2e-test/sslpolicy_test.go
+++ b/cmd/e2e-test/sslpolicy_test.go
@@ -118,7 +118,7 @@ func TestSSLPolicy(t *testing.T) {
 			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
 			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
 			}

--- a/cmd/e2e-test/upgrade/basic_http.go
+++ b/cmd/e2e-test/upgrade/basic_http.go
@@ -85,7 +85,7 @@ func (bh *BasicHTTP) PreUpgrade() error {
 	}
 	bh.t.Logf("GCLB resources created (%s)", ingKey)
 
-	if _, err := e2e.WhiteboxTest(ing, bh.s, bh.framework.Cloud, ""); err != nil {
+	if _, err := e2e.WhiteboxTest(ing, nil, bh.framework.Cloud, "", bh.s); err != nil {
 		bh.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}
 	return nil
@@ -119,7 +119,7 @@ func (bh *BasicHTTP) PostUpgrade() error {
 		bh.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
 	}
 	bh.t.Logf("GCLB is stable (%s)", ingKey)
-	gclb, err := e2e.WhiteboxTest(ing, bh.s, bh.framework.Cloud, "")
+	gclb, err := e2e.WhiteboxTest(ing, nil, bh.framework.Cloud, "", bh.s)
 	if err != nil {
 		bh.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}

--- a/cmd/e2e-test/upgrade/finalizer.go
+++ b/cmd/e2e-test/upgrade/finalizer.go
@@ -86,7 +86,7 @@ func (fr *Finalizer) PreUpgrade() error {
 		fr.t.Fatalf("len(GetFinalizers()) = %d, want 0", l)
 	}
 
-	if _, err := e2e.WhiteboxTest(fr.ing, fr.s, fr.framework.Cloud, ""); err != nil {
+	if _, err := e2e.WhiteboxTest(fr.ing, nil, fr.framework.Cloud, "", fr.s); err != nil {
 		fr.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}
 	return nil
@@ -113,7 +113,7 @@ func (fr *Finalizer) PostUpgrade() error {
 	if err := e2e.CheckV1Finalizer(ing); err != nil {
 		fr.t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
 	}
-	gclb, err := e2e.WhiteboxTest(ing, fr.s, fr.framework.Cloud, "")
+	gclb, err := e2e.WhiteboxTest(ing, nil, fr.framework.Cloud, "", fr.s)
 	if err != nil {
 		fr.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}

--- a/cmd/e2e-test/upgrade/v2frontendnamer.go
+++ b/cmd/e2e-test/upgrade/v2frontendnamer.go
@@ -85,7 +85,7 @@ func (vf *V2FrontendNamer) PreUpgrade() error {
 	}
 
 	// Perform whitebox testing.
-	if _, err := e2e.WhiteboxTest(ing, vf.s, vf.framework.Cloud, ""); err != nil {
+	if _, err := e2e.WhiteboxTest(ing, nil, vf.framework.Cloud, "", vf.s); err != nil {
 		vf.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}
 	return nil
@@ -127,7 +127,7 @@ func (vf *V2FrontendNamer) PostUpgrade() error {
 	}
 
 	// Perform whitebox testing.
-	gclb, err := e2e.WhiteboxTest(ing, vf.s, vf.framework.Cloud, "")
+	gclb, err := e2e.WhiteboxTest(ing, nil, vf.framework.Cloud, "", vf.s)
 	if err != nil {
 		vf.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 	}

--- a/cmd/e2e-test/v2frontendnamer_test.go
+++ b/cmd/e2e-test/v2frontendnamer_test.go
@@ -107,7 +107,7 @@ func TestV2FrontendNamer(t *testing.T) {
 					}
 				}
 				// Perform whitebox testing. This also tests naming scheme.
-				gclb, err := e2e.WhiteboxTest(ing, s, Framework.Cloud, "")
+				gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
 				if err != nil {
 					t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 				}
@@ -139,7 +139,7 @@ func TestV2FrontendNamer(t *testing.T) {
 			}
 			ingKey := common.NamespacedName(updatedIngs[1])
 			// Verify that GCLB resources of second ingress are intact.
-			gclb, err := e2e.WhiteboxTest(updatedIngs[1], s, Framework.Cloud, "")
+			gclb, err := e2e.WhiteboxTest(updatedIngs[1], nil, Framework.Cloud, "", s)
 			if err != nil {
 				t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
 			}

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -219,7 +219,7 @@ func WaitForFinalizer(s *Sandbox, ing *v1beta1.Ingress) (*v1beta1.Ingress, error
 }
 
 // WhiteboxTest retrieves GCP load-balancer for Ingress VIP and runs the whitebox tests.
-func WhiteboxTest(ing *v1beta1.Ingress, s *Sandbox, cloud cloud.Cloud, region string) (*fuzz.GCLB, error) {
+func WhiteboxTest(ing *v1beta1.Ingress, fc *frontendconfigv1beta1.FrontendConfig, cloud cloud.Cloud, region string, s *Sandbox) (*fuzz.GCLB, error) {
 	if len(ing.Status.LoadBalancer.Ingress) < 1 {
 		return nil, fmt.Errorf("ingress does not have an IP: %+v", ing.Status)
 	}
@@ -236,7 +236,7 @@ func WhiteboxTest(ing *v1beta1.Ingress, s *Sandbox, cloud cloud.Cloud, region st
 		return nil, fmt.Errorf("error getting GCP resources for LB with IP = %q: %v", vip, err)
 	}
 
-	if err := performWhiteboxTests(s, ing, nil, gclb); err != nil {
+	if err := performWhiteboxTests(s, ing, fc, gclb); err != nil {
 		return nil, fmt.Errorf("error performing whitebox tests: %v", err)
 	}
 	return gclb, nil

--- a/pkg/fuzz/features/https_redirects.go
+++ b/pkg/fuzz/features/https_redirects.go
@@ -59,6 +59,7 @@ func (v *HTTPSRedirectsFeature) ConfigureAttributes(env fuzz.ValidatorEnv, ing *
 		return err
 	}
 	if fc == nil || fc.Spec.RedirectToHttps == nil || !fc.Spec.RedirectToHttps.Enabled {
+		v.expectedResponseCode = 200
 		return nil
 	}
 
@@ -79,7 +80,7 @@ func (v *HTTPSRedirectsFeature) ConfigureAttributes(env fuzz.ValidatorEnv, ing *
 
 // CheckResponse implements fuzz.FeatureValidator.
 func (v *HTTPSRedirectsFeature) CheckResponse(host, path string, resp *http.Response, body []byte) (fuzz.CheckResponseAction, error) {
-	if v.expectedResponseCode != 0 && resp.Request.URL.Scheme == "http" {
+	if v.expectedResponseCode != 200 && resp.Request.URL.Scheme == "http" {
 		if resp.StatusCode == v.expectedResponseCode {
 			return fuzz.CheckResponseSkip, nil
 		} else {


### PR DESCRIPTION
During the transition test refactor, a couple bugs were introduced that caused the test to not ensure the Ingress and FrontendConfig correctly.