### PR TITLE
Create NodePoolConfig for better NodePool constructor style

### DIFF
--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -53,7 +53,13 @@ func TestLink(t *testing.T) {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeNodePool := instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
@@ -84,7 +90,13 @@ func TestLinkWithCreationModeError(t *testing.T) {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeNodePool := instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -47,7 +47,13 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeInstancePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeInstancePool := instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+	})
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaBackendServices.UpdateHook = mock.UpdateAlphaBackendServiceHook

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -45,7 +45,13 @@ func linkerTestClusterValues() gce.TestClusterValues {
 func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{uscentralzone}}
-	fakeInstancePool := instances.NewNodePool(fakeIGs, l4Namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeInstancePool := instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      l4Namer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+	})
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -206,12 +206,13 @@ func NewControllerContext(
 		context.UseEndpointSlices,
 		context.KubeClient,
 	)
-	context.InstancePool = instances.NewNodePool(context.Cloud,
-		context.ClusterNamer,
-		context,
-		utils.GetBasePath(context.Cloud),
-		context.Translator,
-	)
+	context.InstancePool = instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      context.Cloud,
+		Namer:      context.ClusterNamer,
+		Recorders:  context,
+		BasePath:   utils.GetBasePath(context.Cloud),
+		ZoneLister: context.Translator,
+	})
 
 	return context
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -75,7 +75,13 @@ func newLoadBalancerController() *LoadBalancerController {
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
-	lbc.instancePool = instances.NewNodePool(instances.NewEmptyFakeInstanceGroups(), namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	lbc.instancePool = instances.NewNodePool(instances.NodePoolConfig{
+		Cloud:      instances.NewEmptyFakeInstanceGroups(),
+		Namer:      namer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+	})
 	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(fakeGCE, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, ""))
 
 	lbc.hasSynced = func() bool { return true }

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -52,16 +52,24 @@ type recorderSource interface {
 	Recorder(ns string) record.EventRecorder
 }
 
-// NewNodePool creates a new node pool.
-// - cloud: implements InstanceGroups, used to sync Kubernetes nodes with
-//   members of the cloud InstanceGroup.
-func NewNodePool(cloud InstanceGroups, namer namer.BackendNamer, recorders recorderSource, basePath string, zl ZoneLister) NodePool {
+// NodePoolConfig is used for NodePool constructor.
+type NodePoolConfig struct {
+	// Cloud implements InstanceGroups, used to sync Kubernetes nodes with members of the cloud InstanceGroup.
+	Cloud      InstanceGroups
+	Namer      namer.BackendNamer
+	Recorders  recorderSource
+	BasePath   string
+	ZoneLister ZoneLister
+}
+
+// NewNodePool creates a new node pool using NodePoolConfig.
+func NewNodePool(config NodePoolConfig) NodePool {
 	return &Instances{
-		cloud:              cloud,
-		namer:              namer,
-		recorder:           recorders.Recorder(""), // No namespace
-		instanceLinkFormat: basePath + "zones/%s/instances/%s",
-		ZoneLister:         zl,
+		cloud:              config.Cloud,
+		namer:              config.Namer,
+		recorder:           config.Recorders.Recorder(""), // No namespace
+		instanceLinkFormat: config.BasePath + "zones/%s/instances/%s",
+		ZoneLister:         config.ZoneLister,
 	}
 }
 

--- a/pkg/instances/instances_test.go
+++ b/pkg/instances/instances_test.go
@@ -35,8 +35,13 @@ const (
 var defaultNamer = namer.NewNamer("uid1", "fw1")
 
 func newNodePool(f *FakeInstanceGroups, zone string) NodePool {
-	fakeZL := &FakeZoneLister{[]string{zone}}
-	pool := NewNodePool(f, defaultNamer, &test.FakeRecorderSource{}, basePath, fakeZL)
+	pool := NewNodePool(NodePoolConfig{
+		Cloud:      f,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   basePath,
+		ZoneLister: &FakeZoneLister{[]string{zone}},
+	})
 	return pool
 }
 


### PR DESCRIPTION
This is part of splitting single big PR https://github.com/kubernetes/ingress-gce/pull/1707

PRs sequence:

1 - current
2 - https://github.com/kubernetes/ingress-gce/pull/1715
3 - https://github.com/kubernetes/ingress-gce/pull/1707