### PR TITLE
Truncate nodes list to maximum instance group size (1000) before adding to instance group

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -388,7 +388,6 @@ func (lc *L4NetLBController) ensureBackendLinking(port utils.ServicePort) error 
 }
 
 func (lc *L4NetLBController) ensureInstanceGroups(service *v1.Service, nodeNames []string) error {
-	// TODO(kl52752) implement limit for 1000 nodes in instance group
 	// TODO(kl52752) Move instance creation and deletion logic to NodeController
 	// to avoid race condition between controllers
 	_, _, nodePorts, _ := utils.GetPortsAndProtocol(service.Spec.Ports)

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"google.golang.org/api/googleapi"
+	"k8s.io/ingress-gce/pkg/flags"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -581,6 +582,8 @@ func TestInternalLoadBalancerShouldNotBeProcessByL4NetLBController(t *testing.T)
 }
 
 func TestProcessServiceCreationFailed(t *testing.T) {
+	flags.F.MaxIgSize = 1000
+
 	for _, param := range []struct {
 		addMockFunc   func(*cloud.MockGCE)
 		expectedError string
@@ -670,6 +673,8 @@ func TestProcessServiceDeletionFailed(t *testing.T) {
 }
 
 func TestProcessServiceUpdate(t *testing.T) {
+	flags.F.MaxIgSize = 1000
+
 	for _, param := range []struct {
 		Update      func(*v1.Service)
 		CheckResult func(*L4NetLBController, *v1.Service) error

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -490,6 +490,11 @@ func FakeGoogleAPIConflictErr() *googleapi.Error {
 	return &googleapi.Error{Code: http.StatusConflict}
 }
 
+// FakeGoogleAPIRequestEntityTooLargeError creates a StatusRequestEntityTooLarge error with type googleapi.Error
+func FakeGoogleAPIRequestEntityTooLargeError() *googleapi.Error {
+	return &googleapi.Error{Code: http.StatusRequestEntityTooLarge}
+}
+
 func InstancesListToNameSet(instancesList []*compute.InstanceWithNamedPorts) (sets.String, error) {
 	instancesSet := sets.NewString()
 	for _, instance := range instancesList {


### PR DESCRIPTION
This fixes a bug for clusters bigger than instance group max size, cause we were trying to add more than allowed number of nodes to instance group and gcp api returned an error