### PR TITLE
Do not claim custom named negs with empty desc

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -198,6 +198,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				epc,
 				string(manager.kubeSystemUID),
 				manager.svcNegClient,
+				!manager.namer.IsNEG(portInfo.NegName),
 			)
 			manager.syncerMap[syncerKey] = syncer
 		}
@@ -542,6 +543,12 @@ func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string
 	}
 
 	if expectedDesc != nil {
+		// Controller managed custom named negs will always have a populated description, so do not delete custom named
+		// negs with empty descriptions.
+		if !manager.namer.IsNEG(name) && neg.Description == "" {
+			klog.V(2).Infof("Skipping deletion of Neg %s in %s because name was not generated and empty description", name, zone)
+			return nil
+		}
 		if matches, err := utils.VerifyDescription(*expectedDesc, neg.Description, name, zone); !matches {
 			klog.V(2).Infof("Skipping deletion of Neg %s in %s because of conflicting description: %s", name, zone, err)
 			return nil

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1187,18 +1187,24 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 		expectCrGC           bool
 		expectErr            bool
 		gcError              error
+
+		// expectGenNamedNegGC indicates that the Neg GC only occurs if using a generated name
+		// expectNegGC will take precedence over this value
+		expectGenNamedNegGC bool
 	}{
 		{desc: "neg config not in svcPortMap, marked for deletion",
 			negsExist:         true,
 			markedForDeletion: true,
 			expectNegGC:       true,
 			expectCrGC:        true,
+			negDesc:           matchingDesc.String(),
 		},
 		{desc: "neg config not in svcPortMap",
 			negsExist:         true,
 			markedForDeletion: false,
 			expectNegGC:       true,
 			expectCrGC:        true,
+			negDesc:           matchingDesc.String(),
 		},
 		{desc: "neg config not in svcPortMap, marked for deletion, empty neg list",
 			negsExist:         true,
@@ -1206,6 +1212,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			emptyNegRefList:   true,
 			expectNegGC:       true,
 			expectCrGC:        true,
+			negDesc:           matchingDesc.String(),
 		},
 		{desc: "neg config not in svcPortMap, empty neg list",
 			negsExist:         true,
@@ -1213,6 +1220,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			emptyNegRefList:   true,
 			expectNegGC:       true,
 			expectCrGC:        true,
+			negDesc:           matchingDesc.String(),
 		},
 		{desc: "neg config not in svcPortMap, malformed neg selflink",
 			negsExist:            true,
@@ -1222,6 +1230,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			expectNegGC:          true,
 			expectCrGC:           true,
 			expectErr:            true,
+			negDesc:              matchingDesc.String(),
 		},
 		{desc: "neg config not in svcPortMap, empty neg list, neg has matching description",
 			negsExist:         true,
@@ -1238,6 +1247,14 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			expectNegGC:       false,
 			expectCrGC:        true,
 			negDesc:           wrongDesc.String(),
+		},
+		{desc: "neg config not in svcPortMap, empty neg list, neg has empty description",
+			negsExist:           true,
+			markedForDeletion:   false,
+			emptyNegRefList:     true,
+			expectGenNamedNegGC: true,
+			expectCrGC:          true,
+			negDesc:             "",
 		},
 		{desc: "neg config in svcPortMap, marked for deletion",
 			negsExist:         true,
@@ -1269,6 +1286,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			expectCrGC:        true,
 			expectErr:         false,
 			gcError:           &googleapi.Error{Code: http.StatusBadRequest},
+			negDesc:           matchingDesc.String(),
 		},
 		{desc: "error during neg gc, config not in svcPortMap",
 			negsExist:         true,
@@ -1276,12 +1294,13 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 			expectCrGC:        true,
 			expectErr:         true,
 			gcError:           fmt.Errorf("gc-error"),
+			negDesc:           matchingDesc.String(),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			for _, negName := range []string{"test", ""} {
+			for _, customName := range []bool{true, false} {
 				for _, networkEndpointType := range []negtypes.NetworkEndpointType{negtypes.VmIpPortEndpointType, negtypes.NonGCPPrivateEndpointType, negtypes.VmIpEndpointType} {
 
 					kubeClient := fake.NewSimpleClientset()
@@ -1297,8 +1316,9 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 					}
 
 					// Create NEG to be GC'ed
-					if negName == "" {
-						negName = manager.namer.NEG("test", "test", port80)
+					negName := manager.namer.NEG("test", "test", port80)
+					if customName {
+						negName = "test"
 					}
 
 					for _, zone := range zones {
@@ -1370,9 +1390,10 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 
 					numExistingNegs, negsDeleted := checkForNegDeletions(negs, negName)
 
-					if tc.negsExist && tc.expectNegGC && !negsDeleted {
+					expectNegGC := tc.expectNegGC || (tc.expectGenNamedNegGC && !customName)
+					if tc.negsExist && expectNegGC && !negsDeleted {
 						t.Errorf("expected negs to be GCed, but found %d", numExistingNegs)
-					} else if tc.negsExist && !tc.expectNegGC && numExistingNegs != 2 {
+					} else if tc.negsExist && !expectNegGC && numExistingNegs != 2 {
 						t.Errorf("expected two negs in the cloud, but found %d", numExistingNegs)
 					}
 

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -82,9 +82,12 @@ type transactionSyncer struct {
 
 	//svcNegClient used to update status on corresponding NEG CRs when not nil
 	svcNegClient svcnegclient.Interface
+
+	// customName indicates whether the NEG name is a generated one or custom one
+	customName bool
 }
 
-func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, nodeLister cache.Indexer, svcNegLister cache.Indexer, reflector readiness.Reflector, epc negtypes.NetworkEndpointsCalculator, kubeSystemUID string, svcNegClient svcnegclient.Interface) negtypes.NegSyncer {
+func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, nodeLister cache.Indexer, svcNegLister cache.Indexer, reflector readiness.Reflector, epc negtypes.NetworkEndpointsCalculator, kubeSystemUID string, svcNegClient svcnegclient.Interface, customName bool) negtypes.NegSyncer {
 	// TransactionSyncer implements the syncer core
 	ts := &transactionSyncer{
 		NegSyncerKey:        negSyncerKey,
@@ -102,6 +105,7 @@ func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.Ev
 		reflector:           reflector,
 		kubeSystemUID:       kubeSystemUID,
 		svcNegClient:        svcNegClient,
+		customName:          customName,
 	}
 	// Syncer implements life cycle logic
 	syncer := newSyncer(negSyncerKey, serviceLister, recorder, ts)
@@ -250,6 +254,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 			s.serviceLister,
 			s.recorder,
 			s.NegSyncerKey.GetAPIVersion(),
+			s.customName,
 		)
 		if err != nil {
 			errList = append(errList, err)

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -380,6 +380,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			nil,
 			nil,
 			tc.apiVersion,
+			false,
 		)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
@@ -428,6 +429,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			nil,
 			nil,
 			tc.apiVersion,
+			false,
 		)
 
 		if err != nil {
@@ -438,7 +440,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false)
 	podLister := transactionSyncer.podLister
 
 	// add all pods in default endpoint into podLister
@@ -796,7 +798,7 @@ func TestMakeEndpointBatch(t *testing.T) {
 func TestShouldPodBeInNeg(t *testing.T) {
 	t.Parallel()
 
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false)
 
 	podLister := transactionSyncer.podLister
 
@@ -898,6 +900,7 @@ func TestNameUniqueness(t *testing.T) {
 		nil,
 		nil,
 		apiVersion,
+		false,
 	)
 	if err != nil {
 		t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -926,6 +929,7 @@ func TestNameUniqueness(t *testing.T) {
 		nil,
 		nil,
 		apiVersion,
+		false,
 	)
 
 	if err == nil {
@@ -967,6 +971,7 @@ func TestNegObjectCrd(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			false,
 		)
 		if err != nil {
 			t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -1006,6 +1011,7 @@ func TestNegObjectCrd(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			false,
 		)
 
 		if err != nil {
@@ -1057,6 +1063,7 @@ func TestNEGRecreate(t *testing.T) {
 		negDescription string
 		expectRecreate bool
 		expectError    bool
+		customName     bool
 	}{
 		{
 			desc:           "incorrect network, empty neg description, GCP endpoint type",
@@ -1075,6 +1082,16 @@ func TestNEGRecreate(t *testing.T) {
 			negDescription: "",
 			expectRecreate: true,
 			expectError:    false,
+		},
+		{
+			desc:           "correct network, correct subnetwork, customName, empty neg description, GCP endpoint type",
+			network:        testNetwork,
+			subnetwork:     testSubnetwork,
+			negType:        negtypes.VmIpPortEndpointType,
+			negDescription: "",
+			expectRecreate: false,
+			expectError:    true,
+			customName:     true,
 		},
 		{
 			desc:           "incorrect network, matching neg description, GCP endpoint type",
@@ -1159,6 +1176,7 @@ func TestNEGRecreate(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			tc.customName,
 		)
 		if !tc.expectError && err != nil {
 			t.Errorf("TestCase: %s, Errored while ensuring network endpoint groups: %s", tc.desc, err)


### PR DESCRIPTION
 * ensures that controller only manages custom named negs that were
 created by the neg controller
 * only delete custom named negs that have a populated description