### PR TITLE
Generate URL for GCE instances resource

### DIFF
--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -48,8 +48,8 @@ func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instances.NodePool) *i
 
 func TestLink(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{})
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE))
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
@@ -78,8 +78,8 @@ func TestLink(t *testing.T) {
 
 func TestLinkWithCreationModeError(t *testing.T) {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{})
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE))
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -46,7 +46,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
-	fakeInstancePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{})
+	fakeInstancePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE))
 	fakeInstancePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -109,7 +109,7 @@ func NewLoadBalancerController(
 	})
 
 	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service)
-	instancePool := instances.NewNodePool(ctx.Cloud, ctx.ClusterNamer, ctx)
+	instancePool := instances.NewNodePool(ctx.Cloud, ctx.ClusterNamer, ctx, utils.GetBasePath(ctx.Cloud))
 	backendPool := backends.NewPool(ctx.Cloud, ctx.ClusterNamer)
 
 	lbc := LoadBalancerController{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -76,7 +76,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
-	lbc.instancePool = instances.NewNodePool(instances.NewFakeInstanceGroups(sets.NewString(), namer), namer, &test.FakeRecorderSource{})
+	lbc.instancePool = instances.NewNodePool(instances.NewFakeInstanceGroups(sets.NewString(), namer), namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE))
 	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(fakeGCE, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, ""))
 	lbc.instancePool.Init(&instances.FakeZoneLister{Zones: []string{fakeZone}})
 

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -156,7 +156,7 @@ func newIngress() *networkingv1.Ingress {
 
 func newFakeLoadBalancerPool(cloud *gce.Cloud, t *testing.T, namer *namer_util.Namer) L7s {
 	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), namer)
-	nodePool := instances.NewNodePool(fakeIGs, namer, &test.FakeRecorderSource{})
+	nodePool := instances.NewNodePool(fakeIGs, namer, &test.FakeRecorderSource{}, utils.GetBasePath(cloud))
 	nodePool.Init(&instances.FakeZoneLister{Zones: []string{defaultZone}})
 
 	return L7s{cloud, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, "")}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/slice"
+	"k8s.io/legacy-cloud-providers/gce"
 )
 
 const (
@@ -621,4 +622,22 @@ func NewStringPointer(s string) *string {
 // NewInt64Pointer returns a pointer to the provided int64 literal
 func NewInt64Pointer(i int64) *int64 {
 	return &i
+}
+
+// GetBasePath returns the compute API endpoint with the `projects/<project-id>` element
+// compute API v0.36 changed basepath and dropped the `projects/` suffix, therefore suffix
+// must be added back when generating compute resource urls.
+func GetBasePath(cloud *gce.Cloud) string {
+	basePath := cloud.ComputeServices().GA.BasePath
+
+	if basePath[len(basePath)-1] != '/' {
+		basePath += "/"
+	}
+	// Trim  the trailing /, so that split will not consider the last element as empty
+	elements := strings.Split(strings.TrimSuffix(basePath, "/"), "/")
+
+	if elements[len(elements)-1] != "projects" {
+		return fmt.Sprintf("%sprojects/%s/", basePath, cloud.ProjectID())
+	}
+	return fmt.Sprintf("%s%s/", basePath, cloud.ProjectID())
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/annotations"
@@ -993,5 +995,54 @@ func TestBackendToServicePortID(t *testing.T) {
 				t.Errorf("expected svc port id to be %+v, but got %+v", expectedID, svcPortID)
 			}
 		})
+	}
+}
+
+func TestGetBasePath(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	for _, tc := range []struct {
+		desc             string
+		basePath         string
+		expectedBasePath string
+	}{
+		{
+			desc:             "basepath does not end in `/projects/`",
+			basePath:         "path/to/api/",
+			expectedBasePath: fmt.Sprintf("path/to/api/projects/%s/", fakeGCE.ProjectID()),
+		},
+		{
+			desc:             "basepath does not end in `/projects/` and does not have trailing /",
+			basePath:         "path/to/api",
+			expectedBasePath: fmt.Sprintf("path/to/api/projects/%s/", fakeGCE.ProjectID()),
+		},
+		{
+			desc:             "basepath ends in `/projects/`",
+			basePath:         "path/to/api/projects/",
+			expectedBasePath: fmt.Sprintf("path/to/api/projects/%s/", fakeGCE.ProjectID()),
+		},
+		{
+			desc:             "basepath ends in `/projects`, without trailing /",
+			basePath:         "path/to/api/projects",
+			expectedBasePath: fmt.Sprintf("path/to/api/projects/%s/", fakeGCE.ProjectID()),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE.ComputeServices().GA.BasePath = tc.basePath
+			path := GetBasePath(fakeGCE)
+			if path != tc.expectedBasePath {
+				t.Errorf("wanted %s, but got %s", tc.expectedBasePath, path)
+			}
+		})
+	}
+}
+
+// Unit test is to catch any changes to the base path that could occur in the compute api dependency
+func TestComputeBasePath(t *testing.T) {
+	services, err := compute.NewService(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected error :%s", err)
+	}
+	if services.BasePath != "https://compute.googleapis.com/compute/v1/" {
+		t.Errorf("Compute basePath has changed. Verify selflink generation has not broken and update path in test")
 	}
 }


### PR DESCRIPTION
 - removes dependency on legacy-cloud-provider for generating the
 instance references/URLs


/cc @prameshj @spencerhance 
/assign @freehan 