### PR TITLE
Skip using deprecated zone label for Nodes.

### DIFF
--- a/docs/deploy/gke/non-gcp/README.md
+++ b/docs/deploy/gke/non-gcp/README.md
@@ -10,10 +10,10 @@ following commands to label ALL nodes in the GKE On-Prem cluster:
 
 ```sh
 kubectl label nodes <node-name> \
-  failure-domain.beta.kubernetes.io/zone=<GCP_ZONE>
+  topology.kubernetes.io/zone=<GCP_ZONE>
 
 kubectl label nodes <node-name> \
-  failure-domain.beta.kubernetes.io/region=<GCP_REGION>
+  topology.kubernetes.io/region=<GCP_REGION>
 ```
 
 # Create a service account

--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -65,7 +65,7 @@ const (
 	GceL7ILBIngressClass = "gce-internal"
 
 	// Label key to denote which GCE zone a Kubernetes node is in.
-	ZoneKey     = "failure-domain.beta.kubernetes.io/zone"
+	ZoneKey     = "topology.kubernetes.io/zone"
 	DefaultZone = ""
 
 	// InstanceGroupsAnnotationKey is the annotation key used by controller to

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -83,7 +83,7 @@ func SpreadPodAcrossZones(deployment *apps.Deployment) {
 					Weight: int32(1),
 					PodAffinityTerm: v1.PodAffinityTerm{
 						LabelSelector: metav1.SetAsLabelSelector(labels.Set(podLabels)),
-						TopologyKey:   v1.LabelZoneFailureDomain,
+						TopologyKey:   v1.LabelZoneFailureDomainStable,
 					},
 				},
 			},

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -181,8 +181,8 @@ func CreateAndInsertNodes(gce *gce.Cloud, nodeNames []string, zoneName string) (
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: name,
 					Labels: map[string]string{
-						api_v1.LabelHostname:          name,
-						api_v1.LabelZoneFailureDomain: zoneName,
+						api_v1.LabelHostname:                name,
+						api_v1.LabelZoneFailureDomainStable: zoneName,
 					},
 				},
 				Status: api_v1.NodeStatus{


### PR DESCRIPTION
"failure-domain.beta.kubernetes.io/zone" is deprecated in favor of "topology.kubernetes.io/zone" - https://kubernetes.io/docs/reference/labels-annotations-taints/

/assign @freehan @swetharepakula 