### PR TITLE
Remove empty error from error message

### DIFF
--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -330,7 +330,7 @@ func (c *Controller) getForwardingRule(namespace, svcName string) (string, error
 	}
 
 	if !exists {
-		return "", fmt.Errorf("failed to get Service %s/%s: %q", namespace, svcName, err)
+		return "", fmt.Errorf("failed to get Service %s/%s", namespace, svcName)
 	}
 
 	svc := obj.(*v1.Service)


### PR DESCRIPTION
Since error is always nil, remove from error message.