### PR TITLE
corrected link for cluster-setup.md

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -111,7 +111,7 @@ test project. If you think the failures are related to project quota, cleanup
 leaked resources and bump up quota before debugging the leak.
 
 If the preceding identification process fails, it's likely that the Ingress api
-is broken upstream. Try to setup a [dev environment](/docs/dev/setup-cluster.md) from
+is broken upstream. Try to setup a [dev environment](/docs/contrib/cluster-setup.md) from
 HEAD and create an Ingress. You should be deploying the [latest](https://github.com/kubernetes/ingress/releases)
 release image to the local cluster.
 


### PR DESCRIPTION
link for cluster-setup.md in https://github.com/kubernetes/ingress-gce/tree/master/docs/faq#an-ingress-controller-e2e-is-failing-what-should-i-do section was broken