### PR TITLE
Increase Neg GC Poll timeout

### DIFF
--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -68,7 +68,7 @@ const (
 
 	negPollInterval  = 5 * time.Second
 	negPollTimeout   = 3 * time.Minute
-	negGCPollTimeout = 3 * time.Minute
+	negGCPollTimeout = 5 * time.Minute
 
 	k8sApiPoolInterval = 10 * time.Second
 	k8sApiPollTimeout  = 30 * time.Minute


### PR DESCRIPTION
 - ensures 2 rounds of GC complete before test failure