### PR TITLE
only ignore not found error when getting NEG

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -460,6 +460,7 @@ func (manager *syncerManager) garbageCollectNEGWithCRD() error {
 			errList = append(errList, err)
 		}
 	}
+
 	return utilerrors.NewAggregate(errList)
 }
 
@@ -467,8 +468,7 @@ func (manager *syncerManager) garbageCollectNEGWithCRD() error {
 func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string) error {
 	_, err := manager.cloud.GetNetworkEndpointGroup(name, zone, meta.VersionGA)
 	if err != nil {
-		// Assume error is caused by not existing
-		return nil
+		return utils.IgnoreHTTPNotFound(err)
 	}
 	klog.V(2).Infof("Deleting NEG %q in %q.", name, zone)
 	return manager.cloud.DeleteNetworkEndpointGroup(name, zone, meta.VersionGA)

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -75,6 +75,7 @@ type FakeNetworkEndpointGroupCloud struct {
 	mu                    sync.Mutex
 }
 
+// DEPRECATED: Please do not use this mock function. Use the pkg/neg/types/mock.go instead.
 func NewFakeNetworkEndpointGroupCloud(subnetwork, network string) NetworkEndpointGroupCloud {
 	return &FakeNetworkEndpointGroupCloud{
 		Subnetwork:            subnetwork,


### PR DESCRIPTION
this is to prevent the small chance of GCE Get NEG API returns a non not found error. 