### PR TITLE
Fix GC for switching between LB Scopes on Namer V2

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -116,7 +116,11 @@ type Ingress struct {
 
 // FromIngress extracts the annotations from an Ingress definition.
 func FromIngress(ing *v1beta1.Ingress) *Ingress {
-	return &Ingress{ing.Annotations}
+	result := &Ingress{}
+	if ing != nil {
+		result.v = ing.Annotations
+	}
+	return result
 }
 
 // AllowHTTP returns the allowHTTP flag. True by default.

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/api/networking/v1beta1"
 )
 
@@ -26,9 +27,11 @@ type LoadBalancerPool interface {
 	// Ensure ensures a loadbalancer and its resources given the RuntimeInfo.
 	Ensure(ri *L7RuntimeInfo) (*L7, error)
 	// GCv2 garbage collects loadbalancer associated with given ingress using v2 naming scheme.
-	GCv2(ing *v1beta1.Ingress) error
+	GCv2(ing *v1beta1.Ingress, scope meta.KeyType) error
 	// GCv1 garbage collects loadbalancers not in the input list using v1 naming scheme.
 	GCv1(names []string) error
+	// FrontendScopeChangeGC checks if GC is needed for an ingress that has changed scopes
+	FrontendScopeChangeGC(ing *v1beta1.Ingress) (*meta.KeyType, error)
 	// Shutdown deletes all loadbalancers for given list of ingresses.
 	Shutdown(ings []*v1beta1.Ingress) error
 	// HasUrlMap returns true if an URL map exists in GCE for given ingress.

--- a/pkg/loadbalancers/l7s_test.go
+++ b/pkg/loadbalancers/l7s_test.go
@@ -525,7 +525,7 @@ func TestV2GC(t *testing.T) {
 				createFakeLoadbalancer(cloud, feNamerFactory.Namer(ing), versions, defaultScope)
 			}
 
-			err := l7sPool.GCv2(tc.ingressToDelete)
+			err := l7sPool.GCv2(tc.ingressToDelete, features.ScopeFromIngress(tc.ingressToDelete))
 			if err != nil {
 				t.Errorf("l7sPool.GC(%q) = %v, want nil for case %q", common.NamespacedName(tc.ingressToDelete), err, tc.desc)
 			}
@@ -604,7 +604,7 @@ func TestDoNotLeakV2LB(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			feNamer := feNamerFactory.Namer(tc.ing)
 			createFakeLoadbalancer(l7sPool.cloud, feNamer, versions, defaultScope)
-			err := l7sPool.GCv2(tc.ing)
+			err := l7sPool.GCv2(tc.ing, features.ScopeFromIngress(tc.ing))
 			if err != nil {
 				t.Errorf("l7sPool.GC(%q) = %v, want nil for case %q", common.NamespacedName(tc.ing), err, tc.desc)
 			}

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -54,6 +54,8 @@ func (l *L7) ensureComputeURLMap() error {
 	}
 
 	if currentMap == nil {
+		// Check for transitions between elb and ilb
+
 		klog.V(2).Infof("Creating URLMap %q", expectedMap.Name)
 		if err := composite.CreateUrlMap(l.cloud, key, expectedMap); err != nil {
 			return fmt.Errorf("CreateUrlMap: %v", err)

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sync
 
 import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -30,7 +31,7 @@ type Syncer interface {
 	// GC workflow performs frontend resource deletion based on given gc algorithm.
 	// TODO(rramkumar): Do we need to rethink the strategy of GC'ing
 	// all Ingresses at once?
-	GC(ings []*v1beta1.Ingress, currIng *v1beta1.Ingress, frontendGCAlgorithm utils.FrontendGCAlgorithm) error
+	GC(ings []*v1beta1.Ingress, currIng *v1beta1.Ingress, frontendGCAlgorithm utils.FrontendGCAlgorithm, scope meta.KeyType) error
 }
 
 // Controller is an interface for ingress controllers and declares methods
@@ -47,7 +48,7 @@ type Controller interface {
 	GCv1LoadBalancers(toKeep []*v1beta1.Ingress) error
 	// GCv2LoadBalancer garbage collects front-end load balancer resources for given ingress
 	// with v2 naming policy.
-	GCv2LoadBalancer(ing *v1beta1.Ingress) error
+	GCv2LoadBalancer(ing *v1beta1.Ingress, scope meta.KeyType) error
 	// PostProcess allows for doing some post-processing after an Ingress is synced to a GCLB.
 	PostProcess(state interface{}) error
 	// EnsureDeleteV1Finalizers ensures that v1 finalizers are removed for given list of ingresses.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -107,6 +107,10 @@ const (
 	// CleanupV2FrontendResources specifies that frontend resources for ingresses
 	// that use v2 naming scheme need to be deleted.
 	CleanupV2FrontendResources
+	// CleanupV2FrontendResourcesScopeChange specifies that frontend resources for ingresses
+	// that use v2 naming scheme and have changed their LB scope (e.g. ILB -> ELB or vice versa)
+	// need to be deleted
+	CleanupV2FrontendResourcesScopeChange
 	// AffinityTypeNone - no session affinity.
 	gceAffinityTypeNone = "NONE"
 	// AffinityTypeClientIP - affinity based on Client IP.


### PR DESCRIPTION
The V2 GC currently doesn't support GC of duplicate frontend resources from a different scope

cc: @skmatti for V2 namer

/assign @freehan 

Issue: #1252 