### PR TITLE
Remove nodes from LocalTrafficPolicy NEG if they are not a ready candidate

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -296,7 +296,7 @@ func NewController(
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode := old.(*apiv1.Node)
 				currentNode := cur.(*apiv1.Node)
-				nodeReadyCheck := utils.GetNodeConditionPredicate()
+				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyNodes()
 				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
 					klog.Infof("Node %q has changed, enqueueing", currentNode.Name)
 					negController.enqueueNode(currentNode)

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -298,6 +298,7 @@ func NewController(
 				currentNode := cur.(*apiv1.Node)
 				nodeReadyCheck := utils.GetNodeConditionPredicate()
 				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
+					klog.Infof("Node %q has changed, enqueueing", currentNode.Name)
 					negController.enqueueNode(currentNode)
 				}
 			},

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -58,7 +58,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 	zoneNodeMap := make(map[string][]*v1.Node)
 	processedNodes := sets.String{}
 	numEndpoints := 0
-	candidateNodeCheck := utils.GetNodeConditionPredicate()
+	candidateNodeCheck := utils.NodeConditionPredicateIncludeUnreadyNodes()
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -130,7 +130,7 @@ func (l *ClusterL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
-	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.GetNodeConditionPredicate())
+	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.NodeConditionPredicateIncludeUnreadyNodes())
 
 	zoneNodeMap := make(map[string][]*v1.Node)
 	for _, node := range nodes {

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -56,8 +56,9 @@ func (l *LocalL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// List all nodes where the service endpoints are running. Get a subset of the desired count.
 	zoneNodeMap := make(map[string][]*v1.Node)
-	nodeNames := sets.String{}
+	processedNodes := sets.String{}
 	numEndpoints := 0
+	candidateNodeCheck := utils.GetNodeConditionPredicate()
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -69,13 +70,17 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 				continue
 			}
 			numEndpoints++
-			if nodeNames.Has(*addr.NodeName) {
+			if processedNodes.Has(*addr.NodeName) {
 				continue
 			}
-			nodeNames.Insert(*addr.NodeName)
+			processedNodes.Insert(*addr.NodeName)
 			node, err := l.nodeLister.Get(*addr.NodeName)
 			if err != nil {
 				klog.Errorf("failed to retrieve node object for %q: %v", *addr.NodeName, err)
+				continue
+			}
+			if ok := candidateNodeCheck(node); !ok {
+				klog.Infof("Dropping Node %q from subset since it is not a valid LB candidate", node.Name)
 				continue
 			}
 			zone, err := l.zoneGetter.GetZoneForNode(node.Name)

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -24,7 +24,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -34,32 +36,6 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	t.Parallel()
 	mode := negtypes.L4LocalMode
 	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), mode, false)
-	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
-	for i := 0; i < len(nodeNames); i++ {
-		err := transactionSyncer.nodeLister.Add(&v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				//Namespace: testServiceNamespace,
-				Name: nodeNames[i],
-			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
-					{
-						Type:    v1.NodeInternalIP,
-						Address: fmt.Sprintf("1.2.3.%d", i+1),
-					},
-				},
-				Conditions: []v1.NodeCondition{
-					{
-						Type:   v1.NodeReady,
-						Status: v1.ConditionTrue,
-					},
-				},
-			},
-		})
-		if err != nil {
-			t.Errorf("Failed to add node %s to syncer's nodeLister, err %v", nodeNames[i], err)
-		}
-	}
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	nodeLister := listers.NewNodeLister(transactionSyncer.nodeLister)
 
@@ -68,6 +44,9 @@ func TestLocalGetEndpointSet(t *testing.T) {
 		endpointsData       []negtypes.EndpointsData
 		endpointSets        map[string]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
+		nodeLabelsMap       map[string]map[string]string
+		nodeAnnotationsMap  map[string]map[string]string
+		nodeNames           []string
 	}{
 		{
 			desc:          "default endpoints",
@@ -78,6 +57,26 @@ func TestLocalGetEndpointSet(t *testing.T) {
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+		},
+		{
+			desc:          "default endpoints, some nodes marked as non-candidates",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			nodeLabelsMap: map[string]map[string]string{
+				testInstance1: {utils.LabelNodeRoleExcludeBalancer: "true"},
+			},
+			nodeAnnotationsMap: map[string]map[string]string{
+				testInstance3: {utils.GKECurrentOperationAnnotation: fmt.Sprintf("{'Timestamp': '12345', 'Operation': '%s'}", utils.GKEUpgradeOperation)},
+				// annotation for testInstance4 will not remove it from endpoints list, since operation value is "random".
+				testInstance4: {utils.GKECurrentOperationAnnotation: "{'Timestamp': '12345', 'Operation': 'random'}"},
+			},
+			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			// only 2 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes. 2 out of those 4 are non-candidates.
+			endpointSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType: negtypes.VmIpEndpointType,
 		},
 		{
 			desc:          "no endpoints",
@@ -85,11 +84,13 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			// No nodes are picked as there are no service endpoints.
 			endpointSets:        nil,
 			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 		},
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	ec := NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey)
 	for _, tc := range testCases {
+		createNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, transactionSyncer.nodeLister)
 		retSet, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
@@ -97,6 +98,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 		if !reflect.DeepEqual(retSet, tc.endpointSets) {
 			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
 		}
+		deleteNodes(t, tc.nodeNames, transactionSyncer.nodeLister)
 	}
 }
 
@@ -105,31 +107,6 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	t.Parallel()
 	mode := negtypes.L4ClusterMode
 	_, transactionSyncer := newL4ILBTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), mode, false)
-	nodeNames := []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6}
-	for i := 0; i < len(nodeNames); i++ {
-		err := transactionSyncer.nodeLister.Add(&v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nodeNames[i],
-			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
-					{
-						Type:    v1.NodeInternalIP,
-						Address: fmt.Sprintf("1.2.3.%d", i+1),
-					},
-				},
-				Conditions: []v1.NodeCondition{
-					{
-						Type:   v1.NodeReady,
-						Status: v1.ConditionTrue,
-					},
-				},
-			},
-		})
-		if err != nil {
-			t.Errorf("Failed to add node %s to syncer's nodeLister, err %v", nodeNames[i], err)
-		}
-	}
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	nodeLister := listers.NewNodeLister(transactionSyncer.nodeLister)
 	testCases := []struct {
@@ -137,6 +114,9 @@ func TestClusterGetEndpointSet(t *testing.T) {
 		endpointsData       []negtypes.EndpointsData
 		endpointSets        map[string]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
+		nodeLabelsMap       map[string]map[string]string
+		nodeAnnotationsMap  map[string]map[string]string
+		nodeNames           []string
 	}{
 		{
 			desc:          "default endpoints",
@@ -148,6 +128,27 @@ func TestClusterGetEndpointSet(t *testing.T) {
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+		},
+		{
+			desc:          "default endpoints, some nodes marked as non-candidates",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			// all valid candidate nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
+			endpointSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
+			},
+			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			nodeLabelsMap: map[string]map[string]string{
+				testInstance1: {utils.LabelNodeRoleExcludeBalancer: "true"},
+			},
+			nodeAnnotationsMap: map[string]map[string]string{
+				testInstance3: {utils.GKECurrentOperationAnnotation: fmt.Sprintf("{'Timestamp': '12345', 'Operation': '%s'}", utils.GKEUpgradeOperation)},
+				// annotation for testInstance4 will not remove it from endpoints list, since operation value is "random".
+				testInstance4: {utils.GKECurrentOperationAnnotation: "{'Timestamp': '12345', 'Operation': 'random'}"},
+			},
 		},
 		{
 			desc: "no endpoints",
@@ -160,11 +161,13 @@ func TestClusterGetEndpointSet(t *testing.T) {
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 		},
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	ec := NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey)
 	for _, tc := range testCases {
+		createNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, transactionSyncer.nodeLister)
 		retSet, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
@@ -172,5 +175,57 @@ func TestClusterGetEndpointSet(t *testing.T) {
 		if !reflect.DeepEqual(retSet, tc.endpointSets) {
 			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
 		}
+		deleteNodes(t, tc.nodeNames, transactionSyncer.nodeLister)
 	}
+}
+
+func createNodes(t *testing.T, nodeNames []string, nodeLabels, nodeAnnotations map[string]map[string]string, nodeIndexer cache.Indexer) {
+	t.Helper()
+	for i, nodeName := range nodeNames {
+		var labels, annotations map[string]string
+		if nodeLabels != nil {
+			labels = nodeLabels[nodeName]
+			annotations = nodeAnnotations[nodeName]
+		}
+		err := nodeIndexer.Add(&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        nodeName,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeInternalIP,
+						Address: fmt.Sprintf("1.2.3.%d", i+1),
+					},
+				},
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to add node %s to syncer's nodeLister, err %v", nodeNames[i], err)
+		}
+	}
+
+}
+
+func deleteNodes(t *testing.T, nodeNames []string, nodeIndexer cache.Indexer) {
+	t.Helper()
+	for _, nodeName := range nodeNames {
+		node, exists, err := nodeIndexer.GetByKey(nodeName)
+		if err != nil || !exists {
+			t.Errorf("Could not lookuo node %q, err - %v", nodeName, err)
+			continue
+		}
+		if err := nodeIndexer.Delete(node); err != nil {
+			t.Errorf("Failed to delete node %q, err - %v", nodeName, err)
+		}
+	}
+
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -83,11 +83,8 @@ const (
 	// exclude from load balancers created by a cloud provider. This label is deprecated and will
 	// be removed in 1.18.
 	LabelAlphaNodeRoleExcludeBalancer = "alpha.service-controller.kubernetes.io/exclude-balancer"
-
-	// LegacyNodeRoleBehaviorFeature is the feature gate name that enables legacy
-	// behavior to vary cluster functionality on the node-role.kubernetes.io
-	// labels.
-	LegacyNodeRoleBehaviorFeature = "LegacyNodeRoleBehavior"
+	GKEUpgradeOperation               = "operation_type: UPGRADE_NODES"
+	GKECurrentOperationAnnotation     = "gke-current-operation"
 )
 
 // FrontendGCAlgorithm species GC algorithm used for ingress frontend resources.
@@ -377,6 +374,10 @@ func GetNodeConditionPredicate() NodeConditionPredicate {
 		}
 
 		if _, hasExcludeBalancerLabel := node.Labels[LabelNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
+			return false
+		}
+		// This node is about to be upgraded.
+		if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
 			return false
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -355,46 +355,61 @@ type NodeConditionPredicate func(node *api_v1.Node) bool
 // kubernetes/kubernetes/pkg/controller/service/service_controller.go
 func GetNodeConditionPredicate() NodeConditionPredicate {
 	return func(node *api_v1.Node) bool {
-		// Get all nodes that have a taint with NoSchedule effect
-		for _, taint := range node.Spec.Taints {
-			if taint.Key == ToBeDeletedTaint {
-				return false
-			}
-		}
+		return nodePredicateInternal(node, false)
+	}
+}
 
-		// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
-		// Recognize nodes labeled as master, and filter them also, as we were doing previously.
-		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
-			return false
-		}
+// NodeConditionPredicateIncludeUnreadyNodes returns a predicate function that tolerates unready nodes.
+func NodeConditionPredicateIncludeUnreadyNodes() NodeConditionPredicate {
+	return func(node *api_v1.Node) bool {
+		return nodePredicateInternal(node, true)
+	}
+}
 
-		// Will be removed in 1.18
-		if _, hasExcludeBalancerLabel := node.Labels[LabelAlphaNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
+func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes bool) bool {
+	// Get all nodes that have a taint with NoSchedule effect
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == ToBeDeletedTaint {
 			return false
 		}
+	}
 
-		if _, hasExcludeBalancerLabel := node.Labels[LabelNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
-			return false
-		}
-		// This node is about to be upgraded.
-		if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
-			return false
-		}
+	// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
+	// Recognize nodes labeled as master, and filter them also, as we were doing previously.
+	if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
+		return false
+	}
 
-		// If we have no info, don't accept
-		if len(node.Status.Conditions) == 0 {
-			return false
-		}
-		for _, cond := range node.Status.Conditions {
-			// We consider the node for load balancing only when its NodeReady condition status
-			// is ConditionTrue
-			if cond.Type == api_v1.NodeReady && cond.Status != api_v1.ConditionTrue {
-				klog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
-				return false
-			}
-		}
+	// Will be removed in 1.18
+	if _, hasExcludeBalancerLabel := node.Labels[LabelAlphaNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
+		return false
+	}
+
+	if _, hasExcludeBalancerLabel := node.Labels[LabelNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
+		return false
+	}
+	// This node is about to be upgraded.
+	if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
+		return false
+	}
+
+	// If we have no info, don't accept
+	if len(node.Status.Conditions) == 0 {
+		return false
+	}
+	if includeUnreadyNodes {
 		return true
 	}
+	for _, cond := range node.Status.Conditions {
+		// We consider the node for load balancing only when its NodeReady condition status
+		// is ConditionTrue
+		if cond.Type == api_v1.NodeReady && cond.Status != api_v1.ConditionTrue {
+			klog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
+			return false
+		}
+	}
+	return true
+
 }
 
 // ListWithPredicate gets nodes that matches predicate function.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -498,14 +498,15 @@ func TestTraverseIngressBackends(t *testing.T) {
 
 func TestGetNodeConditionPredicate(t *testing.T) {
 	tests := []struct {
-		node         api_v1.Node
-		expectAccept bool
-		name         string
+		node                                             api_v1.Node
+		expectAccept, expectAcceptByUnreadyNodePredicate bool
+		name                                             string
 	}{
 		{
 			node:         api_v1.Node{},
 			expectAccept: false,
-			name:         "empty",
+
+			name: "empty",
 		},
 		{
 			node: api_v1.Node{
@@ -515,8 +516,33 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: true,
-			name:         "basic",
+			expectAccept:                       true,
+			expectAcceptByUnreadyNodePredicate: true,
+			name:                               "ready node",
+		},
+		{
+			node: api_v1.Node{
+				Status: api_v1.NodeStatus{
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionFalse},
+					},
+				},
+			},
+			expectAccept:                       false,
+			expectAcceptByUnreadyNodePredicate: true,
+			name:                               "uneady node",
+		},
+		{
+			node: api_v1.Node{
+				Status: api_v1.NodeStatus{
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionUnknown},
+					},
+				},
+			},
+			expectAccept:                       false,
+			expectAcceptByUnreadyNodePredicate: true,
+			name:                               "ready status unknown",
 		},
 		{
 			node: api_v1.Node{
@@ -530,8 +556,9 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: false,
-			name:         "ready node, excluded from loadbalancers",
+			expectAccept:                       false,
+			expectAcceptByUnreadyNodePredicate: false,
+			name:                               "ready node, excluded from loadbalancers",
 		},
 		{
 			node: api_v1.Node{
@@ -547,8 +574,9 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: false,
-			name:         "ready node, upgrade in progress",
+			expectAccept:                       false,
+			expectAcceptByUnreadyNodePredicate: false,
+			name:                               "ready node, upgrade in progress",
 		},
 		{
 			node: api_v1.Node{
@@ -564,8 +592,9 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: true,
-			name:         "ready node, non-upgrade operation",
+			expectAccept:                       true,
+			expectAcceptByUnreadyNodePredicate: true,
+			name:                               "ready node, non-upgrade operation",
 		},
 		{
 			node: api_v1.Node{
@@ -576,8 +605,9 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: true,
-			name:         "unschedulable",
+			expectAccept:                       true,
+			expectAcceptByUnreadyNodePredicate: true,
+			name:                               "unschedulable",
 		},
 		{
 			node: api_v1.Node{
@@ -596,15 +626,21 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: false,
-			name:         "ToBeDeletedByClusterAutoscaler-taint",
+			expectAccept:                       false,
+			expectAcceptByUnreadyNodePredicate: false,
+			name:                               "ToBeDeletedByClusterAutoscaler-taint",
 		},
 	}
 	pred := GetNodeConditionPredicate()
+	unreadyPred := NodeConditionPredicateIncludeUnreadyNodes()
 	for _, test := range tests {
 		accept := pred(&test.node)
 		if accept != test.expectAccept {
-			t.Errorf("Test failed for %s, expected %v, saw %v", test.name, test.expectAccept, accept)
+			t.Errorf("Test failed for %s, got %v, want %v", test.name, accept, test.expectAccept)
+		}
+		unreadyAccept := unreadyPred(&test.node)
+		if unreadyAccept != test.expectAcceptByUnreadyNodePredicate {
+			t.Errorf("Test failed for unreadyNodesPredicate in case %s, got %v, want %v", test.name, unreadyAccept, test.expectAcceptByUnreadyNodePredicate)
 		}
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -520,6 +520,55 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 		},
 		{
 			node: api_v1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   "node1",
+					Labels: map[string]string{LabelNodeRoleExcludeBalancer: "true"},
+				},
+				Status: api_v1.NodeStatus{
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept: false,
+			name:         "ready node, excluded from loadbalancers",
+		},
+		{
+			node: api_v1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						GKECurrentOperationAnnotation: fmt.Sprintf("{'Timestamp': '12345', 'Operation': '%s'}", GKEUpgradeOperation),
+					},
+				},
+				Status: api_v1.NodeStatus{
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept: false,
+			name:         "ready node, upgrade in progress",
+		},
+		{
+			node: api_v1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						GKECurrentOperationAnnotation: "{'Timestamp': '12345', 'Operation': 'random'}",
+					},
+				},
+				Status: api_v1.NodeStatus{
+					Conditions: []api_v1.NodeCondition{
+						{Type: api_v1.NodeReady, Status: api_v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept: true,
+			name:         "ready node, non-upgrade operation",
+		},
+		{
+			node: api_v1.Node{
 				Spec: api_v1.NodeSpec{Unschedulable: true},
 				Status: api_v1.NodeStatus{
 					Conditions: []api_v1.NodeCondition{
@@ -529,7 +578,8 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			},
 			expectAccept: true,
 			name:         "unschedulable",
-		}, {
+		},
+		{
 			node: api_v1.Node{
 				Spec: api_v1.NodeSpec{
 					Taints: []api_v1.Taint{


### PR DESCRIPTION
Nodes that are about to be upgraded/scaled down/marked to exclude from LB backends should be skipped by Endpoints calculator in the Local mode. They are already skipped in the cluster mode.

/assign @freehan 