### PR TITLE
PSC uses V1 ServiceAttachment

### DIFF
--- a/pkg/backendconfig/backendconfig.go
+++ b/pkg/backendconfig/backendconfig.go
@@ -44,8 +44,8 @@ func CRDMeta() *crd.CRDMeta {
 		"backendconfig",
 		"backendconfigs",
 		[]*crd.Version{
-			crd.NewVersion("v1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.BackendConfig", backendconfigv1.GetOpenAPIDefinitions),
-			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.BackendConfig", backendconfigv1beta1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1.BackendConfig", backendconfigv1.GetOpenAPIDefinitions, false),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1.BackendConfig", backendconfigv1beta1.GetOpenAPIDefinitions, false),
 		},
 		"bc",
 	)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	sav1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
 	sav1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
 	informerbackendconfig "k8s.io/ingress-gce/pkg/backendconfig/client/informers/externalversions/backendconfig/v1"
@@ -49,7 +50,7 @@ import (
 	informeringparams "k8s.io/ingress-gce/pkg/ingparams/client/informers/externalversions/ingparams/v1beta1"
 	"k8s.io/ingress-gce/pkg/metrics"
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
-	informerserviceattachment "k8s.io/ingress-gce/pkg/serviceattachment/client/informers/externalversions/serviceattachment/v1beta1"
+	informerserviceattachment "k8s.io/ingress-gce/pkg/serviceattachment/client/informers/externalversions/serviceattachment/v1"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	informersvcneg "k8s.io/ingress-gce/pkg/svcneg/client/informers/externalversions/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -428,7 +429,10 @@ func (ctx *ControllerContext) generateScheme() *runtime.Scheme {
 
 	if ctx.SAInformer != nil {
 		if err := sav1beta1.AddToScheme(controllerScheme); err != nil {
-			klog.Errorf("Failed to add ServiceAttachment CRD scheme to event recorder")
+			klog.Errorf("Failed to add v1beta1 ServiceAttachment CRD scheme to event recorder: %s", err)
+		}
+		if err := sav1.AddToScheme(controllerScheme); err != nil {
+			klog.Errorf("Failed to add v1 ServiceAttachment CRD scheme to event recorder: %s", err)
 		}
 	}
 	return controllerScheme

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -129,10 +129,11 @@ func crd(meta *CRDMeta, namespacedScoped bool) *apiextensionsv1.CustomResourceDe
 			klog.Errorf("No validation schema exists for for %v CRD(%s API)", meta.kind, v.name)
 		}
 		version := apiextensionsv1.CustomResourceDefinitionVersion{
-			Name:    v.name,
-			Served:  true,
-			Storage: false,
-			Schema:  validationSchema,
+			Name:       v.name,
+			Served:     true,
+			Storage:    false,
+			Schema:     validationSchema,
+			Deprecated: v.deprecated,
 		}
 		// Set storage to true for the latest version.
 		if i == 0 {

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -32,7 +32,7 @@ var (
 	crdMeta = &CRDMeta{
 		groupName: "test.group.com",
 		versions: []*Version{
-			NewVersion("v1alpha1", "pkg/apis/test/v1alpha1.Test", testGetOpenAPIDefinitions),
+			NewVersion("v1alpha1", "pkg/apis/test/v1alpha1.Test", testGetOpenAPIDefinitions, false),
 		},
 		kind:     "Test",
 		listKind: "TestList",

--- a/pkg/crd/meta.go
+++ b/pkg/crd/meta.go
@@ -55,13 +55,15 @@ type Version struct {
 	name       string
 	typeSource string
 	fn         common.GetOpenAPIDefinitions
+	deprecated bool
 }
 
 // NewVersion returns a CRD API version with validation metadata.
-func NewVersion(name, typeSource string, fn common.GetOpenAPIDefinitions) *Version {
+func NewVersion(name, typeSource string, fn common.GetOpenAPIDefinitions, deprecated bool) *Version {
 	return &Version{
 		name:       name,
 		typeSource: typeSource,
 		fn:         fn,
+		deprecated: deprecated,
 	}
 }

--- a/pkg/e2e/adapter/psc.go
+++ b/pkg/e2e/adapter/psc.go
@@ -1,0 +1,260 @@
+package adapter
+
+// Legacy conversion code for the old extensions v1beta1 API group.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sav1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
+	sav1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
+	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/utils/patch"
+	"k8s.io/klog"
+)
+
+const (
+	v1PSC                 = "networking.gke.io/v1"
+	v1beta1PSC            = "networking.gke.io/v1beta1"
+	serviceAttachmentKind = "ServiceAttachment"
+)
+
+//TODO(srepakula) Remove adapter client once v1beta1 is no longer supported
+
+// ServiceAttachmentCRUD wraps basic CRUD to allow use of old and new APIs.
+type ServiceAttachmentCRUD struct {
+	C serviceattachmentclient.Interface
+}
+
+// Get ServiceAttachment resource.
+func (crud *ServiceAttachmentCRUD) Get(ns, name string) (*sav1.ServiceAttachment, error) {
+	useV1, err := crud.supportsV1API()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Get %s/%s", ns, name)
+	if useV1 {
+		return crud.C.NetworkingV1().ServiceAttachments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	}
+	klog.Warning("Using v1beta1 API")
+	sa, err := crud.C.NetworkingV1beta1().ServiceAttachments(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return toPSCV1(sa), nil
+}
+
+// Create ServiceAttachment resource.
+func (crud *ServiceAttachmentCRUD) Create(sa *sav1.ServiceAttachment) (*sav1.ServiceAttachment, error) {
+	useV1, err := crud.supportsV1API()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Create %s/%s", sa.Namespace, sa.Name)
+	if useV1 {
+		return crud.C.NetworkingV1().ServiceAttachments(sa.Namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+	}
+
+	klog.Warning("Using v1beta1 API")
+	legacySA := toPSCV1beta1(sa)
+
+	legacySA, err = crud.C.NetworkingV1beta1().ServiceAttachments(sa.Namespace).Create(context.TODO(), legacySA, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return toPSCV1(legacySA), nil
+}
+
+// Update ServiceAttachment resource.
+func (crud *ServiceAttachmentCRUD) Update(sa *sav1.ServiceAttachment) (*sav1.ServiceAttachment, error) {
+	useV1, err := crud.supportsV1API()
+	if err != nil {
+		return nil, err
+	}
+	klog.Infof("Update %s/%s", sa.Namespace, sa.Name)
+	if useV1 {
+		return crud.C.NetworkingV1().ServiceAttachments(sa.Namespace).Update(context.TODO(), sa, metav1.UpdateOptions{})
+	}
+
+	klog.Warning("Using legacy API")
+	legacySA := toPSCV1beta1(sa)
+
+	legacySA, err = crud.C.NetworkingV1beta1().ServiceAttachments(sa.Namespace).Update(context.TODO(), legacySA, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return toPSCV1(legacySA), nil
+}
+
+// Patch ServiceAttachment resource.
+func (crud *ServiceAttachmentCRUD) Patch(oldV1SA, newV1SA *sav1.ServiceAttachment) (*sav1.ServiceAttachment, error) {
+	useV1, err := crud.supportsV1API()
+	if err != nil {
+		return nil, err
+	}
+
+	var oldSA, newSA interface{}
+	if useV1 {
+		oldSA = oldV1SA
+		newSA = newV1SA
+	} else {
+		oldSA = toPSCV1beta1(oldV1SA)
+		newSA = toPSCV1beta1(newV1SA)
+	}
+
+	saKey := fmt.Sprintf("%s/%s", oldV1SA.Namespace, oldV1SA.Name)
+	oldData, err := json.Marshal(oldSA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal service attachment %+v: %v", oldSA, err)
+	}
+	newData, err := json.Marshal(newSA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal service attachment %+v: %v", newSA, err)
+	}
+
+	patchBytes, err := patch.MergePatchBytes(oldData, newData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MergePatch for service attachment %s: %v, old sa: %+v new sa: %+v", saKey, err, oldSA, newSA)
+	}
+
+	klog.Infof("Patch %s/%s", oldV1SA.Namespace, oldV1SA.Name)
+	if useV1 {
+		return crud.C.NetworkingV1().ServiceAttachments(oldV1SA.Namespace).Patch(context.TODO(), oldV1SA.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	}
+
+	klog.Warning("Using v1beta1 API")
+	legacyIng, err := crud.C.NetworkingV1beta1().ServiceAttachments(oldV1SA.Namespace).Patch(context.TODO(), oldV1SA.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return toPSCV1(legacyIng), nil
+}
+
+// Delete ServiceAttachment resource.
+func (crud *ServiceAttachmentCRUD) Delete(ns, name string) error {
+	useV1, err := crud.supportsV1API()
+	if err != nil {
+		return err
+	}
+	klog.Infof("Delete %s/%s", ns, name)
+	if useV1 {
+		return crud.C.NetworkingV1().ServiceAttachments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+	klog.Warning("Using v1beta1 API")
+	return crud.C.NetworkingV1beta1().ServiceAttachments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// supportsV1API returns true if the V1 API is available
+func (crud *ServiceAttachmentCRUD) supportsV1API() (bool, error) {
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion(v1PSC); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == serviceAttachmentKind {
+				return true, nil
+			}
+		}
+	}
+	if apiList, err := crud.C.Discovery().ServerResourcesForGroupVersion(v1beta1PSC); err == nil {
+		for _, r := range apiList.APIResources {
+			if r.Kind == serviceAttachmentKind {
+				return false, nil
+			}
+		}
+	}
+	return false, errors.New("no Service Attachment resource found")
+}
+
+// toPSCV1 converts the v1beta1 object to a v1 object
+func toPSCV1(in *sav1beta1.ServiceAttachment) *sav1.ServiceAttachment {
+	out := &sav1.ServiceAttachment{}
+	out.ObjectMeta = in.ObjectMeta
+	out.TypeMeta = metav1.TypeMeta{
+		Kind:       in.Kind,
+		APIVersion: v1PSC,
+	}
+
+	out.Spec = sav1.ServiceAttachmentSpec{
+		ConnectionPreference: in.Spec.ConnectionPreference,
+		NATSubnets:           in.Spec.NATSubnets,
+		ResourceRef:          in.Spec.ResourceRef,
+		ProxyProtocol:        in.Spec.ProxyProtocol,
+		ConsumerAllowList:    convertConsumerProjectToV1(in.Spec.ConsumerAllowList),
+		ConsumerRejectList:   in.Spec.ConsumerRejectList,
+	}
+
+	out.Status = sav1.ServiceAttachmentStatus{
+		ServiceAttachmentURL:    in.Status.ServiceAttachmentURL,
+		ForwardingRuleURL:       in.Status.ForwardingRuleURL,
+		ConsumerForwardingRules: convertForwardingRulesToV1(in.Status.ConsumerForwardingRules),
+		LastModifiedTimestamp:   in.Status.LastModifiedTimestamp,
+	}
+
+	return out
+}
+
+// convertConsumerProjectToV1 converts a list of v1beta1 Consumer Projects to a v1 list
+func convertConsumerProjectToV1(in []sav1beta1.ConsumerProject) []sav1.ConsumerProject {
+	var out []sav1.ConsumerProject
+	for _, proj := range in {
+		out = append(out, sav1.ConsumerProject(proj))
+	}
+	return out
+}
+
+// convertConsumerForwardingRulesToV1 converts a list of v1beta Consumer Forwarding Rules to a v1 list
+func convertForwardingRulesToV1(in []sav1beta1.ConsumerForwardingRule) []sav1.ConsumerForwardingRule {
+	var out []sav1.ConsumerForwardingRule
+	for _, rule := range in {
+		out = append(out, sav1.ConsumerForwardingRule(rule))
+	}
+	return out
+}
+
+// toPSCV1beta1 converts the v1 object to a v1beta1 object
+func toPSCV1beta1(in *sav1.ServiceAttachment) *sav1beta1.ServiceAttachment {
+	out := &sav1beta1.ServiceAttachment{}
+	out.ObjectMeta = in.ObjectMeta
+	out.TypeMeta = metav1.TypeMeta{
+		Kind:       in.Kind,
+		APIVersion: v1beta1PSC,
+	}
+
+	out.Spec = sav1beta1.ServiceAttachmentSpec{
+		ConnectionPreference: in.Spec.ConnectionPreference,
+		NATSubnets:           in.Spec.NATSubnets,
+		ResourceRef:          in.Spec.ResourceRef,
+		ProxyProtocol:        in.Spec.ProxyProtocol,
+		ConsumerAllowList:    convertConsumerProjectToV1beta1(in.Spec.ConsumerAllowList),
+		ConsumerRejectList:   in.Spec.ConsumerRejectList,
+	}
+
+	out.Status = sav1beta1.ServiceAttachmentStatus{
+		ServiceAttachmentURL:    in.Status.ServiceAttachmentURL,
+		ForwardingRuleURL:       in.Status.ForwardingRuleURL,
+		ConsumerForwardingRules: convertForwardingRulesToV1beta1(in.Status.ConsumerForwardingRules),
+		LastModifiedTimestamp:   in.Status.LastModifiedTimestamp,
+	}
+
+	return out
+}
+
+// convertConsumerProjectToV1 converts a list of v1 Consumer Projects to a v1beta1 list
+func convertConsumerProjectToV1beta1(in []sav1.ConsumerProject) []sav1beta1.ConsumerProject {
+	var out []sav1beta1.ConsumerProject
+	for _, proj := range in {
+		out = append(out, sav1beta1.ConsumerProject(proj))
+	}
+	return out
+}
+
+// convertConsumerForwardingRulesToV1 converts a list of v1 Consumer Forwarding Rules to a v1beta1 list
+func convertForwardingRulesToV1beta1(in []sav1.ConsumerForwardingRule) []sav1beta1.ConsumerForwardingRule {
+	var out []sav1beta1.ConsumerForwardingRule
+	for _, rule := range in {
+		out = append(out, sav1beta1.ConsumerForwardingRule(rule))
+	}
+	return out
+}

--- a/pkg/e2e/adapter/psc_test.go
+++ b/pkg/e2e/adapter/psc_test.go
@@ -1,0 +1,107 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sav1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
+	sav1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
+)
+
+func TestPSCConversions(t *testing.T) {
+	for _, tc := range []struct {
+		netV1beta1 *sav1beta1.ServiceAttachment
+		netV1      *sav1.ServiceAttachment
+	}{
+		{
+			netV1beta1: &sav1beta1.ServiceAttachment{
+				TypeMeta:   v1.TypeMeta{APIVersion: v1beta1PSC},
+				ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "foo"},
+				Spec: sav1beta1.ServiceAttachmentSpec{
+					ConnectionPreference: "my-preference",
+					NATSubnets:           []string{"my-subnet"},
+					ResourceRef: corev1.TypedLocalObjectReference{
+						Kind: "Service",
+						Name: "my-service",
+					},
+					ProxyProtocol: true,
+					ConsumerAllowList: []sav1beta1.ConsumerProject{
+						{
+							ConnectionLimit: 100,
+							Project:         "my-project-1",
+						},
+						{
+							ConnectionLimit: 102,
+							Project:         "my-project-2",
+						},
+					},
+					ConsumerRejectList: []string{"reject-project-1", "reject-project-2"},
+				},
+				Status: sav1beta1.ServiceAttachmentStatus{
+					ServiceAttachmentURL: "gce-service-attachment-url",
+					ForwardingRuleURL:    "gce-forwarding-rule-url",
+					ConsumerForwardingRules: []sav1beta1.ConsumerForwardingRule{
+						{
+							ForwardingRuleURL: "consumer-rule-1",
+							Status:            "ESTABLISHED",
+						},
+						{
+							ForwardingRuleURL: "consumer-rule-2",
+							Status:            "DISCONNECTED",
+						},
+					},
+				},
+			},
+			netV1: &sav1.ServiceAttachment{
+				TypeMeta:   v1.TypeMeta{APIVersion: v1PSC},
+				ObjectMeta: v1.ObjectMeta{Namespace: "ns1", Name: "foo"},
+				Spec: sav1.ServiceAttachmentSpec{
+					ConnectionPreference: "my-preference",
+					NATSubnets:           []string{"my-subnet"},
+					ResourceRef: corev1.TypedLocalObjectReference{
+						Kind: "Service",
+						Name: "my-service",
+					},
+					ProxyProtocol: true,
+					ConsumerAllowList: []sav1.ConsumerProject{
+						{
+							ConnectionLimit: 100,
+							Project:         "my-project-1",
+						},
+						{
+							ConnectionLimit: 102,
+							Project:         "my-project-2",
+						},
+					},
+					ConsumerRejectList: []string{"reject-project-1", "reject-project-2"},
+				},
+				Status: sav1.ServiceAttachmentStatus{
+					ServiceAttachmentURL: "gce-service-attachment-url",
+					ForwardingRuleURL:    "gce-forwarding-rule-url",
+					ConsumerForwardingRules: []sav1.ConsumerForwardingRule{
+						{
+							ForwardingRuleURL: "consumer-rule-1",
+							Status:            "ESTABLISHED",
+						},
+						{
+							ForwardingRuleURL: "consumer-rule-2",
+							Status:            "DISCONNECTED",
+						},
+					},
+				},
+			},
+		},
+	} {
+		gotV1 := toPSCV1(tc.netV1beta1)
+		gotV1beta1 := toPSCV1beta1(tc.netV1)
+
+		if diff := cmp.Diff(gotV1beta1, tc.netV1beta1); diff != "" {
+			t.Errorf("V1beta1 ServiceAttachments are not the same(-want, +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(gotV1, tc.netV1); diff != "" {
+			t.Errorf("V1 ServiceAttachments are not the same(-want, +got):\n%s", diff)
+		}
+	}
+}

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	frontendconfig "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
-	sav1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
+	sav1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
 	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/utils"
 
@@ -513,12 +513,13 @@ func DeleteDestinationRule(s *Sandbox, namespace, name string) error {
 }
 
 // EnsureServiceAttachment ensures a ServiceAttachment resource
-func EnsureServiceAttachment(s *Sandbox, saName, svcName, subnetName string) (*sav1beta1.ServiceAttachment, error) {
-	sa := &sav1beta1.ServiceAttachment{
+func EnsureServiceAttachment(s *Sandbox, saName, svcName, subnetName string) (*sav1.ServiceAttachment, error) {
+	sa := &sav1.ServiceAttachment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: saName,
+			Name:      saName,
+			Namespace: s.Namespace,
 		},
-		Spec: sav1beta1.ServiceAttachmentSpec{
+		Spec: sav1.ServiceAttachmentSpec{
 			ConnectionPreference: "ACCEPT_AUTOMATIC",
 			NATSubnets:           []string{subnetName},
 			ResourceRef: v1.TypedLocalObjectReference{
@@ -529,15 +530,15 @@ func EnsureServiceAttachment(s *Sandbox, saName, svcName, subnetName string) (*s
 		},
 	}
 
-	existingSA, err := s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Get(context.TODO(), saName, metav1.GetOptions{})
+	existingSA, err := s.f.SAClient.Get(s.Namespace, saName)
 	if err != nil && errors.IsNotFound(err) {
-		return s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
+		return s.f.SAClient.Create(sa)
 	}
 	existingSA.Spec = sa.Spec
-	return s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Update(context.TODO(), existingSA, metav1.UpdateOptions{})
+	return s.f.SAClient.Update(existingSA)
 }
 
 // DeleteServiceAttachment ensures a ServiceAttachment resource
 func DeleteServiceAttachment(s *Sandbox, saName string) error {
-	return s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Delete(context.TODO(), saName, metav1.DeleteOptions{})
+	return s.f.SAClient.Delete(s.Namespace, saName)
 }

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	frontendconfigclient "k8s.io/ingress-gce/pkg/frontendconfig/client/clientset/versioned"
 	serviceattachment "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
@@ -98,7 +99,7 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 		FrontendConfigClient: frontendConfigClient,
 		BackendConfigClient:  backendConfigClient,
 		SvcNegClient:         svcNegClient,
-		SAClient:             saClient,
+		SAClient:             &adapter.ServiceAttachmentCRUD{C: saClient},
 		Project:              options.Project,
 		Region:               options.Region,
 		Network:              options.Network,
@@ -142,7 +143,7 @@ type Framework struct {
 	BackendConfigClient   *backendconfigclient.Clientset
 	FrontendConfigClient  *frontendconfigclient.Clientset
 	SvcNegClient          *svcnegclient.Clientset
-	SAClient              *serviceattachment.Clientset
+	SAClient              *adapter.ServiceAttachmentCRUD
 	Project               string
 	Region                string
 	Network               string

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/ingress-gce/cmd/echo/app"
 	"k8s.io/ingress-gce/pkg/annotations"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
-	sav1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
+	sav1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
 	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/e2e/adapter"
 	"k8s.io/ingress-gce/pkg/fuzz"
@@ -963,7 +963,7 @@ func DeleteNegCR(s *Sandbox, negName string) error {
 func WaitForServiceAttachment(s *Sandbox, saName string) (string, error) {
 	var gceSAURL string
 	err := wait.Poll(negPollInterval, negPollTimeout, func() (bool, error) {
-		saCR, err := s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Get(context.TODO(), saName, metav1.GetOptions{})
+		saCR, err := s.f.SAClient.Get(s.Namespace, saName)
 		if saCR == nil || err != nil {
 			return false, fmt.Errorf("failed to get service attachment %s/%s: %v", s.Namespace, saName, err)
 		}
@@ -1009,7 +1009,7 @@ func WaitForServiceAttachmentDeletion(s *Sandbox, saName, gceSAURL string) error
 
 // CheckServiceAttachmentCRDeletion verifes that the CR does not exist
 func CheckServiceAttachmentCRDeletion(s *Sandbox, saName string) bool {
-	_, err := s.f.SAClient.NetworkingV1beta1().ServiceAttachments(s.Namespace).Get(context.Background(), saName, metav1.GetOptions{})
+	_, err := s.f.SAClient.Get(s.Namespace, saName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return true
@@ -1023,7 +1023,7 @@ func CheckServiceAttachmentCRDeletion(s *Sandbox, saName string) bool {
 
 // CheckServiceAttachment verifes that the CR spec matches the GCE Service Attachment configuration and
 // that the CR's Status was properly populated
-func CheckServiceAttachment(sa *fuzz.ServiceAttachment, cr *sav1beta1.ServiceAttachment) (string, error) {
+func CheckServiceAttachment(sa *fuzz.ServiceAttachment, cr *sav1.ServiceAttachment) (string, error) {
 	if err := CheckServiceAttachmentFinalizer(cr); err != nil {
 		return "", fmt.Errorf("failed checking Service Attachment CR %s/%s: %q", cr.Namespace, cr.Name, err)
 	}
@@ -1053,7 +1053,7 @@ func CheckServiceAttachment(sa *fuzz.ServiceAttachment, cr *sav1beta1.ServiceAtt
 
 // CheckServiceAttachmentForwardingRule verfies that the forwarding rule used in the GCE Service Attachment creation
 // is the same one created by the Service referenced in the CR
-func CheckServiceAttachmentForwardingRule(s *Sandbox, c cloud.Cloud, cr *sav1beta1.ServiceAttachment) error {
+func CheckServiceAttachmentForwardingRule(s *Sandbox, c cloud.Cloud, cr *sav1.ServiceAttachment) error {
 
 	svc, err := s.f.Clientset.CoreV1().Services(cr.Namespace).Get(context.TODO(), cr.Spec.ResourceRef.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1077,7 +1077,7 @@ func CheckServiceAttachmentForwardingRule(s *Sandbox, c cloud.Cloud, cr *sav1bet
 }
 
 // CheckServiceAttachmentFinalizer verifes that the CR has the ServiceAttachment Finalizer
-func CheckServiceAttachmentFinalizer(cr *sav1beta1.ServiceAttachment) error {
+func CheckServiceAttachmentFinalizer(cr *sav1.ServiceAttachment) error {
 	finalizers := cr.GetFinalizers()
 	if l := len(finalizers); l != 1 {
 		return fmt.Errorf("expected 1 finalizer on service attachment but got %d", l)

--- a/pkg/experimental/workload/workload.go
+++ b/pkg/experimental/workload/workload.go
@@ -30,7 +30,7 @@ func CRDMeta() *crd.CRDMeta {
 		"workload",
 		"workloads",
 		[]*crd.Version{
-			crd.NewVersion("v1alpha1", "k8s.io/ingress-gce/pkg/experimental/apis/workload/v1alpha1.Workload", workloadv1a1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1alpha1", "k8s.io/ingress-gce/pkg/experimental/apis/workload/v1alpha1.Workload", workloadv1a1.GetOpenAPIDefinitions, false),
 		},
 		"wl",
 	)

--- a/pkg/frontendconfig/frontendconfig.go
+++ b/pkg/frontendconfig/frontendconfig.go
@@ -39,7 +39,7 @@ func CRDMeta() *crd.CRDMeta {
 		"frontendconfig",
 		"frontendconfigs",
 		[]*crd.Version{
-			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1.FrontendConfig", frontendconfigv1beta1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1.FrontendConfig", frontendconfigv1beta1.GetOpenAPIDefinitions, false),
 		},
 	)
 	return meta

--- a/pkg/ingparams/ingparams.go
+++ b/pkg/ingparams/ingparams.go
@@ -29,7 +29,7 @@ func CRDMeta() *crd.CRDMeta {
 		"gcpingressparams",
 		"gcpingressparams", // use `gcpingressparams` as singular and plural names
 		[]*crd.Version{
-			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/ingparams/v1beta1.GCPIngressParams", ingparamsv1beta1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/ingparams/v1beta1.GCPIngressParams", ingparamsv1beta1.GetOpenAPIDefinitions, false),
 		},
 		"gcpingparams",
 	)

--- a/pkg/serviceattachment/serviceattachment.go
+++ b/pkg/serviceattachment/serviceattachment.go
@@ -17,6 +17,7 @@ package serviceattachment
 
 import (
 	apisserviceattachment "k8s.io/ingress-gce/pkg/apis/serviceattachment"
+	svcattachv1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1"
 	svcattachv1beta1 "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1"
 	"k8s.io/ingress-gce/pkg/crd"
 )
@@ -29,7 +30,9 @@ func CRDMeta() *crd.CRDMeta {
 		"serviceattachment",
 		"serviceattachments",
 		[]*crd.Version{
-			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1.ServiceAttachment", svcattachv1beta1.GetOpenAPIDefinitions),
+			// latest version should be the first version
+			crd.NewVersion("v1", "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1.ServiceAttachment", svcattachv1.GetOpenAPIDefinitions, false),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/serviceattachment/v1beta1.ServiceAttachment", svcattachv1beta1.GetOpenAPIDefinitions, true),
 		},
 	)
 	return meta

--- a/pkg/svcneg/svcneg.go
+++ b/pkg/svcneg/svcneg.go
@@ -29,7 +29,7 @@ func CRDMeta() *crd.CRDMeta {
 		"servicenetworkendpointgroup",
 		"servicenetworkendpointgroups",
 		[]*crd.Version{
-			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup", negv1beta1.GetOpenAPIDefinitions),
+			crd.NewVersion("v1beta1", "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1.ServiceNetworkEndpointGroup", negv1beta1.GetOpenAPIDefinitions, false),
 		},
 		"svcneg",
 	)


### PR DESCRIPTION
PSC controller uses v1 ServiceAttachment CRD and client to process and manage service attachments

/assign @freehan @prameshj 