### PR TITLE
Add new flag for configuring metrics export frequency

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -148,6 +148,7 @@ func NewControllerContext(
 	clusterNamer *namer.Namer,
 	kubeSystemUID types.UID,
 	config ControllerContextConfig) *ControllerContext {
+
 	context := &ControllerContext{
 		KubeConfig:              kubeConfig,
 		KubeClient:              kubeClient,
@@ -157,7 +158,7 @@ func NewControllerContext(
 		ClusterNamer:            clusterNamer,
 		L4Namer:                 namer.NewL4Namer(string(kubeSystemUID), clusterNamer),
 		KubeSystemUID:           kubeSystemUID,
-		ControllerMetrics:       metrics.NewControllerMetrics(),
+		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval),
 		ControllerContextConfig: config,
 		IngressInformer:         informernetworking.NewIngressInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		ServiceInformer:         informerv1.NewServiceInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -90,6 +90,7 @@ var (
 		Version                          bool
 		WatchNamespace                   string
 		LeaderElection                   LeaderElectionConfiguration
+		MetricsExportInterval            time.Duration
 
 		// Feature flags should be named Enablexxx.
 		EnableASMConfigMapBasedConfig  bool
@@ -245,6 +246,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableEndpointSlices, "enable-endpoint-slices", false, "Enable using Endpoint Slices API instead of Endpoints API")
 	flag.BoolVar(&F.EnableMultipleIgs, "enable-multiple-igs", false, "Enable using unmanaged instance group management")
 	flag.IntVar(&F.MaxIgSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
+	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)
 }
 
 type RateLimitSpecs struct {

--- a/pkg/metrics/l4metrics_test.go
+++ b/pkg/metrics/l4metrics_test.go
@@ -157,7 +157,7 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4ILBService(fmt.Sprint(i), serviceState)
 			}
@@ -307,7 +307,7 @@ func TestComputeL4NetLBMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4NetLBService(fmt.Sprint(i), serviceState)
 			}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1004,7 +1004,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for _, ingState := range tc.ingressStates {
 				ingKey := fmt.Sprintf("%s/%s", defaultNamespace, ingState.ingress.Name)
 				newMetrics.SetIngress(ingKey, ingState)
@@ -1122,7 +1122,7 @@ func TestComputeNegMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for i, negState := range tc.negStates {
 				newMetrics.SetNegService(fmt.Sprint(i), negState)
 			}
@@ -1222,7 +1222,7 @@ func TestComputePSCMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for i, serviceState := range tc.saStates {
 				newMetrics.SetServiceAttachment(strconv.Itoa(i), serviceState)
 			}
@@ -1284,7 +1284,7 @@ func TestComputeServiceMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := NewControllerMetrics()
+			newMetrics := FakeControllerMetrics()
 			for _, service := range tc.services {
 				newMetrics.SetService(service)
 			}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -60,7 +60,8 @@ const (
 )
 
 var (
-	defaultBackend = utils.ServicePort{
+	metricsInterval = 10 * time.Minute
+	defaultBackend  = utils.ServicePort{
 		ID: utils.ServicePortID{
 			Service: types.NamespacedName{
 				Name:      "default-http-backend",
@@ -135,7 +136,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		drDynamicInformer.Informer(),
 		testContext.SvcNegInformer,
 		func() bool { return true },
-		metrics.NewControllerMetrics(),
+		metrics.FakeControllerMetrics(),
 		testContext.L4Namer,
 		defaultBackend,
 		negtypes.NewAdapter(testContext.Cloud),


### PR DESCRIPTION
- Add new flag for configuring metrics export.
- Modify tests to use naive fake for controller metrics 

This will allow us to increase export frequency to comply with sampling theorem: https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem
