### PR TITLE
Skip unsupported healths during NEG polling

### DIFF
--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -481,6 +481,23 @@ func TestPoll(t *testing.T) {
 	pollAndValidate(step, false, true, 2)
 	pollAndValidate(step, false, true, 2)
 
+	step = "NE has unsupported health"
+	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
+		{
+			NetworkEndpoint: ne,
+			Healths: []*composite.HealthStatusForNetworkEndpoint{
+				{
+					HealthCheckService: &composite.HealthCheckServiceReference{
+						HealthCheckService: negName,
+					},
+					HealthState: "HEALTHY",
+				},
+			},
+		},
+	})
+	pollAndValidate(step, false, false, 3)
+	pollAndValidate(step, false, false, 4)
+
 	step = "NE has healthy status"
 	bsName := "bar"
 	backendServiceUrl := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/foo/global/backendServices/%v", bsName)
@@ -498,9 +515,9 @@ func TestPoll(t *testing.T) {
 		},
 		irrelevantEntry,
 	})
-	pollAndValidate(step, false, false, 3)
+	pollAndValidate(step, false, false, 5)
 	pacherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), meta.GlobalKey(bsName))
-	pollAndValidate(step, false, false, 4)
+	pollAndValidate(step, false, false, 6)
 	pacherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), meta.GlobalKey(bsName))
 }
 


### PR DESCRIPTION
Currently there are 4 types of healths a network endpoint can have:
  * forwardingRule
  * backendService
  * healthCheck
  * healthCheckService

Currently, the NEG controller explicitly checks for a backendService,
however if there is any of the other healths, rather than fast-failing
it will timeout waiting for a backendService to appear and become
healthy.

This is really just a workaround, and ideally the code would be
refactored to support all possible healths. For now, this will bring
back correctness to the fast-fail waiting on health iff
backendServices does not exist in healths.

See: https://cloud.google.com/compute/docs/reference/rest/v1/networkEndpointGroups/listNetworkEndpoints