### PR TITLE
Multiple instance group management #1

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
 	"k8s.io/ingress-gce/pkg/ingparams"
+	"k8s.io/ingress-gce/pkg/instancegroup"
 	"k8s.io/ingress-gce/pkg/l4lb"
 	"k8s.io/ingress-gce/pkg/psc"
 	"k8s.io/ingress-gce/pkg/serviceattachment"
@@ -46,17 +47,16 @@ import (
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 
-	ingctx "k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/controller"
-	"k8s.io/ingress-gce/pkg/neg"
-	negtypes "k8s.io/ingress-gce/pkg/neg/types"
-
 	"k8s.io/ingress-gce/cmd/glbc/app"
 	"k8s.io/ingress-gce/pkg/backendconfig"
+	ingctx "k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/controller"
 	"k8s.io/ingress-gce/pkg/crd"
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/flags"
 	_ "k8s.io/ingress-gce/pkg/klog"
+	"k8s.io/ingress-gce/pkg/neg"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/version"
 )
 
@@ -350,8 +350,13 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	ctx.Start(stopCh)
 
-	nodeController := controller.NewNodeController(ctx, stopCh)
-	go nodeController.Run()
+	if flags.F.EnableMultipleIGs {
+		multiIGNodeController := instancegroup.NewMultiIGNodeController(ctx, stopCh)
+		go multiIGNodeController.Run()
+	} else {
+		nodeController := controller.NewNodeController(ctx, stopCh)
+		go nodeController.Run()
+	}
 
 	// The L4NetLbController will be run when RbsMode flag is Set
 	if flags.F.RunL4NetLBController {

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -81,11 +81,13 @@ func NewInstanceGroupLinker(instancePool instances.NodePool, backendPool Pool) L
 func (l *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) error {
 	var igLinks []string
 	for _, group := range groups {
-		ig, err := l.instancePool.Get(sp.IGName(), group.Zone)
+		igs, err := l.instancePool.Get(sp.IGName(), group.Zone)
 		if err != nil {
 			return fmt.Errorf("error retrieving IG for linking with backend %+v: %w", sp, err)
 		}
-		igLinks = append(igLinks, ig.SelfLink)
+		for _, ig := range igs {
+			igLinks = append(igLinks, ig.SelfLink)
+		}
 	}
 
 	// ig_linker only supports L7 HTTP(s) External Load Balancer

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -199,9 +199,9 @@ func TestSyncChaosMonkey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to find instance group %v", defaultNamer.InstanceGroup())
 	}
-	groupPath, err := utils.RelativeResourceName(gotGroup.SelfLink)
+	groupPath, err := utils.RelativeResourceName(gotGroup[0].SelfLink)
 	if err != nil {
-		t.Fatalf("Failed to get resource path from %q", gotGroup.SelfLink)
+		t.Fatalf("Failed to get resource path from %q", gotGroup[0].SelfLink)
 	}
 
 	for _, be := range gotBackend.Backends {

--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -43,6 +43,7 @@ func (linker *RegionalInstanceGroupLinker) Link(sp utils.ServicePort, projectID 
 
 	for _, zone := range zones {
 		key := meta.ZonalKey(sp.IGName(), zone)
+		//TODO (cezarygerard): link all IGs by reusing []*compute.InstanceGroup returned from instancepool in the l4 controller
 		igSelfLink := cloudprovider.SelfLink(meta.VersionGA, projectID, "instanceGroups", key)
 		igLinks = append(igLinks, igSelfLink)
 	}

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -84,7 +84,7 @@ func TestRegionalLink(t *testing.T) {
 		t.Fatalf("Expected Backends to be created")
 	}
 	ig, _ := linker.instancePool.Get(sp.IGName(), uscentralzone)
-	expectedLink, _ := utils.RelativeResourceName(ig.SelfLink)
+	expectedLink, _ := utils.RelativeResourceName(ig[0].SelfLink)
 	if be.Backends[0].Group != expectedLink {
 		t.Fatalf("Expected Backend Group: %s received: %s", expectedLink, be.Backends[0].Group)
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -206,13 +206,21 @@ func NewControllerContext(
 		context.UseEndpointSlices,
 		context.KubeClient,
 	)
-	context.InstancePool = instances.NewNodePool(context.Cloud,
-		context.ClusterNamer,
-		context,
-		utils.GetBasePath(context.Cloud),
-		context.Translator,
-	)
-
+	if flags.F.EnableMultipleIGs {
+		context.InstancePool = instances.NewMultiIGInstances(context.Cloud,
+			context.ClusterNamer,
+			context,
+			utils.GetBasePath(context.Cloud),
+			context.Translator,
+		)
+	} else {
+		context.InstancePool = instances.NewNodePool(context.Cloud,
+			context.ClusterNamer,
+			context,
+			utils.GetBasePath(context.Cloud),
+			context.Translator,
+		)
+	}
 	return context
 }
 

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	compute "google.golang.org/api/compute/v1"
-	api_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -56,16 +55,6 @@ func uniq(svcPorts []utils.ServicePort) []utils.ServicePort {
 		svcPorts = append(svcPorts, sp)
 	}
 	return svcPorts
-}
-
-func nodeStatusChanged(old, cur *api_v1.Node) bool {
-	if old.Spec.Unschedulable != cur.Spec.Unschedulable {
-		return true
-	}
-	if utils.NodeIsReady(old) != utils.NodeIsReady(cur) {
-		return true
-	}
-	return false
 }
 
 func convert(ings []*v1.Ingress) (retVal []interface{}) {

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -158,51 +158,6 @@ func TestAddInstanceGroupsAnnotation(t *testing.T) {
 	}
 }
 
-func TestNodeStatusChanged(t *testing.T) {
-	testCases := []struct {
-		desc   string
-		mutate func(node *api_v1.Node)
-		expect bool
-	}{
-		{
-			"no change",
-			func(node *api_v1.Node) {},
-			false,
-		},
-		{
-			"unSchedulable changes",
-			func(node *api_v1.Node) {
-				node.Spec.Unschedulable = true
-			},
-			true,
-		},
-		{
-			"readiness changes",
-			func(node *api_v1.Node) {
-				node.Status.Conditions[0].Status = api_v1.ConditionFalse
-				node.Status.Conditions[0].LastTransitionTime = meta_v1.NewTime(time.Now())
-			},
-			true,
-		},
-		{
-			"new heartbeat",
-			func(node *api_v1.Node) {
-				node.Status.Conditions[0].LastHeartbeatTime = meta_v1.NewTime(time.Now())
-			},
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		node := testNode()
-		tc.mutate(node)
-		res := nodeStatusChanged(testNode(), node)
-		if res != tc.expect {
-			t.Fatalf("Test case %q got: %v, expected: %v", tc.desc, res, tc.expect)
-		}
-	}
-}
-
 func TestUniq(t *testing.T) {
 	testCases := []struct {
 		desc   string
@@ -365,31 +320,6 @@ func TestGetNodePortsUsedByIngress(t *testing.T) {
 		}
 	}
 
-}
-
-func testNode() *api_v1.Node {
-	return &api_v1.Node{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: "ns",
-			Name:      "node",
-			Annotations: map[string]string{
-				"key1": "value1",
-			},
-		},
-		Spec: api_v1.NodeSpec{
-			Unschedulable: false,
-		},
-		Status: api_v1.NodeStatus{
-			Conditions: []api_v1.NodeCondition{
-				{
-					Type:               api_v1.NodeReady,
-					Status:             api_v1.ConditionTrue,
-					LastHeartbeatTime:  meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
-					LastTransitionTime: meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
-				},
-			},
-		},
-	}
 }
 
 func testServicePort(namespace, name, port string, servicePort, nodePort int, enableNEG bool) utils.ServicePort {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -106,7 +106,7 @@ var (
 		EnableIngressGAFields          bool
 		EnableTrafficScaling           bool
 		EnableEndpointSlices           bool
-		EnableMultipleIgs              bool
+		EnableMultipleIGs              bool
 		MaxIgSize                      int
 	}{
 		GCERateLimitScale: 1.0,
@@ -244,7 +244,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.GKEClusterType, "gke-cluster-type", "ZONAL", "The cluster type of the GKE cluster this Ingress Controller will be interacting with")
 	flag.BoolVar(&F.EnableTrafficScaling, "enable-traffic-scaling", false, "Enable support for Service {max-rate-per-endpoint, capacity-scaler}")
 	flag.BoolVar(&F.EnableEndpointSlices, "enable-endpoint-slices", false, "Enable using Endpoint Slices API instead of Endpoints API")
-	flag.BoolVar(&F.EnableMultipleIgs, "enable-multiple-igs", false, "Enable using unmanaged instance group management")
+	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multi instance group management")
 	flag.IntVar(&F.MaxIgSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)
 }

--- a/pkg/instancegroup/multi_ig_node_controller.go
+++ b/pkg/instancegroup/multi_ig_node_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package instancegroup
 
 import (
-	"time"
-
 	apiv1 "k8s.io/api/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -26,73 +24,79 @@ import (
 	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
+	"time"
 )
 
-// NodeController synchronizes the state of the nodes to the unmanaged instance
-// groups.
-type NodeController struct {
+type MultiIGNodeController struct {
+	instancePool instances.NodePool
 	// lister is a cache of the k8s Node resources.
 	lister cache.Indexer
 	// queue is the TaskQueue used to manage the node worker updates.
 	queue utils.TaskQueue
-	// instancePool is a NodePool to manage kubernetes nodes.
-	instancePool instances.NodePool
 	// hasSynced returns true if relevant caches have done their initial
 	// synchronization.
 	hasSynced func() bool
 
-	stopCh chan struct{}
+	stopCh <-chan struct{}
 }
 
-// NewNodeController returns a new node update controller.
-func NewNodeController(ctx *context.ControllerContext, stopCh chan struct{}) *NodeController {
-	c := &NodeController{
-		lister:       ctx.NodeInformer.GetIndexer(),
-		instancePool: ctx.InstancePool,
-		hasSynced:    ctx.HasSynced,
-		stopCh:       stopCh,
+// NewMultiIGNodeController returns a new multi instances group controller.
+func NewMultiIGNodeController(ctx *context.ControllerContext, stopCh <-chan struct{}) *MultiIGNodeController {
+	igc := &MultiIGNodeController{
+		lister:    ctx.NodeInformer.GetIndexer(),
+		hasSynced: ctx.HasSynced,
+		stopCh:    stopCh,
 	}
-	c.queue = utils.NewPeriodicTaskQueue("", "nodes", c.sync)
+	igc.queue = utils.NewPeriodicTaskQueue("", "nodes", igc.sync)
+
+	// Cast or die
+	pool, ok := ctx.InstancePool.(*instances.MultiIGInstances)
+	if !ok {
+		klog.Fatalf("provided InstancePool must be of type MultiIGInstances")
+	}
+	igc.instancePool = pool
 
 	ctx.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			c.queue.Enqueue(obj)
+			igc.queue.Enqueue(obj)
 		},
 		DeleteFunc: func(obj interface{}) {
-			c.queue.Enqueue(obj)
+			igc.queue.Enqueue(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			// TODO(cezarygerard) trigger sync periodically.
 			if utils.NodeStatusChanged(oldObj.(*apiv1.Node), newObj.(*apiv1.Node)) {
-				c.queue.Enqueue(newObj)
+				igc.queue.Enqueue(newObj)
 			}
 		},
 	})
-	return c
+	return igc
 }
 
-// Run the queue to process updates for the controller. This must be run in a
+// Run the queue to process updates for the nodes. This must be run in a
 // separate goroutine (method will block until queue shutdown).
-func (c *NodeController) Run() {
+func (igc *MultiIGNodeController) Run() {
 	start := time.Now()
-	for !c.hasSynced() {
+	for !igc.hasSynced() {
 		klog.V(2).Infof("Waiting for hasSynced (%s elapsed)", time.Now().Sub(start))
 		time.Sleep(1 * time.Second)
 	}
 	klog.V(2).Infof("Caches synced (took %s)", time.Now().Sub(start))
-	go c.queue.Run()
-	<-c.stopCh
-	c.Shutdown()
+	go igc.queue.Run()
+	<-igc.stopCh
+	igc.Shutdown()
 }
 
 // Shutdown shuts down the goroutine that processes node updates.
-func (c *NodeController) Shutdown() {
-	c.queue.Shutdown()
+func (igc *MultiIGNodeController) Shutdown() {
+	igc.queue.Shutdown()
 }
 
-func (c *NodeController) sync(key string) error {
-	nodeNames, err := utils.GetReadyNodeNames(listers.NewNodeLister(c.lister))
+func (igc *MultiIGNodeController) sync(key string) error {
+	_, err := utils.GetReadyNodeNames(listers.NewNodeLister(igc.lister))
 	if err != nil {
 		return err
 	}
-	return c.instancePool.Sync(nodeNames)
+	//TODO (panslava) do the actual IG sync
+	return nil
 }

--- a/pkg/instances/interfaces.go
+++ b/pkg/instances/interfaces.go
@@ -34,11 +34,8 @@ type NodePool interface {
 	EnsureInstanceGroupsAndPorts(name string, ports []int64) ([]*compute.InstanceGroup, error)
 	DeleteInstanceGroup(name string) error
 
-	// TODO: Refactor for modularity
-	Add(groupName string, nodeNames []string) error
-	Remove(groupName string, nodeNames []string) error
 	Sync(nodeNames []string) error
-	Get(name, zone string) (*compute.InstanceGroup, error)
+	Get(name, zone string) ([]*compute.InstanceGroup, error)
 	List() ([]string, error)
 }
 

--- a/pkg/instances/multi_ig_instances.go
+++ b/pkg/instances/multi_ig_instances.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instances
+
+import (
+	"fmt"
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog"
+)
+
+// MultiIGInstances implements NodePool Interface. It can use multiple instance groups belonging to cluster but it does not
+// create/delete them. This is a job for separate controller (MultiIGNodeController).
+type MultiIGInstances struct {
+	*Instances
+}
+
+func NewMultiIGInstances(cloud InstanceGroups, namer namer.BackendNamer, recorders recorderSource, basePath string, zl ZoneLister) *MultiIGInstances {
+	multiIGInstances := &MultiIGInstances{
+		Instances: &Instances{
+			cloud:              cloud,
+			namer:              namer,
+			recorder:           recorders.Recorder(""), // No namespace
+			instanceLinkFormat: basePath + "zones/%s/instances/%s",
+			ZoneLister:         zl,
+		},
+	}
+	return multiIGInstances
+}
+
+func (igc *MultiIGInstances) DeleteInstanceGroup(name string) error {
+	klog.Infof("DeleteInstanceGroup is a no-op. Instance groups will be deleted when the cluster is deleted.")
+	return nil
+}
+
+func (igc *MultiIGInstances) Sync(nodeNames []string) error {
+	klog.Infof("Sync is a no-op. Instance groups will be synced in the separate controller.")
+	return nil
+}
+
+func (igc *MultiIGInstances) Get(name, zone string) ([]*compute.InstanceGroup, error) {
+	var igs []*compute.InstanceGroup
+	igsForZone, err := igc.cloud.ListInstanceGroups(zone)
+	if err != nil {
+		return nil, err
+	}
+	for _, ig := range igsForZone {
+		if igc.namer.NameBelongsToCluster(ig.Name) {
+			igs = append(igs, ig)
+		}
+	}
+	if len(igs) == 0 {
+		return nil, fmt.Errorf("no Instance Groups belong to cluster")
+	}
+	return igs, nil
+}
+
+func (igc *MultiIGInstances) EnsureInstanceGroupsAndPorts(name string, ports []int64) (igs []*compute.InstanceGroup, err error) {
+	// Instance groups need to be created only in zones that have ready nodes.
+	zones, err := igc.Instances.ListZones(utils.CandidateNodesPredicate)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, zone := range zones {
+
+		ig, err := igc.Get(name, zone)
+		if err != nil {
+			return nil, err
+		}
+		err = igc.setPorts(ig, name, zone, ports)
+		if err != nil {
+			return nil, err
+		}
+		igs = append(igs, ig...)
+	}
+	return igs, nil
+}

--- a/pkg/instances/multi_ig_instances_test.go
+++ b/pkg/instances/multi_ig_instances_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instances
+
+import (
+	"fmt"
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/test"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"testing"
+)
+
+const (
+	clusterID         = "clusterUID"
+	igName            = "igname"
+	zone              = "zone1"
+	emptyBasePath     = ""
+	emptyFirewallName = ""
+)
+
+func TestGetInstanceGroups(t *testing.T) {
+	recorder := &test.FakeRecorderSource{}
+	backendNamer := namer.NewNamer(clusterID, emptyFirewallName)
+	zones := []string{zone}
+	zoneLister := &FakeZoneLister{zones}
+	fakeCloud := NewFakeInstanceGroups(nil, defaultNamer)
+	multiIGInst := NewMultiIGInstances(fakeCloud, backendNamer, recorder, emptyBasePath, zoneLister)
+
+	testCases := []struct {
+		name           string
+		instanceGroups []*compute.InstanceGroup
+		expecetedIGs   int
+		expectedError  bool
+	}{
+		{
+			name:           "Single IG in cluster",
+			instanceGroups: []*compute.InstanceGroup{{Name: "k8s-ig--clusterUIDdef"}},
+			expecetedIGs:   1,
+			expectedError:  false,
+		},
+
+		{
+			name:           "Single IG, not in cluster",
+			instanceGroups: []*compute.InstanceGroup{{Name: "k8s-ig--cluster2UIDdef-1"}},
+			expecetedIGs:   0,
+			expectedError:  true,
+		},
+		{
+			name: "Multiple IGs in cluster",
+			instanceGroups: []*compute.InstanceGroup{
+				{Name: "k8s-ig--clusterUIDdef"},
+				{Name: "k8s-ig--clusterUIDdef-1"},
+				{Name: "k8s-ig--clusterUIDdef-2"},
+				{Name: "k8s-ig--clusterUIDdef-3"},
+				{Name: "k8s-ig--clusterUIDdef-5"},
+			},
+			expecetedIGs:  5,
+			expectedError: false,
+		},
+		{
+			name: "Multiple IGs, some in cluster",
+			instanceGroups: []*compute.InstanceGroup{
+				{Name: "k8s-ig--cluster1UIDdef"},
+				{Name: "k8s-ig--cluster2UIDdef-1"},
+				{Name: "k8s-ig--clusterUIDdef-2"},
+				{Name: "k8s-ig--clusterUIDdef-3"},
+				{Name: "k8s-ig--cluster1UIDdef-5"},
+			},
+			expecetedIGs:  2,
+			expectedError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeCloud.instanceGroups = tc.instanceGroups
+			result, err := multiIGInst.Get(igName, zone)
+			if len(result) != tc.expecetedIGs {
+				t.Errorf("Incorrect number of instance grouos, got: %v, want: %v", len(result), tc.expecetedIGs)
+			}
+			gotError := (err != nil)
+			if gotError != tc.expectedError {
+				t.Errorf("Unexpected error, got: %v, want any error: %v", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestEnsureInstanceGroupsAndPorts(t *testing.T) {
+	recorder := &test.FakeRecorderSource{}
+	backendNamer := namer.NewNamer(clusterID, emptyFirewallName)
+	zones := []string{zone}
+	zoneLister := &FakeZoneLister{zones}
+	fakeCloud := NewFakeInstanceGroups(nil, defaultNamer)
+	multiIGInst := NewMultiIGInstances(fakeCloud, backendNamer, recorder, emptyBasePath, zoneLister)
+
+	testCases := []struct {
+		name           string
+		instanceGroups []*compute.InstanceGroup
+		ports          []int64
+		expecetedIGs   int
+		expectedError  bool
+	}{
+		{
+			name:           "No instance groups",
+			instanceGroups: []*compute.InstanceGroup{},
+			expecetedIGs:   0,
+			expectedError:  true,
+		},
+		{
+			name:          "Nil instance groups",
+			expecetedIGs:  0,
+			expectedError: true,
+		},
+		{
+			name:           "Nil ports",
+			instanceGroups: []*compute.InstanceGroup{{Name: "k8s-ig--clusterUIDdef", Zone: zone}},
+			expecetedIGs:   1,
+			expectedError:  false,
+		},
+		{
+			name:           "No instance groups for cluster",
+			instanceGroups: []*compute.InstanceGroup{{Name: "k8s-ig--cluster2UIDdef", Zone: zone}},
+			ports:          []int64{22, 80, 8888},
+			expecetedIGs:   0,
+			expectedError:  true,
+		},
+		{
+			name: "Ports set to 2 instance groups",
+			instanceGroups: []*compute.InstanceGroup{
+				{Name: "k8s-ig--clusterUIDdef", Zone: zone},
+				{Name: "k8s-ig--clusterUIDdef-3", Zone: zone},
+			},
+			ports:         []int64{22, 80, 8888},
+			expecetedIGs:  2,
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeCloud.instanceGroups = tc.instanceGroups
+			result, err := multiIGInst.EnsureInstanceGroupsAndPorts(igName, tc.ports)
+			if len(result) != tc.expecetedIGs {
+				t.Errorf("Incorrect number of instance grouos, got: %v, want: %v", len(result), tc.expecetedIGs)
+			}
+			gotError := (err != nil)
+			if gotError != tc.expectedError {
+				t.Errorf("Unexpected error, got: %v, want any error: %v ", err, tc.expectedError)
+			}
+			for _, resultIG := range result {
+				if len(resultIG.NamedPorts) != len(tc.ports) {
+					t.Errorf("unexpected number of named ports. Got: %+v, want: %v", len(resultIG.NamedPorts), len(tc.ports))
+				}
+				for i, np := range resultIG.NamedPorts {
+					expectedPort := tc.ports[i]
+					if np.Port != expectedPort || np.Name != fmt.Sprint("port", expectedPort) {
+						t.Errorf("invalid ports set on instance group. IG named port: %+v, want: %v", expectedPort, tc.ports)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -391,7 +391,9 @@ func (lc *L4NetLBController) ensureInstanceGroups(service *v1.Service, nodeNames
 	// TODO(kl52752) implement limit for 1000 nodes in instance group
 	// TODO(kl52752) Move instance creation and deletion logic to NodeController
 	// to avoid race condition between controllers
+	// TODO(cezarygerard) ignore named ports in the L4, they are not needed
 	_, _, nodePorts, _ := utils.GetPortsAndProtocol(service.Spec.Ports)
+	// TODO(cezarygerard) return instance groups from this function to be used for IG Linker
 	_, err := lc.instancePool.EnsureInstanceGroupsAndPorts(lc.ctx.ClusterNamer.InstanceGroup(), nodePorts)
 	if err != nil {
 		return err
@@ -416,6 +418,10 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service)
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error reseting L4 External LoadBalancer status to empty, err: %v", err)
 		result.Error = fmt.Errorf("Failed to reset L4 External LoadBalancer status, err: %w", err)
+		return result
+	}
+	if err := lc.deleteIG(svc); err != nil {
+		result.Error = fmt.Errorf("Failed to remove L4 External LoadBalancer Instance Group, err: %w", err)
 		return result
 	}
 
@@ -473,4 +479,13 @@ func (lc *L4NetLBController) publishSyncMetrics(result *loadbalancers.L4NetLBSyn
 		return
 	}
 	metrics.PublishL4NetLBSyncError(result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime)
+}
+
+func (lc *L4NetLBController) deleteIG(svc *v1.Service) error {
+	if err := lc.instancePool.DeleteInstanceGroup(lc.ctx.ClusterNamer.InstanceGroup()); err != nil && !utils.IsInUsedByError(err) {
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
+			"Error Instance Group, err: %v", err)
+		return err
+	}
+	return nil
 }

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -294,7 +294,13 @@ func (n *Namer) NameBelongsToCluster(name string) bool {
 	// The cluster name is 16a1467191ad30 which is longer than clusterNameEvalThreshold.
 	// Case 2: k8s-fws-test-sandbox-50a6f22a4cd34e91-ingress-1111111111111--10
 	// The cluster name is 10 which is shorter than clusterNameEvalThreshold.
-	return len(componentClusterName) > clusterNameEvalThreshold && strings.HasPrefix(fullClusterName, componentClusterName)
+	//
+	// The component belongs to cluster if  componentClusterName is a prefix of cluster name [1]
+	// or when full  cluster name is a prefix componentClusterName [2]
+	// [1] takes place when long component name is (optionally truncated) cluster name
+	// [2] takes place when component name is a  cluster name with suffix, e.g. 0123456789abcdef-1 (extracted from "k8s-ig--0123456789abcdef-1")
+	return len(componentClusterName) > clusterNameEvalThreshold &&
+		(strings.HasPrefix(fullClusterName, componentClusterName) || strings.HasPrefix(componentClusterName, fullClusterName))
 
 }
 

--- a/pkg/utils/namer/namer_test.go
+++ b/pkg/utils/namer/namer_test.go
@@ -133,6 +133,8 @@ func TestNameBelongsToCluster(t *testing.T) {
 			// short names
 			newNamer.IGBackend(80),
 			newNamer.InstanceGroup(),
+			newNamer.InstanceGroup() + "-1",
+			newNamer.InstanceGroup() + "-23",
 			newNamer.TargetProxy(lbName, HTTPProtocol),
 			newNamer.TargetProxy(lbName, HTTPSProtocol),
 			newNamer.SSLCertName("default/my-ing", secretHash),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -356,6 +356,16 @@ func NodeIsReady(node *api_v1.Node) bool {
 	return false
 }
 
+func NodeStatusChanged(old, cur *api_v1.Node) bool {
+	if old.Spec.Unschedulable != cur.Spec.Unschedulable {
+		return true
+	}
+	if NodeIsReady(old) != NodeIsReady(cur) {
+		return true
+	}
+	return false
+}
+
 // NodeConditionPredicate is a function that indicates whether the given node's conditions meet
 // some set of criteria defined by the function.
 type NodeConditionPredicate func(node *api_v1.Node) bool

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -496,6 +496,76 @@ func TestTraverseIngressBackends(t *testing.T) {
 	}
 }
 
+func TestNodeStatusChanged(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		mutate func(node *api_v1.Node)
+		expect bool
+	}{
+		{
+			"no change",
+			func(node *api_v1.Node) {},
+			false,
+		},
+		{
+			"unSchedulable changes",
+			func(node *api_v1.Node) {
+				node.Spec.Unschedulable = true
+			},
+			true,
+		},
+		{
+			"readiness changes",
+			func(node *api_v1.Node) {
+				node.Status.Conditions[0].Status = api_v1.ConditionFalse
+				node.Status.Conditions[0].LastTransitionTime = v1.NewTime(time.Now())
+			},
+			true,
+		},
+		{
+			"new heartbeat",
+			func(node *api_v1.Node) {
+				node.Status.Conditions[0].LastHeartbeatTime = v1.NewTime(time.Now())
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		node := testNode()
+		tc.mutate(node)
+		res := NodeStatusChanged(testNode(), node)
+		if res != tc.expect {
+			t.Fatalf("Test case %q got: %v, expected: %v", tc.desc, res, tc.expect)
+		}
+	}
+}
+
+func testNode() *api_v1.Node {
+	return &api_v1.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "node",
+			Annotations: map[string]string{
+				"key1": "value1",
+			},
+		},
+		Spec: api_v1.NodeSpec{
+			Unschedulable: false,
+		},
+		Status: api_v1.NodeStatus{
+			Conditions: []api_v1.NodeCondition{
+				{
+					Type:               api_v1.NodeReady,
+					Status:             api_v1.ConditionTrue,
+					LastHeartbeatTime:  v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
+					LastTransitionTime: v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+}
+
 func TestGetNodeConditionPredicate(t *testing.T) {
 	tests := []struct {
 		node                                             api_v1.Node


### PR DESCRIPTION
This part creates new implementation of NodePool interface that can handle multiple Instance Groups in existing controllers


The "enable-multiple-igs" flag keeps new logic disabled.