### PR TITLE
Cherrypick #1406[Fix cloud armor security policy workflow] into release-1.11

### DIFF
--- a/pkg/backends/features/securitypolicy_test.go
+++ b/pkg/backends/features/securitypolicy_test.go
@@ -168,7 +168,7 @@ func TestEnsureSecurityPolicy(t *testing.T) {
 				var desiredPolicyRef *compute.SecurityPolicyReference
 				if tc.desiredConfig.Spec.SecurityPolicy != nil && tc.desiredConfig.Spec.SecurityPolicy.Name != "" {
 					desiredPolicyRef = &compute.SecurityPolicyReference{
-						SecurityPolicy: tc.desiredConfig.Spec.SecurityPolicy.Name,
+						SecurityPolicy: cloud.SelfLink(meta.VersionGA, fakeGCE.ProjectID(), "securityPolicies", meta.GlobalKey(tc.desiredConfig.Spec.SecurityPolicy.Name)),
 					}
 				}
 				if diff := cmp.Diff(desiredPolicyRef, policyRef); diff != "" {

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -119,6 +119,10 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 	}
 
 	if sp.BackendConfig != nil {
+		// Scope is used to validate if cloud armor security policy feature is
+		// available. meta.Key is not needed as security policy supported only for
+		// global backends.
+		be.Scope = scope
 		if err := features.EnsureSecurityPolicy(s.cloud, sp, be); err != nil {
 			return err
 		}

--- a/pkg/composite/composite.go
+++ b/pkg/composite/composite.go
@@ -19,6 +19,7 @@ package composite
 
 import (
 	"fmt"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	computealpha "google.golang.org/api/compute/v0.alpha"
@@ -237,19 +238,22 @@ func SetSecurityPolicy(gceCloud *gce.Cloud, backendService *BackendService, secu
 	case meta.VersionAlpha:
 		var ref *computealpha.SecurityPolicyReference
 		if securityPolicy != "" {
-			ref = &computealpha.SecurityPolicyReference{SecurityPolicy: securityPolicy}
+			securityPolicyLink := cloud.SelfLink(meta.VersionAlpha, gceCloud.ProjectID(), "securityPolicies", meta.GlobalKey(securityPolicy))
+			ref = &computealpha.SecurityPolicyReference{SecurityPolicy: securityPolicyLink}
 		}
 		return mc.Observe(gceCloud.Compute().AlphaBackendServices().SetSecurityPolicy(ctx, key, ref))
 	case meta.VersionBeta:
 		var ref *computebeta.SecurityPolicyReference
 		if securityPolicy != "" {
-			ref = &computebeta.SecurityPolicyReference{SecurityPolicy: securityPolicy}
+			securityPolicyLink := cloud.SelfLink(meta.VersionBeta, gceCloud.ProjectID(), "securityPolicies", meta.GlobalKey(securityPolicy))
+			ref = &computebeta.SecurityPolicyReference{SecurityPolicy: securityPolicyLink}
 		}
 		return mc.Observe(gceCloud.Compute().BetaBackendServices().SetSecurityPolicy(ctx, key, ref))
 	default:
 		var ref *compute.SecurityPolicyReference
 		if securityPolicy != "" {
-			ref = &compute.SecurityPolicyReference{SecurityPolicy: securityPolicy}
+			securityPolicyLink := cloud.SelfLink(meta.VersionGA, gceCloud.ProjectID(), "securityPolicies", meta.GlobalKey(securityPolicy))
+			ref = &compute.SecurityPolicyReference{SecurityPolicy: securityPolicyLink}
 		}
 		return mc.Observe(gceCloud.Compute().BackendServices().SetSecurityPolicy(ctx, key, ref))
 	}


### PR DESCRIPTION
1. This fixes an error where backend service scope is empty.
We emit an error that the security policy is not supported
if the scope is empty.
2. Uses full security policy resource link when updating
the backend service.

/assign @MrHohn 