### PR TITLE
Look for UPGRADE_NODES annotation only for ILB Subsetting.

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -296,7 +296,7 @@ func NewController(
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode := old.(*apiv1.Node)
 				currentNode := cur.(*apiv1.Node)
-				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyNodes()
+				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
 				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
 					klog.Infof("Node %q has changed, enqueueing", currentNode.Name)
 					negController.enqueueNode(currentNode)

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -58,7 +58,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 	zoneNodeMap := make(map[string][]*v1.Node)
 	processedNodes := sets.String{}
 	numEndpoints := 0
-	candidateNodeCheck := utils.NodeConditionPredicateIncludeUnreadyNodes()
+	candidateNodeCheck := utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -130,7 +130,7 @@ func (l *ClusterL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
-	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.NodeConditionPredicateIncludeUnreadyNodes())
+	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes())
 
 	zoneNodeMap := make(map[string][]*v1.Node)
 	for _, node := range nodes {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -353,21 +353,22 @@ func NodeIsReady(node *api_v1.Node) bool {
 type NodeConditionPredicate func(node *api_v1.Node) bool
 
 // This is a duplicate definition of the function in:
-// kubernetes/kubernetes/pkg/controller/service/service_controller.go
+// https://github.com/kubernetes/kubernetes/blob/3723713c550f649b6ba84964edef9da6cc334f9d/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L668
 func GetNodeConditionPredicate() NodeConditionPredicate {
 	return func(node *api_v1.Node) bool {
-		return nodePredicateInternal(node, false)
+		return nodePredicateInternal(node, false, false)
 	}
 }
 
-// NodeConditionPredicateIncludeUnreadyNodes returns a predicate function that tolerates unready nodes.
-func NodeConditionPredicateIncludeUnreadyNodes() NodeConditionPredicate {
+// NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes returns a predicate function that tolerates unready nodes and excludes nodes that are being upgraded.
+// Skipping nodes that are about to be upgraded allows the
+func NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes() NodeConditionPredicate {
 	return func(node *api_v1.Node) bool {
-		return nodePredicateInternal(node, true)
+		return nodePredicateInternal(node, true, true)
 	}
 }
 
-func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes bool) bool {
+func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes, excludeUpgradingNodes bool) bool {
 	// Get all nodes that have a taint with NoSchedule effect
 	for _, taint := range node.Spec.Taints {
 		if taint.Key == ToBeDeletedTaint {
@@ -389,9 +390,11 @@ func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes bool) bool {
 	if _, hasExcludeBalancerLabel := node.Labels[LabelNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
 		return false
 	}
-	// This node is about to be upgraded.
-	if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
-		return false
+	if excludeUpgradingNodes {
+		// This node is about to be upgraded.
+		if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
+			return false
+		}
 	}
 
 	// If we have no info, don't accept

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -574,7 +574,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept:                       false,
+			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: false,
 			name:                               "ready node, upgrade in progress",
 		},
@@ -632,7 +632,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 		},
 	}
 	pred := GetNodeConditionPredicate()
-	unreadyPred := NodeConditionPredicateIncludeUnreadyNodes()
+	unreadyPred := NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
 	for _, test := range tests {
 		accept := pred(&test.node)
 		if accept != test.expectAccept {


### PR DESCRIPTION
The predicate function used for Instance groups should not check this - to prevent race with service controller. Removing nodes that are about to be upgraded can cause disruption for existing traffic, since non-subsetting ILBs do not configure connectionDraining.

This is a follow up of  https://github.com/kubernetes/ingress-gce/pull/1532 where the annotation check was introduced.

/assign @freehan 