### PR TITLE
Use local method to get instance references

### DIFF
--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -294,7 +294,7 @@ func (i *Instances) Remove(groupName string, names []string) error {
 	var errs []error
 	for zone, nodeNames := range i.splitNodesByZone(names) {
 		klog.V(1).Infof("Removing nodes %v from %v in zone %v", nodeNames, groupName, zone)
-		if err := i.cloud.RemoveInstancesFromInstanceGroup(groupName, zone, i.cloud.ToInstanceReferences(zone, nodeNames)); err != nil {
+		if err := i.cloud.RemoveInstancesFromInstanceGroup(groupName, zone, i.getInstanceReferences(zone, nodeNames)); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
 * ensures that on delete, instance urls are properly formed with
   `/projects` suffix on the basepath
   
   
 Without the fix errors like the below are seen when removing a node:
```
 2021-07-30T20:51:20.620095578Z stderr F I0730 20:51:20.619477       1 instances.go:354] Remove(<instance-group>, _) = RemoveInstances: [googleapi: Error 400: Invalid value for field 'instances[0].instance': '<url-without-projects-suffix>'. The URL is malformed., invalid] (took 40.291331ms); nodes = [<node-name>]
 ```
 
 With the change logs show successful removal of node:
```
Removing 1, adding 0 nodes
2021-07-30T21:00:18.088782643Z stderr F I0730 21:00:18.088590       1 instances.go:296] Removing nodes [<node-name>] from <instance-group>in zone <zone>
2021-07-30T21:00:18.089973988Z stderr F I0730 21:00:18.089766       1 event.go:282] Event(v1.ObjectReference{Kind:"", Namespace:"", Name:"", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'IngressGCE_RemoveNodes' Removing [<node-name>] from InstanceGroup <instance-group>
2021-07-30T21:00:19.718672812Z stderr F I0730 21:00:19.718506       1 instances.go:354] Remove(<instance-group>, _) = <nil> (took 1.629976317s); nodes = [<node-name>]
```

/assing @prameshj @freehan 