### PR TITLE
[1.12] Prevent race conditions between service and subsetting controllers.

### DIFF
--- a/pkg/l4/l4controller.go
+++ b/pkg/l4/l4controller.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -164,22 +165,37 @@ func (l4c *L4Controller) shutdown() {
 	l4c.svcQueue.Shutdown()
 }
 
-// processServiceCreateOrUpdate ensures load balancer resources for the given service, as needed.
-// Returns an error if processing the service update failed.
-func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Service) *loadbalancers.SyncResult {
+// shouldProcessService returns if the given LoadBalancer service should be processed by this controller.
+// If the service has either the v1 finalizer or the forwarding rule created by v1 implementation(service controller),
+// the subsetting controller will not process it. Processing it will fail forwarding rule creation with the same IP anyway.
+// This check prevents processing of v1-implemented services whose finalizer field got wiped out.
+func (l4c *L4Controller) shouldProcessService(service *v1.Service, l4 *loadbalancers.L4) bool {
 	// skip services that are being handled by the legacy service controller.
 	if utils.IsLegacyL4ILBService(service) {
 		klog.Warningf("Ignoring update for service %s:%s managed by service controller", service.Namespace, service.Name)
-		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerSkipped",
-			fmt.Sprintf("skipping l4 load balancer sync as service contains '%s' finalizer", common.LegacyILBFinalizer))
+		return false
+	}
+	frName := utils.LegacyForwardingRuleName(service)
+	// Processing should continue if an external forwarding rule exists. This can happen if the service is transitioning from External to Internal.
+	// The external forwarding rule might not be deleted by the time this controller starts processing the service.
+	if fr := l4.GetForwardingRule(frName, meta.VersionGA); fr != nil && fr.LoadBalancingScheme == string(cloud.SchemeInternal) {
+		klog.Warningf("Ignoring update for service %s:%s as it contains legacy forwarding rule %q", service.Namespace, service.Name, frName)
+		return false
+	}
+	return true
+}
+
+// processServiceCreateOrUpdate ensures load balancer resources for the given service, as needed.
+// Returns an error if processing the service update failed.
+func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Service) *loadbalancers.SyncResult {
+	l4 := loadbalancers.NewL4Handler(service, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(service.Namespace), &l4c.sharedResourcesLock)
+	if !l4c.shouldProcessService(service, l4) {
 		return nil
 	}
-
 	// Ensure v2 finalizer
 	if err := common.EnsureServiceFinalizer(service, common.ILBFinalizerV2, l4c.ctx.KubeClient); err != nil {
 		return &loadbalancers.SyncResult{Error: fmt.Errorf("Failed to attach finalizer to service %s/%s, err %w", service.Namespace, service.Name, err)}
 	}
-	l4 := loadbalancers.NewL4Handler(service, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(service.Namespace), &l4c.sharedResourcesLock)
 	nodeNames, err := utils.GetReadyNodeNames(l4c.nodeLister)
 	if err != nil {
 		return &loadbalancers.SyncResult{Error: err}
@@ -368,7 +384,7 @@ func mergeAnnotations(existing, ilbAnnotations map[string]string) map[string]str
 }
 
 func needsDeletion(svc *v1.Service) bool {
-	if !common.HasGivenFinalizer(svc.ObjectMeta, common.ILBFinalizerV2) {
+	if !utils.IsSubsettingL4ILBService(svc) {
 		return false
 	}
 	if common.IsDeletionCandidateForGivenFinalizer(svc.ObjectMeta, common.ILBFinalizerV2) {

--- a/pkg/l4/l4controller_test.go
+++ b/pkg/l4/l4controller_test.go
@@ -31,6 +31,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/cloud-provider"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/context"
@@ -151,6 +152,29 @@ func validateSvcStatus(svc *api_v1.Service, expectStatus bool, t *testing.T) {
 	}
 }
 
+func createLegacyForwardingRule(t *testing.T, svc *api_v1.Service, cloud *gce.Cloud, scheme string) {
+	t.Helper()
+	frName := cloudprovider.DefaultLoadBalancerName(svc)
+	key, err := composite.CreateKey(cloud, frName, meta.Regional)
+	if err != nil {
+		t.Errorf("Unexpected error when creating key - %v", err)
+	}
+	var ip string
+	if len(svc.Status.LoadBalancer.Ingress) > 0 {
+		ip = svc.Status.LoadBalancer.Ingress[0].IP
+	}
+	existingFwdRule := &composite.ForwardingRule{
+		Name:                frName,
+		IPAddress:           ip,
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: scheme,
+	}
+	if err = composite.CreateForwardingRule(cloud, key, existingFwdRule); err != nil {
+		t.Errorf("Failed to create fake forwarding rule %s, err %v", frName, err)
+	}
+}
+
 // TestProcessCreateOrUpdate verifies the processing loop in L4Controller.
 // This test adds a new service, then performs a valid update and then modifies the service type to External and ensures
 // that the status field is as expected in each case.
@@ -264,6 +288,55 @@ func TestProcessCreateLegacyService(t *testing.T) {
 	}
 	validateSvcStatus(svc, false, t)
 	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{}, t)
+}
+
+func TestProcessCreateServiceWithLegacyInternalForwardingRule(t *testing.T) {
+	l4c := newServiceController(t, newFakeGCE())
+	prevMetrics := test.GetL4LatencyMetric(t)
+	newSvc := test.NewL4ILBService(false, 8080)
+	addILBService(l4c, newSvc)
+	// Mimic addition of NEG. This will not actually happen, but this test verifies that sync is skipped
+	// even if a NEG got added.
+	addNEG(l4c, newSvc)
+	// Create legacy forwarding rule to mimic service controller.
+	// A service can have the v1 finalizer reset due to a buggy script/manual operation.
+	// Subsetting controller should only process the service if it doesn't already have a forwarding rule.
+	createLegacyForwardingRule(t, newSvc, l4c.ctx.Cloud, string(cloud.SchemeInternal))
+	err := l4c.sync(getKeyForSvc(newSvc, t))
+	if err != nil {
+		t.Errorf("Failed to sync newly added service %s, err %v", newSvc.Name, err)
+	}
+	// List the service and ensure that the status field is not updated.
+	svc, err := l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, err)
+	}
+	validateSvcStatus(svc, false, t)
+	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{}, t)
+}
+
+func TestProcessCreateServiceWithLegacyExternalForwardingRule(t *testing.T) {
+	l4c := newServiceController(t, newFakeGCE())
+	prevMetrics := test.GetL4LatencyMetric(t)
+	newSvc := test.NewL4ILBService(false, 8080)
+	addILBService(l4c, newSvc)
+	// Mimic addition of NEG. This will happen in parallel with ILB sync, by the NEG controller.
+	addNEG(l4c, newSvc)
+	// Create legacy external forwarding rule to mimic transition from external to internal LB.
+	// Service processing should succeed in that case. The external forwarding rule will be deleted
+	// by service controller.
+	createLegacyForwardingRule(t, newSvc, l4c.ctx.Cloud, string(cloud.SchemeExternal))
+	err := l4c.sync(getKeyForSvc(newSvc, t))
+	if err != nil {
+		t.Errorf("Failed to sync newly added service %s, err %v", newSvc.Name, err)
+	}
+	// List the service and ensure that the status is updated.
+	svc, err := l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, err)
+	}
+	validateSvcStatus(svc, true, t)
+	prevMetrics.ValidateDiff(test.GetL4LatencyMetric(t), &test.L4ILBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
 }
 
 func TestProcessUpdateClusterIPToILBService(t *testing.T) {

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -294,7 +294,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	return composite.GetForwardingRule(l.cloud, key, fr.Version)
 }
 
-func (l *L4) getForwardingRule(name string, version meta.Version) *composite.ForwardingRule {
+func (l *L4) GetForwardingRule(name string, version meta.Version) *composite.ForwardingRule {
 	key, err := l.CreateKey(name)
 	if err != nil {
 		klog.Errorf("Failed to create key for fetching existing forwarding rule %s, err: %v", name, err)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -296,11 +296,11 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service)
 	if err != nil {
 		klog.Errorf("Failed to lookup existing backend service, ignoring err: %v", err)
 	}
-	existingFR := l.getForwardingRule(l.GetFRName(), meta.VersionGA)
+	existingFR := l.GetForwardingRule(l.GetFRName(), meta.VersionGA)
 	if existingBS != nil && existingBS.Protocol != string(protocol) {
 		klog.Infof("Protocol changed from %q to %q for service %s", existingBS.Protocol, string(protocol), l.NamespacedName)
 		// Delete forwarding rule if it exists
-		existingFR = l.getForwardingRule(l.getFRNameWithProtocol(existingBS.Protocol), meta.VersionGA)
+		existingFR = l.GetForwardingRule(l.getFRNameWithProtocol(existingBS.Protocol), meta.VersionGA)
 		l.deleteForwardingRule(l.getFRNameWithProtocol(existingBS.Protocol), meta.VersionGA)
 	}
 

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -560,10 +560,11 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 	if wantsILB, _ := annotations.WantsL4ILB(service); !wantsILB {
 		return nil
 	}
-	if utils.IsLegacyL4ILBService(service) {
-		msg := fmt.Sprintf("Ignoring ILB Service %s, namespace %s as it contains legacy resources created by service controller", service.Name, service.Namespace)
+	// Only process ILB services after L4 controller has marked it with v2 finalizer.
+	if !utils.IsSubsettingL4ILBService(service) {
+		msg := fmt.Sprintf("Ignoring ILB Service %s, namespace %s as it does not have the v2 finalizer", service.Name, service.Namespace)
 		klog.Warning(msg)
-		c.recorder.Eventf(service, apiv1.EventTypeWarning, "ProcessServiceFailed", msg)
+		c.recorder.Eventf(service, apiv1.EventTypeWarning, "ProcessServiceSkipped", msg)
 		return nil
 	}
 

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -327,9 +327,8 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	manager := controller.manager.(*syncerManager)
 	defer controller.stop()
 	var prevSyncerKey, updatedSyncerKey negtypes.NegSyncerKey
-	localMode := false
 	t.Logf("Creating L4 ILB service with ExternalTrafficPolicy:Cluster")
-	controller.serviceLister.Add(newTestILBService(controller, localMode, 80))
+	controller.serviceLister.Add(newTestILBService(controller, false, 80))
 	svcClient := controller.client.CoreV1().Services(testServiceNamespace)
 	svcKey := utils.ServiceKeyFunc(testServiceNamespace, testServiceName)
 	err := controller.processService(svcKey)
@@ -340,8 +339,25 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Service was not created.(*apiv1.Service) successfully, err: %v", err)
 	}
+	// No syncers created yet, because the service does not have the v2 finalizer.
+	validateSyncers(t, controller, 0, true)
+	svc.Finalizers = []string{gce.ILBFinalizerV2}
+	if svc, err = controller.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update test L4 ILB service with V2 finalizer: %v", err)
+	}
+	if err = controller.serviceLister.Update(svc); err != nil {
+		t.Fatalf("Failed to update service lister: %v", err)
+	}
+	if err = controller.processService(svcKey); err != nil {
+		t.Fatalf("Failed to process updated L4 ILB service with finalizer: %v", err)
+	}
+	// GET the service with the latest annotations.
+	svc, err = svcClient.Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Service was not created.(*apiv1.Service) successfully, err: %v", err)
+	}
 	expectedPortInfoMap := negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName,
-		controller.l4Namer, localMode)
+		controller.l4Namer, false)
 	// There will be only one entry in the map
 	for key, val := range expectedPortInfoMap {
 		prevSyncerKey = manager.getSyncerKey(testServiceNamespace, testServiceName, key, val)
@@ -351,15 +367,18 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	validateServiceAnnotationWithPortInfoMap(t, svc, expectedPortInfoMap)
 	// Now Update the service to change the TrafficPolicy
 	t.Logf("Updating L4 ILB service from ExternalTrafficPolicy:Cluster to Local")
-	localMode = true
-	if err = controller.serviceLister.Update(updateTestILBService(controller, localMode, svc)); err != nil {
-		t.Fatalf("Failed to update test L4 ILB service: %v", err)
+	svc.Spec.ExternalTrafficPolicy = apiv1.ServiceExternalTrafficPolicyTypeLocal
+	if svc, err = controller.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update test L4 ILB service with Local trafficPolicy: %v", err)
+	}
+	if err = controller.serviceLister.Update(svc); err != nil {
+		t.Fatalf("Failed to update service lister: %v", err)
 	}
 	if err = controller.processService(svcKey); err != nil {
 		t.Fatalf("Failed to process updated L4 ILB srvice: %v", err)
 	}
 	expectedPortInfoMap = negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName,
-		controller.l4Namer, localMode)
+		controller.l4Namer, true)
 	// There will be only one entry in the map
 	for key, val := range expectedPortInfoMap {
 		updatedSyncerKey = manager.getSyncerKey(testServiceNamespace, testServiceName, key, val)
@@ -1604,16 +1623,6 @@ func newTestILBService(c *Controller, onlyLocal bool, port int) *apiv1.Service {
 	}
 
 	c.client.CoreV1().Services(testServiceNamespace).Create(context.TODO(), svc, metav1.CreateOptions{})
-	return svc
-}
-
-func updateTestILBService(c *Controller, onlyLocal bool, svc *apiv1.Service) *apiv1.Service {
-	if onlyLocal {
-		svc.Spec.ExternalTrafficPolicy = apiv1.ServiceExternalTrafficPolicyTypeLocal
-	} else {
-		svc.Spec.ExternalTrafficPolicy = apiv1.ServiceExternalTrafficPolicyTypeCluster
-	}
-	c.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{})
 	return svc
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/cloud-provider"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -586,6 +587,15 @@ func TranslateAffinityType(affinityType string) string {
 // IsLegacyL4ILBService returns true if the given LoadBalancer service is managed by service controller.
 func IsLegacyL4ILBService(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.LegacyILBFinalizer, nil)
+}
+
+// IsSubsettingL4ILBService returns true if the given LoadBalancer service is managed by NEG and L4 controller.
+func IsSubsettingL4ILBService(svc *api_v1.Service) bool {
+	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.ILBFinalizerV2, nil)
+}
+
+func LegacyForwardingRuleName(svc *api_v1.Service) string {
+	return cloudprovider.DefaultLoadBalancerName(svc)
 }
 
 // L4ILBResourceDescription stores the description fields for L4 ILB resources.


### PR DESCRIPTION
Cherrypick of 3 PRs - https://github.com/kubernetes/ingress-gce/pull/1545, https://github.com/kubernetes/ingress-gce/pull/1552, https://github.com/kubernetes/ingress-gce/pull/1554

Main target is 1.11 branch, cherrypicking in 1.12 for completeness.

/assign @freehan @swetharepakula 