### PR TITLE
Cherrypick: Add rate limiting scaling parameter

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -71,6 +71,7 @@ var (
 		DeleteAllOnQuit                  bool
 		GCEOperationPollInterval         time.Duration
 		GCERateLimit                     RateLimitSpecs
+		GCERateLimitScale                float64
 		HealthCheckPath                  string
 		HealthzPort                      int
 		InCluster                        bool
@@ -98,7 +99,9 @@ var (
 		FinalizerRemove                bool // Should have been named Enablexxx.
 		EnablePSC                      bool
 		EnableIngressGAFields          bool
-	}{}
+	}{
+		GCERateLimitScale: 1.0,
+	}
 )
 
 type LeaderElectionConfiguration struct {
@@ -175,6 +178,9 @@ specify this flag, the default is to rate limit Operations.Get for all versions.
 If you do specify this flag one or more times, this default will be overwritten.
 If you want to still use the default, simply specify it along with your other
 values.`)
+	flag.Float64Var(&F.GCERateLimitScale, "gce-ratelimit-scale", 1.0,
+		`Optional, scales rate limit options by a constant factor.
+1.0 is no multiplier. 5.0 means increase all rate and capacity by 5x.`)
 	flag.DurationVar(&F.GCEOperationPollInterval, "gce-operation-poll-interval", time.Second,
 		`Minimum time between polling requests to GCE for checking the status of an operation.`)
 	flag.StringVar(&F.HealthCheckPath, "health-check-path", "/",

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -19,6 +19,8 @@ package ratelimit
 import (
 	"testing"
 	"time"
+
+	"k8s.io/ingress-gce/pkg/flags"
 )
 
 func TestGCERateLimiter(t *testing.T) {
@@ -54,4 +56,18 @@ func TestGCERateLimiter(t *testing.T) {
 			t.Errorf("Expected an error for test case: %v", testCase)
 		}
 	}
+}
+
+func TestRateLimitScale(t *testing.T) {
+	// no parallel
+	oldScale := flags.F.GCERateLimitScale
+	defer func() { flags.F.GCERateLimitScale = oldScale }()
+
+	flags.F.GCERateLimitScale = 2
+	const cfg = "ga.Addresses.Get,qps,1,5"
+	_, err := NewGCERateLimiter([]string{cfg}, time.Second)
+	if err != nil {
+		t.Errorf("NewGCERateLimiter([]string{%q}, time.Second) = %v, want nil", cfg, err)
+	}
+	// TODO(bowei) -- this does not actually test the parameters were scaled.
 }


### PR DESCRIPTION
Adds flag --gce-ratelimit-scale

907fac5b5ecb7d5df6c53cedd7dcc0c7e76dcc32