### PR TITLE
update to use CRD v1

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -200,7 +200,7 @@ func (ctx *ControllerContext) initEnableASM() {
 		ctx.ASMConfigController.DisableASM()
 		return
 	}
-	destinationRuleCRD, err := apiextensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context2.TODO(), destinationRuleCRDName, metav1.GetOptions{})
+	destinationRuleCRD, err := apiextensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context2.TODO(), destinationRuleCRDName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			ctx.ASMConfigController.RecordEvent("Warning", "FailedValidateDestinationRuleCRD", "Cannot find DestinationRule CRD, disabling ASM Mode, please check Istio setup.")
@@ -210,9 +210,9 @@ func (ctx *ControllerContext) initEnableASM() {
 		ctx.ASMConfigController.DisableASM()
 		return
 	}
-	if destinationRuleCRD.Spec.Version != destinationRuleAPIVersion {
+	if destinationRuleCRD.Spec.Versions[0].Name != destinationRuleAPIVersion {
 		ctx.ASMConfigController.RecordEvent("Warning", "FailedValidateDestinationRuleCRD", fmt.Sprintf("Only Support Istio API: %s, but found %s, disabling the ASM Mode, please check Istio setup.",
-			destinationRuleAPIVersion, destinationRuleCRD.Spec.Version))
+			destinationRuleAPIVersion, destinationRuleCRD.Spec.Versions[0].Name))
 		ctx.ASMConfigController.DisableASM()
 		return
 	}

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -104,7 +104,7 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 
 	// Preparing dynamic client if Istio:DestinationRule CRD exisits and matches the required version.
 	// The client is used by the ASM e2e tests.
-	destinationRuleCRD, err := f.crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), destinationRuleCRDName, metav1.GetOptions{})
+	destinationRuleCRD, err := f.crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), destinationRuleCRDName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Infof("Cannot load DestinationRule CRD, Istio is disabled on this cluster.")
@@ -112,8 +112,8 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 			klog.Fatalf("Failed to load DestinationRule CRD, error: %s", err)
 		}
 	} else {
-		if destinationRuleCRD.Spec.Version != destinationRuleAPIVersion {
-			klog.Fatalf("The cluster Istio version not meet the testing requirement, want: %s, got: %s.", destinationRuleAPIVersion, destinationRuleCRD.Spec.Version)
+		if destinationRuleCRD.Spec.Versions[0].Name != destinationRuleAPIVersion {
+			klog.Fatalf("The cluster Istio version not meet the testing requirement, want: %s, got: %s.", destinationRuleAPIVersion, destinationRuleCRD.Spec.Versions[0].Name)
 		} else {
 			dynamicClient, err := dynamic.NewForConfig(config)
 			if err != nil {

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"net"
 	"net/http"
 	"reflect"
@@ -33,7 +34,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -737,7 +737,7 @@ func WaitConfigMapEvents(s *Sandbox, namespace, name string, msgs []string, time
 // by the ingress controller.
 func waitForBackendConfigCRDEstablish(crdClient *apiextensionsclient.Clientset) error {
 	condition := func() (bool, error) {
-		bcCRD, err := crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), backendConfigCRDName, metav1.GetOptions{})
+		bcCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), backendConfigCRDName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.V(3).Infof("CRD %s is not found, retrying", backendConfigCRDName)
@@ -746,7 +746,7 @@ func waitForBackendConfigCRDEstablish(crdClient *apiextensionsclient.Clientset) 
 			return false, err
 		}
 		for _, c := range bcCRD.Status.Conditions {
-			if c.Type == apiextensionsv1beta1.Established && c.Status == apiextensionsv1beta1.ConditionTrue {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/100560

CRD v1beta1 is being removed in kubernetes 1.22, which starts development shortly.  This updates the GETs to be CRD v1 and tweaks the version check code to match.  From the godoc on CRD v1beta1 .spec.version: `Must match the name of the first item in the `versions` list if `version` and `versions` are both specified.`.

I haven't found these CRDs are defined.  It doesn't appear to be in this repo, but I'm concerned that they are also v1beta1.  Any hints?

@liggitt 