### PR TITLE
Prevent Empty Neg Refs on CRs

### DIFF
--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 const (
@@ -85,7 +86,7 @@ func NewFakeNetworkEndpointGroupCloud(subnetwork, network string) NetworkEndpoin
 	}
 }
 
-var NotFoundError = fmt.Errorf("not Found")
+var NotFoundError = utils.FakeGoogleAPINotFoundErr()
 
 func (f *FakeNetworkEndpointGroupCloud) GetNetworkEndpointGroup(name string, zone string, version meta.Version) (*composite.NetworkEndpointGroup, error) {
 	f.mu.Lock()


### PR DESCRIPTION
- Return error when fail to find neg to prevent empty neg ref being set on neg cr
- attempt to delete by zone, if self link is malformed