### PR TITLE
Skip processing non-ILB services in NEG controller.

### DIFF
--- a/pkg/l4/l4controller.go
+++ b/pkg/l4/l4controller.go
@@ -172,15 +172,11 @@ func (l4c *L4Controller) shouldProcessService(service *v1.Service, l4 *loadbalan
 	// skip services that are being handled by the legacy service controller.
 	if utils.IsLegacyL4ILBService(service) {
 		klog.Warningf("Ignoring update for service %s:%s managed by service controller", service.Namespace, service.Name)
-		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerSkipped",
-			fmt.Sprintf("skipping l4 load balancer sync as service contains '%s' finalizer", common.LegacyILBFinalizer))
 		return false
 	}
 	frName := utils.LegacyForwardingRuleName(service)
 	if fr := l4.GetForwardingRule(frName, meta.VersionGA); fr != nil {
 		klog.Warningf("Ignoring update for service %s:%s as it contains legacy forwarding rule %q", service.Namespace, service.Name, frName)
-		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerSkipped",
-			fmt.Sprintf("skipping l4 load balancer sync as service contains legacy forwarding rule %q", frName))
 		return false
 	}
 	return true

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -575,6 +575,9 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 
 // mergeVmIpNEGsPortInfo merges the PortInfo for ILB services using GCE_VM_IP NEGs into portInfoMap
 func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usage.NegServiceState) error {
+	if wantsILB, _ := annotations.WantsL4ILB(service); !wantsILB {
+		return nil
+	}
 	// Only process ILB services after L4 controller has marked it with v2 finalizer.
 	if !utils.IsSubsettingL4ILBService(service) {
 		msg := fmt.Sprintf("Ignoring ILB Service %s, namespace %s as it does not have the v2 finalizer", service.Name, service.Namespace)


### PR DESCRIPTION
Do not emit events about services being skipped. Events about one controller processing the service and another skipping it, will be confusing for users.

/assign @freehan 