### PR TITLE
Update svcNeg resources with original neg CR

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -599,32 +599,39 @@ func (manager *syncerManager) ensureSvcNegCR(svcKey serviceKey, portInfo negtype
 
 	needUpdate, err := ensureNegCRLabels(negCR, labels)
 	if err != nil {
+		klog.Errorf("failed to ensure labels for neg %s/%s for service %s: %s", negCR.Namespace, negCR.Name, service.Name, err)
 		return err
 	}
 	needUpdate = ensureNegCROwnerRef(negCR, newCR.OwnerReferences) || needUpdate
 
 	if needUpdate {
-		newCR.Status = negCR.Status
-		_, err = manager.svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcKey.namespace).Update(context.Background(), &newCR, metav1.UpdateOptions{})
+		_, err = manager.svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcKey.namespace).Update(context.Background(), negCR, metav1.UpdateOptions{})
 		return err
 	}
 	return nil
 }
 
 func ensureNegCRLabels(negCR *negv1beta1.ServiceNetworkEndpointGroup, labels map[string]string) (bool, error) {
-	//Check that required labels exist and are matching
+	needsUpdate := false
 	existingLabels := negCR.GetLabels()
+	klog.V(4).Infof("existing neg %s/%s labels: %+v", negCR.Namespace, negCR.Name, existingLabels)
+
+	//Check that required labels exist and are matching
 	for key, value := range labels {
-		if existingVal := existingLabels[key]; existingVal != value {
-			return false, fmt.Errorf("Neg already exists with name %s but label %s has value %s instead of %s. Delete previous neg before creating this configuration", negCR.Name, key, existingVal, value)
+		existingVal, ok := existingLabels[key]
+		if !ok {
+			negCR.Labels[key] = value
+			needsUpdate = true
+		} else if existingVal != value {
+			svcName := ""
+			if len(negCR.OwnerReferences) == 1 {
+				svcName = negCR.OwnerReferences[0].Name
+			}
+			return false, fmt.Errorf("Neg %s/%s has a label mismatch. Expected key %s to have the value %s but found %s. Neg is likely taken by % service. Please remove previous neg before creating this configuration", negCR.Namespace, negCR.Name, key, value, existingVal, svcName)
 		}
 	}
 
-	if !reflect.DeepEqual(existingLabels, labels) {
-		negCR.Labels = labels
-		return true, nil
-	}
-	return false, nil
+	return needsUpdate, nil
 }
 
 func ensureNegCROwnerRef(negCR *negv1beta1.ServiceNetworkEndpointGroup, expectedOwnerRef []metav1.OwnerReference) bool {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -846,11 +846,16 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 		svcTuple          negtypes.SvcPortTuple
 		markedForDeletion bool
 		expectErr         bool
-		modifyObjectMeta  bool
+		extraLabel        bool
+		incorrectLabel    bool
+		incorrectSvcUID   bool
+		missingLabel      bool
 		crExists          bool
+		expectUpdate      bool
 	}{
 		{desc: "no cr exists yet",
-			crExists: false,
+			crExists:     false,
+			expectUpdate: true,
 		},
 		{desc: "same service, same port configuration, original cr is not marked for deletion",
 			svc:               svc1,
@@ -858,14 +863,16 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 			markedForDeletion: false,
 			expectErr:         false,
 			crExists:          true,
+			expectUpdate:      false,
 		},
-		{desc: "same service, same port configuration, original cr is not marked for deletion and has unexpected labels",
+		{desc: "same service, same port configuration, original cr and has extra labels",
 			svc:               svc1,
 			svcTuple:          svcTuple1,
 			markedForDeletion: false,
 			expectErr:         false,
-			modifyObjectMeta:  true,
+			extraLabel:        true,
 			crExists:          true,
+			expectUpdate:      false,
 		},
 		{desc: "same service, same port configuration, original cr is marked for deletion",
 			svc:               svc1,
@@ -873,20 +880,15 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 			markedForDeletion: true,
 			expectErr:         false,
 			crExists:          true,
+			expectUpdate:      false,
 		},
-		{desc: "same service, different port configuration, original cr is not marked for deletion",
+		{desc: "same service, different port configuration, original cr",
 			svc:               svc1,
 			svcTuple:          svcTuple2,
 			markedForDeletion: false,
 			expectErr:         true,
 			crExists:          true,
-		},
-		{desc: "same service, different port configuration, original cr is marked for deletion",
-			svc:               svc1,
-			svcTuple:          svcTuple2,
-			markedForDeletion: true,
-			expectErr:         true,
-			crExists:          true,
+			expectUpdate:      false,
 		},
 		{desc: "different service name",
 			svc:               svc2,
@@ -894,6 +896,34 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 			markedForDeletion: false,
 			expectErr:         true,
 			crExists:          true,
+			expectUpdate:      false,
+		},
+		{desc: "same service, same port config, incorrect svcUID",
+			svc:               svc1,
+			svcTuple:          svcTuple1,
+			markedForDeletion: false,
+			incorrectSvcUID:   true,
+			expectErr:         false,
+			crExists:          true,
+			expectUpdate:      true,
+		},
+		{desc: "same service, same port config, incorrect label",
+			svc:               svc1,
+			svcTuple:          svcTuple1,
+			markedForDeletion: false,
+			incorrectLabel:    true,
+			expectErr:         true,
+			crExists:          true,
+			expectUpdate:      false,
+		},
+		{desc: "same service, same port config, missing label",
+			svc:               svc1,
+			svcTuple:          svcTuple1,
+			markedForDeletion: false,
+			missingLabel:      true,
+			expectErr:         false,
+			crExists:          true,
+			expectUpdate:      true,
 		},
 	}
 
@@ -917,8 +947,19 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 					testNeg.SetDeletionTimestamp(&deletionTS)
 				}
 
-				if tc.modifyObjectMeta {
+				if tc.extraLabel {
 					testNeg.Labels["extra-label"] = "extra-value"
+				}
+
+				if tc.incorrectLabel {
+					testNeg.Labels[negtypes.NegCRManagedByKey] = "wrong-value"
+				}
+
+				if tc.missingLabel {
+					delete(testNeg.Labels, negtypes.NegCRManagedByKey)
+				}
+
+				if tc.incorrectSvcUID {
 					testNeg.OwnerReferences = append(testNeg.OwnerReferences, metav1.OwnerReference{UID: "extra-uid"})
 				}
 
@@ -952,8 +993,8 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 				t.Errorf("expected to retrieve one negs, retrieved %d", len(negs.Items))
 			}
 
-			if tc.expectErr || tc.markedForDeletion {
-				// If errored, marked for deletion or neg cr is already correct, no update should occur
+			if !tc.expectUpdate {
+				// If errored or if neg cr is already correct, no update should occur
 				if !reflect.DeepEqual(testNeg, negs.Items[0]) {
 					t.Errorf("test neg should not have been updated")
 				}
@@ -961,6 +1002,12 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 				svcKey := serviceKey{namespace: namespace, name: svc1Name}
 				portInfo := portInfoMap[negtypes.PortInfoMapKey{ServicePort: svcTuple1.Port, Subset: ""}]
 				checkNegCR(t, &negs.Items[0], svcKey, svc1.UID, portInfo)
+				// If update was unnecessary, the resource version should not change.
+				// If upate was necessary, the same CR should be used for an update so the resource
+				// version should be unchanged. API server will change resource version.
+				if negs.Items[0].ResourceVersion != testNeg.ResourceVersion {
+					t.Errorf("neg resource version should not be updated")
+				}
 			}
 
 			// make sure there is no leaking go routine
@@ -1567,7 +1614,6 @@ func createNegCR(service *v1.Service, svcKey serviceKey, portInfo negtypes.PortI
 		negtypes.NegCRServicePortKey: fmt.Sprint(portInfo.PortTuple.Port),
 	}
 
-	// TODO: Add finalizer once NEG CRD GC is implemented
 	return negv1beta1.ServiceNetworkEndpointGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            portInfo.NegName,


### PR DESCRIPTION
 - ensure that extra user provided labels are not overwritten when
 ensuring svc negs