### PR TITLE
Ensure GCPIngressParams CRD

### DIFF
--- a/cmd/workload-controller/main.go
+++ b/cmd/workload-controller/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 	crdHandler := crd.NewCRDHandler(crdClient)
 	workloadCRDMeta := workload.CRDMeta()
-	if _, err := crdHandler.EnsureCRD(workloadCRDMeta); err != nil {
+	if _, err := crdHandler.EnsureCRD(workloadCRDMeta, true); err != nil {
 		klog.Fatalf("Failed to ensure Workload CRD: %v", err)
 	}
 	workloadClient, err := workloadclient.NewForConfig(kubeConfig)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,6 +92,9 @@ type LoadBalancerController struct {
 
 	// Ingress usage metrics.
 	metrics metrics.IngressMetricsCollector
+
+	ingClassLister  cache.Indexer
+	ingParamsLister cache.Indexer
 }
 
 // NewLoadBalancerController creates a controller for gce loadbalancers.
@@ -123,6 +126,12 @@ func NewLoadBalancerController(
 		igLinker:      backends.NewInstanceGroupLinker(instancePool, backendPool),
 		metrics:       ctx.ControllerMetrics,
 	}
+
+	if ctx.IngClassInformer != nil {
+		lbc.ingClassLister = ctx.IngClassInformer.GetIndexer()
+		lbc.ingParamsLister = ctx.IngParamsInformer.GetIndexer()
+	}
+
 	lbc.ingSyncer = ingsync.NewIngressSyncer(&lbc)
 
 	lbc.ingQueue = utils.NewPeriodicTaskQueue("ingress", "ingresses", lbc.sync)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -74,7 +74,7 @@ func newLoadBalancerController() *LoadBalancerController {
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
 		HealthCheckPath:       "/",
 	}
-	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
+	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
 	lbc.instancePool = instances.NewNodePool(instances.NewFakeInstanceGroups(sets.NewString(), namer), namer, &test.FakeRecorderSource{})

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -64,7 +64,7 @@ func fakeTranslator() *Translator {
 		DefaultBackendSvcPort: defaultBackend,
 		HealthCheckPath:       "/",
 	}
-	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, nil, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
+	ctx := context.NewControllerContext(nil, client, backendConfigClient, nil, nil, nil, nil, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	gce := &Translator{
 		ctx: ctx,
 	}

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -49,7 +49,7 @@ func newFirewallController() *FirewallController {
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
 	}
 
-	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
+	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig)
 	fwc := NewFirewallController(ctx, []string{"30000-32767"})
 	fwc.hasSynced = func() bool { return true }
 

--- a/pkg/ingparams/ingparams.go
+++ b/pkg/ingparams/ingparams.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ingparams
+
+import (
+	apisingparams "k8s.io/ingress-gce/pkg/apis/ingparams"
+	ingparamsv1beta1 "k8s.io/ingress-gce/pkg/apis/ingparams/v1beta1"
+	"k8s.io/ingress-gce/pkg/crd"
+)
+
+func CRDMeta() *crd.CRDMeta {
+	meta := crd.NewCRDMeta(
+		apisingparams.GroupName,
+		"GCPIngressParams",
+		"GCPIngressParamsList",
+		"gcpingressparams",
+		"gcpingressparamses",
+		[]*crd.Version{
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/ingparams/v1beta1.GCPIngressParams", ingparamsv1beta1.GetOpenAPIDefinitions),
+		},
+		"gcpingparams",
+	)
+	return meta
+}

--- a/pkg/l4/l4controller_test.go
+++ b/pkg/l4/l4controller_test.go
@@ -56,7 +56,7 @@ func newServiceController(t *testing.T) *L4Controller {
 		Namespace:    api_v1.NamespaceAll,
 		ResyncPeriod: 1 * time.Minute,
 	}
-	ctx := context.NewControllerContext(nil, kubeClient, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
+	ctx := context.NewControllerContext(nil, kubeClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	// Add some nodes so that NEG linker kicks in during ILB creation.
 	nodes, err := test.CreateAndInsertNodes(ctx.Cloud, []string{"instance-1"}, vals.ZoneName)
 	if err != nil {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/ingress-gce/pkg/metrics"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/ingress-gce/pkg/metrics"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"

--- a/pkg/neg/types/testing.go
+++ b/pkg/neg/types/testing.go
@@ -17,6 +17,8 @@ limitations under the License.
 package types
 
 import (
+	"time"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	informerv1 "k8s.io/client-go/informers/core/v1"
@@ -30,7 +32,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/legacy-cloud-providers/gce"
-	"time"
 )
 
 const (


### PR DESCRIPTION
 - only ensure if IngressClass resource type exists on cluster
 - ensure GCPIngressParams as a cluster scoped CRD
 - create GCPIngressParams and IngressClass indexers