### PR TITLE
Refactor transition e2e tests to use t.Run()

### DIFF
--- a/cmd/e2e-test/redirects_test.go
+++ b/cmd/e2e-test/redirects_test.go
@@ -84,63 +84,64 @@ func TestHttpsRedirects(t *testing.T) {
 				config: &frontendconfig.HttpsRedirectConfig{Enabled: false},
 			},
 		} {
-			t.Logf("Running transition test %q", tc.desc)
+			t.Run(tc.desc, func(t *testing.T) {
 
-			for _, cert := range certs {
-				tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
-			}
-
-			// FrontendConfig Ensure
-			var feConfig *frontendconfig.FrontendConfig
-			if tc.config != nil {
-				tc.ingBuilder.SetFrontendConfig("e2e-test")
-				feConfig = &frontendconfig.FrontendConfig{ObjectMeta: metav1.ObjectMeta{Name: "e2e-test"}, Spec: frontendconfig.FrontendConfigSpec{RedirectToHttps: tc.config}}
-				if _, err := e2e.EnsureFrontendConfig(s, feConfig); err != nil {
-					t.Fatalf("Error ensuring frontendconfig: %v", err)
+				for _, cert := range certs {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
 				}
-			}
 
-			ing = tc.ingBuilder.Build()
-			ing.Namespace = s.Namespace // namespace depends on sandbox
-
-			_, err := e2e.CreateEchoService(s, "service-1", nil)
-			if err != nil {
-				t.Fatalf("Error creating echo service: %v", err)
-			}
-			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
-
-			// Ensure Ingress
-			crud := adapter.IngressCRUD{C: Framework.Clientset}
-			_, err = crud.Create(ing)
-			if err != nil {
-				if errors.IsAlreadyExists(err) {
-					if _, err := crud.Update(ing); err != nil {
-						t.Fatalf("Error updating Ingress: %v", err)
+				// FrontendConfig Ensure
+				var feConfig *frontendconfig.FrontendConfig
+				if tc.config != nil {
+					tc.ingBuilder.SetFrontendConfig("e2e-test")
+					feConfig = &frontendconfig.FrontendConfig{ObjectMeta: metav1.ObjectMeta{Name: "e2e-test"}, Spec: frontendconfig.FrontendConfigSpec{RedirectToHttps: tc.config}}
+					if _, err := e2e.EnsureFrontendConfig(s, feConfig); err != nil {
+						t.Fatalf("Error ensuring frontendconfig: %v", err)
 					}
-				} else {
-					t.Fatalf("Error Creating Ingress: %v", err)
 				}
-			}
 
-			ing, err = e2e.WaitForIngress(s, ing, feConfig, nil)
-			if err != nil {
-				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
-			}
-			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+				ing = tc.ingBuilder.Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
 
-			// Check just for URL map deletion.  This URL map should have been created in another transition test case
-			// TODO(shance): uncomment this once GC has been fixed
-			//if tc.config != nil && !tc.config.Enabled {
-			//	if err := e2e.WaitForRedirectURLMapDeletion(ctx, Framework.Cloud, gclb); err != nil {
-			//		t.Errorf("WaitForRedirectURLMapDeletion(%v) = %v", gclb, err)
-			//	}
-			//}
+				_, err := e2e.CreateEchoService(s, "service-1", nil)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
-			// Perform whitebox testing.
-			gclb, err = e2e.WhiteboxTest(ing, feConfig, Framework.Cloud, "", s)
-			if err != nil {
-				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
-			}
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
+					} else {
+						t.Fatalf("Error Creating Ingress: %v", err)
+					}
+				}
+
+				ing, err = e2e.WaitForIngress(s, ing, feConfig, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Check just for URL map deletion.  This URL map should have been created in another transition test case
+				// TODO(shance): uncomment this once GC has been fixed
+				//if tc.config != nil && !tc.config.Enabled {
+				//	if err := e2e.WaitForRedirectURLMapDeletion(ctx, Framework.Cloud, gclb); err != nil {
+				//		t.Errorf("WaitForRedirectURLMapDeletion(%v) = %v", gclb, err)
+				//	}
+				//}
+
+				// Perform whitebox testing.
+				gclb, err = e2e.WhiteboxTest(ing, feConfig, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+				}
+			})
 		}
 
 		deleteOptions := &fuzz.GCLBDeleteOptions{


### PR DESCRIPTION
Many serial transition tests loop through a variety of test cases but do not explicitly run them with t.Run().  This makes debugging more difficult since it's hard to tell in which case the test failed.