### PR TITLE
Add buckets to gce_api_request_duration_seconds metric

### DIFF
--- a/pkg/composite/metrics/metrics.go
+++ b/pkg/composite/metrics/metrics.go
@@ -84,8 +84,9 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 	metrics := &apiCallMetrics{
 		latency: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "gce_api_request_duration_seconds", // TODO: (shance) reconcile with cloudprovider
-				Help: "Latency of a GCE API call",
+				Name:    "gce_api_request_duration_seconds", // TODO: (shance) reconcile with cloudprovider
+				Help:    "Latency of a GCE API call",
+				Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 			},
 			attributes,
 		),


### PR DESCRIPTION
Define Buckets in gce_api_request_duration_seconds metric to cover latencies from 5ms to 5 minutes+ 

The default buckets: `	DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}`
defined in, github.com/prometheus/client_golang/prometheus/histogram.go
do not cover long running requests, e.g. backend service update takes 30-40 seconds.