### PR TITLE
Include zones with unready nodes when listing zones.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -399,9 +399,9 @@ func (lbc *LoadBalancerController) SyncBackends(state interface{}) error {
 	}
 
 	// Get the zones our groups live in.
-	zones, err := lbc.Translator.ListZones()
+	zones, err := lbc.Translator.ListZones(utils.CandidateNodesPredicate)
 	if err != nil {
-		klog.Errorf("lbc.Translator.ListZones() = %v", err)
+		klog.Errorf("lbc.Translator.ListZones(utils.CandidateNodesPredicate) = %v", err)
 		return err
 	}
 	var groupKeys []backends.GroupKey

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -387,19 +387,19 @@ func (t *Translator) GetZoneForNode(name string) (string, error) {
 	return "", fmt.Errorf("node not found %v", name)
 }
 
-// ListZones returns a list of zones this Kubernetes cluster spans.
-func (t *Translator) ListZones() ([]string, error) {
+// ListZones returns a list of zones containing nodes that satisfy the given predicate.
+func (t *Translator) ListZones(predicate utils.NodeConditionPredicate) ([]string, error) {
 	nodeLister := t.ctx.NodeInformer.GetIndexer()
-	return t.listZonesWithLister(listers.NewNodeLister(nodeLister))
+	return t.listZones(listers.NewNodeLister(nodeLister), predicate)
 }
 
-func (t *Translator) listZonesWithLister(lister listers.NodeLister) ([]string, error) {
+func (t *Translator) listZones(lister listers.NodeLister, predicate utils.NodeConditionPredicate) ([]string, error) {
 	zones := sets.String{}
-	readyNodes, err := utils.ListWithPredicate(lister, utils.GetNodeConditionPredicate())
+	nodes, err := utils.ListWithPredicate(lister, predicate)
 	if err != nil {
 		return zones.List(), err
 	}
-	for _, n := range readyNodes {
+	for _, n := range nodes {
 		zones.Insert(getZone(n))
 	}
 	return zones.List(), nil

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -46,7 +46,7 @@ func TestZoneListing(t *testing.T) {
 		"zone-2": {"n2"},
 	}
 	addNodes(lbc, zoneToNode)
-	zones, err := lbc.Translator.ListZones()
+	zones, err := lbc.Translator.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		t.Errorf("Failed to list zones: %v", err)
 	}

--- a/pkg/instances/fakes.go
+++ b/pkg/instances/fakes.go
@@ -46,7 +46,7 @@ type FakeZoneLister struct {
 }
 
 // ListZones returns the list of zones.
-func (z *FakeZoneLister) ListZones() ([]string, error) {
+func (z *FakeZoneLister) ListZones(_ utils.NodeConditionPredicate) ([]string, error) {
 	return z.Zones, nil
 }
 

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -75,7 +75,8 @@ func (i *Instances) Init(zl ZoneLister) {
 // and adds the given ports to it. Returns a list of one instance group per zone,
 // all of which have the exact same named ports.
 func (i *Instances) EnsureInstanceGroupsAndPorts(name string, ports []int64) (igs []*compute.InstanceGroup, err error) {
-	zones, err := i.ListZones()
+	// Instance groups need to be created only in zones that have ready nodes.
+	zones, err := i.ListZones(utils.CandidateNodesPredicate)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 func (i *Instances) DeleteInstanceGroup(name string) error {
 	errs := []error{}
 
-	zones, err := i.ListZones()
+	zones, err := i.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return err
 	}
@@ -181,7 +182,7 @@ func (i *Instances) DeleteInstanceGroup(name string) error {
 // list lists all instances in all zones.
 func (i *Instances) list(name string) (sets.String, error) {
 	nodeNames := sets.NewString()
-	zones, err := i.ListZones()
+	zones, err := i.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return nodeNames, err
 	}
@@ -216,7 +217,7 @@ func (i *Instances) Get(name, zone string) (*compute.InstanceGroup, error) {
 func (i *Instances) List() ([]string, error) {
 	var igs []*compute.InstanceGroup
 
-	zones, err := i.ListZones()
+	zones, err := i.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/instances/interfaces.go
+++ b/pkg/instances/interfaces.go
@@ -18,11 +18,12 @@ package instances
 
 import (
 	compute "google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // ZoneLister manages lookups for GCE instance groups/instances to zones.
 type ZoneLister interface {
-	ListZones() ([]string, error)
+	ListZones(predicate utils.NodeConditionPredicate) ([]string, error)
 	GetZoneForNode(name string) (string, error)
 }
 

--- a/pkg/l4/l4controller.go
+++ b/pkg/l4/l4controller.go
@@ -277,7 +277,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service) *lo
 // linkNEG associates the NEG to the backendService for the given L4 ILB service.
 func (l4c *L4Controller) linkNEG(l4 *loadbalancers.L4) error {
 	// link neg to backend service
-	zones, err := l4c.translator.ListZones()
+	zones, err := l4c.translator.ListZones(utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes)
 	if err != nil {
 		return nil
 	}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -296,8 +296,8 @@ func NewController(
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode := old.(*apiv1.Node)
 				currentNode := cur.(*apiv1.Node)
-				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
-				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
+				candidateNodeCheck := utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes
+				if candidateNodeCheck(oldNode) != candidateNodeCheck(currentNode) {
 					klog.Infof("Node %q has changed, enqueueing", currentNode.Name)
 					negController.enqueueNode(currentNode)
 				}
@@ -677,7 +677,7 @@ func (c *Controller) getCSMPortInfoMap(namespace, name string, service *apiv1.Se
 // syncNegStatusAnnotation syncs the neg status annotation
 // it takes service namespace, name and the expected service ports for NEGs.
 func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap negtypes.PortInfoMap) error {
-	zones, err := c.zoneGetter.ListZones()
+	zones, err := c.zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(portMap.EndpointsCalculatorMode()))
 	if err != nil {
 		return err
 	}
@@ -720,7 +720,7 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 
 // syncDestinationRuleNegStatusAnnotation syncs the destinationrule related neg status annotation
 func (c *Controller) syncDestinationRuleNegStatusAnnotation(namespace, destinationRuleName string, portmap negtypes.PortInfoMap) error {
-	zones, err := c.zoneGetter.ListZones()
+	zones, err := c.zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(portmap.EndpointsCalculatorMode()))
 	if err != nil {
 		return err
 	}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -346,6 +346,8 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
 	controller := newTestControllerWithParamsAndContext(kubeClient, testContext, true, false)
 	manager := controller.manager.(*syncerManager)
+	// L4 ILB NEGs will be created in zones with ready and unready nodes. Zones with upgrading nodes will be skipped.
+	expectZones := []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3}
 	defer controller.stop()
 	var prevSyncerKey, updatedSyncerKey negtypes.NegSyncerKey
 	t.Logf("Creating L4 ILB service with ExternalTrafficPolicy:Cluster")
@@ -385,7 +387,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	}
 	ValidateSyncerByKey(t, controller, 1, prevSyncerKey, false)
 	validateSyncerManagerWithPortInfoMap(t, controller, testServiceNamespace, testServiceName, expectedPortInfoMap)
-	validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap)
+	validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap, expectZones)
 	// Now Update the service to change the TrafficPolicy
 	t.Logf("Updating L4 ILB service from ExternalTrafficPolicy:Cluster to Local")
 	svc.Spec.ExternalTrafficPolicy = apiv1.ServiceExternalTrafficPolicyTypeLocal
@@ -411,7 +413,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	controller.manager.(*syncerManager).GC()
 	// check the port info map after all stale syncers have been deleted.
 	validateSyncerManagerWithPortInfoMap(t, controller, testServiceNamespace, testServiceName, expectedPortInfoMap)
-	validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap)
+	validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap, expectZones)
 }
 
 func TestEnqueueNodeWithILBSubsetting(t *testing.T) {
@@ -1073,7 +1075,8 @@ func TestNewDestinationRule(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Service was not created successfully, err: %v", err)
 			}
-			validateServiceAnnotationWithPortInfoMap(t, svc, tc.wantSvcPortMap)
+			// zones with unready nodes will be skipped.
+			validateServiceAnnotationWithPortInfoMap(t, svc, tc.wantSvcPortMap, []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone4})
 			if tc.usDestinationRule != nil {
 				usdr, err := controller.destinationRuleClient.Namespace(tc.usDestinationRule.GetNamespace()).Get(context.TODO(), tc.usDestinationRule.GetName(), metav1.GetOptions{})
 				if err != nil {
@@ -1456,24 +1459,25 @@ func validateSyncerManagerWithPortInfoMap(t *testing.T, controller *Controller, 
 	}
 }
 
-func validateServiceAnnotationWithPortInfoMap(t *testing.T, svc *apiv1.Service, portInfoMap negtypes.PortInfoMap) {
+func validateServiceAnnotationWithPortInfoMap(t *testing.T, svc *apiv1.Service, portInfoMap negtypes.PortInfoMap, expectZones []string) {
 	v, ok := svc.Annotations[annotations.NEGStatusKey]
 	if !ok {
 		t.Fatalf("Failed to apply the NEG service state annotation, got %+v", svc.Annotations)
 	}
 
 	zoneGetter := negtypes.NewFakeZoneGetter()
-	zones, _ := zoneGetter.ListZones()
-	for _, zone := range zones {
-		if !strings.Contains(v, zone) {
-			t.Fatalf("Expected NEG service state annotation to contain zone %v, got %v", zone, v)
-		}
+	zones, _ := zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode()))
+	if !sets.NewString(expectZones...).Equal(sets.NewString(zones...)) {
+		t.Errorf("Unexpected zones listed by the predicate function, got %v, want %v", zones, expectZones)
 	}
 
 	// negStatus validation
 	negStatus, err := annotations.ParseNegStatus(v)
 	if err != nil {
 		t.Fatalf("Failed to parse neg status annotation %q: %v", v, err)
+	}
+	if !sets.NewString(negStatus.Zones...).Equal(sets.NewString(zones...)) {
+		t.Errorf("Unexpected zones in NEG service state annotation, got %v, want %v", negStatus.Zones, zones)
 	}
 
 	wantNegStatus := annotations.NewNegStatus(zones, portInfoMap.ToPortNegMap())
@@ -1489,17 +1493,14 @@ func validateDestinationRuleAnnotationWithPortInfoMap(t *testing.T, usdr *unstru
 	}
 
 	zoneGetter := negtypes.NewFakeZoneGetter()
-	zones, _ := zoneGetter.ListZones()
-	for _, zone := range zones {
-		if !strings.Contains(v, zone) {
-			t.Fatalf("Expected NEG service state annotation to contain zone %v, got %v", zone, v)
-		}
-	}
-
+	zones, _ := zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode()))
 	// negStatus validation
 	negStatus, err := annotations.ParseDestinationRuleNEGStatus(v)
 	if err != nil {
 		t.Fatalf("Failed to parse DestinationRule NEG status annotation %q: %v", v, err)
+	}
+	if !sets.NewString(negStatus.Zones...).Equal(sets.NewString(zones...)) {
+		t.Errorf("Unexpected zones in NEG service state annotation, got %v, want %v", negStatus.Zones, zones)
 	}
 
 	wantNegStatus := annotations.NewDestinationRuleNegStatus(zones, portInfoMap.ToPortSubsetNegMap())
@@ -1568,17 +1569,16 @@ func validateServiceStateAnnotationExceptNames(t *testing.T, svc *apiv1.Service,
 	}
 
 	zoneGetter := negtypes.NewFakeZoneGetter()
-	zones, _ := zoneGetter.ListZones()
-	for _, zone := range zones {
-		if !strings.Contains(v, zone) {
-			t.Fatalf("Expected NEG service state annotation to contain zone %v, got %v", zone, v)
-		}
-	}
+	// This routine is called from tests verifying L7 NEGs.
+	zones, _ := zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(negtypes.L7Mode))
 
 	// negStatus validation
 	negStatus, err := annotations.ParseNegStatus(v)
 	if err != nil {
 		t.Fatalf("Failed to parse neg status annotation %q: %v", v, err)
+	}
+	if !sets.NewString(negStatus.Zones...).Equal(sets.NewString(zones...)) {
+		t.Errorf("Unexpected zones in NEG service state annotation, got %v, want %v", negStatus.Zones, zones)
 	}
 
 	if len(negStatus.NetworkEndpointGroups) != len(svcPorts) {

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -471,7 +471,8 @@ func (manager *syncerManager) garbageCollectNEGWithCRD() error {
 	// This would be resolved (sync neg) when the next endpoint update or resync arrives.
 	// TODO: avoid race condition here
 	var errList []error
-	zones, err := manager.zoneGetter.ListZones()
+	// Deletion candidate NEGs should be deleted from all zones, even ones that currently don't have any Ready nodes.
+	zones, err := manager.zoneGetter.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		errList = append(errList, fmt.Errorf("failed to get zones during garbage collection: %w", err))
 	}

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -58,7 +58,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 	zoneNodeMap := make(map[string][]*v1.Node)
 	processedNodes := sets.String{}
 	numEndpoints := 0
-	candidateNodeCheck := utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
+	candidateNodeCheck := utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -130,7 +130,7 @@ func (l *ClusterL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
-	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes())
+	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes)
 
 	zoneNodeMap := make(map[string][]*v1.Node)
 	for _, node := range nodes {

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -187,7 +187,7 @@ func (s *transactionSyncer) syncInternal() error {
 	klog.V(2).Infof("Sync NEG %q for %s, Endpoints Calculator mode %s", s.NegSyncerKey.NegName,
 		s.NegSyncerKey.String(), s.endpointsCalculator.Mode())
 
-	currentMap, err := retrieveExistingZoneNetworkEndpointMap(s.NegSyncerKey.NegName, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion())
+	currentMap, err := retrieveExistingZoneNetworkEndpointMap(s.NegSyncerKey.NegName, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode())
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,8 @@ func (s *transactionSyncer) syncInternal() error {
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	var err error
-	zones, err := s.zoneGetter.ListZones()
+	// NEGs should be created in zones with candidate nodes only.
+	zones, err := s.zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(s.EpCalculatorMode))
 	if err != nil {
 		return err
 	}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -301,19 +301,33 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map
-func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version) (map[string]negtypes.NetworkEndpointSet, error) {
-	zones, err := zoneGetter.ListZones()
+func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode) (map[string]negtypes.NetworkEndpointSet, error) {
+	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
+	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
+	zones, err := zoneGetter.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return nil, err
 	}
 
+	candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodePredicateForEndpointCalculatorMode(mode))
+	if err != nil {
+		return nil, err
+	}
+	candidateZonesMap := sets.NewString(candidateNodeZones...)
+
 	zoneNetworkEndpointMap := map[string]negtypes.NetworkEndpointSet{}
 	for _, zone := range zones {
-		zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()
 		networkEndpointsWithHealthStatus, err := cloud.ListNetworkEndpoints(negName, zone, false, version)
 		if err != nil {
-			return nil, err
+			// It is possible for a NEG to be missing in a zone without candidate nodes. Log and ignore this error.
+			// NEG not found in a candidate zone is an error.
+			if utils.IsNotFoundError(err) && !candidateZonesMap.Has(zone) {
+				klog.Infof("Ignoring NotFound error for NEG %q in zone %q", negName, zone)
+				continue
+			}
+			return nil, fmt.Errorf("Failed to lookup NEG in zone %q, candidate zones %v, err - %v", zone, candidateZonesMap, err)
 		}
+		zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()
 		for _, ne := range networkEndpointsWithHealthStatus {
 			newNE := negtypes.NetworkEndpoint{IP: ne.NetworkEndpoint.IpAddress, Node: ne.NetworkEndpoint.Instance}
 			if ne.NetworkEndpoint.Port != 0 {

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -19,11 +19,12 @@ package types
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // ZoneGetter is an interface for retrieve zone related information
 type ZoneGetter interface {
-	ListZones() ([]string, error)
+	ListZones(predicate utils.NodeConditionPredicate) ([]string, error)
 	GetZoneForNode(name string) (string, error)
 }
 

--- a/pkg/neg/types/simple_zone_getter.go
+++ b/pkg/neg/types/simple_zone_getter.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package types
 
+import "k8s.io/ingress-gce/pkg/utils"
+
 // simpleZoneGetter implements ZoneGetter interface
 // It always return its one single stored zone
 type simpleZoneGetter struct {
@@ -26,7 +28,7 @@ func (s *simpleZoneGetter) GetZoneForNode(string) (string, error) {
 	return s.zone, nil
 }
 
-func (s *simpleZoneGetter) ListZones() ([]string, error) {
+func (s *simpleZoneGetter) ListZones(_ utils.NodeConditionPredicate) ([]string, error) {
 	return []string{s.zone}, nil
 }
 

--- a/pkg/neg/types/simple_zone_getter_test.go
+++ b/pkg/neg/types/simple_zone_getter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"k8s.io/ingress-gce/pkg/utils"
 	"reflect"
 	"testing"
 )
@@ -24,7 +25,7 @@ import (
 func TestSimpleZoneGetter(t *testing.T) {
 	zone := "foo"
 	zoneGetter := NewSimpleZoneGetter(zone)
-	ret, err := zoneGetter.ListZones()
+	ret, err := zoneGetter.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		t.Errorf("expect err = nil, but got %v", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -327,7 +327,7 @@ func IsGLBCIngress(ing *networkingv1.Ingress) bool {
 // TODO(rramkumar): Add a test for this.
 func GetReadyNodeNames(lister listers.NodeLister) ([]string, error) {
 	var nodeNames []string
-	nodes, err := ListWithPredicate(lister, GetNodeConditionPredicate())
+	nodes, err := ListWithPredicate(lister, CandidateNodesPredicate)
 	if err != nil {
 		return nodeNames, err
 	}
@@ -352,21 +352,21 @@ func NodeIsReady(node *api_v1.Node) bool {
 // some set of criteria defined by the function.
 type NodeConditionPredicate func(node *api_v1.Node) bool
 
-// This is a duplicate definition of the function in:
-// https://github.com/kubernetes/kubernetes/blob/3723713c550f649b6ba84964edef9da6cc334f9d/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L668
-func GetNodeConditionPredicate() NodeConditionPredicate {
-	return func(node *api_v1.Node) bool {
+var (
+	// AllNodesPredicate selects all nodes.
+	AllNodesPredicate = func(node *api_v1.Node) bool { return true }
+	// CandidateNodesPredicate selects all nodes that are in ready state and devoid of any exclude labels.
+	// This is a duplicate definition of the function in:
+	// https://github.com/kubernetes/kubernetes/blob/3723713c550f649b6ba84964edef9da6cc334f9d/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L668
+	CandidateNodesPredicate = func(node *api_v1.Node) bool {
 		return nodePredicateInternal(node, false, false)
 	}
-}
-
-// NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes returns a predicate function that tolerates unready nodes and excludes nodes that are being upgraded.
-// Skipping nodes that are about to be upgraded allows the
-func NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes() NodeConditionPredicate {
-	return func(node *api_v1.Node) bool {
+	// CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes selects all nodes except ones that are upgradind and/or have any exclude labels. This function tolerates unready nodes.
+	// TODO(prameshj) - Once the kubernetes/kubernetes Predicate function includes Unready nodes and the GKE nodepool code sets exclude labels on upgrade, this can be replaced with CandidateNodesPredicate.
+	CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes = func(node *api_v1.Node) bool {
 		return nodePredicateInternal(node, true, true)
 	}
-}
+)
 
 func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes, excludeUpgradingNodes bool) bool {
 	// Get all nodes that have a taint with NoSchedule effect

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -631,8 +631,8 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			name:                               "ToBeDeletedByClusterAutoscaler-taint",
 		},
 	}
-	pred := GetNodeConditionPredicate()
-	unreadyPred := NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
+	pred := CandidateNodesPredicate
+	unreadyPred := CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes
 	for _, test := range tests {
 		accept := pred(&test.node)
 		if accept != test.expectAccept {


### PR DESCRIPTION
In case of NEG reconcile/removal or instance group removal, the controller
should check all zones where the cluster has nodes. The current implementation
only checks zones where the cluster has ready/schedulable nodes.

Some failure cases that this change addresses:

1) An L4 NEG can be created in 2 zones - zone1, zone2. Now all nodes in zone2 become unready. Then one node in zone2 becomes ready. NEG will not update the node in zone2 since it will not retrieve the zone2 NEG.

2) NEG/Instance group deletion will not delete the NEG/IG from the zone which only has unready nodes, even though the empty NEG/IG will still exist.

/assign @freehan @swetharepakula 