### PR TITLE
Always enable pathtype

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -19,8 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/ingress-gce/pkg/flags"
-
 	"k8s.io/klog"
 
 	api_v1 "k8s.io/api/core/v1"
@@ -38,6 +36,7 @@ import (
 	"k8s.io/ingress-gce/pkg/backendconfig"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller/errors"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
 )
@@ -304,9 +303,6 @@ func validateAndGetPaths(path v1.HTTPIngressPath) ([]string, error) {
 	pathType := v1.PathTypeImplementationSpecific
 
 	if path.PathType != nil {
-		if !flags.F.EnableIngressGAFields && *path.PathType != v1.PathTypeImplementationSpecific {
-			return nil, fmt.Errorf("only \"ImplementationSpecific\" path type is supported")
-		}
 		pathType = *path.PathType
 	}
 

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -584,35 +584,9 @@ func TestPathValidation(t *testing.T) {
 			path:        "/test/*",
 			expectValid: false,
 		},
-		{
-			desc:              "IngressGA Disabled, empty path type",
-			pathType:          "",
-			path:              "/test",
-			expectValid:       true,
-			expectedPaths:     []string{"/test"},
-			ingressGADisabled: true,
-		},
-		{
-			desc:              "IngressGA Disabled, ImplementationSpecific path type",
-			pathType:          v1.PathTypeImplementationSpecific,
-			path:              "/test",
-			expectValid:       true,
-			expectedPaths:     []string{"/test"},
-			ingressGADisabled: true,
-		},
-		{
-			desc:              "Invalid IngressGA Disabled, non ImplementationSpecific path type",
-			pathType:          v1.PathTypePrefix,
-			path:              "/test",
-			expectValid:       false,
-			expectedPaths:     []string{"/test"},
-			ingressGADisabled: true,
-		},
 	}
 
 	for _, tc := range testcases {
-		flags.F.EnableIngressGAFields = !tc.ingressGADisabled
-
 		path := v1.HTTPIngressPath{
 			Path: tc.path,
 			Backend: v1.IngressBackend{


### PR DESCRIPTION
This PR will separate the path type from the ingress class. That way path type can be enabled as ingress class continues to be developed.

/assign @freehan 