### PR TITLE
Generate a unique name for firewall rule for Healthchecks.

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -86,6 +86,9 @@ const (
 	// HealthcheckKey is the annotation key used by l4 controller to record
 	// GCP Healthcheck name.
 	HealthcheckKey = ServiceStatusPrefix + "/healthcheck"
+	// FirewallRuleForHealthcheckKey is the annotation key used by l4 controller to record
+	// the firewall rule name that allows healthcheck traffic.
+	FirewallRuleForHealthcheckKey = ServiceStatusPrefix + "/firewall-rule-for-hc"
 )
 
 // NegAnnotation is the format of the annotation associated with the

--- a/pkg/l4/l4controller_test.go
+++ b/pkg/l4/l4controller_test.go
@@ -113,7 +113,7 @@ func validateSvcStatus(svc *api_v1.Service, expectStatus bool, t *testing.T) {
 	}
 
 	expectedAnnotationKeys := []string{annotations.FirewallRuleKey, annotations.BackendServiceKey, annotations.HealthcheckKey,
-		annotations.TCPForwardingRuleKey}
+		annotations.TCPForwardingRuleKey, annotations.FirewallRuleForHealthcheckKey}
 
 	missingKeys := []string{}
 	for _, key := range expectedAnnotationKeys {

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -60,7 +60,8 @@ var ILBResourceAnnotationKeys = []string{
 	annotations.TCPForwardingRuleKey,
 	annotations.UDPForwardingRuleKey,
 	annotations.HealthcheckKey,
-	annotations.FirewallRuleKey}
+	annotations.FirewallRuleKey,
+	annotations.FirewallRuleForHealthcheckKey}
 
 // NewL4Handler creates a new L4Handler for the given L4 service.
 func NewL4Handler(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, namer namer.L4ResourcesNamer, recorder record.EventRecorder, lock *sync.Mutex) *L4 {
@@ -235,6 +236,7 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service,
 	if err != nil {
 		return nil, nil, err
 	}
+	annotationsMap[annotations.FirewallRuleForHealthcheckKey] = hcFwName
 
 	// Check if protocol has changed for this service. In this case, forwarding rule should be deleted before
 	// the backend service can be updated.

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1131,6 +1131,7 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 		hcFwName,
 	}
 	expectedAnnotations[annotations.FirewallRuleKey] = resourceName
+	expectedAnnotations[annotations.FirewallRuleForHealthcheckKey] = hcFwName
 	if hcFwName == resourceName {
 		t.Errorf("Got the same name %q for LB firewall rule and Healthcheck firewall rule", hcFwName)
 	}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1131,7 +1131,9 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 		hcFwName,
 	}
 	expectedAnnotations[annotations.FirewallRuleKey] = resourceName
-
+	if hcFwName == resourceName {
+		t.Errorf("Got the same name %q for LB firewall rule and Healthcheck firewall rule", hcFwName)
+	}
 	for _, fwName := range fwNames {
 		firewall, err := l.cloud.GetFirewall(fwName)
 		if err != nil {

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -10,28 +10,59 @@ func TestL4Namer(t *testing.T) {
 	longstring1 := "012345678901234567890123456789012345678901234567890123456789abc"
 	longstring2 := "012345678901234567890123456789012345678901234567890123456789pqr"
 	testCases := []struct {
-		desc          string
-		namespace     string
-		name          string
-		proto         string
-		expectFRName  string
-		expectNEGName string
+		desc           string
+		namespace      string
+		name           string
+		proto          string
+		sharedHC       bool
+		expectFRName   string
+		expectNEGName  string
+		expectHcFwName string
+		expectHcName   string
 	}{
 		{
 			"simple case",
 			"namespace",
 			"name",
 			"TCP",
+			false,
 			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x-fw",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+		},
+		{
+			"simple case, shared healthcheck",
+			"namespace",
+			"name",
+			"TCP",
+			true,
+			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-l4-shared-hc-fw",
+			"k8s2-7kpbhpki-l4-shared-hc",
 		},
 		{
 			"long svc and namespace name",
 			longstring1,
 			longstring2,
 			"UDP",
+			false,
 			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm40-fw",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+		},
+		{
+			"long svc and namespace name, shared healthcheck",
+			longstring1,
+			longstring2,
+			"UDP",
+			true,
+			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+			"k8s2-7kpbhpki-l4-shared-hc-fw",
+			"k8s2-7kpbhpki-l4-shared-hc",
 		},
 	}
 
@@ -39,17 +70,24 @@ func TestL4Namer(t *testing.T) {
 	for _, tc := range testCases {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		negName, ok := newNamer.VMIPNEG(tc.namespace, tc.name)
+		hcName, hcFwName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
 		if !ok {
 			t.Errorf("Namer does not support VMIPNEG")
 		}
-		if len(frName) > 63 || len(negName) > 63 {
-			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, want <= 63", tc.desc, len(frName), len(negName))
+		if len(frName) > maxResourceNameLength || len(negName) > maxResourceNameLength || len(hcName) > maxResourceNameLength || len(hcFwName) > maxResourceNameLength {
+			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, len(hcName) == %v, len(hcFwName) == %v want <= 63", tc.desc, len(frName), len(negName), len(hcName), len(hcFwName))
 		}
 		if frName != tc.expectFRName {
 			t.Errorf("%s ForwardingRuleName: got %q, want %q", tc.desc, frName, tc.expectFRName)
 		}
 		if negName != tc.expectNEGName {
 			t.Errorf("%s VMIPNEGName: got %q, want %q", tc.desc, negName, tc.expectFRName)
+		}
+		if hcFwName != tc.expectHcFwName {
+			t.Errorf("%s FirewallName For Healthcheck: got %q, want %q", tc.desc, hcFwName, tc.expectHcFwName)
+		}
+		if hcName != tc.expectHcName {
+			t.Errorf("%s HealthCheckName: got %q, want %q", tc.desc, hcName, tc.expectHcName)
 		}
 	}
 }


### PR DESCRIPTION
Previous code was using the same name for firewall rule for LoadBalancerIP access as well as firewall rule for healthchecks.
These should be 2 different firewall rules.
This change also includes the Healthcheck firewall name in the service annotations.

/assign @freehan 