### PR TITLE
Continue syncing HTTPS if there is at least one valid TLS secret

### DIFF
--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -325,6 +325,20 @@ func TestSecrets(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			desc: "ingress-single-secret and missing secret",
+			// TODO(rramkumar): Read Ingress spec from a file.
+			ing: &v1beta1.Ingress{
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{
+						{SecretName: "first-secret"},
+						{SecretName: "does-not-exist-secret"},
+					},
+				},
+			},
+			want:    []*api_v1.Secret{secretsMap["first-secret"]},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -343,11 +357,11 @@ func TestSecrets(t *testing.T) {
 				t.Fatalf("NewEnv(): %v", err)
 			}
 
-			got, err := secrets(env)
-			if tc.wantErr && err == nil {
+			got, errors := secrets(env)
+			if tc.wantErr && len(errors) == 0 {
 				t.Fatal("expected Secrets() to return an error")
 			}
-			if !tc.wantErr && err != nil {
+			if !tc.wantErr && len(errors) > 0 {
 				t.Fatalf("Secrets(): %v", err)
 			}
 


### PR DESCRIPTION
This fixes a bug where:
1) User has existing HTTPS LB with TLS secrets
2) User adds a new TLS secret that doesn't exist yet (could be added by another controller)
3) Ingress controller sets up HTTP only, causing their HTTPS resources to be deleted and causes downtime.

What this PR does is continue syncing the HTTPS LB as long as there is at least 1 valid secret.

cc: #388 