### PR TITLE
Remove Enable L7ILB Feature Gate 

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"k8s.io/api/networking/v1beta1"
-	"k8s.io/ingress-gce/pkg/flags"
 )
 
 const (
@@ -147,10 +146,6 @@ func (ing *Ingress) UseNamedTLS() string {
 }
 
 func (ing *Ingress) StaticIPName() (string, error) {
-	if !flags.F.EnableL7Ilb {
-		return ing.GlobalStaticIPName(), nil
-	}
-
 	globalIp := ing.GlobalStaticIPName()
 	regionalIp := ing.RegionalStaticIPName()
 

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/ingress-gce/pkg/flags"
 )
 
 func TestIngress(t *testing.T) {
@@ -74,10 +73,6 @@ func TestIngress(t *testing.T) {
 		},
 	} {
 		ing := FromIngress(tc.ing)
-
-		if tc.ingressClass == GceL7ILBIngressClass {
-			flags.F.EnableL7Ilb = true
-		}
 
 		if x := ing.AllowHTTP(); x != tc.allowHTTP {
 			t.Errorf("ingress %+v; AllowHTTP() = %v, want %v", tc.ing, x, tc.allowHTTP)

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/backends/features"
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/healthchecks"
 	lbfeatures "k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -138,25 +137,22 @@ func (s *backendSyncer) GC(svcPorts []utils.ServicePort) error {
 		return err
 	}
 
-	// Only GC L7 ILB backends if it's enabled
-	if flags.F.EnableL7Ilb {
-		// TODO(shance): Refactor out empty key field
-		key, err := composite.CreateKey(s.cloud, "", meta.Regional)
-		if err != nil {
-			return fmt.Errorf("error creating l7 ilb key: %v", err)
-		}
-		ilbBackends, err := s.backendPool.List(key, lbfeatures.L7ILBVersions().BackendService)
-		if err != nil {
-			return fmt.Errorf("error listing regional backends: %v", err)
-		}
-		err = s.gc(ilbBackends, knownPorts)
-		if err != nil {
-			return fmt.Errorf("error GCing regional Backends: %v", err)
-		}
+	// TODO(shance): Refactor out empty key field
+	key, err := composite.CreateKey(s.cloud, "", meta.Regional)
+	if err != nil {
+		return fmt.Errorf("error creating l7 ilb key: %v", err)
+	}
+	ilbBackends, err := s.backendPool.List(key, lbfeatures.L7ILBVersions().BackendService)
+	if err != nil {
+		return fmt.Errorf("error listing regional backends: %v", err)
+	}
+	err = s.gc(ilbBackends, knownPorts)
+	if err != nil {
+		return fmt.Errorf("error GCing regional Backends: %v", err)
 	}
 
 	// Requires an empty name field until it is refactored out
-	key, err := composite.CreateKey(s.cloud, "", meta.Global)
+	key, err = composite.CreateKey(s.cloud, "", meta.Global)
 	if err != nil {
 		return fmt.Errorf("error creating l7 ilb key: %v", err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -613,14 +613,12 @@ func (lbc *LoadBalancerController) sync(key string) error {
 
 	// Check for scope change GC
 	var oldScope *meta.KeyType
-	if flags.F.EnableL7Ilb {
-		oldScope, err = lbc.l7Pool.FrontendScopeChangeGC(ing)
-		if err != nil {
-			return err
-		}
-		if oldScope != nil {
-			scope = *oldScope
-		}
+	oldScope, err = lbc.l7Pool.FrontendScopeChangeGC(ing)
+	if err != nil {
+		return err
+	}
+	if oldScope != nil {
+		scope = *oldScope
 	}
 
 	// Garbage collection will occur regardless of an error occurring. If an error occurred,

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -198,7 +198,7 @@ func (t *Translator) TranslateIngress(ing *v1beta1.Ingress, systemDefaultBackend
 	urlMap := utils.NewGCEURLMap()
 
 	params := &getServicePortParams{}
-	params.isL7ILB = flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(ing)
+	params.isL7ILB = utils.IsGCEL7ILBIngress(ing)
 
 	for _, rule := range ing.Spec.Rules {
 		if rule.HTTP == nil {

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -181,15 +181,13 @@ func (fwc *FirewallController) sync(key string) error {
 	}
 
 	var additionalRanges []string
-	if flags.F.EnableL7Ilb {
-		ilbRange, err := fwc.ilbFirewallSrcRange(gceIngresses)
-		if err != nil {
-			if err != features.ErrSubnetNotFound && err != ErrNoILBIngress {
-				return err
-			}
-		} else {
-			additionalRanges = append(additionalRanges, ilbRange)
+	ilbRange, err := fwc.ilbFirewallSrcRange(gceIngresses)
+	if err != nil {
+		if err != features.ErrSubnetNotFound && err != ErrNoILBIngress {
+			return err
 		}
+	} else {
+		additionalRanges = append(additionalRanges, ilbRange)
 	}
 
 	var additionalPorts []string

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -91,7 +91,6 @@ var (
 		EnableBackendConfigHealthCheck bool
 		EnableDeleteUnusedFrontends    bool
 		EnableFrontendConfig           bool
-		EnableL7Ilb                    bool
 		EnableNonGCPMode               bool
 		EnableReadinessReflector       bool
 		EnableV2FrontendNamer          bool
@@ -211,8 +210,6 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 		F.FinalizerAdd, "Enable adding Finalizer to Ingress.")
 	flag.BoolVar(&F.FinalizerRemove, "enable-finalizer-remove",
 		F.FinalizerRemove, "Enable removing Finalizer from Ingress.")
-	flag.BoolVar(&F.EnableL7Ilb, "enable-l7-ilb", false,
-		`Optional, whether or not to enable L7-ILB.`)
 	flag.BoolVar(&F.EnableASMConfigMapBasedConfig, "enable-asm-config-map-config", false, "Enable ASMConfigMapBasedConfig")
 	flag.StringVar(&F.ASMConfigMapBasedConfigNamespace, "asm-configmap-based-config-namespace", "kube-system", "ASM Configmap based config: configmap namespace")
 	flag.StringVar(&F.ASMConfigMapBasedConfigCMName, "asm-configmap-based-config-cmname", "ingress-controller-asm-cm-config", "ASM Configmap based config: configmap name")

--- a/pkg/loadbalancers/addresses.go
+++ b/pkg/loadbalancers/addresses.go
@@ -81,7 +81,7 @@ func (l *L7) checkStaticIP() (err error) {
 }
 
 func (l *L7) newStaticAddress(name string) *composite.Address {
-	isInternal := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(&l.ingress)
+	isInternal := utils.IsGCEL7ILBIngress(&l.ingress)
 	address := &composite.Address{Name: name, Address: l.fw.IPAddress, Version: meta.VersionGA}
 	if isInternal {
 		// Used for L7 ILB

--- a/pkg/loadbalancers/addresses_test.go
+++ b/pkg/loadbalancers/addresses_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/flags"
 )
 
 func TestNewStaticAddress(t *testing.T) {
@@ -59,7 +58,6 @@ func TestNewStaticAddress(t *testing.T) {
 			}
 
 			if tc.isInternal {
-				flags.F.EnableL7Ilb = true
 				l7.ingress.Annotations = map[string]string{annotations.IngressClassKey: "gce-internal"}
 			}
 

--- a/pkg/loadbalancers/certificates.go
+++ b/pkg/loadbalancers/certificates.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
@@ -30,7 +29,7 @@ import (
 const SslCertificateMissing = "SslCertificateMissing"
 
 func (l *L7) checkSSLCert() error {
-	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
+	isL7ILB := utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
 	tr := translator.NewTranslator(isL7ILB, l.namer)
 	env := &translator.Env{Region: l.cloud.Region(), Project: l.cloud.ProjectID()}
 	translatorCerts := tr.ToCompositeSSLCertificates(env, l.runtimeInfo.TLSName, l.runtimeInfo.TLS, l.Versions().SslCertificate)

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -85,7 +84,7 @@ func (l *L7) checkForwardingRule(protocol namer.NamerProtocol, name, proxyLink, 
 		return nil, err
 	}
 
-	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
+	isL7ILB := utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
 	tr := translator.NewTranslator(isL7ILB, l.namer)
 	env := &translator.Env{VIP: ip, Network: l.cloud.NetworkURL(), Subnetwork: l.cloud.SubnetworkURL()}
 	fr := tr.ToCompositeForwardingRule(env, protocol, version, proxyLink, description, l.runtimeInfo.StaticIPSubnet)

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -146,7 +146,7 @@ func (l *L7) edgeHop() error {
 	}
 
 	// Check for invalid L7-ILB HTTPS config before attempting sync
-	if flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress) && sslConfigured && l.runtimeInfo.AllowHTTP {
+	if utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress) && sslConfigured && l.runtimeInfo.AllowHTTP {
 		l.recorder.Eventf(l.runtimeInfo.Ingress, corev1.EventTypeWarning, "WillNotConfigureFrontend", "gce-internal Ingress class does not currently support both HTTP and HTTPS served on the same IP (kubernetes.io/ingress.allow-http must be false when using HTTPS).")
 		return fmt.Errorf("error invalid internal ingress https config")
 	}

--- a/pkg/loadbalancers/l7s.go
+++ b/pkg/loadbalancers/l7s.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/ingress-gce/pkg/common/operator"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -173,23 +172,21 @@ func (l *L7s) GCv1(names []string) error {
 	}
 
 	// GC L7-ILB LBs if enabled
-	if flags.F.EnableL7Ilb {
-		key, err := composite.CreateKey(l.cloud, "", meta.Regional)
-		if err != nil {
-			return fmt.Errorf("error getting regional key: %v", err)
-		}
-		urlMaps, err := l.list(key, features.L7ILBVersions().UrlMap)
-		if err != nil {
-			return fmt.Errorf("error listing regional LBs: %v", err)
-		}
+	key, err := composite.CreateKey(l.cloud, "", meta.Regional)
+	if err != nil {
+		return fmt.Errorf("error getting regional key: %v", err)
+	}
+	urlMaps, err := l.list(key, features.L7ILBVersions().UrlMap)
+	if err != nil {
+		return fmt.Errorf("error listing regional LBs: %v", err)
+	}
 
-		if err := l.gc(urlMaps, knownLoadBalancers, features.L7ILBVersions()); err != nil {
-			return fmt.Errorf("error gc-ing regional LBs: %v", err)
-		}
+	if err := l.gc(urlMaps, knownLoadBalancers, features.L7ILBVersions()); err != nil {
+		return fmt.Errorf("error gc-ing regional LBs: %v", err)
 	}
 
 	// TODO(shance): fix list taking a key
-	urlMaps, err := l.list(meta.GlobalKey(""), meta.VersionGA)
+	urlMaps, err = l.list(meta.GlobalKey(""), meta.VersionGA)
 	if err != nil {
 		return fmt.Errorf("error listing global LBs: %v", err)
 	}

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -1833,7 +1833,6 @@ func TestResourceDeletionWithProtocol(t *testing.T) {
 // on updating ingress configuration to change from ELB to ILB or vice versa.
 // This test applies to the V2 naming scheme only
 func TestResourceDeletionWithScopeChange(t *testing.T) {
-	flags.F.EnableL7Ilb = true
 	j := newTestJig(t)
 
 	gceUrlMap := utils.NewGCEURLMap()

--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -53,7 +53,7 @@ func (l *L7) checkProxy() (err error) {
 		return err
 	}
 
-	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
+	isL7ILB := utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
 	tr := translator.NewTranslator(isL7ILB, l.namer)
 
 	description, err := l.description()
@@ -104,7 +104,7 @@ func (l *L7) checkProxy() (err error) {
 }
 
 func (l *L7) checkHttpsProxy() (err error) {
-	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
+	isL7ILB := utils.IsGCEL7ILBIngress(l.runtimeInfo.Ingress)
 	tr := translator.NewTranslator(isL7ILB, l.namer)
 	env := &translator.Env{FrontendConfig: l.runtimeInfo.FrontendConfig}
 

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
@@ -86,7 +85,7 @@ func (l *L7) ensureComputeURLMap() error {
 
 func (l *L7) ensureRedirectURLMap() error {
 	feConfig := l.runtimeInfo.FrontendConfig
-	isL7ILB := flags.F.EnableL7Ilb && utils.IsGCEL7ILBIngress(&l.ingress)
+	isL7ILB := utils.IsGCEL7ILBIngress(&l.ingress)
 
 	t := translator.NewTranslator(isL7ILB, l.namer)
 	env := &translator.Env{FrontendConfig: feConfig, Ing: &l.ingress}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	svcnegv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/controller/translator"
-	"k8s.io/ingress-gce/pkg/flags"
 	usage "k8s.io/ingress-gce/pkg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
@@ -588,11 +587,8 @@ func (c *Controller) mergeDefaultBackendServicePortInfoMap(key string, service *
 		return nil
 	}
 
-	// process default backend service for L7 ILB
-	if flags.F.EnableL7Ilb {
-		if err := scanIngress(utils.IsGCEL7ILBIngress); err != nil {
-			return err
-		}
+	if err := scanIngress(utils.IsGCEL7ILBIngress); err != nil {
+		return err
 	}
 
 	// process default backend service for L7 XLB
@@ -782,7 +778,7 @@ func (c *Controller) enqueueIngressServices(ing *v1beta1.Ingress) {
 	}
 
 	// enqueue default backend service
-	if flags.F.EnableL7Ilb && ing.Spec.Backend == nil {
+	if ing.Spec.Backend == nil {
 		c.enqueueService(cache.ExplicitKey(c.defaultBackendService.ID.Service.String()))
 	}
 }

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/flags"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -375,8 +374,8 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 
 // TestEnableNEGServiceWithILBIngress tests ILB service with NEG enabled
 func TestEnableNEGServiceWithILBIngress(t *testing.T) {
-	// Not running in parallel since enabling global flag
-	flags.F.EnableL7Ilb = true
+	t.Parallel()
+
 	controller := newTestController(fake.NewSimpleClientset())
 	defer controller.stop()
 	controller.serviceLister.Add(newTestService(controller, false, []int32{}))
@@ -838,7 +837,7 @@ func TestMergeDefaultBackendServicePortInfoMap(t *testing.T) {
 			expectNeg:      false,
 		},
 		{
-			desc: "ing4 is L7 ILB, does not has backend and default backend service does not have NEG annotation",
+			desc: "L7ILB is enabled, ing4 is L7 ILB, does not has backend and default backend service does not have NEG annotation",
 			getIngress: func() *v1beta1.Ingress {
 				ing := newTestIngress("ing4")
 				ing.Annotations = map[string]string{annotations.IngressClassKey: annotations.GceL7ILBIngressClass}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -293,8 +293,7 @@ func IsGCEIngress(ing *v1beta1.Ingress) bool {
 	case annotations.GceIngressClass:
 		return true
 	case annotations.GceL7ILBIngressClass:
-		// TODO: (shance) remove flag check for L7-ILB once fully rolled out
-		return flags.F.EnableL7Ilb
+		return true
 	default:
 		return false
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -462,7 +462,6 @@ func TestIsGCEIngress(t *testing.T) {
 		desc             string
 		ingress          *v1beta1.Ingress
 		ingressClassFlag string
-		enableL7IlbFlag  bool
 		expected         bool
 	}{
 		{
@@ -485,25 +484,14 @@ func TestIsGCEIngress(t *testing.T) {
 			expected: false,
 		},
 		{
-			desc: "L7 ILB ingress class with flag disabled",
+			desc: "L7 ILB ingress class",
 			ingress: &v1beta1.Ingress{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						annotations.IngressClassKey: annotations.GceL7ILBIngressClass},
 				},
 			},
-			expected: false,
-		},
-		{
-			desc: "L7 ILB ingress class with flag enabled",
-			ingress: &v1beta1.Ingress{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotations.IngressClassKey: annotations.GceL7ILBIngressClass},
-				},
-			},
-			expected:        true,
-			enableL7IlbFlag: true,
+			expected: true,
 		},
 		{
 			desc: "Set by flag with non-matching class",
@@ -560,10 +548,6 @@ func TestIsGCEIngress(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			if tc.ingressClassFlag != "" {
 				flags.F.IngressClass = tc.ingressClassFlag
-			}
-
-			if tc.enableL7IlbFlag {
-				flags.F.EnableL7Ilb = true
 			}
 
 			result := IsGCEIngress(tc.ingress)


### PR DESCRIPTION
Some neg controller unit tests only pass because when all tests are run and fail when run individually. This is because the EnableL7ILB flag is set in one test and all tests after that have the same flag value. This PR cleans up the test contamination and ensures that the tests will pass when run independently or together.

/assign @freehan 