### PR TITLE
External and Internal Load Balancers backend should use the same k8s2 name convention

### DIFF
--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -104,7 +104,7 @@ func deleteILBService(l4c *L4Controller, svc *api_v1.Service) {
 
 func addNEG(l4c *L4Controller, svc *api_v1.Service) {
 	// Also create a fake NEG for this service since the sync code will try to link the backend service to NEG
-	negName, _ := l4c.namer.VMIPNEG(svc.Namespace, svc.Name)
+	negName, _ := l4c.namer.L4Backend(svc.Namespace, svc.Name)
 	neg := &composite.NetworkEndpointGroup{Name: negName}
 	key := meta.ZonalKey(negName, testGCEZone)
 	composite.CreateNetworkEndpointGroup(l4c.ctx.Cloud, key, neg)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -80,10 +80,10 @@ func getILBOptions(svc *corev1.Service) gce.ILBOptions {
 func (l *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *L4LBSyncResult {
 	klog.V(2).Infof("EnsureInternalLoadBalancerDeleted(%s): attempting delete of load balancer resources", l.NamespacedName.String())
 	result := &L4LBSyncResult{SyncType: SyncTypeDelete, StartTime: time.Now()}
-	// All resources use the NEG Name, except forwarding rule.
-	name, ok := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	// All resources use the L4Backend Name, except forwarding rule.
+	name, ok := l.namer.L4Backend(svc.Namespace, svc.Name)
 	if !ok {
-		result.Error = fmt.Errorf("Namer does not support L4 VMIPNEGs")
+		result.Error = fmt.Errorf("Namer does not support L4 Backends")
 		return result
 	}
 	frName := l.GetFRName()
@@ -198,8 +198,8 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service)
 	}
 
 	l.Service = svc
-	// Use the same resource name for NEG, BackendService as well as FR, FWRule.
-	name, ok := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	// All resources use the L4Backend name, except forwarding rule.
+	name, ok := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	if !ok {
 		result.Error = fmt.Errorf("Namer does not support L4 VMIPNEGs")
 		return result

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -68,7 +68,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
-	bsName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	bsName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	_, err := l.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l.NamespacedName, meta.VersionGA)
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
@@ -130,7 +130,7 @@ func TestEnsureInternalLoadBalancer(t *testing.T) {
 	}
 	assertInternalLbResources(t, svc, l, nodeNames, result.Annotations)
 
-	backendServiceName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	backendServiceName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	key := meta.RegionalKey(backendServiceName, l.cloud.Region())
 	bs, err := composite.GetBackendService(l.cloud, key, meta.VersionGA)
 	if err != nil {
@@ -207,7 +207,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName, _ := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	lbName, _ := l.namer.L4Backend(svc.Namespace, svc.Name)
 
 	// Create the expected resources necessary for an Internal Load Balancer
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(svc)
@@ -256,7 +256,7 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName, _ := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	lbName, _ := l.namer.L4Backend(svc.Namespace, svc.Name)
 	frName := l.GetFRName()
 	key, err := composite.CreateKey(l.cloud, frName, meta.Regional)
 	if err != nil {
@@ -373,7 +373,7 @@ func TestUpdateResourceLinks(t *testing.T) {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
 
-	lbName, _ := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	lbName, _ := l.namer.L4Backend(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Regional)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -447,7 +447,7 @@ func TestEnsureInternalLoadBalancerHealthCheckConfigurable(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
-	lbName, _ := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	lbName, _ := l.namer.L4Backend(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Regional)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -613,7 +613,7 @@ func TestEnsureInternalLoadBalancerWithSpecialHealthCheck(t *testing.T) {
 	}
 	assertInternalLbResources(t, svc, l, nodeNames, result.Annotations)
 
-	lbName, _ := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	lbName, _ := l.namer.L4Backend(svc.Namespace, svc.Name)
 	key, err := composite.CreateKey(l.cloud, lbName, meta.Global)
 	if err != nil {
 		t.Errorf("Unexpected error when creating key - %v", err)
@@ -699,7 +699,7 @@ func TestEnsureInternalLoadBalancerErrors(t *testing.T) {
 			}
 			namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 			l := NewL4Handler(params.service, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
-			//lbName := l.namer.VMIPNEG(params.service.Namespace, params.service.Name)
+			//lbName := l.namer.L4Backend(params.service.Namespace, params.service.Name)
 			frName := l.GetFRName()
 			key, err := composite.CreateKey(l.cloud, frName, meta.Regional)
 			if err != nil {
@@ -745,7 +745,7 @@ func TestEnsureLoadBalancerDeletedSucceedsOnXPN(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
-	fwName := l.namer.VMIPNEG(svc.Namespace, svc.Name)
+	fwName := l.namer.L4Backend(svc.Namespace, svc.Name)
 	status, err := l.EnsureInternalLoadBalancer(nodeNames, svc, &metrics.L4ILBServiceState{})
 	if err != nil {
 		t.Errorf("Failed to ensure loadBalancer, err %v", err)
@@ -955,7 +955,7 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
-	fwName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	fwName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	tc := struct {
 		Input  []int
 		Result []string
@@ -1183,7 +1183,7 @@ func TestEnsureInternalLoadBalancerAllPorts(t *testing.T) {
 func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, nodeNames []string, resourceAnnotations map[string]string) {
 	// Check that Firewalls are created for the LoadBalancer and the HealthCheck
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(apiService)
-	resourceName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	resourceName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	resourceDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, false, utils.ILB)
 	if err != nil {
 		t.Errorf("Failed to create description for resources, err %v", err)
@@ -1308,7 +1308,7 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 
 func assertInternalLbResourcesDeleted(t *testing.T, apiService *v1.Service, firewallsDeleted bool, l *L4) {
 	frName := l.GetFRName()
-	resourceName, _ := l.namer.VMIPNEG(l.Service.Namespace, l.Service.Name)
+	resourceName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	hcNameShared, hcFwNameShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
 	hcNameNonShared, hcFwNameNonShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, false)
 

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -69,6 +69,7 @@ func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, n
 		ID:           portId,
 		BackendNamer: l4netlb.namer,
 		NodePort:     int64(service.Spec.Ports[0].NodePort),
+		L4RBSEnabled: true,
 	}
 	return l4netlb
 }

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -34,17 +34,13 @@ import (
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
-const (
-	defaultNodePort = 30234
-)
-
 func TestEnsureL4NetLoadBalancer(t *testing.T) {
 	t.Parallel()
 	nodeNames := []string{"test-node-1"}
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
 
-	svc := test.NewL4NetLBService(8080, defaultNodePort)
+	svc := test.NewL4NetLBService(8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 
 	l4netlb := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
@@ -91,7 +87,7 @@ func TestDeleteL4NetLoadBalancer(t *testing.T) {
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
 
-	svc := test.NewL4NetLBService(8080, defaultNodePort)
+	svc := test.NewL4NetLBService(8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 
 	l4NetLB := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
@@ -136,7 +132,7 @@ func TestDeleteL4NetLoadBalancerWithSharedHC(t *testing.T) {
 }
 
 func ensureLoadBalancer(port int, vals gce.TestClusterValues, fakeGCE *gce.Cloud, t *testing.T) (*v1.Service, *L4NetLB) {
-	svc := test.NewL4NetLBService(port, defaultNodePort)
+	svc := test.NewL4NetLBService(port)
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 	emptyNodes := []string{}
 	l4NetLB := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -45,7 +45,6 @@ type NetworkEndpointGroupCloud interface {
 // NetworkEndpointGroupNamer is an interface for generating network endpoint group name.
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
-	VMIPNEG(namespace, name string) (string, bool)
 	NEGWithSubset(namespace, name, subset string, port int32) string
 	IsNEG(name string) bool
 }

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -178,7 +178,7 @@ func NewPortInfoMapForVMIPNEG(namespace, name string, namer namer.L4ResourcesNam
 		if local {
 			mode = L4LocalMode
 		}
-		negName, _ := namer.VMIPNEG(namespace, name)
+		negName, _ := namer.L4Backend(namespace, name)
 		ret[PortInfoMapKey{svcPortTuple.Port, ""}] = PortInfo{
 			PortTuple:        svcPortTuple,
 			NegName:          negName,

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -35,10 +35,6 @@ func (*negNamer) NEG(namespace, name string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v", namespace, name, svcPort)
 }
 
-func (*negNamer) VMIPNEG(namespace, name string) (string, bool) {
-	return fmt.Sprintf("%v-%v", namespace, name), true
-}
-
 func (*negNamer) NEGWithSubset(namespace, name, subset string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, subset, svcPort)
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -94,7 +94,7 @@ func NewL4ILBService(onlyLocal bool, port int) *api_v1.Service {
 }
 
 // NewL4NetLBService creates a Service of type LoadBalancer.
-func NewL4NetLBService(port int, nodePort int32) *api_v1.Service {
+func NewL4NetLBService(port int) *api_v1.Service {
 	svc := &api_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      netLbServiceName,
@@ -104,7 +104,7 @@ func NewL4NetLBService(port int, nodePort int32) *api_v1.Service {
 			Type:            api_v1.ServiceTypeLoadBalancer,
 			SessionAffinity: api_v1.ServiceAffinityClientIP,
 			Ports: []api_v1.ServicePort{
-				{Name: "testport", Port: int32(port), Protocol: "TCP", NodePort: nodePort},
+				{Name: "testport", Port: int32(port), Protocol: "TCP"},
 			},
 			ExternalTrafficPolicy: api_v1.ServiceExternalTrafficPolicyTypeCluster,
 		},

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -57,9 +57,10 @@ type BackendNamer interface {
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
-	// VMIPNEG returns the gce neg name based on the service namespace and name.
-	// The second output parameter indicates if the namer supports VM_IP_NEGs.
-	VMIPNEG(namespace, name string) (string, bool)
+	// L4Backend returns the name for L4 LB backend resources, based on the service namespace and name.
+	// It supports ILB with subsetting enabled (VM_IP_NEGs) and NetLB with RBS enabled.
+	// The second output parameter indicates if the namer is supported.
+	L4Backend(namespace, name string) (string, bool)
 	// InstanceGroup constructs the name for an Instance Group.
 	InstanceGroup() string
 	// NamedPort returns the name for a named port.

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -45,11 +45,11 @@ func NewL4Namer(kubeSystemUID string, namer *Namer) *L4Namer {
 	return &L4Namer{v2Prefix: defaultPrefix + schemaVersionV2, v2ClusterUID: clusterUID, Namer: namer}
 }
 
-// VMIPNEG returns the gce VM_IP_NEG name based on the service namespace and name
-// NEG naming convention:
+// L4Backend returns the gce L4 Backend name based on the service namespace and name
+// Naming convention:
 //   k8s2-{uid}-{ns}-{name}-{suffix}
 // Output name is at most 63 characters.
-func (namer *L4Namer) VMIPNEG(namespace, name string) (string, bool) {
+func (namer *L4Namer) L4Backend(namespace, name string) (string, bool) {
 	truncFields := TrimFieldsEvenly(maximumL4CombinedLength, namespace, name)
 	truncNamespace := truncFields[0]
 	truncName := truncFields[1]
@@ -70,10 +70,10 @@ func (namer *L4Namer) L4ForwardingRule(namespace, name, protocol string) string 
 	return strings.Join([]string{namer.v2Prefix, protocol, namer.v2ClusterUID, truncNamespace, truncName, namer.suffix(namespace, name)}, "-")
 }
 
-// L4HealthCheck returns the name of the L4 ILB Healthcheck and the associated firewall rule.
+// L4HealthCheck returns the name of the L4 LB Healthcheck and the associated firewall rule.
 func (namer *L4Namer) L4HealthCheck(namespace, name string, shared bool) (string, string) {
 	if !shared {
-		l4Name, _ := namer.VMIPNEG(namespace, name)
+		l4Name, _ := namer.L4Backend(namespace, name)
 		return l4Name, namer.hcFirewallName(l4Name)
 	}
 	return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedHcSuffix}, "-"),

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -69,7 +69,7 @@ func TestL4Namer(t *testing.T) {
 	newNamer := NewL4Namer(kubeSystemUID, nil)
 	for _, tc := range testCases {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
-		negName, ok := newNamer.VMIPNEG(tc.namespace, tc.name)
+		negName, ok := newNamer.L4Backend(tc.namespace, tc.name)
 		hcName, hcFwName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
 		if !ok {
 			t.Errorf("Namer does not support VMIPNEG")

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -478,8 +478,8 @@ func (n *Namer) IsNEG(name string) bool {
 	return strings.HasPrefix(name, n.negPrefix())
 }
 
-// VMIPNEG is only supported by L4Namer.
-func (namer *Namer) VMIPNEG(namespace, name string) (string, bool) {
+// L4Backend is only supported by L4Namer.
+func (namer *Namer) L4Backend(namespace, name string) (string, bool) {
 	return "", false
 }
 

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -51,6 +51,7 @@ type ServicePort struct {
 	TargetPort     intstr.IntOrString
 	NEGEnabled     bool
 	VMIPNEGEnabled bool
+	L4RBSEnabled   bool
 	L7ILBEnabled   bool
 	BackendConfig  *backendconfigv1.BackendConfig
 	BackendNamer   namer.BackendNamer
@@ -71,9 +72,10 @@ func (sp *ServicePort) GetDescription() Description {
 func (sp *ServicePort) BackendName() string {
 	if sp.NEGEnabled {
 		return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
-	} else if sp.VMIPNEGEnabled {
-		negName, _ := sp.BackendNamer.VMIPNEG(sp.ID.Service.Namespace, sp.ID.Service.Name)
-		return negName
+	} else if sp.VMIPNEGEnabled || sp.L4RBSEnabled {
+		// Use L4 Backend name for both Internal and External LoadBalancers
+		backendName, _ := sp.BackendNamer.L4Backend(sp.ID.Service.Namespace, sp.ID.Service.Name)
+		return backendName
 	}
 	return sp.BackendNamer.IGBackend(sp.NodePort)
 }


### PR DESCRIPTION
Function creating names for ILB aligning with k8s2 convention is
VMIPNEG.
Since we use the same name for neg, backend service and firewall rules I
rename this function to L4Backend. Now we can use the same function for
NetLB services and NetLB does not use NEG so VMIPNEG name is not
suitable here.