### PR TITLE
limit number of gce API calls to get forwarding rule

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -231,6 +231,13 @@ func WantsL4NetLB(service *v1.Service) (bool, string) {
 	return ltype != gce.LBTypeInternal, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
 }
 
+func IsLoadBalancerType(service *v1.Service) bool {
+	if service == nil {
+		return false
+	}
+	return service.Spec.Type == v1.ServiceTypeLoadBalancer
+}
+
 // OnlyStatusAnnotationsChanged returns true if the only annotation change between the 2 services is the NEG or ILB
 // resources annotations.
 // Note : This assumes that the annotations in old and new service are different. If they are identical, this will


### PR DESCRIPTION
this fix prevents forwarding rule check for internal services and  non-loadbalancer type services