### PR TITLE
Create new namer for L4 health check and L4 health check forwarding rule

### DIFF
--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
-	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
 	"k8s.io/legacy-cloud-providers/gce"
 )
@@ -42,9 +41,13 @@ const (
 	gceHcUnhealthyThreshold = int64(3)
 )
 
+type healthCheckNamer interface {
+	L4HealthCheck(namespace, name string, shared bool) (string, string)
+}
+
 // EnsureL4HealthCheck creates a new HTTP health check for an L4 LoadBalancer service, based on the parameters provided.
 // If the healthcheck already exists, it is updated as needed.
-func EnsureL4HealthCheck(cloud *gce.Cloud, svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, string, int32, string, error) {
+func EnsureL4HealthCheck(cloud *gce.Cloud, svc *corev1.Service, namer healthCheckNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, string, int32, string, error) {
 	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 	hcPath, hcPort := gce.GetNodesHealthCheckPath(), gce.GetNodesHealthCheckPort()
 	if !sharedHC {

--- a/pkg/utils/namer/l4_regional_hc_namer.go
+++ b/pkg/utils/namer/l4_regional_hc_namer.go
@@ -1,0 +1,33 @@
+package namer
+
+import (
+	"strings"
+)
+
+const (
+	regionalHcSuffix = "regional"
+)
+
+// L4RegionalHealthCheckNamer is a  namer use only for health check and firewall resources
+// it suffixes firewall rule name with '-regional' string
+type L4RegionalHealthCheckNamer struct {
+	l4namer L4ResourcesNamer
+}
+
+// NewL4RegionalHealthCheckNamer returns new instance of L4RegionalHealthCheckNamer
+func NewL4RegionalHealthCheckNamer(l4namer L4ResourcesNamer) *L4RegionalHealthCheckNamer {
+	l4rhcn := &L4RegionalHealthCheckNamer{
+		l4namer: l4namer,
+	}
+	return l4rhcn
+}
+
+// L4HealthCheck returns the name of the L4 LB Healthcheck and the associated firewall rule.
+// For shared health checks the firewall rule name is suffixed with '-regional' string
+func (l4rhcn *L4RegionalHealthCheckNamer) L4HealthCheck(namespace, name string, shared bool) (string, string) {
+	hc, hcfw := l4rhcn.l4namer.L4HealthCheck(namespace, name, shared)
+	if !shared {
+		return hc, hcfw
+	}
+	return hc, strings.Join([]string{hcfw, regionalHcSuffix}, "-")
+}

--- a/pkg/utils/namer/l4_regional_hc_namer_test.go
+++ b/pkg/utils/namer/l4_regional_hc_namer_test.go
@@ -1,0 +1,56 @@
+package namer
+
+import (
+	"testing"
+)
+
+// TestRegionalL4HealthCheckNamer verifies that all L4 health check names are of the expected length and format.
+func TestRegionalL4HealthCheckNamer(t *testing.T) {
+	longstring1 := "012345678901234567890123456789012345678901234567890123456789abc"
+	longstring2 := "012345678901234567890123456789012345678901234567890123456789pqr"
+	testCases := []struct {
+		desc           string
+		namespace      string
+		name           string
+		sharedHC       bool
+		expectHcFwName string
+		expectHcName   string
+	}{
+		{
+			desc:           "simple case",
+			namespace:      "namespace",
+			name:           "name",
+			sharedHC:       false,
+			expectHcFwName: "k8s2-7kpbhpki-namespace-name-956p2p7x-fw",
+			expectHcName:   "k8s2-7kpbhpki-namespace-name-956p2p7x",
+		},
+		{
+			desc:           "simple case, shared healthcheck",
+			namespace:      "namespace",
+			name:           "name",
+			sharedHC:       true,
+			expectHcFwName: "k8s2-7kpbhpki-l4-shared-hc-fw-regional",
+			expectHcName:   "k8s2-7kpbhpki-l4-shared-hc",
+		},
+		{
+			desc:           "long svc and namespace name",
+			namespace:      longstring1,
+			name:           longstring2,
+			sharedHC:       false,
+			expectHcFwName: "k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm40-fw",
+			expectHcName:   "k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+		},
+	}
+
+	l4namer := NewL4Namer(kubeSystemUID, nil)
+	newNamer := NewL4RegionalHealthCheckNamer(l4namer)
+	for _, tc := range testCases {
+		hcName, hcFwName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
+		if hcFwName != tc.expectHcFwName {
+			t.Errorf("%s FirewallName For Healthcheck: got %q, want %q", tc.desc, hcFwName, tc.expectHcFwName)
+		}
+		if hcName != tc.expectHcName {
+			t.Errorf("%s HealthCheckName: got %q, want %q", tc.desc, hcName, tc.expectHcName)
+		}
+	}
+}


### PR DESCRIPTION
the new name for shared(per-node) L4 health check forwarding rule will prevent l4netlb controller from deleting firewall rules used by l4-ilb-subsetting load balancers

alternative solution to the problem: https://github.com/kubernetes/ingress-gce/pull/1695