### PR TITLE
[Cherrypick #1600 into 1.11] Trigger sync for certain node changes

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -91,6 +91,10 @@ type syncerManager struct {
 	// enableNonGcpMode indicates whether nonGcpMode have been enabled
 	// This will make all NEGs created by NEG controller to be NON_GCP_PRIVATE_IP_PORT type.
 	enableNonGcpMode bool
+
+	// zoneMap keeps track of the last set of zones the neg controller
+	// has seen. zoneMap is protected by the mu mutex.
+	zoneMap map[string]struct{}
 }
 
 func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
@@ -105,6 +109,15 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 	nodeLister,
 	svcNegLister cache.Indexer,
 	enableNonGcpMode bool) *syncerManager {
+
+	zones, err := zoneGetter.ListZones()
+	if err != nil {
+		klog.V(3).Infof("Unable to initialize zone map in neg manager: %s", err)
+	}
+	zoneMap := make(map[string]struct{})
+	for _, zone := range zones {
+		zoneMap[zone] = struct{}{}
+	}
 	return &syncerManager{
 		namer:            namer,
 		recorder:         recorder,
@@ -120,6 +133,7 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 		svcNegClient:     svcNegClient,
 		kubeSystemUID:    kubeSystemUID,
 		enableNonGcpMode: enableNonGcpMode,
+		zoneMap:          zoneMap,
 	}
 }
 
@@ -261,11 +275,34 @@ func (manager *syncerManager) Sync(namespace, name string) {
 func (manager *syncerManager) SyncNodes() {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+
+	// When a zone change occurs (new zone is added or deleted), a sync should be triggered
+	isZoneChange := manager.updateZoneMap()
 	for key, syncer := range manager.syncerMap {
-		if key.NegType == negtypes.VmIpEndpointType && !syncer.IsStopped() {
+		needSync := isZoneChange || key.NegType == negtypes.VmIpEndpointType
+		if needSync && !syncer.IsStopped() {
 			syncer.Sync()
 		}
 	}
+}
+
+// updateZoneMap updates the manager's zone map with the current zones and returns true if the
+// zones have changed. The caller must obtain mu mutex before calling this function
+func (manager *syncerManager) updateZoneMap() bool {
+	zones, err := manager.zoneGetter.ListZones()
+	if err != nil {
+		klog.Warningf("Unable to list zones: %s", err)
+		return false
+	}
+
+	newZoneMap := make(map[string]struct{})
+	for _, zone := range zones {
+		newZoneMap[zone] = struct{}{}
+	}
+
+	zoneChange := !reflect.DeepEqual(manager.zoneMap, newZoneMap)
+	manager.zoneMap = newZoneMap
+	return zoneChange
 }
 
 // ShutDown signals all syncers to stop

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1411,6 +1411,127 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 	}
 }
 
+func TestSyncNodesConditions(t *testing.T) {
+	testcases := []struct {
+		desc          string
+		syncerStopped bool
+		negType       negtypes.NetworkEndpointType
+		expectSync    bool
+		addZones      map[string][]string
+		deleteZones   []string
+	}{
+		{
+			desc:       "vm ip port neg, zones added",
+			expectSync: true,
+			negType:    negtypes.VmIpPortEndpointType,
+			addZones: map[string][]string{
+				"zoneA": []string{"added-instance"},
+			},
+		},
+		{
+			desc:        "vm ip port neg, zones deleted",
+			expectSync:  true,
+			negType:     negtypes.VmIpPortEndpointType,
+			deleteZones: []string{"zone1"},
+		},
+		{
+			desc:       "vm ip port neg, zones are the same",
+			expectSync: false,
+			negType:    negtypes.VmIpPortEndpointType,
+		},
+		{
+			desc:       "vm ip neg, zones added",
+			expectSync: true,
+			negType:    negtypes.VmIpEndpointType,
+			addZones: map[string][]string{
+				"zoneA": []string{"added-instance"},
+			},
+		},
+		{
+			desc:        "vm ip neg, zones deleted",
+			expectSync:  true,
+			negType:     negtypes.VmIpEndpointType,
+			deleteZones: []string{"zone1"},
+		},
+		{
+			desc:       "vm ip neg, zones are the same",
+			expectSync: true,
+			negType:    negtypes.VmIpEndpointType,
+		},
+		{
+			desc:          "vm ip neg syncer is stopped",
+			expectSync:    false,
+			syncerStopped: true,
+			negType:       negtypes.VmIpEndpointType,
+		},
+		{
+			desc:          "vm ip port neg syncer is stopped",
+			expectSync:    false,
+			syncerStopped: true,
+			negType:       negtypes.VmIpPortEndpointType,
+			deleteZones:   []string{"zone1"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			syncCalled := false
+			syncFunc := func() bool {
+				syncCalled = true
+				return false
+			}
+
+			manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+
+			syncer := &fakeSyncer{
+				isStopped: tc.syncerStopped,
+				syncFunc:  syncFunc,
+			}
+			key := negtypes.NegSyncerKey{
+				NegType: tc.negType,
+			}
+			manager.syncerMap = map[negtypes.NegSyncerKey]negtypes.NegSyncer{
+				key: syncer,
+			}
+			fakeZoneGetter := manager.zoneGetter.(*negtypes.FakeZoneGetter)
+			for zone, instances := range tc.addZones {
+				err := fakeZoneGetter.AddZone(zone, instances...)
+				if err != nil {
+					t.Errorf("failed to add zone: %s", err)
+				}
+			}
+
+			for _, zone := range tc.deleteZones {
+				fakeZoneGetter.DeleteZone(zone)
+			}
+
+			manager.SyncNodes()
+			if syncCalled != tc.expectSync {
+				t.Errorf("syncCalled is %t, expected %t", syncCalled, tc.expectSync)
+			}
+
+			if tc.negType == negtypes.VmIpPortEndpointType {
+				syncCalled = false
+				manager.SyncNodes()
+				if syncCalled {
+					t.Errorf("no zone change, sync should not have been called again")
+				}
+			}
+		})
+	}
+}
+
+type fakeSyncer struct {
+	isStopped bool
+	syncFunc  func() bool
+}
+
+func (s *fakeSyncer) Start() error         { return nil }
+func (s *fakeSyncer) Stop()                {}
+func (s *fakeSyncer) Sync() bool           { return s.syncFunc() }
+func (s *fakeSyncer) IsStopped() bool      { return s.isStopped }
+func (s *fakeSyncer) IsShuttingDown() bool { return false }
+
 // getNegObjectRefs generates the NegObjectReference list of all negs with the specified negName in the specified zones
 func getNegObjectRefs(t *testing.T, cloud negtypes.NetworkEndpointGroupCloud, zones []string, negName string, version meta.Version) []negv1beta1.NegObjectReference {
 	var negRefs []negv1beta1.NegObjectReference

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -18,18 +18,18 @@ package syncers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
-	"fmt"
-
-	"strings"
-
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -151,7 +151,7 @@ func (s *transactionSyncer) syncInternal() error {
 	start := time.Now()
 	defer metrics.PublishNegSyncMetrics(string(s.NegSyncerKey.NegType), string(s.endpointsCalculator.Mode()), err, start)
 
-	if s.needInit {
+	if s.needInit || s.isZoneChange() {
 		if err := s.ensureNetworkEndpointGroups(); err != nil {
 			return err
 		}
@@ -421,6 +421,35 @@ func (s *transactionSyncer) commitPods(endpointMap map[string]negtypes.NetworkEn
 		}
 		s.reflector.CommitPods(s.NegSyncerKey, s.NegSyncerKey.NegName, zone, zoneEndpointMap)
 	}
+}
+
+// isZoneChange returns true if a zone change has occurred by comparing which zones the nodes are in
+// with the zones that NEGs are initialized in
+func (s *transactionSyncer) isZoneChange() bool {
+	negCR, err := getNegFromStore(s.svcNegLister, s.Namespace, s.NegSyncerKey.NegName)
+	if err != nil {
+		klog.Warningf("unable to retrieve neg %s/%s from the store: %s", s.Namespace, s.NegName, err)
+		return false
+	}
+
+	existingZones := sets.NewString()
+	for _, ref := range negCR.Status.NetworkEndpointGroups {
+		id, err := cloud.ParseResourceURL(ref.SelfLink)
+		if err != nil {
+			klog.Warningf("unable to parse selflink %s", ref.SelfLink)
+			continue
+		}
+		existingZones.Insert(id.Key.Zone)
+	}
+
+	zones, err := s.zoneGetter.ListZones()
+	if err != nil {
+		klog.Errorf("unable to list zones: %s", err)
+		return false
+	}
+	currZones := sets.NewString(zones...)
+
+	return !currZones.Equal(existingZones)
 }
 
 // filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1202,6 +1202,82 @@ func TestUpdateStatus(t *testing.T) {
 	}
 }
 
+func TestIsZoneChange(t *testing.T) {
+	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
+	testSubnetwork := cloud.ResourcePath("subnetwork", &meta.Key{Name: "test-subnetwork"})
+	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+	testNegType := negtypes.VmIpPortEndpointType
+
+	testCases := []struct {
+		desc           string
+		zoneDeleted    bool
+		zoneAdded      bool
+		expectedResult bool
+	}{
+		{
+			desc:           "zone was added",
+			zoneAdded:      true,
+			expectedResult: true,
+		},
+		{
+			desc:           "zone was deleted",
+			zoneDeleted:    true,
+			expectedResult: true,
+		},
+		{
+			desc:           "no zone change occurred",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, syncer := newTestTransactionSyncer(fakeCloud, testNegType, false)
+
+			fakeZoneGetter := syncer.zoneGetter.(*negtypes.FakeZoneGetter)
+			origZones, err := fakeZoneGetter.ListZones()
+			if err != nil {
+				t.Errorf("errored when retrieving zones: %s", err)
+			}
+
+			for _, zone := range origZones {
+				fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
+					Version:             syncer.NegSyncerKey.GetAPIVersion(),
+					Name:                testNegName,
+					NetworkEndpointType: string(syncer.NegSyncerKey.NegType),
+					Network:             fakeCloud.NetworkURL(),
+					Subnetwork:          fakeCloud.SubnetworkURL(),
+				}, zone)
+			}
+			ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion())
+			negRefMap := negObjectReferences(ret)
+			var refs []negv1beta1.NegObjectReference
+			for _, neg := range negRefMap {
+				refs = append(refs, neg)
+			}
+			negCR := createNegCR(syncer.NegName, v1.Now(), true, true, refs)
+			if err = syncer.svcNegLister.Add(negCR); err != nil {
+				t.Errorf("failed to add neg to store:%s", err)
+			}
+
+			if tc.zoneDeleted {
+				fakeZoneGetter.DeleteZone("zone1")
+			}
+
+			if tc.zoneAdded {
+				if err := fakeZoneGetter.AddZone("zoneA", "instance-1"); err != nil {
+					t.Errorf("failed to add zone:%s", err)
+				}
+			}
+
+			isZoneChange := syncer.isZoneChange()
+			if isZoneChange != tc.expectedResult {
+				t.Errorf("isZoneChange() returned %t, wanted %t", isZoneChange, tc.expectedResult)
+			}
+		})
+
+	}
+}
 func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, mode negtypes.EndpointsCalculatorMode) (negtypes.NegSyncer, *transactionSyncer) {
 	negsyncer, ts := newTestTransactionSyncer(fakeGCE, negtypes.VmIpEndpointType, false)
 	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.zoneGetter, ts.NegSyncerKey, mode)
@@ -1460,6 +1536,7 @@ func createNegCR(testNegName string, creationTS metav1.Time, populateInitialized
 	neg := &negv1beta1.ServiceNetworkEndpointGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              testNegName,
+			Namespace:         testNamespace,
 			CreationTimestamp: creationTS,
 		},
 	}

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -39,12 +39,12 @@ const (
 	TestInstance6 = "instance6"
 )
 
-type fakeZoneGetter struct {
+type FakeZoneGetter struct {
 	zoneInstanceMap map[string]sets.String
 }
 
-func NewFakeZoneGetter() *fakeZoneGetter {
-	return &fakeZoneGetter{
+func NewFakeZoneGetter() *FakeZoneGetter {
+	return &FakeZoneGetter{
 		zoneInstanceMap: map[string]sets.String{
 			TestZone1: sets.NewString(TestInstance1, TestInstance2),
 			TestZone2: sets.NewString(TestInstance3, TestInstance4, TestInstance5, TestInstance6),
@@ -52,20 +52,34 @@ func NewFakeZoneGetter() *fakeZoneGetter {
 	}
 }
 
-func (f *fakeZoneGetter) ListZones() ([]string, error) {
+func (f *FakeZoneGetter) ListZones() ([]string, error) {
 	ret := []string{}
 	for key := range f.zoneInstanceMap {
 		ret = append(ret, key)
 	}
 	return ret, nil
 }
-func (f *fakeZoneGetter) GetZoneForNode(name string) (string, error) {
+func (f *FakeZoneGetter) GetZoneForNode(name string) (string, error) {
 	for zone, instances := range f.zoneInstanceMap {
 		if instances.Has(name) {
 			return zone, nil
 		}
 	}
 	return "", NotFoundError
+}
+
+// Adds a zone with the given instances to the zone getter
+func (f *FakeZoneGetter) AddZone(newZone string, instances ...string) error {
+	if _, ok := f.zoneInstanceMap[newZone]; ok {
+		return fmt.Errorf("zone already exists")
+	}
+	f.zoneInstanceMap[newZone] = sets.NewString(instances...)
+	return nil
+}
+
+// Deletes a zone in the zoneInstanceMap
+func (f *FakeZoneGetter) DeleteZone(newZone string) {
+	delete(f.zoneInstanceMap, newZone)
 }
 
 type FakeNetworkEndpointGroupCloud struct {


### PR DESCRIPTION
 * VmIpPort NEGs should be synced when node change results in a zone
   being added or removed
 * Node informer event handlers are initialized in all cases

Cherrypick #1600 into release-1.11