### PR TITLE
Exclude nodes that have GKE drain operation label, from LB backends.

### DIFF
--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -89,7 +89,7 @@ func (f *FakeZoneGetter) ListZones(predicate utils.NodeConditionPredicate) ([]st
 	for zone := range f.upgradeInstancesMap {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{utils.GKECurrentOperationAnnotation: utils.GKEUpgradeOperation},
+				Labels: map[string]string{utils.GKECurrentOperationLabel: utils.NodeDrain},
 			},
 			Status: v1.NodeStatus{
 				Conditions: []v1.NodeCondition{v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue}}}}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -564,8 +564,8 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			node: api_v1.Node{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{
-						GKECurrentOperationAnnotation: fmt.Sprintf("{'Timestamp': '12345', 'Operation': '%s'}", GKEUpgradeOperation),
+					Labels: map[string]string{
+						GKECurrentOperationLabel: NodeDrain,
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -576,14 +576,14 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			},
 			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: false,
-			name:                               "ready node, upgrade in progress",
+			name:                               "ready node, upgrade/drain in progress",
 		},
 		{
 			node: api_v1.Node{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{
-						GKECurrentOperationAnnotation: "{'Timestamp': '12345', 'Operation': 'random'}",
+					Labels: map[string]string{
+						GKECurrentOperationLabel: "random",
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -594,7 +594,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			},
 			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: true,
-			name:                               "ready node, non-upgrade operation",
+			name:                               "ready node, non-drain operation",
 		},
 		{
 			node: api_v1.Node{


### PR DESCRIPTION
Stop using the previous annotation that is only set for some GKE operations(surge upgrade).
The new label will be set by all gke nodepool operations.

/assign @freehan 