### PR TITLE
Revert "Process ILB service when NEG annotation changes."

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -212,21 +212,22 @@ func WantsL4ILB(service *v1.Service) (bool, string) {
 	return false, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
 }
 
-// OnlyStatusAnnotationsChanged returns true if the only annotation change between the 2 services is in ILB resources annotations.
+// OnlyStatusAnnotationsChanged returns true if the only annotation change between the 2 services is the NEG or ILB
+// resources annotations.
 // Note : This assumes that the annotations in old and new service are different. If they are identical, this will
 // return true.
 func OnlyStatusAnnotationsChanged(oldService, newService *v1.Service) bool {
 	return onlyStatusAnnotationsChanged(oldService, newService) && onlyStatusAnnotationsChanged(newService, oldService)
 }
 
-// onlyStatusAnnotationsChanged returns true if the ILB resources annotations are the only extra annotations present
-// in the new service but not in the old service.
+// onlyStatusAnnotationsChanged returns true if the NEG Status or ILB resources annotations are the only extra
+// annotations present in the new service but not in the old service.
 // Note : This assumes that the annotations in old and new service are different. If they are identical, this will
 // return true.
 func onlyStatusAnnotationsChanged(oldService, newService *v1.Service) bool {
 	for key, val := range newService.ObjectMeta.Annotations {
 		if oldVal, ok := oldService.ObjectMeta.Annotations[key]; !ok || oldVal != val {
-			if strings.HasPrefix(key, ServiceStatusPrefix) {
+			if key == NEGStatusKey || strings.HasPrefix(key, ServiceStatusPrefix) {
 				continue
 			}
 			return false

--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -482,50 +482,10 @@ func TestOnlyStatusAnnotationsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: false,
-		},
-		{
-			desc: "Test new zone in neg annotation",
-			service1: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "service1",
-					Annotations: map[string]string{
-						NEGStatusKey: `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a"]}`,
-					},
-				},
-			},
-			service2: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "service2",
-					Annotations: map[string]string{
-						NEGStatusKey: `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a", "us-central1-b"]}`,
-					},
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			desc: "Test no change in neg annotation",
-			service1: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "service1",
-					Annotations: map[string]string{
-						NEGStatusKey: `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a"]}`,
-					},
-				},
-			},
-			service2: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "service2",
-					Annotations: map[string]string{
-						NEGStatusKey: `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a"]}`,
-					},
-				},
-			},
 			expectedResult: true,
 		},
 		{
-			desc: "Test new annotation added",
+			desc: "Test valid diff",
 			service1: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
@@ -538,7 +498,6 @@ func TestOnlyStatusAnnotationsChanged(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service2",
 					Annotations: map[string]string{
-						NEGStatusKey:       `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a"]}`,
 						"RandomAnnotation": "abcde",
 					},
 				},
@@ -584,7 +543,7 @@ func TestOnlyStatusAnnotationsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			desc: "Test only ILB ForwardingRule annotation diff",
@@ -629,7 +588,6 @@ func TestOnlyStatusAnnotationsChanged(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service2",
 					Annotations: map[string]string{
-						NEGStatusKey:       `{"network_endpoint_groups":{"80":"neg-name"},"zones":["us-central1-a"]}`,
 						"RandomAnnotation": "abcde",
 					},
 				},

--- a/pkg/l4/l4controller.go
+++ b/pkg/l4/l4controller.go
@@ -444,8 +444,7 @@ func (l4c *L4Controller) needsUpdate(oldService *v1.Service, newService *v1.Serv
 		}
 	}
 	if !reflect.DeepEqual(oldService.Annotations, newService.Annotations) {
-		// Ignore update if only ilb resources annotations changed, these are added by the l4 controller.
-		// Annotations added/modified by the NEG controller will still trigger an update.
+		// Ignore update if only neg or ilb resources annotations changed, these are added by the neg/l4 controller.
 		if !annotations.OnlyStatusAnnotationsChanged(oldService, newService) {
 			recorder.Eventf(newService, v1.EventTypeNormal, "Annotations", "%v -> %v",
 				oldService.Annotations, newService.Annotations)


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#1572

NEG annotation does not get updated by neg controller for node addition events. These are processed by the syncer and that updates the serviceNEG status, but not the annotation on the service. 
