### PR TITLE
Enqueue Node updates to VM_IP_NEG controller.

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -271,6 +271,14 @@ func NewController(
 				node := obj.(*apiv1.Node)
 				negController.enqueueNode(node)
 			},
+			UpdateFunc: func(old, cur interface{}) {
+				oldNode := old.(*apiv1.Node)
+				currentNode := cur.(*apiv1.Node)
+				nodeReadyCheck := utils.GetNodeConditionPredicate()
+				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
+					negController.enqueueNode(currentNode)
+				}
+			},
 		})
 	}
 
@@ -333,6 +341,7 @@ func (c *Controller) stop() {
 	klog.V(2).Infof("Shutting down network endpoint group controller")
 	c.serviceQueue.ShutDown()
 	c.endpointQueue.ShutDown()
+	c.nodeQueue.ShutDown()
 	c.manager.ShutDown()
 }
 
@@ -759,7 +768,7 @@ func (c *Controller) enqueueEndpoint(obj interface{}) {
 func (c *Controller) enqueueNode(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		klog.Errorf("Failed to generate endpoint key: %v", err)
+		klog.Errorf("Failed to generate node key: %v", err)
 		return
 	}
 	c.nodeQueue.Add(key)

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/api/core/v1"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog"
 )
 
 const (
@@ -169,6 +170,7 @@ func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, totalLimit int, svcID 
 	for _, zone := range zoneList {
 		// split the limit across the leftover zones.
 		subsetSize = totalLimit / zonesRemaining
+		klog.Infof("Picking subset of size %d for zone %v, service %s", subsetSize, zone, svcID)
 		result[zone.Name] = negtypes.NewNetworkEndpointSet()
 		if currentMap != nil {
 			if zset, ok := currentMap[zone.Name]; ok && zset != nil {


### PR DESCRIPTION
When a node changes state from Unschedulable or Unready to Ready, the NEG controller should Sync the NEGs to include this new node.
This is needed for Cluster trafficPolicy where nodes are selected at random. For Local Traffic Policy, the event of endpoint add/delete would be sufficient.

/assign @freehan 