### PR TITLE
Modify reporting error metrics from L4 RBS services -  only report service in error if resync deadline elapsed

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -158,7 +158,7 @@ func NewControllerContext(
 		ClusterNamer:            clusterNamer,
 		L4Namer:                 namer.NewL4Namer(string(kubeSystemUID), clusterNamer),
 		KubeSystemUID:           kubeSystemUID,
-		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval),
+		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval, flags.F.L4NetLBProvisionDeadline),
 		ControllerContextConfig: config,
 		IngressInformer:         informernetworking.NewIngressInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		ServiceInformer:         informerv1.NewServiceInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -82,6 +82,7 @@ var (
 		NegGCPeriod                      time.Duration
 		NodePortRanges                   PortRanges
 		ResyncPeriod                     time.Duration
+		L4NetLBProvisionDeadline         time.Duration
 		NumL4Workers                     int
 		NumIngressWorkers                int
 		RunIngressController             bool
@@ -204,6 +205,8 @@ the pod secrets for creating a Kubernetes client.`)
 		`Path to kubeconfig file with authorization and master location information.`)
 	flag.DurationVar(&F.ResyncPeriod, "sync-period", 30*time.Second,
 		`Relist and confirm cloud resources this often.`)
+	flag.DurationVar(&F.L4NetLBProvisionDeadline, "l4-netlb-provision-deadline", 20*time.Minute,
+		`Deadline latency for L4 NetLB provisioning.`)
 	flag.IntVar(&F.NumL4Workers, "num-l4-workers", 5,
 		`Number of parallel L4 Service worker goroutines.`)
 	flag.IntVar(&F.NumIngressWorkers, "num-ingress-workers", 1,

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -375,7 +375,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service) *loadbalancers.L4
 		syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
 		return syncResult
 	}
-	syncResult.MetricsState.InSuccess = true
+	syncResult.SetMetricsForSuccessfulService()
 	return syncResult
 }
 

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -66,6 +66,12 @@ type L4NetLBSyncResult struct {
 	StartTime          time.Time
 }
 
+// SetMetricsForSuccessfulService should be call after successful sync.
+func (r *L4NetLBSyncResult) SetMetricsForSuccessfulService() {
+	r.MetricsState.FirstSyncErrorTime = nil
+	r.MetricsState.InSuccess = true
+}
+
 // NewL4NetLB creates a new Handler for the given L4NetLB service.
 func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, namer namer.L4ResourcesNamer, recorder record.EventRecorder, lock *sync.Mutex) *L4NetLB {
 	l4netlb := &L4NetLB{cloud: cloud,
@@ -100,7 +106,8 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 	result := &L4NetLBSyncResult{
 		Annotations: make(map[string]string),
 		StartTime:   time.Now(),
-		SyncType:    SyncTypeCreate}
+		SyncType:    SyncTypeCreate,
+	}
 
 	// If service already has an IP assigned, treat it as an update instead of a new Loadbalancer.
 	if len(svc.Status.LoadBalancer.Ingress) > 0 {

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	v1 "k8s.io/api/networking/v1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -81,6 +83,8 @@ type L4NetLBServiceState struct {
 	InSuccess bool
 	// IsUserError specifies if the error was caused by User misconfiguration.
 	IsUserError bool
+	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
+	FirstSyncErrorTime *time.Time
 }
 
 // IngressMetricsCollector is an interface to update/delete ingress states in the cache


### PR DESCRIPTION
   Add resync timestamp to service metric state
    
    When service sync ends with an error we wants to try to resync it for
    some period of time and after that time if result is still error we will
    increment L4NetLBSInError metric.
    
    Retry period is fixed 20min. It is becasue resync period is 10min.