### PR TITLE
fix the behavior of Backends.Health() to return more reliable value

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -186,6 +186,7 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType)
 
 	// TODO: Include port, ip in the status, since it's in the health info.
 	// TODO (shance) convert to composite types
+	ret := "Unknown"
 	for _, backend := range be.Backends {
 		var hs *compute.BackendServiceGroupHealth
 		switch scope {
@@ -205,10 +206,15 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType)
 			continue
 		}
 
-		// TODO: State transition are important, not just the latest.
-		return hs.HealthStatus[0].HealthState, nil
+		for _, instanceStatus := range hs.HealthStatus {
+			ret = instanceStatus.HealthState
+			// return immediately with the value if we found at least one healthy instance
+			if ret == "HEALTHY" {
+				return ret, nil
+			}
+		}
 	}
-	return "Unknown", nil
+	return ret, nil
 }
 
 // List lists all backends managed by this controller.


### PR DESCRIPTION
Currently the function Backends.Health() returns a status of the first instance of the first backend of the given backend service. (issue #1394) This PR will fix the issue by make the function to return `Healthy` when at lease one healthy instance exists.

So the possible cases are:

1) return `Healthy` when at least one healthy instance exists
2) return `Unhealthy` when all instances are unhealthy (at least one)
3) return `Unknown` when the hs.HealthStatus is empty or nil or something unknown...