### PR TITLE
Do not include User Errors in L4NetLBInError metric

### DIFF
--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -19,7 +19,6 @@ package l4lb
 import (
 	"context"
 	"fmt"
-	"google.golang.org/api/googleapi"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -28,6 +27,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"google.golang.org/api/googleapi"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -604,7 +605,7 @@ func TestProcessServiceCreationFailed(t *testing.T) {
 		key, _ := common.KeyFunc(svc)
 		err := lc.sync(key)
 		if err == nil || err.Error() != param.expectedError {
-			t.Errorf("Error mismatch '%v' != '%v'", err.Error(), param.expectedError)
+			t.Errorf("Error mismatch '%v' != '%v'", err, param.expectedError)
 		}
 	}
 }
@@ -876,10 +877,6 @@ func updateAndAssertExternalTrafficPolicy(newSvc *v1.Service, lc *L4NetLBControl
 	return nil
 }
 
-func isWrongNetworkTierError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "does not have the expected network tier")
-}
-
 func TestControllerUserIPWithStandardNetworkTier(t *testing.T) {
 	// Network Tier from User Static Address should match network tier from forwarding rule.
 	// Premium Network Tier is default for creating forwarding rule so if User wants to use Standard Network Tier for Static Address
@@ -893,7 +890,7 @@ func TestControllerUserIPWithStandardNetworkTier(t *testing.T) {
 	key, _ := common.KeyFunc(svc)
 	addUsersStaticAddress(lc, cloud.NetworkTierStandard)
 	// Sync should return error that Network Tier mismatch because we cannot tear User Managed Address.
-	if err := lc.sync(key); !isWrongNetworkTierError(err) {
+	if err := lc.sync(key); !utils.IsNetworkTierError(err) {
 		t.Errorf("Expected error when trying to ensure service with wrong Network Tier, err: %v", err)
 	}
 	svc.Annotations[annotations.NetworkTierAnnotationKey] = string(cloud.NetworkTierStandard)

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -388,6 +388,11 @@ func (l4netlb *L4NetLB) ensureExternalForwardingRule(bsLink string) (*composite.
 	}
 
 	if existingFwdRule != nil {
+		if existingFwdRule.NetworkTier != fr.NetworkTier {
+			resource := fmt.Sprintf("Forwarding rule (%v)", frName)
+			networkTierMismatchError := utils.NewNetworkTierErr(resource, existingFwdRule.NetworkTier, fr.NetworkTier)
+			return nil, IPAddrUndefined, networkTierMismatchError
+		}
 		equal, err := Equal(existingFwdRule, fr)
 		if err != nil {
 			return existingFwdRule, IPAddrUndefined, err

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -142,6 +142,8 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 	result.Annotations[annotations.BackendServiceKey] = name
 	fr, ipAddrType, err := l4netlb.ensureExternalForwardingRule(bs.SelfLink)
 	if err != nil {
+		// User can misconfigure the forwarding rule if Network Tier will not match service level Network Tier.
+		result.MetricsState.IsUserError = utils.IsUserError(err)
 		result.GCEResourceInError = annotations.ForwardingRuleResource
 		result.Error = fmt.Errorf("Failed to ensure forwarding rule - %w", err)
 		return result

--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -124,6 +124,8 @@ const (
 	l4NetLBInSuccess = feature("L4NetLBInSuccess")
 	// l4NetLBInInError feature specifies that an error had occurred while creating/updating GCE Load Balancer.
 	l4NetLBInError = feature("L4NetLBInError")
+	// l4NetLBInInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
+	l4NetLBInUserError = feature("L4NetLBInUserError")
 
 	// PSC Features
 	sa          = feature("ServiceAttachments")

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -79,6 +79,8 @@ type L4NetLBServiceState struct {
 	IsPremiumTier bool
 	// InSuccess specifies if the NetLB service VIP is configured.
 	InSuccess bool
+	// IsUserError specifies if the error was caused by User misconfiguration.
+	IsUserError bool
 }
 
 // IngressMetricsCollector is an interface to update/delete ingress states in the cache

--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -30,6 +30,9 @@ import (
 
 const (
 	FwIPAddress = "10.0.0.1"
+	// backend-service url, was created based on project and region set in test function DefaultTestClusterValues().
+	// We need whole url for forwarding rule validation.
+	bsUrl = "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-default-netbtest-hgray14h"
 )
 
 func ListErrorHook(ctx context.Context, zone string, fl *filter.F, m *cloud.MockInstanceGroups) (bool, []*compute.InstanceGroup, error) {
@@ -99,6 +102,15 @@ func GetRBSForwardingRule(ctx context.Context, key *meta.Key, m *cloud.MockForwa
 	return true, &fwRule, nil
 }
 
+func GetRBSForwardingRuleInStandardTier(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, *compute.ForwardingRule, error) {
+	fwRule := compute.ForwardingRule{BackendService: bsUrl, LoadBalancingScheme: string(cloud.SchemeExternal), NetworkTier: cloud.NetworkTierStandard.ToGCEValue()}
+	return true, &fwRule, nil
+}
+
 func InsertAddressErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
 	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Cannot reserve region address, the resource already exist"}
+}
+
+func InsertAddressNetworkErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "The network tier of external IP is STANDARD, that of Address must be the same."}
 }


### PR DESCRIPTION
There are errors related to Network Tier that are caused by User misconfigurations and they should be filtered out from ServicesInError metrics.
This errors are:
1. Ip address and forwarding rule Network Tier mismatch
2. User created service in Standard Tier and deleted the annotation, this action will changed desired service Network Tier to PREMIUM but IP address and forwarding rule should be tear down first because we cannot update Network Tier in this resources. We can tear down resources only when Network Tier from annotation mismatch with network tier in IP address or forwarding rule.