### PR TITLE
Fix firewall rule deletion in L4 LBs

### DIFF
--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -132,9 +132,8 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *SyncResult 
 		result.Error = err
 		result.GCEResourceInError = annotations.AddressResource
 	}
-	hcName, hcFwName := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 	// delete fw rules
-	deleteFunc := func(name string) error {
+	deleteFwFunc := func(name string) error {
 		err := firewalls.EnsureL4FirewallRuleDeleted(l.cloud, name)
 		if err != nil {
 			if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
@@ -146,21 +145,13 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *SyncResult 
 		return nil
 	}
 	// delete firewall rule allowing load balancer source ranges
-	err = deleteFunc(name)
+	err = deleteFwFunc(name)
 	if err != nil {
 		klog.Errorf("Failed to delete firewall rule %s for internal loadbalancer service %s, err %v", name, l.NamespacedName.String(), err)
 		result.GCEResourceInError = annotations.FirewallRuleResource
 		result.Error = err
 	}
-
-	// delete firewall rule allowing healthcheck source ranges
-	err = deleteFunc(hcFwName)
-	if err != nil {
-		klog.Errorf("Failed to delete firewall rule %s for internal loadbalancer service %s, err %v", hcFwName, l.NamespacedName.String(), err)
-		result.GCEResourceInError = annotations.FirewallForHealthcheckResource
-		result.Error = err
-	}
-	// delete backend service
+	// Delete backend service
 	err = utils.IgnoreHTTPNotFound(l.backendPool.Delete(name, meta.VersionGA, meta.Regional))
 	if err != nil {
 		klog.Errorf("Failed to delete backends for internal loadbalancer service %s, err  %v", l.NamespacedName.String(), err)
@@ -173,6 +164,7 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *SyncResult 
 		l.sharedResourcesLock.Lock()
 		defer l.sharedResourcesLock.Unlock()
 	}
+	hcName, hcFwName := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 	err = utils.IgnoreHTTPNotFound(healthchecks.DeleteHealthCheck(l.cloud, hcName, meta.Global))
 	if err != nil {
 		if !utils.IsInUsedByError(err) {
@@ -184,6 +176,14 @@ func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *SyncResult 
 		// Ignore deletion error due to health check in use by another resource.
 		// This will be hit if this is a shared healthcheck.
 		klog.V(2).Infof("Failed to delete healthcheck %s: health check in use.", hcName)
+	} else {
+		// Delete healthcheck firewall rule if healthcheck deletion is successful.
+		err = deleteFwFunc(hcFwName)
+		if err != nil {
+			klog.Errorf("Failed to delete firewall rule %s for internal loadbalancer service %s, err %v", hcFwName, l.NamespacedName.String(), err)
+			result.GCEResourceInError = annotations.FirewallForHealthcheckResource
+			result.Error = err
+		}
 	}
 	return result
 }

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -495,7 +495,7 @@ func TestEnsureInternalLoadBalancerDeleted(t *testing.T) {
 	}
 	assertInternalLbResources(t, svc, l, nodeNames, result.Annotations)
 
-	// Delete the loadbalancer
+	// Delete the loadbalancer.
 	result = l.EnsureInternalLoadBalancerDeleted(svc)
 	if result.Error != nil {
 		t.Errorf("Unexpected error %v", result.Error)
@@ -537,6 +537,55 @@ func TestEnsureInternalLoadBalancerDeletedTwiceDoesNotError(t *testing.T) {
 		t.Errorf("Unexpected error %v", result.Error)
 	}
 	assertInternalLbResourcesDeleted(t, svc, true, l)
+}
+
+func TestEnsureInternalLoadBalancerDeletedWithSharedHC(t *testing.T) {
+	t.Parallel()
+
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockHealthChecks.DeleteHook = test.DeleteHealthCheckResourceInUseErrorHook
+	nodeNames := []string{"test-node-1"}
+	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
+
+	_, _, result := ensureService(fakeGCE, namer, nodeNames, vals.ZoneName, 8080, t)
+	if result != nil && result.Error != nil {
+		t.Fatalf("Error ensuring service err: %v", result.Error)
+	}
+	svc2, l, result := ensureService(fakeGCE, namer, nodeNames, vals.ZoneName, 8081, t)
+	if result != nil && result.Error != nil {
+		t.Fatalf("Error ensuring service err: %v", result.Error)
+	}
+
+	// Delete the loadbalancer.
+	result = l.EnsureInternalLoadBalancerDeleted(svc2)
+	if result.Error != nil {
+		t.Errorf("Unexpected error %v", result.Error)
+	}
+	// When health check is shared we expect that hc firewall rule will not be deleted.
+	_, hcFwName := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	firewall, err := l.cloud.GetFirewall(hcFwName)
+	if err != nil || firewall == nil {
+		t.Errorf("Expected firewall exists err: %v, fwR: %v", err, firewall)
+	}
+}
+
+func ensureService(fakeGCE *gce.Cloud, namer *namer_util.L4Namer, nodeNames []string, zoneName string, port int, t *testing.T) (*v1.Service, *L4, *SyncResult) {
+	svc := test.NewL4ILBService(false, 8080)
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, zoneName); err != nil {
+		return nil, nil, &SyncResult{Error: fmt.Errorf("Unexpected error when adding nodes %v", err)}
+	}
+	result := l.EnsureInternalLoadBalancer(nodeNames, svc)
+	if result.Error != nil {
+		return nil, nil, result
+	}
+	if len(result.Status.Ingress) == 0 {
+		result.Error = fmt.Errorf("Got empty loadBalancer status using handler %v", l)
+		return nil, nil, result
+	}
+	assertInternalLbResources(t, svc, l, nodeNames, result.Annotations)
+	return svc, l, nil
 }
 
 func TestEnsureInternalLoadBalancerWithSpecialHealthCheck(t *testing.T) {
@@ -664,7 +713,7 @@ func TestEnsureInternalLoadBalancerErrors(t *testing.T) {
 			if err = composite.CreateForwardingRule(l.cloud, key, &composite.ForwardingRule{Name: frName}); err != nil {
 				t.Errorf("Failed to create fake forwarding rule %s, err %v", frName, err)
 			}
-			// Inject error hooks after creating the forwarding rule
+			// Inject error hooks after creating the forwarding rule.
 			if tc.injectMock != nil {
 				tc.injectMock(fakeGCE.Compute().(*cloud.MockGCE))
 			}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -179,8 +179,6 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *SyncResu
 		result.Error = err
 		result.GCEResourceInError = annotations.AddressResource
 	}
-	sharedHC := !helpers.RequestsOnlyLocalTraffic(svc)
-	hcName, hcFwName := l4netlb.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 
 	deleteFirewallFunc := func(name string) error {
 		err := firewalls.EnsureL4FirewallRuleDeleted(l4netlb.cloud, name)
@@ -201,13 +199,6 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *SyncResu
 		result.Error = err
 	}
 
-	// delete firewall rule allowing healthcheck source ranges
-	err = deleteFirewallFunc(hcFwName)
-	if err != nil {
-		klog.Errorf("Failed to delete firewall rule %s for service %s - %v", hcFwName, l4netlb.NamespacedName.String(), err)
-		result.GCEResourceInError = annotations.FirewallForHealthcheckResource
-		result.Error = err
-	}
 	// delete backend service
 	err = utils.IgnoreHTTPNotFound(l4netlb.backendPool.Delete(name, meta.VersionGA, meta.Regional))
 	if err != nil {
@@ -215,6 +206,8 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *SyncResu
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err
 	}
+	sharedHC := !helpers.RequestsOnlyLocalTraffic(svc)
+	hcName, hcFwName := l4netlb.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 
 	// Delete healthcheck
 	if sharedHC {
@@ -236,6 +229,14 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *SyncResu
 		// Ignore deletion error due to health check in use by another resource.
 		// This will be hit if this is a shared healthcheck.
 		klog.V(2).Infof("Failed to delete healthcheck %s: health check in use.", hcName)
+	} else {
+		// Delete healthcheck firewall rule if healthcheck deletion is successful.
+		err = deleteFirewallFunc(hcFwName)
+		if err != nil {
+			klog.Errorf("Failed to delete firewall rule %s for service %s, err %v", hcFwName, l4netlb.NamespacedName.String(), err)
+			result.GCEResourceInError = annotations.FirewallForHealthcheckResource
+			result.Error = err
+		}
 	}
 	return result
 }

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -88,6 +88,44 @@ func TestDeleteL4NetLoadBalancer(t *testing.T) {
 	}
 	ensureNetLBResourceDeleted(t, svc, l4NetLB)
 }
+
+func TestDeleteL4NetLoadBalancerWithSharedHC(t *testing.T) {
+	t.Parallel()
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionHealthChecks.DeleteHook = test.DeleteRegionalHealthCheckResourceInUseErrorHook
+
+	_, _ = ensureLoadBalancer(8080, vals, fakeGCE, t)
+	svc, l4NetLB := ensureLoadBalancer(8081, vals, fakeGCE, t)
+
+	if err := l4NetLB.EnsureLoadBalancerDeleted(svc); err.Error != nil {
+		t.Errorf("UnexpectedError %v", err.Error)
+	}
+	// Health check is in used by second service
+	// we expect that firewall rule will not be deleted
+	_, hcFwName := l4NetLB.namer.L4HealthCheck(svc.Namespace, svc.Name, true)
+	firewall, err := l4NetLB.cloud.GetFirewall(hcFwName)
+	if err != nil || firewall == nil {
+		t.Fatalf("Firewall rule should not be deleted err: %v", err)
+	}
+}
+
+func ensureLoadBalancer(port int, vals gce.TestClusterValues, fakeGCE *gce.Cloud, t *testing.T) (*v1.Service, *L4NetLB) {
+	svc := test.NewL4NetLBService(port, defaultNodePort)
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
+	emptyNodes := []string{}
+	l4NetLB := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	result := l4NetLB.EnsureFrontend(emptyNodes, svc)
+	if result.Error != nil {
+		t.Errorf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+	if len(result.Status.Ingress) == 0 {
+		t.Errorf("Got empty loadBalancer status using handler %v", l4NetLB)
+	}
+	assertNetLbResources(t, svc, l4NetLB, emptyNodes)
+	return svc, l4NetLB
+}
+
 func ensureNetLBResourceDeleted(t *testing.T, apiService *v1.Service, l4NetLb *L4NetLB) {
 	t.Helper()
 

--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -19,11 +19,13 @@ package test
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -78,6 +80,13 @@ func DeleteBackendServicesErrorHook(ctx context.Context, key *meta.Key, m *cloud
 
 func DeleteHealthCheckErrorHook(ctx context.Context, key *meta.Key, m *cloud.MockRegionHealthChecks) (bool, error) {
 	return true, fmt.Errorf("DeleteHealthCheckErrorHook")
+}
+
+func DeleteRegionalHealthCheckResourceInUseErrorHook(ctx context.Context, key *meta.Key, m *cloud.MockRegionHealthChecks) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Cannot delete health check resource being used by another service"}
+}
+func DeleteHealthCheckResourceInUseErrorHook(ctx context.Context, key *meta.Key, m *cloud.MockHealthChecks) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Cannot delete health check resource being used by another service"}
 }
 
 func GetLegacyForwardingRule(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, *compute.ForwardingRule, error) {


### PR DESCRIPTION
When L4 LoadBalancer is deleted (Internal or External) firewall rule was deleted upfront.
But when ExternalTrafficPolicy is set to Cluster health check is shared
among all ILB or XLB services and removing firewall rule will make those
services unreachable. So in service deletion we need to check if health
check is not in use by another service,