### PR TITLE
Only skip ILB processing if legacy ILB FR is found.

### DIFF
--- a/pkg/l4/l4controller_test.go
+++ b/pkg/l4/l4controller_test.go
@@ -152,7 +152,7 @@ func validateSvcStatus(svc *api_v1.Service, expectStatus bool, t *testing.T) {
 	}
 }
 
-func createLegacyForwardingRule(t *testing.T, svc *api_v1.Service, cloud *gce.Cloud) {
+func createLegacyForwardingRule(t *testing.T, svc *api_v1.Service, cloud *gce.Cloud, scheme string) {
 	t.Helper()
 	frName := cloudprovider.DefaultLoadBalancerName(svc)
 	key, err := composite.CreateKey(cloud, frName, meta.Regional)
@@ -164,10 +164,11 @@ func createLegacyForwardingRule(t *testing.T, svc *api_v1.Service, cloud *gce.Cl
 		ip = svc.Status.LoadBalancer.Ingress[0].IP
 	}
 	existingFwdRule := &composite.ForwardingRule{
-		Name:       frName,
-		IPAddress:  ip,
-		Ports:      []string{"123"},
-		IPProtocol: "TCP",
+		Name:                frName,
+		IPAddress:           ip,
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: scheme,
 	}
 	if err = composite.CreateForwardingRule(cloud, key, existingFwdRule); err != nil {
 		t.Errorf("Failed to create fake forwarding rule %s, err %v", frName, err)
@@ -289,15 +290,18 @@ func TestProcessCreateLegacyService(t *testing.T) {
 	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{}, t)
 }
 
-func TestProcessCreateServiceWithLegacyForwardingRule(t *testing.T) {
+func TestProcessCreateServiceWithLegacyInternalForwardingRule(t *testing.T) {
 	l4c := newServiceController(t, newFakeGCE())
 	prevMetrics := test.GetL4LatencyMetric(t)
 	newSvc := test.NewL4ILBService(false, 8080)
 	addILBService(l4c, newSvc)
+	// Mimic addition of NEG. This will not actually happen, but this test verifies that sync is skipped
+	// even if a NEG got added.
+	addNEG(l4c, newSvc)
 	// Create legacy forwarding rule to mimic service controller.
 	// A service can have the v1 finalizer reset due to a buggy script/manual operation.
 	// Subsetting controller should only process the service if it doesn't already have a forwarding rule.
-	createLegacyForwardingRule(t, newSvc, l4c.ctx.Cloud)
+	createLegacyForwardingRule(t, newSvc, l4c.ctx.Cloud, string(cloud.SchemeInternal))
 	err := l4c.sync(getKeyForSvc(newSvc, t))
 	if err != nil {
 		t.Errorf("Failed to sync newly added service %s, err %v", newSvc.Name, err)
@@ -309,6 +313,30 @@ func TestProcessCreateServiceWithLegacyForwardingRule(t *testing.T) {
 	}
 	validateSvcStatus(svc, false, t)
 	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{}, t)
+}
+
+func TestProcessCreateServiceWithLegacyExternalForwardingRule(t *testing.T) {
+	l4c := newServiceController(t, newFakeGCE())
+	prevMetrics := test.GetL4LatencyMetric(t)
+	newSvc := test.NewL4ILBService(false, 8080)
+	addILBService(l4c, newSvc)
+	// Mimic addition of NEG. This will happen in parallel with ILB sync, by the NEG controller.
+	addNEG(l4c, newSvc)
+	// Create legacy external forwarding rule to mimic transition from external to internal LB.
+	// Service processing should succeed in that case. The external forwarding rule will be deleted
+	// by service controller.
+	createLegacyForwardingRule(t, newSvc, l4c.ctx.Cloud, string(cloud.SchemeExternal))
+	err := l4c.sync(getKeyForSvc(newSvc, t))
+	if err != nil {
+		t.Errorf("Failed to sync newly added service %s, err %v", newSvc.Name, err)
+	}
+	// List the service and ensure that the status is updated.
+	svc, err := l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, err)
+	}
+	validateSvcStatus(svc, true, t)
+	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
 }
 
 func TestProcessUpdateClusterIPToILBService(t *testing.T) {


### PR DESCRIPTION
If a legacy external Forwarding rule is found, ILB processing should continue.

/assign @freehan 