### PR TITLE
Refactor SSLPolicy e2e tests

### DIFF
--- a/cmd/e2e-test/sslpolicy_test.go
+++ b/cmd/e2e-test/sslpolicy_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-gce/pkg/e2e"
 	"k8s.io/ingress-gce/pkg/e2e/adapter"
@@ -33,12 +34,21 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
+const policyName = "e2e-ssl-policy"
+
+// TestSSLPolicy is a transition test
 func TestSSLPolicy(t *testing.T) {
 	ctx := context.Background()
 	port80 := intstr.FromInt(80)
 
 	// Run all test cases in the same sandbox to share certs
 	Framework.RunWithSandbox("sslpolicy_e2e", t, func(t *testing.T, s *e2e.Sandbox) {
+		// Shared amongst all tests
+		sslPolicy := &compute.SslPolicy{Name: policyName, MinTlsVersion: "TLS_1_0", Profile: "COMPATIBLE"}
+		ingBuilder := fuzz.NewIngressBuilder("", "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			AddPath("test.com", "/", "service-1", port80)
+
 		// Setup Certificates
 		hosts := []string{"test.com"}
 		var certs []*e2e.Cert
@@ -56,115 +66,105 @@ func TestSSLPolicy(t *testing.T) {
 			defer cert.Delete(s)
 		}
 
+		var gclb *fuzz.GCLB
+		var ing *v1beta1.Ingress
 		for _, tc := range []struct {
-			desc       string
-			ingBuilder *fuzz.IngressBuilder
-			policy     *compute.SslPolicy
+			desc             string
+			configPolicyName string
 		}{
 			{
-				desc: "Set SslPolicy",
-				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
-					DefaultBackend("service-1", port80).
-					AddPath("test.com", "/", "service-1", port80),
-				policy: &compute.SslPolicy{Name: e2e.Truncate("e2e-ssl-policy-" + s.Namespace), MinTlsVersion: "TLS_1_0", Profile: "COMPATIBLE"},
+				desc:             "Set SslPolicy",
+				configPolicyName: policyName,
+			},
+			{
+				desc:             "Remove SslPolicy",
+				configPolicyName: "",
 			},
 		} {
-			tc := tc // Capture tc as we are running this in parallel.
-			t.Parallel()
+			t.Run(tc.desc, func(t *testing.T) {
+				for _, cert := range certs {
+					ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
 
-			for _, cert := range certs {
-				tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
-			}
-
-			// Create Ssl Policy
-			var policyName string
-			if tc.policy != nil && tc.policy.Name != "" {
-				err := Framework.Cloud.SslPolicies().Insert(ctx, meta.GlobalKey(tc.policy.Name), tc.policy)
+				// Ensure Ssl Policy exists, we re-use it for all e2e tests that run in the same project.
+				err := Framework.Cloud.SslPolicies().Insert(ctx, meta.GlobalKey(policyName), sslPolicy)
 				if err != nil {
 					if !utils.IsHTTPErrorCode(err, http.StatusConflict) {
-						t.Errorf("SslPolicies().Insert(%v, %v) = %v, want nil", meta.GlobalKey(tc.policy.Name), tc.policy, err)
+						t.Errorf("SslPolicies().Insert(%v, %v) = %v, want nil", meta.GlobalKey(policyName), sslPolicy, err)
+					}
+				} else {
+					t.Logf("SslPolicy %q Created", policyName)
+				}
+
+				// Ensure FrontendConfig
+				feConfig, err := e2e.EnsureFrontendConfig(s, fuzz.NewFrontendConfigBuilder(s.Namespace, "e2e-feconfig").SetSslPolicy(tc.configPolicyName).Build())
+				if err != nil {
+					t.Errorf("EnsureFrontendConfig(%v) = %v, want nil", feConfig, err)
+				}
+
+				ing = ingBuilder.SetFrontendConfig(feConfig.Name).Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
+
+				_, err = e2e.CreateEchoService(s, "service-1", nil)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
 					} else {
-						t.Logf("SslPolicies().Insert(%v, %v) = %v, want nil", meta.GlobalKey(tc.policy.Name), tc.policy, err)
-					}
-				} else {
-					t.Logf("SslPolicy %q Created", tc.policy.Name)
-				}
-				policyName = tc.policy.Name
-			} else {
-				t.Logf("Not creating sslPolicy for testcase %q", tc.desc)
-			}
-
-			// policyname will be an empty string if no policy/empty policy is provided, and won't be omitted unless nil
-			builder := fuzz.NewFrontendConfigBuilder(s.Namespace, "e2e-feconfig")
-			if tc.policy != nil {
-				builder.SetSslPolicy(policyName)
-			}
-			feConfig := builder.Build()
-
-			if _, err := Framework.FrontendConfigClient.NetworkingV1beta1().FrontendConfigs(s.Namespace).Create(context.TODO(), feConfig, metav1.CreateOptions{}); err != nil {
-				t.Errorf("FrontendConfigs(%q).Create(%v) = %v, want nil", s.Namespace, feConfig, err)
-			}
-
-			ing := tc.ingBuilder.SetFrontendConfig(feConfig.Name).Build()
-			ing.Namespace = s.Namespace // namespace depends on sandbox
-
-			_, err := e2e.CreateEchoService(s, "service-1", nil)
-			if err != nil {
-				t.Fatalf("Error creating echo service: %v", err)
-			}
-			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
-
-			crud := adapter.IngressCRUD{C: Framework.Clientset}
-			if _, err := crud.Create(ing); err != nil {
-				t.Fatalf("error creating Ingress spec: %v", err)
-			}
-			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
-
-			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
-			if err != nil {
-				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
-			}
-			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
-
-			// Perform whitebox testing.
-			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
-			if err != nil {
-				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
-			}
-
-			// Check that SslPolicy is added to Target Proxy
-			if len(gclb.TargetHTTPSProxy) == 0 {
-				t.Errorf("No target https proxy found")
-			}
-
-			for _, tps := range gclb.TargetHTTPSProxy {
-				if tps.GA.SslPolicy != "" {
-					resourceID, err := cloud.ParseResourceURL(tps.GA.SslPolicy)
-					if err != nil {
-						t.Fatalf("ParseResourceURL(%q) = %v, want nil", tps.GA.SslPolicy, err)
-					}
-
-					if resourceID.Key == nil || resourceID.Key.Name != policyName {
-						t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, policyName)
-					}
-				} else {
-					if policyName != "" {
-						t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, policyName)
+						t.Fatalf("Error Creating Ingress: %v", err)
 					}
 				}
-			}
 
-			deleteOptions := &fuzz.GCLBDeleteOptions{
-				SkipDefaultBackend: true,
-			}
-			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
-				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
-			}
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
 
-			// Cleanup resource but do not fail if we can't
-			if err := Framework.Cloud.SslPolicies().Delete(ctx, meta.GlobalKey(policyName)); err != nil {
-				t.Logf("Error deleting SslPolicy: %v", err)
-			}
+				// Perform whitebox testing.
+				gclb, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+				}
+
+				// Check that SslPolicy is added to Target Proxy
+				if len(gclb.TargetHTTPSProxy) == 0 {
+					t.Errorf("No target https proxy found")
+				}
+
+				for _, tps := range gclb.TargetHTTPSProxy {
+					if tps.GA.SslPolicy != "" {
+						resourceID, err := cloud.ParseResourceURL(tps.GA.SslPolicy)
+						if err != nil {
+							t.Fatalf("ParseResourceURL(%q) = %v, want nil", tps.GA.SslPolicy, err)
+						}
+
+						if resourceID.Key == nil || resourceID.Key.Name != tc.configPolicyName {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, tc.configPolicyName)
+						}
+					} else {
+						if tc.configPolicyName != "" {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, tc.configPolicyName)
+						}
+					}
+				}
+			})
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
 		}
 	})
 }

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -289,14 +289,6 @@ func EnsureFrontendConfig(s *Sandbox, fc *frontendconfig.FrontendConfig) (*front
 	}
 	// Update fc spec if they are not equal
 	if !reflect.DeepEqual(fc.Spec, currentFc.Spec) {
-		//fc.ResourceVersion = "1"
-		//if currentFc.ResourceVersion != "" {
-		//	curVersion, err := strconv.Atoi(currentFc.ResourceVersion)
-		//	if err != nil {
-		//		return nil, err
-		//	}
-		//	fc.ResourceVersion = strconv.Itoa(curVersion + 1)
-		//}
 		currentFc.Spec = fc.Spec
 		return s.f.FrontendConfigClient.NetworkingV1beta1().FrontendConfigs(s.Namespace).Update(context.TODO(), currentFc, metav1.UpdateOptions{})
 	}


### PR DESCRIPTION
-Change tests to transition test
-Re-use sslpolicy since we do not need to delete it
-General cleanup