### PR TITLE
Add a lock for the recorders map.

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -104,7 +104,7 @@ type ControllerContext struct {
 
 	healthChecks map[string]func() error
 
-	lock sync.Mutex
+	hcLock, recorderLock sync.Mutex
 
 	// Map of namespace => record.EventRecorder.
 	recorders map[string]record.EventRecorder
@@ -192,7 +192,7 @@ func NewControllerContext(
 	return context
 }
 
-// Init inits the Context, so that we can defers some config until the main thread enter actually get the leader lock.
+// Init inits the Context, so that we can defers some config until the main thread enter actually get the leader hcLock.
 func (ctx *ControllerContext) Init() {
 	klog.V(2).Infof("Controller Context initializing with %+v", ctx.ControllerContextConfig)
 	// Initialize controller context internals based on ASMConfigMap
@@ -317,6 +317,8 @@ func (ctx *ControllerContext) HasSynced() bool {
 
 // Recorder return the event recorder for the given namespace.
 func (ctx *ControllerContext) Recorder(ns string) record.EventRecorder {
+	ctx.recorderLock.Lock()
+	defer ctx.recorderLock.Unlock()
 	if rec, ok := ctx.recorders[ns]; ok {
 		return rec
 	}
@@ -334,8 +336,8 @@ func (ctx *ControllerContext) Recorder(ns string) record.EventRecorder {
 
 // AddHealthCheck registers function to be called for healthchecking.
 func (ctx *ControllerContext) AddHealthCheck(id string, hc func() error) {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
+	ctx.hcLock.Lock()
+	defer ctx.hcLock.Unlock()
 
 	ctx.healthChecks[id] = hc
 }
@@ -345,8 +347,8 @@ type HealthCheckResults map[string]error
 
 // HealthCheck runs all registered healthcheck functions.
 func (ctx *ControllerContext) HealthCheck() HealthCheckResults {
-	ctx.lock.Lock()
-	defer ctx.lock.Unlock()
+	ctx.hcLock.Lock()
+	defer ctx.hcLock.Unlock()
 
 	healthChecks := make(map[string]error)
 	for component, f := range ctx.healthChecks {


### PR DESCRIPTION
This adds a new lock instead of reusing healthcheck lock. Healthcheck lock is taken before running all the healthcheck functions ( for neg, l7, l4 controllers).
Since this happens periodically, it would be wasteful for event recorder to wait for the same lock.


Context - the healthcheck lock was renamed in https://github.com/kubernetes/ingress-gce/pull/413, but I think it makes sense to rename it back to a specific name given the frequency of the lock usage.

Verified with `go test -race` - failed before fix, passed after.

/assign @swetharepakula 
@spencerhance 