### PR TITLE
Add errors to healthcheck merge() func

### DIFF
--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -69,7 +69,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	jig := newTestJig(fakeGCE)
 
-	sp := utils.ServicePort{NodePort: 80, BackendNamer: defaultNamer}
+	sp := utils.ServicePort{NodePort: 80, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}
 	_, err := jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
 	if err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -351,7 +351,7 @@ func TestGCMixed(t *testing.T) {
 		{NodePort: 84, Protocol: annotations.ProtocolHTTP, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
 		{NodePort: 85, Protocol: annotations.ProtocolHTTPS, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
 		{NodePort: 86, Protocol: annotations.ProtocolHTTP, NEGEnabled: true, L7ILBEnabled: true, BackendNamer: defaultNamer},
-		{ID: utils.ServicePortID{Service: types.NamespacedName{Name: "testsvc"}}, VMIPNEGEnabled: true, BackendNamer: defaultNamer},
+		{ID: utils.ServicePortID{Service: types.NamespacedName{Name: "testsvc"}}, VMIPNEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 	}
 	ps := newPortset(svcNodePorts)
 	if err := ps.add(svcNodePorts); err != nil {
@@ -397,62 +397,62 @@ func TestSyncQuota(t *testing.T) {
 		desc          string
 	}{
 		{
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}},
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
 			false,
 			"Same port",
 		},
 		{
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}},
-			[]utils.ServicePort{{NodePort: 9000, BackendNamer: defaultNamer}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
+			[]utils.ServicePort{{NodePort: 9000, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
 			true,
 			"Different port",
 		},
 		{
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}},
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}, {NodePort: 443, BackendNamer: defaultNamer}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}, {NodePort: 443, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
 			false,
 			"Same port plus additional port",
 		},
 		{
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}},
-			[]utils.ServicePort{{NodePort: 3000, BackendNamer: defaultNamer}, {NodePort: 4000, BackendNamer: defaultNamer}, {NodePort: 5000, BackendNamer: defaultNamer}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
+			[]utils.ServicePort{{NodePort: 3000, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}, {NodePort: 4000, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}, {NodePort: 5000, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
 			true,
 			"New set of ports not including the same port",
 		},
 		// Need to fill the TargetPort field on ServicePort to make sure
 		// NEG Backend naming is unique
 		{
-			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer}, {NodePort: 443, BackendNamer: defaultNamer}},
+			[]utils.ServicePort{{NodePort: 8080, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}, {NodePort: 443, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}},
 			[]utils.ServicePort{
-				{Port: 8080, NodePort: 8080, NEGEnabled: true, BackendNamer: defaultNamer},
-				{Port: 443, NodePort: 443, NEGEnabled: true, BackendNamer: defaultNamer},
+				{Port: 8080, NodePort: 8080, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 443, NodePort: 443, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 			},
 			true,
 			"Same port converted to NEG, plus one new NEG port",
 		},
 		{
 			[]utils.ServicePort{
-				{Port: 80, NodePort: 80, NEGEnabled: true, BackendNamer: defaultNamer},
-				{Port: 90, NodePort: 90, BackendNamer: defaultNamer},
+				{Port: 80, NodePort: 80, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 90, NodePort: 90, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 			},
 			[]utils.ServicePort{
-				{Port: 80, BackendNamer: defaultNamer},
-				{Port: 90, NEGEnabled: true, BackendNamer: defaultNamer},
+				{Port: 80, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 90, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 			},
 			true,
 			"Mixed NEG and non-NEG ports",
 		},
 		{
 			[]utils.ServicePort{
-				{Port: 100, NodePort: 100, NEGEnabled: true, BackendNamer: defaultNamer},
-				{Port: 110, NodePort: 110, NEGEnabled: true, BackendNamer: defaultNamer},
-				{Port: 120, NodePort: 120, NEGEnabled: true, BackendNamer: defaultNamer},
+				{Port: 100, NodePort: 100, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 110, NodePort: 110, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 120, NodePort: 120, NEGEnabled: true, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 			},
 			[]utils.ServicePort{
-				{Port: 100, NodePort: 100, BackendNamer: defaultNamer},
-				{Port: 110, NodePort: 110, BackendNamer: defaultNamer},
-				{Port: 120, NodePort: 120, BackendNamer: defaultNamer},
+				{Port: 100, NodePort: 100, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 110, NodePort: 110, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
+				{Port: 120, NodePort: 120, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP},
 			},
 			true,
 			"Same ports as NEG, then non-NEG",

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -147,7 +147,11 @@ func (h *HealthChecks) sync(hc *translator.HealthCheck, bchcc *backendconfigv1.H
 
 // TODO(shance): merge with existing hc code
 func (h *HealthChecks) createILB(hc *translator.HealthCheck) error {
-	compositeType, err := composite.AlphaToHealthCheck(hc.ToAlphaComputeHealthCheck())
+	alpha, err := hc.ToAlphaComputeHealthCheck()
+	if err != nil {
+		return err
+	}
+	compositeType, err := composite.AlphaToHealthCheck(alpha)
 	if err != nil {
 		return fmt.Errorf("Error converting hc to composite: %w", err)
 	}
@@ -181,7 +185,11 @@ func (h *HealthChecks) create(hc *translator.HealthCheck, bchcc *backendconfigv1
 	switch hc.Version() {
 	case meta.VersionAlpha:
 		klog.V(2).Infof("Creating alpha health check with protocol %v", hc.Type)
-		return h.cloud.CreateAlphaHealthCheck(hc.ToAlphaComputeHealthCheck())
+		alphaHC, err := hc.ToAlphaComputeHealthCheck()
+		if err != nil {
+			return err
+		}
+		return h.cloud.CreateAlphaHealthCheck(alphaHC)
 	case meta.VersionBeta:
 		klog.V(2).Infof("Creating beta health check with protocol %v", hc.Type)
 		betaHC, err := hc.ToBetaComputeHealthCheck()
@@ -204,7 +212,11 @@ func (h *HealthChecks) create(hc *translator.HealthCheck, bchcc *backendconfigv1
 // TODO(shance): merge with existing hc code
 func (h *HealthChecks) updateILB(hc *translator.HealthCheck) error {
 	// special case ILB to avoid mucking with stable HC code
-	compositeType, err := composite.AlphaToHealthCheck(hc.ToAlphaComputeHealthCheck())
+	alpha, err := hc.ToAlphaComputeHealthCheck()
+	if err != nil {
+		return err
+	}
+	compositeType, err := composite.AlphaToHealthCheck(alpha)
 	if err != nil {
 		return fmt.Errorf("Error converting newHC to composite: %w", err)
 	}
@@ -225,7 +237,11 @@ func (h *HealthChecks) update(hc *translator.HealthCheck) error {
 	switch hc.Version() {
 	case meta.VersionAlpha:
 		klog.V(2).Infof("Updating alpha health check with protocol %v", hc.Type)
-		return h.cloud.UpdateAlphaHealthCheck(hc.ToAlphaComputeHealthCheck())
+		alpha, err := hc.ToAlphaComputeHealthCheck()
+		if err != nil {
+			return err
+		}
+		return h.cloud.UpdateAlphaHealthCheck(alpha)
 	case meta.VersionBeta:
 		klog.V(2).Infof("Updating beta health check with protocol %v", hc.Type)
 		beta, err := hc.ToBetaComputeHealthCheck()

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -257,11 +257,14 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 	hc := translator.DefaultHealthCheck(1234, annotations.ProtocolHTTP2)
 	hc.Name = testNamer.IGBackend(1234)
 
-	alphahc := hc.ToAlphaComputeHealthCheck()
+	alphahc, err := hc.ToAlphaComputeHealthCheck()
+	if err != nil {
+		t.Error(err)
+	}
 	fakeGCE.CreateAlphaHealthCheck(alphahc)
 
 	// Delete only HTTP2 1234
-	err := healthChecks.Delete(testNamer.IGBackend(1234), meta.Global)
+	err = healthChecks.Delete(testNamer.IGBackend(1234), meta.Global)
 	if err != nil {
 		t.Errorf("unexpected error when deleting health check, err: %v", err)
 	}

--- a/pkg/translator/healthchecks_test.go
+++ b/pkg/translator/healthchecks_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"testing"
+
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	"k8s.io/ingress-gce/pkg/annotations"
+)
+
+func TestMerge(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		hc      *HealthCheck
+		wantErr bool
+	}{
+		{
+			desc: "HTTP",
+			hc:   &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "HTTP"}},
+		},
+		{
+			desc: "HTTP2",
+			hc:   &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "HTTP2"}},
+		},
+		{
+			desc: "HTTPS",
+			hc:   &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "HTTPS"}},
+		},
+		{
+			desc:    "Malformed Protocol",
+			hc:      &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "http"}},
+			wantErr: true,
+		},
+		{
+			desc: "PortSpecification is set",
+			hc:   &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "HTTP"}, HTTPHealthCheck: computealpha.HTTPHealthCheck{PortSpecification: "FOO"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.hc.merge()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("hc.merge() = %v, wantErr = %t", err, tc.wantErr)
+			}
+
+			// Verify correct struct was set
+			switch tc.hc.Protocol() {
+			case annotations.ProtocolHTTP:
+				if tc.hc.HttpHealthCheck == nil || tc.hc.HttpsHealthCheck != nil || tc.hc.Http2HealthCheck != nil {
+					t.Errorf("Invalid HC %v for protocol %q", tc.hc, annotations.ProtocolHTTP)
+				}
+			case annotations.ProtocolHTTPS:
+				if tc.hc.HttpHealthCheck != nil || tc.hc.HttpsHealthCheck == nil || tc.hc.Http2HealthCheck != nil {
+					t.Errorf("Invalid HC %v for protocol %q", tc.hc, annotations.ProtocolHTTPS)
+				}
+			case annotations.ProtocolHTTP2:
+				if tc.hc.HttpHealthCheck != nil || tc.hc.HttpsHealthCheck != nil || tc.hc.Http2HealthCheck == nil {
+					t.Errorf("Invalid HC %v for protocol %q", tc.hc, annotations.ProtocolHTTP2)
+				}
+			}
+
+			// Verify port spec
+			if tc.hc.PortSpecification != "" && tc.hc.PortSpecification != "USE_FIXED_PORT" {
+				if tc.hc.Port != 0 {
+					t.Errorf("Error Port must be 0 if PortSpecification is specified: %v", tc.hc)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- HealthCheck.merge() and ToAlphaComputeHealthCheck() now optionally return errors
- merge() now returns an error if the specified protocol is invalid

Example error:

```
Warning  Sync    1s (x3 over 3s)     loadbalancer-controller  Error syncing to GCP: error running backend syncing routine: error ensuring health check: Protocol "http" is not valid, must be one of ["HTTP","HTTPS","HTTP2"]
```

Old error:

```
Health check "k8s1-xxx-yyy" update error: googleapi: Error 400: Invalid value for field 'resource.httpHealthCheck': ''. HTTP healthCheck missing., invalid
```

/assign @freehan 