### PR TITLE
This PR fixes the /metrics from being exposed to the Internet by

### DIFF
--- a/Dockerfile.404-server-with-metrics
+++ b/Dockerfile.404-server-with-metrics
@@ -16,5 +16,5 @@ FROM gcr.io/distroless/static:latest
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 # nobody:nobody
 USER 65534:65534
-EXPOSE 8080
+EXPOSE 8080 8081
 ENTRYPOINT ["/ARG_BIN"]

--- a/cmd/404-server-with-metrics/prometheus.yml
+++ b/cmd/404-server-with-metrics/prometheus.yml
@@ -23,4 +23,4 @@ scrape_configs:
   - job_name: 'defaultHTTPServer'
     scrape_interval:     5s 
     static_configs:
-    - targets: ['localhost:8080']
+    - targets: ['localhost:8081']


### PR DESCRIPTION
having the /mterics and /healthz handlers server from a different server
listening on default port of 8081. 