### PR TITLE
[1.13] Look for UPGRADE_NODES annotation only for ILB Subsetting.

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -274,7 +274,7 @@ func NewController(
 			UpdateFunc: func(old, cur interface{}) {
 				oldNode := old.(*apiv1.Node)
 				currentNode := cur.(*apiv1.Node)
-				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyNodes()
+				nodeReadyCheck := utils.NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
 				if nodeReadyCheck(oldNode) != nodeReadyCheck(currentNode) {
 					klog.Infof("Node %q has changed, enqueueing", currentNode.Name)
 					negController.enqueueNode(currentNode)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -573,7 +573,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept:                       false,
+			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: false,
 			name:                               "ready node, upgrade in progress",
 		},
@@ -631,7 +631,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 		},
 	}
 	pred := GetNodeConditionPredicate()
-	unreadyPred := NodeConditionPredicateIncludeUnreadyNodes()
+	unreadyPred := NodeConditionPredicateIncludeUnreadyExcludeUpgradingNodes()
 	for _, test := range tests {
 		accept := pred(&test.node)
 		if accept != test.expectAccept {


### PR DESCRIPTION
The predicate function used for Instance groups should not check this - to prevent race with service controller.

Cherrypick of https://github.com/kubernetes/ingress-gce/pull/1564

/assign @freehan 