### PR TITLE
Make sure L4 Forwarding rule is atmost 63 characters

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -66,6 +66,7 @@ type ControllerContext struct {
 
 	ClusterNamer  *namer.Namer
 	KubeSystemUID types.UID
+	L4Namer       namer.L4ResourcesNamer
 
 	ControllerContextConfig
 	ASMConfigController *cmconfig.ConfigMapConfigController
@@ -112,7 +113,7 @@ func NewControllerContext(
 	frontendConfigClient frontendconfigclient.Interface,
 	svcnegClient svcnegclient.Interface,
 	cloud *gce.Cloud,
-	namer *namer.Namer,
+	clusterNamer *namer.Namer,
 	kubeSystemUID types.UID,
 	config ControllerContextConfig) *ControllerContext {
 
@@ -121,7 +122,8 @@ func NewControllerContext(
 		KubeClient:              kubeClient,
 		SvcNegClient:            svcnegClient,
 		Cloud:                   cloud,
-		ClusterNamer:            namer,
+		ClusterNamer:            clusterNamer,
+		L4Namer:                 namer.NewL4Namer(string(kubeSystemUID), clusterNamer),
 		KubeSystemUID:           kubeSystemUID,
 		ControllerMetrics:       metrics.NewControllerMetrics(),
 		ControllerContextConfig: config,

--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -37,8 +37,6 @@ const (
 	gceHcHealthyThreshold = int64(1)
 	// Defaults to 3 * 8 = 24 seconds before the LB will steer traffic away.
 	gceHcUnhealthyThreshold = int64(3)
-	sharedHcSuffix          = "l4-shared-hc"
-	firewallHcSuffix        = sharedHcSuffix + "-fw"
 )
 
 // EnsureL4HealthCheck creates a new HTTP health check for an L4 LoadBalancer service, based on the parameters provided.
@@ -86,18 +84,6 @@ func DeleteHealthCheck(cloud *gce.Cloud, name string) error {
 		return fmt.Errorf("Failed to create composite key for healthcheck %s - %v", name, err)
 	}
 	return composite.DeleteHealthCheck(cloud, key, meta.VersionGA)
-}
-
-// HealthCheckName returns the name of the healthcheck as well as the name of the associated firewall rule
-// that opens up access for the healthheck.
-func HealthCheckName(shared bool, clusteruid, lbName string) (string, string) {
-	hcName := lbName
-	fwName := lbName
-	if shared {
-		hcName = "k8s1-" + clusteruid + sharedHcSuffix
-		fwName = "k8s1-" + clusteruid + firewallHcSuffix
-	}
-	return hcName, fwName
 }
 
 func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32) *composite.HealthCheck {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -316,7 +316,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 		t.Fatalf("Service was not created.(*apiv1.Service) successfully, err: %v", err)
 	}
 	expectedPortInfoMap := negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName,
-		controller.namer, localMode)
+		controller.l4Namer, localMode)
 	// There will be only one entry in the map
 	for key, val := range expectedPortInfoMap {
 		prevSyncerKey = getSyncerKey(testServiceNamespace, testServiceName, key, val)
@@ -334,7 +334,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 		t.Fatalf("Failed to process updated L4 ILB srvice: %v", err)
 	}
 	expectedPortInfoMap = negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName,
-		controller.namer, localMode)
+		controller.l4Namer, localMode)
 	// There will be only one entry in the map
 	for key, val := range expectedPortInfoMap {
 		updatedSyncerKey = getSyncerKey(testServiceNamespace, testServiceName, key, val)

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -45,7 +45,7 @@ type NetworkEndpointGroupCloud interface {
 // NetworkEndpointGroupNamer is an interface for generating network endpoint group name.
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
-	VMIPNEG(namespace, name string) string
+	VMIPNEG(namespace, name string) (string, bool)
 	NEGWithSubset(namespace, name, subset string, port int32) string
 	IsNEG(name string) bool
 }

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
 type NetworkEndpointType string
@@ -162,7 +163,7 @@ func NewPortInfoMap(namespace, name string, svcPortTupleSet SvcPortTupleSet, nam
 
 // NewPortInfoMapForVMIPNEG creates PortInfoMap with empty port tuple. Since VM_IP NEGs target
 // the node instead of the pod, there is no port info to be stored.
-func NewPortInfoMapForVMIPNEG(namespace, name string, namer NetworkEndpointGroupNamer, local bool) PortInfoMap {
+func NewPortInfoMapForVMIPNEG(namespace, name string, namer namer.L4ResourcesNamer, local bool) PortInfoMap {
 	ret := PortInfoMap{}
 	svcPortSet := make(SvcPortTupleSet)
 	svcPortSet.Insert(
@@ -174,9 +175,10 @@ func NewPortInfoMapForVMIPNEG(namespace, name string, namer NetworkEndpointGroup
 		if local {
 			mode = L4LocalMode
 		}
+		negName, _ := namer.VMIPNEG(namespace, name)
 		ret[PortInfoMapKey{svcPortTuple.Port, ""}] = PortInfo{
 			PortTuple:        svcPortTuple,
-			NegName:          namer.VMIPNEG(namespace, name),
+			NegName:          negName,
 			EpCalculatorMode: mode,
 		}
 	}

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -32,8 +32,8 @@ func (*negNamer) NEG(namespace, name string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v", namespace, name, svcPort)
 }
 
-func (*negNamer) VMIPNEG(namespace, name string) string {
-	return fmt.Sprintf("%v-%v", namespace, name)
+func (*negNamer) VMIPNEG(namespace, name string) (string, bool) {
+	return fmt.Sprintf("%v-%v", namespace, name), true
 }
 
 func (*negNamer) NEGWithSubset(namespace, name, subset string, svcPort int32) string {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -185,6 +185,9 @@ func CreateAndInsertNodes(gce *gce.Cloud, nodeNames []string, zoneName string) (
 					NodeInfo: api_v1.NodeSystemInfo{
 						KubeProxyVersion: "v1.7.2",
 					},
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionTrue},
+					},
 				},
 			},
 		)

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -57,8 +57,9 @@ type BackendNamer interface {
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
-	// VMIPNEG returns the gce neg name based on the service namespace and name
-	VMIPNEG(namespace, name string) string
+	// VMIPNEG returns the gce neg name based on the service namespace and name.
+	// The second output parameter indicates if the namer supports VM_IP_NEGs.
+	VMIPNEG(namespace, name string) (string, bool)
 	// InstanceGroup constructs the name for an Instance Group.
 	InstanceGroup() string
 	// NamedPort returns the name for a named port.
@@ -77,4 +78,16 @@ type V1FrontendNamer interface {
 	// NameBelongsToCluster checks if a given frontend resource name is tagged with
 	// this cluster's UID.
 	NameBelongsToCluster(resourceName string) bool
+}
+
+// L4ResourcesNamer is an interface to name L4 LoadBalancing resources.
+type L4ResourcesNamer interface {
+	// BackendNamer is included so implementations of this interface can be used along with backendPools for linking VM_IP_NEGs.
+	BackendNamer
+	// L4ForwardingRule returns the name of the forwarding rule for the given service and protocol.
+	L4ForwardingRule(namespace, name, protocol string) string
+	// L4HealthCheck returns the names of the Healthcheck and HC-firewall rule.
+	L4HealthCheck(namespace, name string, shared bool) (string, string)
+	// IsNEG returns if the given name is a VM_IP_NEG name.
+	IsNEG(name string) bool
 }

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -1,0 +1,90 @@
+package namer
+
+import (
+	"k8s.io/ingress-gce/pkg/utils/common"
+	"strings"
+)
+
+// maximumL4CombinedLength is the maximum combined length of namespace and
+// name portions in the L4 LB resource name. The name format is:
+// k8s2-{uid}-{ns}-{name}-{suffix}
+// This is computed by subtracting: k8s2 - 4, dashes - 4,
+// kubesystemUID - 8,  suffix - 8, from the total max len of gce resource = 63
+// value is 63 - 24 = 39
+// for forwarding rule, 4 more chars need to be subtracted.
+const (
+	maximumL4CombinedLength = 39
+	sharedHcSuffix          = "l4-shared-hc"
+	firewallHcSuffix        = sharedHcSuffix + "-fw"
+)
+
+// L4Namer implements naming scheme for L4 LoadBalancer resources.
+// This uses the V2 Naming scheme
+// Example:
+// For Service - namespace/svc, clusterUID/clusterName - uid01234, prefix - k8s2, protocol TCP
+// Assume that hash("uid01234;svc;namespace") = cysix1wq
+// The resource names are -
+// TCP Forwarding Rule : k8s2-tcp-uid01234-namespace-svc-cysix1wq
+// UDP Forwarding Rule : k8s2-udp-uid01234-namespace-svc-cysix1wq
+// All other resources : k8s2-uid01234-namespace-svc-cysix1wq
+// The "namespace-svc" part of the string will be trimmed as needed.
+type L4Namer struct {
+	// Namer is needed to implement all methods required by BackendNamer interface.
+	*Namer
+	// v2Prefix is the string 'k8sv2'
+	v2Prefix string
+	// v2ClusterUID is the kube-system UID.
+	v2ClusterUID string
+}
+
+func NewL4Namer(kubeSystemUID string, namer *Namer) *L4Namer {
+	clusterUID := common.ContentHash(kubeSystemUID, clusterUIDLength)
+	return &L4Namer{v2Prefix: defaultPrefix + schemaVersionV2, v2ClusterUID: clusterUID, Namer: namer}
+}
+
+// VMIPNEG returns the gce VM_IP_NEG name based on the service namespace and name
+// NEG naming convention:
+//   k8s2-{uid}-{ns}-{name}-{suffix}
+// Output name is at most 63 characters.
+func (namer *L4Namer) VMIPNEG(namespace, name string) (string, bool) {
+	truncFields := TrimFieldsEvenly(maximumL4CombinedLength, namespace, name)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, truncNamespace, truncName, namer.suffix(namespace, name)}, "-"), true
+
+}
+
+// L4ForwardingRule returns the name of the L4 forwarding rule name based on the service namespace, name and protocol.
+// Naming convention:
+//   k8s2-{protocol}-{uid}-{ns}-{name}-{suffix}
+// Output name is at most 63 characters.
+func (namer *L4Namer) L4ForwardingRule(namespace, name, protocol string) string {
+	// add 1 for hyphen
+	protoLen := len(protocol) + 1
+	truncFields := TrimFieldsEvenly(maximumL4CombinedLength-protoLen, namespace, name)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	return strings.Join([]string{namer.v2Prefix, protocol, namer.v2ClusterUID, truncNamespace, truncName, namer.suffix(namespace, name)}, "-")
+}
+
+// L4HealthCheck returns the name of the L4 ILB Healthcheck and the associated firewall rule.
+func (namer *L4Namer) L4HealthCheck(namespace, name string, shared bool) (string, string) {
+	if !shared {
+		l4Name, _ := namer.VMIPNEG(namespace, name)
+		return l4Name, l4Name
+	}
+	return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedHcSuffix}, "-"),
+		strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, firewallHcSuffix}, "-")
+}
+
+// IsNEG indicates if the given name is a NEG following the L4 naming convention.
+func (namer *L4Namer) IsNEG(name string) bool {
+	return strings.HasPrefix(name, namer.v2Prefix+"-"+namer.v2ClusterUID)
+}
+
+// suffix returns hash string of length 8 of a concatenated string generated from
+// kube-system uid, namespace and name. These fields in combination define an l4 load-balancer uniquely.
+func (n *L4Namer) suffix(namespace, name string) string {
+	lbString := strings.Join([]string{n.v2ClusterUID, namespace, name}, ";")
+	return common.ContentHash(lbString, 8)
+}

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -1,0 +1,55 @@
+package namer
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestL4Namer verifies that all L4 resource names are of the expected length and format.
+func TestL4Namer(t *testing.T) {
+	longstring1 := "012345678901234567890123456789012345678901234567890123456789abc"
+	longstring2 := "012345678901234567890123456789012345678901234567890123456789pqr"
+	testCases := []struct {
+		desc          string
+		namespace     string
+		name          string
+		proto         string
+		expectFRName  string
+		expectNEGName string
+	}{
+		{
+			"simple case",
+			"namespace",
+			"name",
+			"TCP",
+			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+		},
+		{
+			"long svc and namespace name",
+			longstring1,
+			longstring2,
+			"UDP",
+			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+		},
+	}
+
+	newNamer := NewL4Namer(kubeSystemUID, nil)
+	for _, tc := range testCases {
+		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
+		negName, ok := newNamer.VMIPNEG(tc.namespace, tc.name)
+		if !ok {
+			t.Errorf("Namer does not support VMIPNEG")
+		}
+		if len(frName) > 63 || len(negName) > 63 {
+			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, want <= 63", tc.desc, len(frName), len(negName))
+		}
+		if frName != tc.expectFRName {
+			t.Errorf("%s ForwardingRuleName: got %q, want %q", tc.desc, frName, tc.expectFRName)
+		}
+		if negName != tc.expectNEGName {
+			t.Errorf("%s VMIPNEGName: got %q, want %q", tc.desc, negName, tc.expectFRName)
+		}
+	}
+}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -67,7 +67,8 @@ func (sp ServicePort) BackendName() string {
 	if sp.NEGEnabled {
 		return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
 	} else if sp.VMIPNEGEnabled {
-		return sp.BackendNamer.VMIPNEG(sp.ID.Service.Namespace, sp.ID.Service.Name)
+		negName, _ := sp.BackendNamer.VMIPNEG(sp.ID.Service.Namespace, sp.ID.Service.Name)
+		return negName
 	}
 	return sp.BackendNamer.IGBackend(sp.NodePort)
 }


### PR DESCRIPTION
The forwarding rule gets the protocol added as suffix. The rest of the name should be truncated to ensure a total of 63 chars.

/assign @freehan 