### PR TITLE
[1.11] Allow Unschedulable nodes to be part of the LB backends list.

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -367,12 +367,6 @@ type NodeConditionPredicate func(node *api_v1.Node) bool
 // kubernetes/kubernetes/pkg/controller/service/service_controller.go
 func GetNodeConditionPredicate() NodeConditionPredicate {
 	return func(node *api_v1.Node) bool {
-		// We add the master to the node list, but its unschedulable.  So we use this to filter
-		// the master.
-		if node.Spec.Unschedulable {
-			return false
-		}
-
 		// Get all nodes that have a taint with NoSchedule effect
 		for _, taint := range node.Spec.Taints {
 			if taint.Key == ToBeDeletedTaint {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -425,7 +425,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: false,
+			expectAccept: true,
 			name:         "unschedulable",
 		}, {
 			node: api_v1.Node{


### PR DESCRIPTION
This was allowed in service controller in https://github.com/kubernetes/kubernetes/pull/90823

Cherrypick of https://github.com/kubernetes/ingress-gce/pull/1537

/assign @freehan 