### PR TITLE
Use %w to wrap errors.

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -177,7 +177,7 @@ func (b *Backends) Delete(name string, version meta.Version, scope meta.KeyType)
 func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType) (string, error) {
 	be, err := b.Get(name, version, scope)
 	if err != nil {
-		return "Unknown", fmt.Errorf("error getting backend service %s: %v", name, err)
+		return "Unknown", fmt.Errorf("error getting backend service %s: %w", name, err)
 	}
 	if len(be.Backends) == 0 {
 		return "Unknown", fmt.Errorf("no backends found for backend service %q", name)
@@ -198,7 +198,7 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType)
 		}
 
 		if err != nil {
-			return "Unknown", fmt.Errorf("error getting health for backend %q: %v", name, err)
+			return "Unknown", fmt.Errorf("error getting health for backend %q: %w", name, err)
 		}
 		if len(hs.HealthStatus) == 0 || hs.HealthStatus[0] == nil {
 			klog.V(3).Infof("backend service %q does not have health status: %v", name, hs.HealthStatus)

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -85,7 +85,7 @@ func (l *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) erro
 	for _, group := range groups {
 		ig, err := l.instancePool.Get(sp.IGName(), group.Zone)
 		if err != nil {
-			return fmt.Errorf("error retrieving IG for linking with backend %+v: %v", sp, err)
+			return fmt.Errorf("error retrieving IG for linking with backend %+v: %w", sp, err)
 		}
 		igLinks = append(igLinks, ig.SelfLink)
 	}
@@ -172,7 +172,7 @@ func getInstanceGroupsToAdd(be *composite.BackendService, igLinks []string) ([]s
 	for _, existingBe := range be.Backends {
 		path, err := utils.RelativeResourceName(existingBe.Group)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse instance group: %v", err)
+			return nil, fmt.Errorf("failed to parse instance group: %w", err)
 		}
 		existingIGs.Insert(path)
 	}
@@ -181,7 +181,7 @@ func getInstanceGroupsToAdd(be *composite.BackendService, igLinks []string) ([]s
 	for _, igLink := range igLinks {
 		path, err := utils.RelativeResourceName(igLink)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse instance group: %v", err)
+			return nil, fmt.Errorf("failed to parse instance group: %w", err)
 		}
 		wantIGs.Insert(path)
 	}

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -81,7 +81,7 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort) error {
 	// Ensure health check for backend service exists.
 	hcLink, err := s.ensureHealthCheck(sp)
 	if err != nil {
-		return fmt.Errorf("error ensuring health check: %v", err)
+		return fmt.Errorf("error ensuring health check: %w", err)
 	}
 
 	// Verify existence of a backend service for the proper port
@@ -140,29 +140,29 @@ func (s *backendSyncer) GC(svcPorts []utils.ServicePort) error {
 	// TODO(shance): Refactor out empty key field
 	key, err := composite.CreateKey(s.cloud, "", meta.Regional)
 	if err != nil {
-		return fmt.Errorf("error creating l7 ilb key: %v", err)
+		return fmt.Errorf("error creating l7 ilb key: %w", err)
 	}
 	ilbBackends, err := s.backendPool.List(key, lbfeatures.L7ILBVersions().BackendService)
 	if err != nil {
-		return fmt.Errorf("error listing regional backends: %v", err)
+		return fmt.Errorf("error listing regional backends: %w", err)
 	}
 	err = s.gc(ilbBackends, knownPorts)
 	if err != nil {
-		return fmt.Errorf("error GCing regional Backends: %v", err)
+		return fmt.Errorf("error GCing regional Backends: %w", err)
 	}
 
 	// Requires an empty name field until it is refactored out
 	key, err = composite.CreateKey(s.cloud, "", meta.Global)
 	if err != nil {
-		return fmt.Errorf("error creating l7 ilb key: %v", err)
+		return fmt.Errorf("error creating l7 ilb key: %w", err)
 	}
 	backends, err := s.backendPool.List(key, meta.VersionGA)
 	if err != nil {
-		return fmt.Errorf("error listing backends: %v", err)
+		return fmt.Errorf("error listing backends: %w", err)
 	}
 	err = s.gc(backends, knownPorts)
 	if err != nil {
-		return fmt.Errorf("error GCing Backends: %v", err)
+		return fmt.Errorf("error GCing Backends: %w", err)
 	}
 
 	return nil
@@ -240,7 +240,7 @@ func (s *backendSyncer) ensureHealthCheck(sp utils.ServicePort) (string, error) 
 	if s.prober != nil {
 		probe, err = s.prober.GetProbe(sp)
 		if err != nil {
-			return "", fmt.Errorf("Error getting prober: %v", err)
+			return "", fmt.Errorf("Error getting prober: %w", err)
 		}
 	}
 	return s.healthChecker.SyncServicePort(&sp, probe)

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -149,7 +149,7 @@ func (h *HealthChecks) sync(hc *translator.HealthCheck, bchcc *backendconfigv1.H
 func (h *HealthChecks) createILB(hc *translator.HealthCheck) error {
 	compositeType, err := composite.AlphaToHealthCheck(hc.ToAlphaComputeHealthCheck())
 	if err != nil {
-		return fmt.Errorf("Error converting hc to composite: %v", err)
+		return fmt.Errorf("Error converting hc to composite: %w", err)
 	}
 
 	cloud := h.cloud.(*gce.Cloud)
@@ -162,7 +162,7 @@ func (h *HealthChecks) createILB(hc *translator.HealthCheck) error {
 	compositeType.Region = key.Region
 	err = composite.CreateHealthCheck(cloud, key, compositeType)
 	if err != nil {
-		return fmt.Errorf("Error creating health check %v: %v", compositeType, err)
+		return fmt.Errorf("Error creating health check %v: %w", compositeType, err)
 	}
 
 	return nil
@@ -206,7 +206,7 @@ func (h *HealthChecks) updateILB(hc *translator.HealthCheck) error {
 	// special case ILB to avoid mucking with stable HC code
 	compositeType, err := composite.AlphaToHealthCheck(hc.ToAlphaComputeHealthCheck())
 	if err != nil {
-		return fmt.Errorf("Error converting newHC to composite: %v", err)
+		return fmt.Errorf("Error converting newHC to composite: %w", err)
 	}
 	cloud := h.cloud.(*gce.Cloud)
 	key, err := composite.CreateKey(cloud, hc.Name, features.L7ILBScope())

--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -45,7 +45,7 @@ func EnsureL4HealthCheck(cloud *gce.Cloud, name string, svcName types.Namespaced
 	selfLink := ""
 	key, err := composite.CreateKey(cloud, name, meta.Global)
 	if err != nil {
-		return nil, selfLink, fmt.Errorf("Failed to create composite key for healthcheck %s - %v", name, err)
+		return nil, selfLink, fmt.Errorf("Failed to create composite key for healthcheck %s - %w", name, err)
 	}
 	hc, err := composite.GetHealthCheck(cloud, key, meta.VersionGA)
 	if err != nil {
@@ -81,7 +81,7 @@ func EnsureL4HealthCheck(cloud *gce.Cloud, name string, svcName types.Namespaced
 func DeleteHealthCheck(cloud *gce.Cloud, name string) error {
 	key, err := composite.CreateKey(cloud, name, meta.Global)
 	if err != nil {
-		return fmt.Errorf("Failed to create composite key for healthcheck %s - %v", name, err)
+		return fmt.Errorf("Failed to create composite key for healthcheck %s - %w", name, err)
 	}
 	return composite.DeleteHealthCheck(cloud, key, meta.VersionGA)
 }

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -246,7 +246,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	frDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(l.Service.Namespace, l.Service.Name), ipToUse,
 		version, false)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %v", loadBalancerName,
+		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %w", loadBalancerName,
 			err)
 	}
 
@@ -322,11 +322,11 @@ func (l *L4) deleteForwardingRule(name string, version meta.Version) {
 func Equal(fr1, fr2 *composite.ForwardingRule) (bool, error) {
 	id1, err := cloud.ParseResourceURL(fr1.BackendService)
 	if err != nil {
-		return false, fmt.Errorf("forwardingRulesEqual(): failed to parse backend resource URL from FR, err - %v", err)
+		return false, fmt.Errorf("forwardingRulesEqual(): failed to parse backend resource URL from FR, err - %w", err)
 	}
 	id2, err := cloud.ParseResourceURL(fr2.BackendService)
 	if err != nil {
-		return false, fmt.Errorf("forwardingRulesEqual(): failed to parse resource URL from FR, err - %v", err)
+		return false, fmt.Errorf("forwardingRulesEqual(): failed to parse resource URL from FR, err - %w", err)
 	}
 	return fr1.IPAddress == fr2.IPAddress &&
 		fr1.IPProtocol == fr2.IPProtocol &&

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -448,7 +448,7 @@ func (c *Controller) processService(key string) error {
 	// merges csmSVCPortInfoMap, because eventually those NEG will sync with the service annotation.
 	// merges destinationRulesPortInfoMap later, because we only want them sync with the DestinationRule annotation.
 	if err := svcPortInfoMap.Merge(csmSVCPortInfoMap); err != nil {
-		return fmt.Errorf("failed to merge CSM service PortInfoMap: %v, error: %v", csmSVCPortInfoMap, err)
+		return fmt.Errorf("failed to merge CSM service PortInfoMap: %v, error: %w", csmSVCPortInfoMap, err)
 	}
 	if c.runL4 {
 		if err := c.mergeVmIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, &negUsage); err != nil {
@@ -462,7 +462,7 @@ func (c *Controller) processService(key string) error {
 		}
 		// Merge destinationRule related NEG after the Service NEGStatus Sync, we don't want DR related NEG status go into service.
 		if err := svcPortInfoMap.Merge(destinationRulesPortInfoMap); err != nil {
-			return fmt.Errorf("failed to merge service ports referenced by Istio:DestinationRule (%v): %v", destinationRulesPortInfoMap, err)
+			return fmt.Errorf("failed to merge service ports referenced by Istio:DestinationRule (%v): %w", destinationRulesPortInfoMap, err)
 		}
 
 		negUsage.SuccessfulNeg, negUsage.ErrorNeg, err = c.manager.EnsureSyncers(namespace, name, svcPortInfoMap)
@@ -497,7 +497,7 @@ func (c *Controller) mergeIngressPortInfo(service *apiv1.Service, name types.Nam
 		ingressSvcPortTuples := gatherPortMappingUsedByIngress(ings, service)
 		ingressPortInfoMap := negtypes.NewPortInfoMap(name.Namespace, name.Name, ingressSvcPortTuples, c.namer, true, nil)
 		if err := portInfoMap.Merge(ingressPortInfoMap); err != nil {
-			return fmt.Errorf("failed to merge service ports referenced by ingress (%v): %v", ingressPortInfoMap, err)
+			return fmt.Errorf("failed to merge service ports referenced by ingress (%v): %w", ingressPortInfoMap, err)
 		}
 	}
 	return nil
@@ -536,7 +536,7 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 		negUsage.CustomNamedNeg = len(customNames)
 
 		if err := portInfoMap.Merge(negtypes.NewPortInfoMap(name.Namespace, name.Name, exposedNegSvcPort, c.namer /*readinessGate*/, true, customNames)); err != nil {
-			return fmt.Errorf("failed to merge service ports exposed as standalone NEGs (%v) into ingress referenced service ports (%v): %v", exposedNegSvcPort, portInfoMap, err)
+			return fmt.Errorf("failed to merge service ports exposed as standalone NEGs (%v) into ingress referenced service ports (%v): %w", exposedNegSvcPort, portInfoMap, err)
 		}
 	}
 
@@ -624,7 +624,7 @@ func (c *Controller) getCSMPortInfoMap(namespace, name string, service *apiv1.Se
 				klog.Warningf("DestinationRule(%s) contains duplicated subset, creating NEGs for the newer ones. %s", namespacedName.Name, err)
 			}
 			if err := destinationRulesPortInfoMap.Merge(destinationRulePortInfoMap); err != nil {
-				return servicePortInfoMap, destinationRulesPortInfoMap, fmt.Errorf("failed to merge service ports referenced by Istio:DestinationRule (%v): %v", destinationRulePortInfoMap, err)
+				return servicePortInfoMap, destinationRulesPortInfoMap, fmt.Errorf("failed to merge service ports referenced by Istio:DestinationRule (%v): %w", destinationRulePortInfoMap, err)
 			}
 			if err = c.syncDestinationRuleNegStatusAnnotation(namespacedName.Namespace, namespacedName.Name, destinationRulePortInfoMap); err != nil {
 				return servicePortInfoMap, destinationRulesPortInfoMap, err

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -166,7 +166,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 		// To reduce the possibility of NEGs being leaked, ensure a SvcNeg CR exists for every
 		// desired port.
 		if err := manager.ensureSvcNegCR(key, portInfo); err != nil {
-			errList = append(errList, fmt.Errorf("failed to ensure svc neg cr %s/%s/%d for existing port: %s", namespace, portInfo.NegName, portInfo.PortTuple.Port, err))
+			errList = append(errList, fmt.Errorf("failed to ensure svc neg cr %s/%s/%d for existing port: %w", namespace, portInfo.NegName, portInfo.PortTuple.Port, err))
 			errorSyncers += 1
 		} else {
 			successfulSyncers += 1
@@ -183,7 +183,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 			// syncer for the NEG until the NEG CR is successfully created. This will reduce the
 			// possibility of invalid states and reduces complexity of garbage collection
 			if err := manager.ensureSvcNegCR(key, portInfo); err != nil {
-				errList = append(errList, fmt.Errorf("failed to ensure svc neg cr %s/%s/%d for new port: %s ", namespace, portInfo.NegName, svcPort.ServicePort, err))
+				errList = append(errList, fmt.Errorf("failed to ensure svc neg cr %s/%s/%d for new port: %w ", namespace, portInfo.NegName, svcPort.ServicePort, err))
 				errorSyncers += 1
 				continue
 			}
@@ -293,7 +293,7 @@ func (manager *syncerManager) GC() error {
 		err = manager.garbageCollectNEG()
 	}
 	if err != nil {
-		err = fmt.Errorf("failed to garbage collect negs: %v", err)
+		err = fmt.Errorf("failed to garbage collect negs: %w", err)
 	}
 	metrics.PublishNegManagerProcessMetrics(metrics.GCProcess, err, start)
 	return err
@@ -355,7 +355,7 @@ func (manager *syncerManager) ensureDeleteSvcNegCR(namespace, negName string) er
 	}
 	obj, exists, err := manager.svcNegLister.GetByKey(fmt.Sprintf("%s/%s", namespace, negName))
 	if err != nil {
-		return fmt.Errorf("failed retrieving neg %s/%s to delete: %s", namespace, negName, err)
+		return fmt.Errorf("failed retrieving neg %s/%s to delete: %w", namespace, negName, err)
 	}
 	if !exists {
 		return nil
@@ -364,7 +364,7 @@ func (manager *syncerManager) ensureDeleteSvcNegCR(namespace, negName string) er
 
 	if neg.GetDeletionTimestamp().IsZero() {
 		if err = manager.svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(namespace).Delete(context.Background(), negName, metav1.DeleteOptions{}); err != nil {
-			return fmt.Errorf("errored while deleting neg cr %s/%s: %s", negName, namespace, err)
+			return fmt.Errorf("errored while deleting neg cr %s/%s: %w", negName, namespace, err)
 		}
 		klog.V(2).Infof("Deleted neg cr %s/%s", negName, namespace)
 	}
@@ -387,7 +387,7 @@ func (manager *syncerManager) garbageCollectNEG() error {
 	// Compare against svcPortMap and Remove unintended NEGs by best effort
 	negList, err := manager.cloud.AggregatedListNetworkEndpointGroup(meta.VersionGA)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve aggregated NEG list: %v", err)
+		return fmt.Errorf("failed to retrieve aggregated NEG list: %w", err)
 	}
 
 	deleteCandidates := map[string][]string{}
@@ -422,7 +422,7 @@ func (manager *syncerManager) garbageCollectNEG() error {
 	for name, zones := range deleteCandidates {
 		for _, zone := range zones {
 			if err := manager.ensureDeleteNetworkEndpointGroup(name, zone, nil); err != nil {
-				return fmt.Errorf("failed to delete NEG %q in %q: %v", name, zone, err)
+				return fmt.Errorf("failed to delete NEG %q in %q: %w", name, zone, err)
 			}
 		}
 	}
@@ -466,7 +466,7 @@ func (manager *syncerManager) garbageCollectNEGWithCRD() error {
 	var errList []error
 	zones, err := manager.zoneGetter.ListZones()
 	if err != nil {
-		errList = append(errList, fmt.Errorf("failed to get zones during garbage collection: %s", err))
+		errList = append(errList, fmt.Errorf("failed to get zones during garbage collection: %w", err))
 	}
 
 	// deleteNegOrReportErr will attempt to delete the specified NEG resource in the cloud. If an error

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -195,7 +195,7 @@ func (s *transactionSyncer) syncInternal() error {
 
 	targetMap, endpointPodMap, err := s.endpointsCalculator.CalculateEndpoints(ep.(*apiv1.Endpoints), currentMap)
 	if err != nil {
-		err = fmt.Errorf("endpoints calculation error in mode %q, err: %v", s.endpointsCalculator.Mode(), err)
+		err = fmt.Errorf("endpoints calculation error in mode %q, err: %w", s.endpointsCalculator.Mode(), err)
 		return err
 	}
 	s.logStats(targetMap, "desired NEG endpoints")
@@ -540,7 +540,7 @@ func (s *transactionSyncer) updateStatus(syncErr error) {
 func getNegFromStore(svcNegLister cache.Indexer, namespace, negName string) (*negv1beta1.ServiceNetworkEndpointGroup, error) {
 	n, exists, err := svcNegLister.GetByKey(fmt.Sprintf("%s/%s", namespace, negName))
 	if err != nil {
-		return nil, fmt.Errorf("Error getting neg %s/%s from cache: %s", namespace, negName, err)
+		return nil, fmt.Errorf("Error getting neg %s/%s from cache: %w", namespace, negName, err)
 	}
 	if !exists {
 		return nil, fmt.Errorf("neg %s/%s is not in store", namespace, negName)
@@ -553,7 +553,7 @@ func getNegFromStore(svcNegLister cache.Indexer, namespace, negName string) (*ne
 func patchNegStatus(svcNegClient svcnegclient.Interface, oldStatus, newStatus negv1beta1.ServiceNetworkEndpointGroupStatus, namespace, negName string) (*negv1beta1.ServiceNetworkEndpointGroup, error) {
 	patchBytes, err := patch.MergePatchBytes(negv1beta1.ServiceNetworkEndpointGroup{Status: oldStatus}, negv1beta1.ServiceNetworkEndpointGroup{Status: newStatus})
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare patch bytes: %s", err)
+		return nil, fmt.Errorf("failed to prepare patch bytes: %w", err)
 	}
 
 	return svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(namespace).Patch(context.Background(), negName, types.MergePatchType, patchBytes, metav1.PatchOptions{})

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -141,7 +141,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 		}
 		if matches, err := utils.VerifyDescription(expectedDesc, neg.Description, negName, zone); !matches {
 			klog.Errorf("Neg Name %s is already in use: %s", negName, err)
-			return negv1beta1.NegObjectReference{}, fmt.Errorf("neg name %s is already in use, found conflicting description: %s", negName, err)
+			return negv1beta1.NegObjectReference{}, fmt.Errorf("neg name %s is already in use, found conflicting description: %w", negName, err)
 		}
 
 		if networkEndpointType != negtypes.NonGCPPrivateEndpointType &&
@@ -268,7 +268,7 @@ func toZoneNetworkEndpointMap(endpoints *apiv1.Endpoints, zoneGetter negtypes.Zo
 				}
 				zone, err := zoneGetter.GetZoneForNode(*address.NodeName)
 				if err != nil {
-					return fmt.Errorf("failed to retrieve associated zone of node %q: %v", *address.NodeName, err)
+					return fmt.Errorf("failed to retrieve associated zone of node %q: %w", *address.NodeName, err)
 				}
 				if zoneNetworkEndpointMap[zone] == nil {
 					zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()
@@ -347,7 +347,7 @@ func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.N
 		} else {
 			portNum, err := strconv.Atoi(networkEndpoint.Port)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode endpoint port %v: %v", networkEndpoint, err)
+				return nil, fmt.Errorf("failed to decode endpoint port %v: %w", networkEndpoint, err)
 			}
 			endpointBatch[networkEndpoint] = &composite.NetworkEndpoint{
 				Instance:  networkEndpoint.Node,


### PR DESCRIPTION
This allows the errors to be unwrapped to classify it correctly without having to do string matches - https://blog.golang.org/go1.13-errors#TOC_3.3.

One usecase is to use the GCE API errors as prometheus metric labels. Wrapping errors will make this classification easier.

@swetharepakula @spencerhance 

/assign @freehan 