### PR TITLE
Add multiple zones support to fake instance groups

### DIFF
--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends/features"
 	"k8s.io/ingress-gce/pkg/composite"
@@ -48,7 +47,7 @@ func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instances.NodePool) *i
 }
 
 func TestLink(t *testing.T) {
-	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
+	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
 	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
@@ -79,7 +78,7 @@ func TestLink(t *testing.T) {
 }
 
 func TestLinkWithCreationModeError(t *testing.T) {
-	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
+	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
 	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -45,7 +45,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
-	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), defaultNamer)
+	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
 	fakeInstancePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
 

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -44,7 +43,7 @@ func linkerTestClusterValues() gce.TestClusterValues {
 }
 
 func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
-	fakeIGs := instances.NewFakeInstanceGroups(sets.NewString(), l4Namer.Namer)
+	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{uscentralzone}}
 	fakeInstancePool := instances.NewNodePool(fakeIGs, l4Namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -33,7 +33,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/ingress-gce/pkg/annotations"
 	backendconfigclient "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned/fake"
@@ -76,7 +75,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
-	lbc.instancePool = instances.NewNodePool(instances.NewFakeInstanceGroups(sets.NewString(), namer), namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	lbc.instancePool = instances.NewNodePool(instances.NewEmptyFakeInstanceGroups(), namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
 	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(fakeGCE, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, ""))
 
 	lbc.hasSynced = func() bool { return true }

--- a/pkg/firewalls/fakes.go
+++ b/pkg/firewalls/fakes.go
@@ -21,8 +21,7 @@ import (
 	"fmt"
 
 	compute "google.golang.org/api/compute/v1"
-
-	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/test"
 )
 
 type fakeFirewallsProvider struct {
@@ -49,7 +48,7 @@ func (ff *fakeFirewallsProvider) GetFirewall(name string) (*compute.Firewall, er
 	if exists {
 		return rule, nil
 	}
-	return nil, utils.FakeGoogleAPINotFoundErr()
+	return nil, test.FakeGoogleAPINotFoundErr()
 }
 
 func (ff *fakeFirewallsProvider) doCreateFirewall(f *compute.Firewall) error {
@@ -66,7 +65,7 @@ func (ff *fakeFirewallsProvider) doCreateFirewall(f *compute.Firewall) error {
 
 func (ff *fakeFirewallsProvider) CreateFirewall(f *compute.Firewall) error {
 	if ff.fwReadOnly {
-		return utils.FakeGoogleAPIForbiddenErr()
+		return test.FakeGoogleAPIForbiddenErr()
 	}
 
 	return ff.doCreateFirewall(f)
@@ -76,7 +75,7 @@ func (ff *fakeFirewallsProvider) doDeleteFirewall(name string) error {
 	// We need the full name for the same reason as CreateFirewall.
 	_, exists := ff.fw[name]
 	if !exists {
-		return utils.FakeGoogleAPINotFoundErr()
+		return test.FakeGoogleAPINotFoundErr()
 	}
 
 	delete(ff.fw, name)
@@ -85,7 +84,7 @@ func (ff *fakeFirewallsProvider) doDeleteFirewall(name string) error {
 
 func (ff *fakeFirewallsProvider) DeleteFirewall(name string) error {
 	if ff.fwReadOnly {
-		return utils.FakeGoogleAPIForbiddenErr()
+		return test.FakeGoogleAPIForbiddenErr()
 	}
 
 	return ff.doDeleteFirewall(name)
@@ -108,7 +107,7 @@ func (ff *fakeFirewallsProvider) doUpdateFirewall(f *compute.Firewall) error {
 
 func (ff *fakeFirewallsProvider) UpdateFirewall(f *compute.Firewall) error {
 	if ff.fwReadOnly {
-		return utils.FakeGoogleAPIForbiddenErr()
+		return test.FakeGoogleAPIForbiddenErr()
 	}
 
 	return ff.doUpdateFirewall(f)

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 )
 
@@ -110,7 +111,7 @@ func (f *FakeZoneGetter) GetZoneForNode(name string) (string, error) {
 			return zone, nil
 		}
 	}
-	return "", NotFoundError
+	return "", test.FakeGoogleAPINotFoundErr()
 }
 
 // Adds a zone with the given instances to the zone getter
@@ -145,8 +146,6 @@ func NewFakeNetworkEndpointGroupCloud(subnetwork, network string) NetworkEndpoin
 	}
 }
 
-var NotFoundError = utils.FakeGoogleAPINotFoundErr()
-
 func (f *FakeNetworkEndpointGroupCloud) GetNetworkEndpointGroup(name string, zone string, version meta.Version) (*composite.NetworkEndpointGroup, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -158,7 +157,7 @@ func (f *FakeNetworkEndpointGroupCloud) GetNetworkEndpointGroup(name string, zon
 			}
 		}
 	}
-	return nil, NotFoundError
+	return nil, test.FakeGoogleAPINotFoundErr()
 }
 
 func networkEndpointKey(name, zone string) string {
@@ -210,7 +209,7 @@ func (f *FakeNetworkEndpointGroupCloud) DeleteNetworkEndpointGroup(name string, 
 		newList = append(newList, neg)
 	}
 	if !found {
-		return NotFoundError
+		return test.FakeGoogleAPINotFoundErr()
 	}
 	f.NetworkEndpointGroups[zone] = newList
 	return nil
@@ -250,7 +249,7 @@ func (f *FakeNetworkEndpointGroupCloud) ListNetworkEndpoints(name, zone string, 
 	ret := []*composite.NetworkEndpointWithHealthStatus{}
 	nes, ok := f.NetworkEndpoints[networkEndpointKey(name, zone)]
 	if !ok {
-		return nil, NotFoundError
+		return nil, test.FakeGoogleAPINotFoundErr()
 	}
 	for _, ne := range nes {
 		ret = append(ret, &composite.NetworkEndpointWithHealthStatus{NetworkEndpoint: ne})

--- a/pkg/psc/controller_test.go
+++ b/pkg/psc/controller_test.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	safake "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/test"
-	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	sautils "k8s.io/ingress-gce/pkg/utils/serviceattachment"
 	"k8s.io/legacy-cloud-providers/gce"
@@ -701,7 +700,7 @@ func TestServiceAttachmentGarbageCollection(t *testing.T) {
 		},
 		{
 			desc:           "service attachment not found error during gc",
-			getError:       utils.FakeGoogleAPINotFoundErr(),
+			getError:       test.FakeGoogleAPINotFoundErr(),
 			expectDeletion: true,
 		},
 		{
@@ -921,7 +920,7 @@ func TestFilterError(t *testing.T) {
 	}{
 		{
 			desc:          "google api status not found error",
-			err:           utils.FakeGoogleAPINotFoundErr(),
+			err:           test.FakeGoogleAPINotFoundErr(),
 			expectedError: nil,
 		},
 		{
@@ -946,7 +945,7 @@ func TestFilterError(t *testing.T) {
 		},
 		{
 			desc:          "wrapped google api status not found error",
-			err:           fmt.Errorf("wrap 1: %w", fmt.Errorf("wrap 2: %w", utils.FakeGoogleAPINotFoundErr())),
+			err:           fmt.Errorf("wrap 1: %w", fmt.Errorf("wrap 2: %w", test.FakeGoogleAPINotFoundErr())),
 			expectedError: nil,
 		},
 		{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -128,16 +128,6 @@ const (
 	gceAffinityTypeClientIP = "CLIENT_IP"
 )
 
-// FakeGoogleAPIForbiddenErr creates a Forbidden error with type googleapi.Error
-func FakeGoogleAPIForbiddenErr() *googleapi.Error {
-	return &googleapi.Error{Code: http.StatusForbidden}
-}
-
-// FakeGoogleAPINotFoundErr creates a NotFound error with type googleapi.Error
-func FakeGoogleAPINotFoundErr() *googleapi.Error {
-	return &googleapi.Error{Code: http.StatusNotFound}
-}
-
 // IsHTTPErrorCode checks if the given error matches the given HTTP Error code.
 // For this to work the error must be a googleapi Error.
 func IsHTTPErrorCode(err error, code int) bool {


### PR DESCRIPTION
We are using FakeInstanceGroups from `pkg/instances/fakes.go` as a mock for testing interactions with GCE instance groups api.  

This PR rewrites FakeInstanceGroups so it can support multiple instance groups in multiple zones

This PR does not involve any production code changes, only test code changes