### PR TITLE
[Cherrypick #1470] into release-1.11: Process service if old ingress class was glbc

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -219,9 +219,12 @@ func NewController(
 				negController.enqueueIngressServices(delIng)
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				oldIng := cur.(*v1beta1.Ingress)
+				oldIng := old.(*v1beta1.Ingress)
 				curIng := cur.(*v1beta1.Ingress)
-				if !utils.IsGLBCIngress(curIng) {
+
+				// Check if ingress class changed and previous class was a GCE ingress
+				// Ingress class change may require cleanup so enqueue related services
+				if !utils.IsGLBCIngress(curIng) && !utils.IsGLBCIngress(oldIng) {
 					klog.V(4).Infof("Ignoring update for ingress %v based on annotation %v", common.NamespacedName(curIng), annotations.IngressClassKey)
 					return
 				}


### PR DESCRIPTION
Cherrypicks #1470 fix for Finalizer test and longer resync periods to release 1.11.

Description in original fix includes details about the test fix.