### PR TITLE
Updates E2E test images registry

### DIFF
--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -420,7 +420,8 @@ func CreatePorterDeployment(s *Sandbox, name string, replics int32, version stri
 					Containers: []apiv1.Container{
 						{
 							Name:  "hostname",
-							Image: "gcr.io/kubernetes-e2e-test-images/porter-alpine:1.0",
+							Image: "k8s.gcr.io/e2e-test-images/agnhost:2.32",
+							Args:  []string{"porter"},
 							Env:   []apiv1.EnvVar{{Name: env, Value: env}},
 							Ports: []apiv1.ContainerPort{{Name: "server", ContainerPort: porterPort}},
 						},


### PR DESCRIPTION
We're moving away from google.com gcp projects. These images are now on community-owned infra.

Note that the porter image has been centralized into the agnhost image.

Related: https://github.com/kubernetes/k8s.io/issues/1522