### PR TITLE
[1.14] Exclude nodes that have GKE drain operation label, from LB backends.

### DIFF
--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -89,7 +89,7 @@ func (f *fakeZoneGetter) ListZones(predicate utils.NodeConditionPredicate) ([]st
 	for zone := range f.upgradeInstancesMap {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{utils.GKECurrentOperationAnnotation: utils.GKEUpgradeOperation},
+				Labels: map[string]string{utils.GKECurrentOperationLabel: utils.NodeDrain},
 			},
 			Status: v1.NodeStatus{
 				Conditions: []v1.NodeCondition{v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue}}}}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -76,7 +76,12 @@ const (
 	LabelNodeRoleExcludeBalancer = "node.kubernetes.io/exclude-from-external-load-balancers"
 	// ToBeDeletedTaint is the taint that the autoscaler adds when a node is scheduled to be deleted
 	// https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-0.5.2/cluster-autoscaler/utils/deletetaint/delete.go#L33
-	ToBeDeletedTaint         = "ToBeDeletedByClusterAutoscaler"
+	ToBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+	// GKECurrentOperationLabel is added by the GKE control plane, to nodes that are about to be drained as a result of an upgrade/resize operation.
+	// The operation value is "drain".
+	GKECurrentOperationLabel = "operation.gke.io/type"
+	// NodeDrain is the string used to indicate the Node Draining operation.
+	NodeDrain                = "drain"
 	L4ILBServiceDescKey      = "networking.gke.io/service-name"
 	L4ILBSharedResourcesDesc = "This resource is shared by all L4 ILB Services using ExternalTrafficPolicy: Cluster."
 
@@ -84,8 +89,6 @@ const (
 	// exclude from load balancers created by a cloud provider. This label is deprecated and will
 	// be removed in 1.18.
 	LabelAlphaNodeRoleExcludeBalancer = "alpha.service-controller.kubernetes.io/exclude-balancer"
-	GKEUpgradeOperation               = "operation_type: UPGRADE_NODES"
-	GKECurrentOperationAnnotation     = "gke-current-operation"
 )
 
 // FrontendGCAlgorithm species GC algorithm used for ingress frontend resources.
@@ -391,8 +394,8 @@ func nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes, excludeUpgrad
 		return false
 	}
 	if excludeUpgradingNodes {
-		// This node is about to be upgraded.
-		if opVal, _ := node.Annotations[GKECurrentOperationAnnotation]; strings.Contains(opVal, GKEUpgradeOperation) {
+		// This node is about to be upgraded or deleted as part of resize.
+		if operation, _ := node.Labels[GKECurrentOperationLabel]; operation == NodeDrain {
 			return false
 		}
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -564,8 +564,8 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			node: api_v1.Node{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{
-						GKECurrentOperationAnnotation: fmt.Sprintf("{'Timestamp': '12345', 'Operation': '%s'}", GKEUpgradeOperation),
+					Labels: map[string]string{
+						GKECurrentOperationLabel: NodeDrain,
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -576,14 +576,14 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			},
 			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: false,
-			name:                               "ready node, upgrade in progress",
+			name:                               "ready node, upgrade/drain in progress",
 		},
 		{
 			node: api_v1.Node{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "node1",
-					Annotations: map[string]string{
-						GKECurrentOperationAnnotation: "{'Timestamp': '12345', 'Operation': 'random'}",
+					Labels: map[string]string{
+						GKECurrentOperationLabel: "random",
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -594,7 +594,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 			},
 			expectAccept:                       true,
 			expectAcceptByUnreadyNodePredicate: true,
-			name:                               "ready node, non-upgrade operation",
+			name:                               "ready node, non-drain operation",
 		},
 		{
 			node: api_v1.Node{


### PR DESCRIPTION
Stop using the previous annotation that is only set for some GKE operations(surge upgrade).
The new label will be set by all gke nodepool operations.

Cherrypick of https://github.com/kubernetes/ingress-gce/pull/1615 into release-1.14

/assign @swetharepakula 