### PR TITLE
Extend L4LBServiceDescription to support Internal and External LB

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -255,7 +255,7 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 	if err != nil && !utils.IsNotFoundError(err) {
 		return nil, err
 	}
-	desc, err := utils.MakeL4ILBServiceDescription(nm.String(), "", meta.VersionGA, false)
+	desc, err := utils.MakeL4LBServiceDescription(nm.String(), "", meta.VersionGA, false, utils.ILB)
 	if err != nil {
 		klog.Warningf("EnsureL4BackendService: Failed to generate description for BackendService %s, err %v",
 			name, err)

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -36,7 +36,7 @@ func EnsureL4InternalFirewallRule(cloud *gce.Cloud, fwName, lbIP, nsName string,
 	if err != nil {
 		return err
 	}
-	fwDesc, err := utils.MakeL4ILBServiceDescription(nsName, lbIP, meta.VersionGA, sharedRule)
+	fwDesc, err := utils.MakeL4LBServiceDescription(nsName, lbIP, meta.VersionGA, sharedRule, utils.ILB)
 	if err != nil {
 		klog.Warningf("EnsureL4InternalFirewallRule: Failed to generate description for rule %s, err: %v",
 			fwName, err)

--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -53,7 +53,7 @@ func EnsureL4HealthCheck(cloud *gce.Cloud, name string, svcName types.Namespaced
 			return nil, selfLink, err
 		}
 	}
-	expectedHC := NewL4HealthCheck(name, svcName, shared, path, port)
+	expectedHC := NewL4HealthCheck(name, svcName, shared, path, port, utils.ILB)
 	if hc == nil {
 		// Create the healthcheck
 		klog.V(2).Infof("Creating healthcheck %s for service %s, shared = %v", name, svcName, shared)
@@ -86,13 +86,13 @@ func DeleteHealthCheck(cloud *gce.Cloud, name string) error {
 	return composite.DeleteHealthCheck(cloud, key, meta.VersionGA)
 }
 
-func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32) *composite.HealthCheck {
+func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32, l4Type utils.L4LBType) *composite.HealthCheck {
 	httpSettings := composite.HTTPHealthCheck{
 		Port:        int64(port),
 		RequestPath: path,
 	}
 
-	desc, err := utils.MakeL4ILBServiceDescription(svcName.String(), "", meta.VersionGA, shared)
+	desc, err := utils.MakeL4LBServiceDescription(svcName.String(), "", meta.VersionGA, shared, l4Type)
 	if err != nil {
 		klog.Warningf("Failed to generate description for L4HealthCheck %s, err %v", name, err)
 	}

--- a/pkg/healthchecks/healthchecks_l4_test.go
+++ b/pkg/healthchecks/healthchecks_l4_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package healthchecks
 
 import (
+	"testing"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-gce/pkg/composite"
-	"testing"
+	"k8s.io/ingress-gce/pkg/utils"
 )
 
 func TestMergeHealthChecks(t *testing.T) {
@@ -46,7 +48,7 @@ func TestMergeHealthChecks(t *testing.T) {
 		{"unhealthy threshold - user configured - should keep", gceHcCheckIntervalSeconds, gceHcTimeoutSeconds, gceHcHealthyThreshold, gceHcUnhealthyThreshold + 1, gceHcCheckIntervalSeconds, gceHcTimeoutSeconds, gceHcHealthyThreshold, gceHcUnhealthyThreshold + 1},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345)
+			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB)
 			hc := &composite.HealthCheck{
 				CheckIntervalSec:   tc.checkIntervalSec,
 				TimeoutSec:         tc.timeoutSec,
@@ -92,8 +94,8 @@ func TestCompareHealthChecks(t *testing.T) {
 		{"unhealthy threshold does not need update", func(hc *composite.HealthCheck) { hc.UnhealthyThreshold = gceHcUnhealthyThreshold + 1 }, false},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			hc := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345)
-			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345)
+			hc := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB)
+			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB)
 			if tc.modifier != nil {
 				tc.modifier(hc)
 			}

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -243,8 +243,8 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 
 	ports, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
 	// Create the forwarding rule
-	frDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(l.Service.Namespace, l.Service.Name), ipToUse,
-		version, false)
+	frDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(l.Service.Namespace, l.Service.Name), ipToUse,
+		version, false, utils.ILB)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %w", loadBalancerName,
 			err)

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -747,7 +747,7 @@ func TestEnsureInternalLoadBalancerEnableGlobalAccess(t *testing.T) {
 		t.Errorf("Got empty loadBalancer status using handler %v", l)
 	}
 	assertInternalLbResources(t, svc, l, nodeNames, result.Annotations)
-	descString, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(svc.Namespace, svc.Name), "1.2.3.0", meta.VersionGA, false)
+	descString, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(svc.Namespace, svc.Name), "1.2.3.0", meta.VersionGA, false, utils.ILB)
 	if err != nil {
 		t.Errorf("Unexpected error when creating description - %v", err)
 	}
@@ -1128,11 +1128,11 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 	// Check that Firewalls are created for the LoadBalancer and the HealthCheck
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(apiService)
 	resourceName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
-	resourceDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, false)
+	resourceDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, false, utils.ILB)
 	if err != nil {
 		t.Errorf("Failed to create description for resources, err %v", err)
 	}
-	sharedResourceDesc, err := utils.MakeL4ILBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, true)
+	sharedResourceDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, true, utils.ILB)
 	if err != nil {
 		t.Errorf("Failed to create description for shared resources, err %v", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -76,9 +76,9 @@ const (
 	LabelNodeRoleExcludeBalancer = "node.kubernetes.io/exclude-from-external-load-balancers"
 	// ToBeDeletedTaint is the taint that the autoscaler adds when a node is scheduled to be deleted
 	// https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-0.5.2/cluster-autoscaler/utils/deletetaint/delete.go#L33
-	ToBeDeletedTaint         = "ToBeDeletedByClusterAutoscaler"
-	L4ILBServiceDescKey      = "networking.gke.io/service-name"
-	L4ILBSharedResourcesDesc = "This resource is shared by all L4 ILB Services using ExternalTrafficPolicy: Cluster."
+	ToBeDeletedTaint        = "ToBeDeletedByClusterAutoscaler"
+	L4ILBServiceDescKey     = "networking.gke.io/service-name"
+	L4LBSharedResourcesDesc = "This resource is shared by all L4 %s Services using ExternalTrafficPolicy: Cluster."
 
 	// LabelAlphaNodeRoleExcludeBalancer specifies that the node should be
 	// exclude from load balancers created by a cloud provider. This label is deprecated and will
@@ -87,6 +87,21 @@ const (
 	GKEUpgradeOperation               = "operation_type: UPGRADE_NODES"
 	GKECurrentOperationAnnotation     = "gke-current-operation"
 )
+
+// L4LBType indicates if L4 LoadBalancer is Internal or External
+type L4LBType int
+
+const (
+	ILB L4LBType = iota
+	XLB
+)
+
+func (lbType L4LBType) ToString() string {
+	if lbType == ILB {
+		return "ILB"
+	}
+	return "XLB"
+}
 
 // FrontendGCAlgorithm species GC algorithm used for ingress frontend resources.
 type FrontendGCAlgorithm int
@@ -623,9 +638,9 @@ func LegacyForwardingRuleName(svc *api_v1.Service) string {
 	return cloudprovider.DefaultLoadBalancerName(svc)
 }
 
-// L4ILBResourceDescription stores the description fields for L4 ILB resources.
-// This is useful to indetify which resources correspond to which L4 ILB service.
-type L4ILBResourceDescription struct {
+// L4LBResourceDescription stores the description fields for L4 ILB or NetLB resources.
+// This is useful to indetify which resources correspond to which L4 LB service.
+type L4LBResourceDescription struct {
 	// ServiceName indicates the name of the service the resource is for.
 	ServiceName string `json:"networking.gke.io/service-name"`
 	// APIVersion stores the version og the compute API used to create this resource.
@@ -635,7 +650,7 @@ type L4ILBResourceDescription struct {
 }
 
 // Marshal returns the description as a JSON-encoded string.
-func (d *L4ILBResourceDescription) Marshal() (string, error) {
+func (d *L4LBResourceDescription) Marshal() (string, error) {
 	out, err := json.Marshal(d)
 	if err != nil {
 		return "", err
@@ -644,15 +659,15 @@ func (d *L4ILBResourceDescription) Marshal() (string, error) {
 }
 
 // Unmarshal converts the JSON-encoded description string into the struct.
-func (d *L4ILBResourceDescription) Unmarshal(desc string) error {
+func (d *L4LBResourceDescription) Unmarshal(desc string) error {
 	return json.Unmarshal([]byte(desc), d)
 }
 
-func MakeL4ILBServiceDescription(svcName, ip string, version meta.Version, shared bool) (string, error) {
+func MakeL4LBServiceDescription(svcName, ip string, version meta.Version, shared bool, lbType L4LBType) (string, error) {
 	if shared {
-		return (&L4ILBResourceDescription{APIVersion: version, ResourceDescription: L4ILBSharedResourcesDesc}).Marshal()
+		return (&L4LBResourceDescription{APIVersion: version, ResourceDescription: fmt.Sprintf(L4LBSharedResourcesDesc, lbType.ToString())}).Marshal()
 	}
-	return (&L4ILBResourceDescription{ServiceName: svcName, ServiceIP: ip, APIVersion: version}).Marshal()
+	return (&L4LBResourceDescription{ServiceName: svcName, ServiceIP: ip, APIVersion: version}).Marshal()
 }
 
 // NewStringPointer returns a pointer to the provided string literal


### PR DESCRIPTION
Added functionality that sets description of the service based on its
type. Right now Ingress-GCE supports only Internal L4 LB but
External L4 LB will be introduced soon.