### PR TITLE
Fix NEG handling for default backend service when it contains the NEG annotation

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -397,7 +397,7 @@ func (c *Controller) processService(key string) error {
 	}
 	negUsage := usage.NegServiceState{}
 	svcPortInfoMap := make(negtypes.PortInfoMap)
-	if err := c.mergeDefaultBackendServicePortInfoMap(key, svcPortInfoMap); err != nil {
+	if err := c.mergeDefaultBackendServicePortInfoMap(key, service, svcPortInfoMap); err != nil {
 		return err
 	}
 	negUsage.IngressNeg = len(svcPortInfoMap)
@@ -538,15 +538,15 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 // in the ingress spec.  It is either inferred and then managed by the controller, or
 // it is passed to the controller via a command line flag.
 // Additionally, supporting NEGs for default backends is only for L7-ILB
-func (c *Controller) mergeDefaultBackendServicePortInfoMap(key string, portInfoMap negtypes.PortInfoMap) error {
-	// process default backend service
-	// Only enable for L7-ILB for now to limit possible issues
-	// TODO(shance): investigate enabling this for all ingresses
+func (c *Controller) mergeDefaultBackendServicePortInfoMap(key string, service *apiv1.Service, portInfoMap negtypes.PortInfoMap) error {
+	if c.defaultBackendService.ID.Service.String() != key {
+		return nil
+	}
 
-	if flags.F.EnableL7Ilb && c.defaultBackendService.ID.Service.String() == key {
+	scanIngress := func(qualify func(*v1beta1.Ingress) bool) error {
 		for _, m := range c.ingressLister.List() {
 			ing := *m.(*v1beta1.Ingress)
-			if utils.IsGCEL7ILBIngress(&ing) && ing.Spec.Backend == nil {
+			if qualify(&ing) && ing.Spec.Backend == nil {
 				svcPortTupleSet := make(negtypes.SvcPortTupleSet)
 				svcPortTupleSet.Insert(negtypes.SvcPortTuple{
 					Name:       c.defaultBackendService.ID.Port.String(),
@@ -557,8 +557,28 @@ func (c *Controller) mergeDefaultBackendServicePortInfoMap(key string, portInfoM
 				return portInfoMap.Merge(defaultServicePortInfoMap)
 			}
 		}
+		return nil
 	}
-	return nil
+
+	// process default backend service for L7 ILB
+	if flags.F.EnableL7Ilb {
+		if err := scanIngress(utils.IsGCEL7ILBIngress); err != nil {
+			return err
+		}
+	}
+
+	// process default backend service for L7 XLB
+	negAnnotation, foundNEGAnnotation, err := annotations.FromService(service).NEGAnnotation()
+	if err != nil {
+		return err
+	}
+	if !foundNEGAnnotation {
+		return nil
+	}
+	if negAnnotation.Ingress == false {
+		return nil
+	}
+	return scanIngress(utils.IsGCEIngress)
 }
 
 // getCSMPortInfoMap gets the PortInfoMap for service and DestinationRules.

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -75,6 +75,47 @@ var (
 		},
 		Port:       80,
 		TargetPort: "9376"}
+
+	defaultBackendService = &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-system",
+			Name:      "default-http-backend",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "1.2.3.4",
+			Type:      v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(9376),
+					NodePort:   30001,
+				},
+			},
+		},
+	}
+
+	defaultBackendServiceWithNeg = &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-system",
+			Name:      "default-http-backend",
+			Annotations: map[string]string{
+				annotations.NEGAnnotationKey: "{\"ingress\":true}",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "1.2.3.4",
+			Type:      v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(9376),
+					NodePort:   30001,
+				},
+			},
+		},
+	}
 )
 
 func newTestController(kubeClient kubernetes.Interface) *Controller {
@@ -626,7 +667,7 @@ func TestSyncNegAnnotation(t *testing.T) {
 	}
 }
 
-func TestDefaultBackendServicePortInfoMap(t *testing.T) {
+func TestDefaultBackendServicePortInfoMapForL7ILB(t *testing.T) {
 	// Not using t.Parallel() since we are sharing the controller
 	controller := newTestController(fake.NewSimpleClientset())
 	defer controller.stop()
@@ -728,9 +769,130 @@ func TestDefaultBackendServicePortInfoMap(t *testing.T) {
 				t.Fatal(err)
 			}
 			result := make(negtypes.PortInfoMap)
-			controller.mergeDefaultBackendServicePortInfoMap(controller.defaultBackendService.ID.Service.String(), result)
+			controller.mergeDefaultBackendServicePortInfoMap(controller.defaultBackendService.ID.Service.String(), defaultBackendService, result)
 			if !reflect.DeepEqual(tc.want, result) {
 				t.Fatalf("got %+v, want %+v", result, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeDefaultBackendServicePortInfoMap(t *testing.T) {
+	controller := newTestController(fake.NewSimpleClientset())
+	controller.defaultBackendService = defaultBackend
+	newTestService(controller, false, []int32{})
+	defaultBackendServiceKey := defaultBackend.ID.Service.String()
+	expectPortMap := negtypes.NewPortInfoMap(
+		defaultBackend.ID.Service.Namespace,
+		defaultBackend.ID.Service.Name,
+		negtypes.NewSvcPortTupleSet(negtypes.SvcPortTuple{Name: "http", Port: 80, TargetPort: defaultBackend.TargetPort}),
+		controller.namer,
+		false,
+		nil,
+	)
+	expectEmptyPortmap := make(negtypes.PortInfoMap)
+
+	for _, tc := range []struct {
+		desc           string
+		getIngress     func() *v1beta1.Ingress
+		defaultService *v1.Service
+		expectNeg      bool
+	}{
+		{
+			desc:           "no ingress",
+			getIngress:     func() *v1beta1.Ingress { return nil },
+			defaultService: defaultBackendService,
+			expectNeg:      false,
+		},
+		{
+			desc:           "no ingress and default backend service has NEG annotation",
+			getIngress:     func() *v1beta1.Ingress { return nil },
+			defaultService: defaultBackendServiceWithNeg,
+			expectNeg:      false,
+		},
+		{
+			desc: "ing1 has backend and default backend service does not have NEG annotation",
+			getIngress: func() *v1beta1.Ingress {
+				ing := newTestIngress("ing1")
+				ing.Spec.Backend = &v1beta1.IngressBackend{
+					ServiceName: "svc1",
+				}
+				return ing
+			},
+			defaultService: defaultBackendService,
+			expectNeg:      false,
+		},
+		{
+			desc:           "ing1 has backend and default backend service has NEG annotation",
+			getIngress:     func() *v1beta1.Ingress { return nil },
+			defaultService: defaultBackendServiceWithNeg,
+			expectNeg:      false,
+		},
+		{
+			desc: "ing2 does not backend and default backend service does not have NEG annotation",
+			getIngress: func() *v1beta1.Ingress {
+				ing := newTestIngress("ing2")
+				ing.Spec.Backend = nil
+				return ing
+			},
+			defaultService: defaultBackendService,
+			expectNeg:      false,
+		},
+		{
+			desc:           "ing2 does not backend and default backend service has NEG annotation",
+			getIngress:     func() *v1beta1.Ingress { return nil },
+			defaultService: defaultBackendServiceWithNeg,
+			expectNeg:      true,
+		},
+		{
+			desc: "ing3 is L7 ILB, has backend and default backend service does not have NEG annotation",
+			getIngress: func() *v1beta1.Ingress {
+				ing := newTestIngress("ing3")
+				ing.Annotations = map[string]string{annotations.IngressClassKey: annotations.GceL7ILBIngressClass}
+				return ing
+			},
+			defaultService: defaultBackendService,
+			expectNeg:      false,
+		},
+		{
+			desc: "ing4 is L7 ILB, does not has backend and default backend service does not have NEG annotation",
+			getIngress: func() *v1beta1.Ingress {
+				ing := newTestIngress("ing4")
+				ing.Annotations = map[string]string{annotations.IngressClassKey: annotations.GceL7ILBIngressClass}
+				ing.Spec.Backend = nil
+				return ing
+			},
+			defaultService: defaultBackendService,
+			expectNeg:      true,
+		},
+		{
+			desc:           "cluster has many ingresses (ILB and XLB) without backend and default backend service has NEG annotation",
+			getIngress:     func() *v1beta1.Ingress { return nil },
+			defaultService: defaultBackendServiceWithNeg,
+			expectNeg:      true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ing := tc.getIngress()
+			if ing != nil {
+				if err := controller.ingressLister.Add(ing); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			portMap := make(negtypes.PortInfoMap)
+			if err := controller.mergeDefaultBackendServicePortInfoMap(defaultBackendServiceKey, tc.defaultService, portMap); err != nil {
+				t.Errorf("for test case %q, expect err == nil; but got %v", tc.desc, err)
+			}
+
+			if tc.expectNeg {
+				if !reflect.DeepEqual(portMap, expectPortMap) {
+					t.Errorf("for test case %q, expect port map == %v, but got %v", tc.desc, expectPortMap, portMap)
+				}
+			} else {
+				if !reflect.DeepEqual(portMap, expectEmptyPortmap) {
+					t.Errorf("for test case %q, expect port map == %v, but got %v", tc.desc, expectEmptyPortmap, portMap)
+				}
 			}
 		})
 	}
@@ -1429,7 +1591,7 @@ func newTestServiceCustomNamedNeg(c *Controller, negSvcPorts map[int32]string, i
 	}
 
 	// append additional ports if the service does not contain the service port
-	for port, _ := range negSvcPorts {
+	for port := range negSvcPorts {
 		exists := false
 
 		for _, svcPort := range ports {


### PR DESCRIPTION
When the default backend service has the NEG annotation, NEG controller currently does not create NEGs for default backend if a L7 XLB needs it. 

cc: @spencerhance @swetharepakula 