### PR TITLE
Fix GC for RedirectURLMaps

### DIFF
--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -113,8 +113,8 @@ func (l *L7) ensureRedirectURLMap() error {
 	// Do not expect to have a RedirectUrlMap
 	if expectedMap == nil {
 		// Check if we need to GC
-		status, ok := l.ingress.Annotations[annotations.RedirectUrlMapKey]
-		if !ok || status == "" {
+		_, ok := l.ingress.Annotations[annotations.RedirectUrlMapKey]
+		if !ok {
 			return nil
 		} else {
 			if err := composite.DeleteUrlMap(l.cloud, key, l.Versions().UrlMap); err != nil {


### PR DESCRIPTION
We currently cannot rely on the annotation as a way to confirm that the
url map has been deleted.  This will cause us to leak Redirect URL Maps