### PR TITLE
Cherrypick #1374 to release-1.10: Do not claim custom named negs with empty desc

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -82,9 +82,12 @@ type transactionSyncer struct {
 
 	//svcNegClient used to update status on corresponding NEG CRs when not nil
 	svcNegClient svcnegclient.Interface
+
+	// customName indicates whether the NEG name is a generated one or custom one
+	customName bool
 }
 
-func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, nodeLister cache.Indexer, svcNegLister cache.Indexer, reflector readiness.Reflector, epc negtypes.NetworkEndpointsCalculator, kubeSystemUID string, svcNegClient svcnegclient.Interface) negtypes.NegSyncer {
+func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.EventRecorder, cloud negtypes.NetworkEndpointGroupCloud, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, serviceLister cache.Indexer, endpointLister cache.Indexer, nodeLister cache.Indexer, svcNegLister cache.Indexer, reflector readiness.Reflector, epc negtypes.NetworkEndpointsCalculator, kubeSystemUID string, svcNegClient svcnegclient.Interface, customName bool) negtypes.NegSyncer {
 	// TransactionSyncer implements the syncer core
 	ts := &transactionSyncer{
 		NegSyncerKey:        negSyncerKey,
@@ -102,6 +105,7 @@ func NewTransactionSyncer(negSyncerKey negtypes.NegSyncerKey, recorder record.Ev
 		reflector:           reflector,
 		kubeSystemUID:       kubeSystemUID,
 		svcNegClient:        svcNegClient,
+		customName:          customName,
 	}
 	// Syncer implements life cycle logic
 	syncer := newSyncer(negSyncerKey, serviceLister, recorder, ts)
@@ -250,6 +254,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 			s.serviceLister,
 			s.recorder,
 			s.NegSyncerKey.GetAPIVersion(),
+			s.customName,
 		)
 		if err != nil {
 			errList = append(errList, err)

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -115,7 +115,7 @@ func getService(serviceLister cache.Indexer, namespace, name string) *apiv1.Serv
 }
 
 // ensureNetworkEndpointGroup ensures corresponding NEG is configured correctly in the specified zone.
-func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName, kubeSystemUID, port string, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version) (negv1beta1.NegObjectReference, error) {
+func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName, kubeSystemUID, port string, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version, customName bool) (negv1beta1.NegObjectReference, error) {
 	var negRef negv1beta1.NegObjectReference
 	neg, err := cloud.GetNetworkEndpointGroup(negName, zone, version)
 	if err != nil {
@@ -135,6 +135,10 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 			Namespace:   svcNamespace,
 			ServiceName: svcName,
 			Port:        port,
+		}
+		if customName && neg.Description == "" {
+			klog.Errorf("Found Neg with custom name %s but empty description", negName)
+			return negv1beta1.NegObjectReference{}, fmt.Errorf("neg name %s is already in use, found a custom named neg with an empty description", negName)
 		}
 		if matches, err := utils.VerifyDescription(expectedDesc, neg.Description, negName, zone); !matches {
 			klog.Errorf("Neg Name %s is already in use: %s", negName, err)

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -386,6 +386,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			nil,
 			nil,
 			tc.apiVersion,
+			false,
 		)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
@@ -441,6 +442,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 			nil,
 			nil,
 			tc.apiVersion,
+			false,
 		)
 
 		if err != nil {
@@ -451,7 +453,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false)
 	podLister := transactionSyncer.podLister
 
 	// add all pods in default endpoint into podLister
@@ -809,7 +811,7 @@ func TestMakeEndpointBatch(t *testing.T) {
 func TestShouldPodBeInNeg(t *testing.T) {
 	t.Parallel()
 
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType)
+	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false)
 
 	podLister := transactionSyncer.podLister
 
@@ -947,6 +949,7 @@ func TestNameUniqueness(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			false,
 		)
 		if err != nil {
 			t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -976,6 +979,7 @@ func TestNameUniqueness(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			false,
 		)
 
 		if tc.expectError && err == nil {
@@ -1023,6 +1027,7 @@ func TestNegObjectCrd(t *testing.T) {
 				nil,
 				nil,
 				apiVersion,
+				false,
 			)
 			if err != nil {
 				t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -1066,6 +1071,7 @@ func TestNegObjectCrd(t *testing.T) {
 				nil,
 				nil,
 				apiVersion,
+				false,
 			)
 
 			if err != nil {
@@ -1118,6 +1124,7 @@ func TestNEGRecreate(t *testing.T) {
 		negDescription string
 		expectRecreate bool
 		expectError    bool
+		customName     bool
 	}{
 		{
 			desc:           "incorrect network, empty neg description, GCP endpoint type",
@@ -1136,6 +1143,16 @@ func TestNEGRecreate(t *testing.T) {
 			negDescription: "",
 			expectRecreate: true,
 			expectError:    false,
+		},
+		{
+			desc:           "correct network, correct subnetwork, customName, empty neg description, GCP endpoint type",
+			network:        testNetwork,
+			subnetwork:     testSubnetwork,
+			negType:        negtypes.VmIpPortEndpointType,
+			negDescription: "",
+			expectRecreate: false,
+			expectError:    true,
+			customName:     true,
 		},
 		{
 			desc:           "incorrect network, matching neg description, GCP endpoint type",
@@ -1220,6 +1237,7 @@ func TestNEGRecreate(t *testing.T) {
 			nil,
 			nil,
 			apiVersion,
+			tc.customName,
 		)
 		if !tc.expectError && err != nil {
 			t.Errorf("TestCase: %s, Errored while ensuring network endpoint groups: %s", tc.desc, err)


### PR DESCRIPTION
Cherrypick #1374 into release-1.10

 * ensures that controller only manages custom named negs that were
 created by the neg controller
 * only delete custom named negs that have a populated description