### PR TITLE
Fix adapter client patch

### DIFF
--- a/pkg/e2e/adapter/ingress.go
+++ b/pkg/e2e/adapter/ingress.go
@@ -111,7 +111,7 @@ func (crud *IngressCRUD) Patch(oldV1Ing, newV1Ing *v1.Ingress) (*v1.Ingress, err
 		if oldIng, err = toIngressV1beta1(oldV1Ing); err != nil {
 			return nil, err
 		}
-		if newIng, err = toIngressV1beta1(oldV1Ing); err != nil {
+		if newIng, err = toIngressV1beta1(newV1Ing); err != nil {
 			return nil, err
 		}
 		dataStruct = v1beta1.Ingress{}


### PR DESCRIPTION
In v1beta1 Patch, old ingress is converted twice instead of the 


cc @prameshj @spencerhance 
/assign @freehan 