### PR TITLE
Fix HttpsRedirects Lifecycle

### DIFF
--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -38,7 +38,6 @@ func (l *L7) checkProxy() (err error) {
 	// TODO(shance): move to translator
 	var umName string
 	if flags.F.EnableFrontendConfig {
-		// TODO(shance): check for empty name?
 		if l.redirectUm != nil && l.runtimeInfo.FrontendConfig.Spec.RedirectToHttps != nil && l.runtimeInfo.FrontendConfig.Spec.RedirectToHttps.Enabled {
 			umName = l.redirectUm.Name
 		} else {

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -119,7 +119,10 @@ func (l *L7) ensureRedirectURLMap() error {
 			return nil
 		} else {
 			if err := composite.DeleteUrlMap(l.cloud, key, l.Versions().UrlMap); err != nil {
-				return err
+				// Do not block LB sync if this fails
+				klog.Errorf("DeleteUrlMap(%s) = %v", key, err)
+				// Signal to the rest of the controller that the UrlMap still exists
+				l.redirectUm = &composite.UrlMap{Name: key.Name}
 			}
 		}
 		return nil


### PR DESCRIPTION
* Fixes a bug preventing the disabling and deletion of HttpsRedirects
due to UrlMap Ensure happening before the TargetProxy Ensure
* EnsureRedirectUrlMap() now does not return an error if deletion fails
* Prevents premature removal of the `redirect-url-map` annotation (which prevented deletion)

Our e2e test does not catch this because it wipes out the annotation on ingress update().  This will be fixed in a follow-up.