### PR TITLE
Populate namespace when creating ingress

### DIFF
--- a/cmd/e2e-test/customrequestheaders_test.go
+++ b/cmd/e2e-test/customrequestheaders_test.go
@@ -73,6 +73,7 @@ func TestCustomRequestHeaders(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
 
+			ing.Namespace = s.Namespace
 			crud := adapter.IngressCRUD{C: Framework.Clientset}
 			if _, err := crud.Create(ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)

--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -100,6 +100,7 @@ func TestILB(t *testing.T) {
 			}
 			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
 
+			tc.ing.Namespace = s.Namespace
 			if _, err := crud.Create(tc.ing); err != nil {
 				t.Fatalf("error creating Ingress spec: %v", err)
 			}


### PR DESCRIPTION
Ingress V1 requires namespace to be populated at creation.


@spencerhance 
/assign @freehan 