### PR TITLE
ensure ingress controller always generate consistent uid and provider uid

### DIFF
--- a/cmd/glbc/app/namer.go
+++ b/cmd/glbc/app/namer.go
@@ -139,10 +139,10 @@ func getFirewallName(kubeClient kubernetes.Interface, name, clusterUID string) (
 	if firewallName, err := useDefaultOrLookupVault(cfgVault, storage.ProviderDataKey, name); err != nil {
 		return "", err
 	} else if firewallName != "" {
-		return firewallName, cfgVault.Put(storage.ProviderDataKey, firewallName)
+		return firewallName, cfgVault.Put(storage.ProviderDataKey, firewallName, false)
 	} else {
 		klog.Infof("Using cluster UID %v as firewall name", clusterUID)
-		return clusterUID, cfgVault.Put(storage.ProviderDataKey, clusterUID)
+		return clusterUID, cfgVault.Put(storage.ProviderDataKey, clusterUID, false)
 	}
 }
 
@@ -172,18 +172,19 @@ func getClusterUID(kubeClient kubernetes.Interface, name string) (string, error)
 		if len(ing.Status.LoadBalancer.Ingress) != 0 {
 			c := namer.ParseName(loadbalancers.GCEResourceName(ing.Annotations, "forwarding-rule"))
 			if c.ClusterName != "" {
-				return c.ClusterName, cfgVault.Put(storage.UIDDataKey, c.ClusterName)
+				return c.ClusterName, cfgVault.Put(storage.UIDDataKey, c.ClusterName, false)
 			}
 			klog.Infof("Found a working Ingress, assuming uid is empty string")
-			return "", cfgVault.Put(storage.UIDDataKey, "")
+			return "", cfgVault.Put(storage.UIDDataKey, "", false)
 		}
 	}
 
+	// Generate a random uid if it does not exist
 	uid, err := randomUID()
 	if err != nil {
 		return "", err
 	}
-	return uid, cfgVault.Put(storage.UIDDataKey, uid)
+	return uid, cfgVault.Put(storage.UIDDataKey, uid, true)
 }
 
 func randomUID() (string, error) {

--- a/pkg/storage/configmaps.go
+++ b/pkg/storage/configmaps.go
@@ -71,7 +71,7 @@ func (c *ConfigMapVault) Get(key string) (string, bool, error) {
 
 // Put inserts a key/value pair in the cluster config map.
 // If the key already exists, the value provided is stored.
-func (c *ConfigMapVault) Put(key, val string) error {
+func (c *ConfigMapVault) Put(key, val string, createOnly bool) error {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 	apiObj := &api_v1.ConfigMap{
@@ -85,6 +85,9 @@ func (c *ConfigMapVault) Put(key, val string) error {
 	item, exists, err := c.configMapStore.GetByKey(cfgMapKey)
 	if err == nil && exists {
 		data := item.(*api_v1.ConfigMap).Data
+		if createOnly {
+			return fmt.Errorf("failed to create configmap %v, it is already existed with data %v.", cfgMapKey, data)
+		}
 		existingVal, ok := data[key]
 		if ok && existingVal == val {
 			// duplicate, no need to update.


### PR DESCRIPTION
This would ensure that only one ingress controller can create the `ingress-uid` config map on bootstrap.  This ensures that the provider-uid and uid are consistent. 