### PR TITLE
Fix duplicate service ports sync

### DIFF
--- a/pkg/utils/gceurlmap.go
+++ b/pkg/utils/gceurlmap.go
@@ -127,13 +127,19 @@ func (g *GCEURLMap) PutPathRulesForHost(hostname string, pathRules []PathRule) {
 
 // AllServicePorts return a list of all ServicePorts contained in the GCEURLMap.
 func (g *GCEURLMap) AllServicePorts() (svcPorts []ServicePort) {
+
+	uniqueServerPorts := make(map[ServicePortID]bool)
 	if g.DefaultBackend != nil {
 		svcPorts = append(svcPorts, *g.DefaultBackend)
+		uniqueServerPorts[*&g.DefaultBackend.ID] = true
 	}
 
 	for _, rules := range g.HostRules {
 		for _, rule := range rules.Paths {
-			svcPorts = append(svcPorts, rule.Backend)
+			if !uniqueServerPorts[rule.Backend.ID] {
+				svcPorts = append(svcPorts, rule.Backend)
+				uniqueServerPorts[rule.Backend.ID] = true
+			}
 		}
 	}
 

--- a/pkg/utils/gceurlmap_test.go
+++ b/pkg/utils/gceurlmap_test.go
@@ -178,6 +178,29 @@ func TestAllServicePorts(t *testing.T) {
 
 }
 
+func TestAllServicePortsDistinct(t *testing.T) {
+	t.Parallel()
+	m := NewGCEURLMap()
+	b := NewServicePortWithID("svc-X", "ns", v1.ServiceBackendPort{Number: 80})
+	b1 := NewServicePortWithID("svc-X", "ns", v1.ServiceBackendPort{Number: 80})
+	b2 := NewServicePortWithID("svc-X", "ns", v1.ServiceBackendPort{Number: 80})
+	m.DefaultBackend = &b
+	rules := []PathRule{
+		PathRule{Path: "/ex1", Backend: b1},
+		PathRule{Path: "/ex2", Backend: b2},
+	}
+	m.PutPathRulesForHost("example.com", rules)
+
+	wantPorts := []ServicePort{
+		NewServicePortWithID("svc-X", "ns", v1.ServiceBackendPort{Number: 80}),
+	}
+
+	gotPorts := m.AllServicePorts()
+	if !reflect.DeepEqual(gotPorts, wantPorts) {
+		t.Errorf("AllServicePorts(%+v) = \n%+v\nwant\n%+v", m, gotPorts, wantPorts)
+	}
+}
+
 func newTestMap() *GCEURLMap {
 	m := NewGCEURLMap()
 	b := NewServicePortWithID("svc-X", "ns", v1.ServiceBackendPort{Number: 80})


### PR DESCRIPTION
The backend service synchronization triggers multiple times when multiple paths use the same backend service 

For example for this configuration  

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-ingress
spec:
  rules:
  - host: "example.com"
    http:
      paths:
      - path: /alpha
        pathType: ImplementationSpecific
        backend:
          service:
            name: backend-service
            port:
              number: 80
      - path: /beta
        pathType: ImplementationSpecific
        backend:
          service:
            name: backend-service
            port:
              number: 80
      # more paths here
```

the backend synchronization (health checks, cdn, iap, ...) will run for each of the paths, and each sync triggers api call to the GCE, and I assume there is a quota and rate limiting because it takes lot of time just for one backend service.

Fix for #1447 
