### PR TITLE
Add maxIGSize to NodePool constructor, instead of using global flag

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -198,6 +198,7 @@ func main() {
 		ASMConfigMapNamespace: flags.F.ASMConfigMapBasedConfigNamespace,
 		ASMConfigMapName:      flags.F.ASMConfigMapBasedConfigCMName,
 		EndpointSlicesEnabled: flags.F.EnableEndpointSlices,
+		MaxIGSize:             flags.F.MaxIGSize,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, svcNegClient, ingParamsClient, svcAttachmentClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -53,7 +53,14 @@ func TestLink(t *testing.T) {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeNodePool := instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+		MaxIGSize:  1000,
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
@@ -84,7 +91,14 @@ func TestLinkWithCreationModeError(t *testing.T) {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeNodePool := instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+		MaxIGSize:  1000,
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -47,7 +47,14 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeInstancePool := instances.NewNodePool(fakeIGs, defaultNamer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeInstancePool := instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      defaultNamer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+		MaxIGSize:  1000,
+	})
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaBackendServices.UpdateHook = mock.UpdateAlphaBackendServiceHook

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -45,7 +45,14 @@ func linkerTestClusterValues() gce.TestClusterValues {
 func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
 	fakeIGs := instances.NewEmptyFakeInstanceGroups()
 	fakeZL := &instances.FakeZoneLister{Zones: []string{uscentralzone}}
-	fakeInstancePool := instances.NewNodePool(fakeIGs, l4Namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	fakeInstancePool := instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      fakeIGs,
+		Namer:      l4Namer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+		MaxIGSize:  1000,
+	})
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -133,6 +133,7 @@ type ControllerContextConfig struct {
 	ASMConfigMapNamespace string
 	ASMConfigMapName      string
 	EndpointSlicesEnabled bool
+	MaxIGSize             int
 }
 
 // NewControllerContext returns a new shared set of informers.
@@ -206,12 +207,14 @@ func NewControllerContext(
 		context.UseEndpointSlices,
 		context.KubeClient,
 	)
-	context.InstancePool = instances.NewNodePool(context.Cloud,
-		context.ClusterNamer,
-		context,
-		utils.GetBasePath(context.Cloud),
-		context.Translator,
-	)
+	context.InstancePool = instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      context.Cloud,
+		Namer:      context.ClusterNamer,
+		Recorders:  context,
+		BasePath:   utils.GetBasePath(context.Cloud),
+		ZoneLister: context.Translator,
+		MaxIGSize:  config.MaxIGSize,
+	})
 
 	return context
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -75,7 +75,14 @@ func newLoadBalancerController() *LoadBalancerController {
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
-	lbc.instancePool = instances.NewNodePool(instances.NewEmptyFakeInstanceGroups(), namer, &test.FakeRecorderSource{}, utils.GetBasePath(fakeGCE), fakeZL)
+	lbc.instancePool = instances.NewNodePool(&instances.NodePoolConfig{
+		Cloud:      instances.NewEmptyFakeInstanceGroups(),
+		Namer:      namer,
+		Recorders:  &test.FakeRecorderSource{},
+		BasePath:   utils.GetBasePath(fakeGCE),
+		ZoneLister: fakeZL,
+		MaxIGSize:  1000,
+	})
 	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(fakeGCE, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, ""))
 
 	lbc.hasSynced = func() bool { return true }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -107,9 +107,9 @@ var (
 		EnableIngressGAFields          bool
 		EnableTrafficScaling           bool
 		EnableEndpointSlices           bool
-		EnableMultipleIgs              bool
 		EnablePinhole                  bool
-		MaxIgSize                      int
+		EnableMultipleIGs              bool
+		MaxIGSize                      int
 	}{
 		GCERateLimitScale: 1.0,
 	}
@@ -249,8 +249,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableTrafficScaling, "enable-traffic-scaling", false, "Enable support for Service {max-rate-per-endpoint, capacity-scaler}")
 	flag.BoolVar(&F.EnableEndpointSlices, "enable-endpoint-slices", false, "Enable using Endpoint Slices API instead of Endpoints API")
 	flag.BoolVar(&F.EnablePinhole, "enable-pinhole", false, "Enable Pinhole firewall feature")
-	flag.BoolVar(&F.EnableMultipleIgs, "enable-multiple-igs", false, "Enable using unmanaged instance group management")
-	flag.IntVar(&F.MaxIgSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
+	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multiple unmanaged instance groups")
+	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)
 }
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -27,13 +27,11 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/api/googleapi"
-	"k8s.io/ingress-gce/pkg/flags"
-
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	ga "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -226,6 +224,7 @@ func buildContext(vals gce.TestClusterValues) *ingctx.ControllerContext {
 		Namespace:    v1.NamespaceAll,
 		ResyncPeriod: 1 * time.Minute,
 		NumL4Workers: 5,
+		MaxIGSize:    1000,
 	}
 	return ingctx.NewControllerContext(nil, kubeClient, nil, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 }
@@ -581,8 +580,6 @@ func TestInternalLoadBalancerShouldNotBeProcessByL4NetLBController(t *testing.T)
 }
 
 func TestProcessServiceCreationFailed(t *testing.T) {
-	flags.F.MaxIgSize = 1000
-
 	for _, param := range []struct {
 		addMockFunc   func(*cloud.MockGCE)
 		expectedError string
@@ -709,8 +706,6 @@ func TestServiceStatusForSuccessSync(t *testing.T) {
 }
 
 func TestProcessServiceUpdate(t *testing.T) {
-	flags.F.MaxIgSize = 1000
-
 	for _, param := range []struct {
 		Update      func(*v1.Service)
 		CheckResult func(*L4NetLBController, *v1.Service) error
@@ -1126,8 +1121,6 @@ func TestShouldProcessService(t *testing.T) {
 }
 
 func TestPreventTargetPoolToRBSMigration(t *testing.T) {
-	flags.F.MaxIgSize = 1000
-
 	testCases := []struct {
 		desc                         string
 		frHook                       getForwardingRuleHook


### PR DESCRIPTION
This is refactoring of NodePool, following from this https://github.com/kubernetes/ingress-gce/pull/1707