### PR TITLE
Add custom buckets for ILB Sync latency.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,6 +73,8 @@ var (
 		prometheus.HistogramOpts{
 			Name: "l4_ilb_sync_duration_seconds",
 			Help: "Latency of an L4 ILB Sync",
+			// custom buckets - [30s, 60s, 120s, 240s(4min), 480s(8min), 960s(16m), +Inf]
+			Buckets: prometheus.ExponentialBuckets(30, 2, 6),
 		},
 		l4ILBSyncLatencyMetricsLabels,
 	)


### PR DESCRIPTION
The default buckets have an upper bound of 10s. Since sync latency can take upto
a couple of minutes, custom buckets will be beneficial.

@swetharepakula 
/assign @freehan 