### PR TITLE
avoid panic when reflector under load and rate limited

### DIFF
--- a/pkg/neg/readiness/poller.go
+++ b/pkg/neg/readiness/poller.go
@@ -224,8 +224,15 @@ func (p *poller) processHealthStatus(key negMeta, healthStatuses []*composite.Ne
 		}
 	}
 
+	retry := false
+	if target, ok := p.pollMap[key]; ok {
+		if patchCount < len(target.endpointMap) {
+			retry = true
+		}
+	}
+
 	// If we didn't patch all of the endpoints, we must keep polling for health status
-	return patchCount < len(p.pollMap[key].endpointMap), utilerrors.NewAggregate(errList)
+	return retry, utilerrors.NewAggregate(errList)
 }
 
 // getHealthyBackendService returns one of the first backend service key where the endpoint is considered healthy.

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -503,3 +503,25 @@ func TestPoll(t *testing.T) {
 	pollAndValidate(step, false, false, 4)
 	pacherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), meta.GlobalKey(bsName))
 }
+
+func TestProcessHealthStatus(t *testing.T) {
+	t.Parallel()
+	poller := newFakePoller()
+
+	// key was not in pollMap
+	key := negMeta{
+		SyncerKey: negtypes.NegSyncerKey{},
+		Name:      "foo",
+		Zone:      "zone",
+	}
+	res := []*composite.NetworkEndpointWithHealthStatus{}
+
+	// processHealthStatus should not crash when pollMap does not have corresponding key.
+	retry, err := poller.processHealthStatus(key, res)
+	if retry != false {
+		t.Errorf("exepect retry == false, but got %v", retry)
+	}
+	if err != nil {
+		t.Errorf("expect err == nil, but got %v", err)
+	}
+}


### PR DESCRIPTION
When ratelimiting kicks in and delays the NEG readiness reflector from getting health status via ListNetworkEndpoint GCE API call, the reflector may hit a nil pointer panic when trying to retrieve `p.pollMap[key].endpointMap` when key has been removed from pollMap.

The reason the key might be removed from pollMap is because NEG readiness condition timeout on the pod and all ednpoints/pods behind the NEG has been marked as ready. However, poller is still blocked by ratelimiter from issuing ListNetworkEndpoint API call. 

