### PR TITLE
Add a new L4 ILB metric for sync errors

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -74,22 +74,28 @@ const (
 	ServiceStatusPrefix = "service.kubernetes.io"
 	// TCPForwardingRuleKey is the annotation key used by l4 controller to record
 	// GCP TCP forwarding rule name.
-	TCPForwardingRuleKey = ServiceStatusPrefix + "/tcp-forwarding-rule"
+	TCPForwardingRuleKey = ServiceStatusPrefix + "/tcp-" + ForwardingRuleResource
 	// UDPForwardingRuleKey is the annotation key used by l4 controller to record
 	// GCP UDP forwarding rule name.
-	UDPForwardingRuleKey = ServiceStatusPrefix + "/udp-forwarding-rule"
+	UDPForwardingRuleKey = ServiceStatusPrefix + "/udp-" + ForwardingRuleResource
 	// BackendServiceKey is the annotation key used by l4 controller to record
 	// GCP Backend service name.
-	BackendServiceKey = ServiceStatusPrefix + "/backend-service"
+	BackendServiceKey = ServiceStatusPrefix + "/" + BackendServiceResource
 	// FirewallRuleKey is the annotation key used by l4 controller to record
 	// GCP Firewall rule name.
-	FirewallRuleKey = ServiceStatusPrefix + "/firewall-rule"
+	FirewallRuleKey = ServiceStatusPrefix + "/" + FirewallRuleResource
 	// HealthcheckKey is the annotation key used by l4 controller to record
 	// GCP Healthcheck name.
-	HealthcheckKey = ServiceStatusPrefix + "/healthcheck"
+	HealthcheckKey = ServiceStatusPrefix + "/" + HealthcheckResource
 	// FirewallRuleForHealthcheckKey is the annotation key used by l4 controller to record
 	// the firewall rule name that allows healthcheck traffic.
-	FirewallRuleForHealthcheckKey = ServiceStatusPrefix + "/firewall-rule-for-hc"
+	FirewallRuleForHealthcheckKey  = ServiceStatusPrefix + "/" + FirewallForHealthcheckResource
+	ForwardingRuleResource         = "forwarding-rule"
+	BackendServiceResource         = "backend-service"
+	FirewallRuleResource           = "firewall-rule"
+	HealthcheckResource            = "healthcheck"
+	FirewallForHealthcheckResource = "firewall-rule-for-hc"
+	AddressResource                = "address"
 )
 
 // NegAnnotation is the format of the annotation associated with the

--- a/pkg/l4/metrics/metrics.go
+++ b/pkg/l4/metrics/metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+const (
+	statusSuccess = "success"
+	statusError   = "error"
+)
+
+var (
+	l4ILBSyncLatencyMetricsLabels = []string{
+		"sync_result", // result of the sync
+		"sync_type",   // whether this is a new service, update or delete
+	}
+	l4ILBSyncErrorMetricLabels = []string{
+		"sync_type",    // whether this is a new service, update or delete
+		"gce_resource", // The GCE resource whose update caused the error
+		// max number of values for error_type = 18 k8s error reasons + 60 http status errors.
+		// In production, we will see much fewer number, since many of the error codes are not applicable.
+		"error_type", // what type of error it was
+	}
+	l4ILBSyncLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "l4_ilb_sync_duration_seconds",
+			Help: "Latency of an L4 ILB Sync",
+			// custom buckets - [30s, 60s, 120s, 240s(4min), 480s(8min), 960s(16m), +Inf]
+			Buckets: prometheus.ExponentialBuckets(30, 2, 6),
+		},
+		l4ILBSyncLatencyMetricsLabels,
+	)
+	l4ILBSyncErrorCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "l4_ilb_sync_error_count",
+			Help: "Count of L4 ILB Sync errors",
+		},
+		l4ILBSyncErrorMetricLabels,
+	)
+)
+
+// init registers l4 ilb sync metrics.
+func init() {
+	klog.V(3).Infof("Registering L4 ILB controller metrics %v, %v", l4ILBSyncLatency, l4ILBSyncErrorCount)
+	prometheus.MustRegister(l4ILBSyncLatency, l4ILBSyncErrorCount)
+}
+
+// PublishL4ILBSyncMetrics exports metrics related to the L4 ILB sync.
+func PublishILBSyncMetrics(success bool, syncType, gceResource, errType string, startTime time.Time) {
+	publishL4ILBSyncLatency(success, syncType, startTime)
+	if !success {
+		publishL4ILBSyncErrorCount(syncType, gceResource, errType)
+	}
+}
+
+// publishL4ILBSyncLatency exports the given sync latency datapoint.
+func publishL4ILBSyncLatency(success bool, syncType string, startTime time.Time) {
+	status := statusSuccess
+	if !success {
+		status = statusError
+	}
+	l4ILBSyncLatency.WithLabelValues(status, syncType).Observe(time.Since(startTime).Seconds())
+}
+
+// publishL4ILBSyncLatency exports the given sync latency datapoint.
+func publishL4ILBSyncErrorCount(syncType, gceResource, errorType string) {
+	l4ILBSyncErrorCount.WithLabelValues(syncType, gceResource, errorType).Inc()
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/api/googleapi"
 	api_v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -176,6 +177,18 @@ func IsNotFoundError(err error) bool {
 // IsForbiddenError returns true if the operation was forbidden
 func IsForbiddenError(err error) bool {
 	return IsHTTPErrorCode(err, http.StatusForbidden)
+}
+
+func GetErrorType(err error) string {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return http.StatusText(gerr.Code)
+	}
+	var k8serr *k8serrors.StatusError
+	if errors.As(err, &k8serr) {
+		return "k8s " + string(k8serrors.ReasonForError(k8serr))
+	}
+	return ""
 }
 
 // PrettyJson marshals an object in a human-friendly format.


### PR DESCRIPTION
The new metric will count the number of failed L4 ILB syncs along with the GCE resource that failed and the type of error that was thrown.

This PR has 3 changes:

1) Adding a new pkg/l4/metrics/metrics.go - for exporting L4 ILB sync metrics.
2) refactoring logic in l4controller.go to publish the new and existing ILB metrics.
3) Unit test changes.

Verified that errors are published correctly by creating 200 ILB services on a cluster and hitting quota errors.

cc @swetharepakula @skmatti 

/assign @freehan 