### PR TITLE
Implement migration from L4 Legacy Target Pool based services to L4 RBS

### DIFF
--- a/pkg/composite/composite.go
+++ b/pkg/composite/composite.go
@@ -185,7 +185,7 @@ func SetUrlMapForTargetHttpProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpP
 	}
 }
 
-// SetProxyForForwardingRule() sets the target proxy for a forwarding rule
+// SetProxyForForwardingRule sets the target proxy for a forwarding rule
 func SetProxyForForwardingRule(gceCloud *gce.Cloud, key *meta.Key, forwardingRule *ForwardingRule, targetProxyLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -91,6 +91,8 @@ type L4ResourcesNamer interface {
 	L4HealthCheck(namespace, name string, shared bool) (string, string)
 	// IsNEG returns if the given name is a VM_IP_NEG name.
 	IsNEG(name string) bool
+	// ClusterID returns cluster's id
+	ClusterID() string
 }
 
 type ServiceAttachmentNamer interface {

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -101,3 +101,8 @@ func (n *L4Namer) hcFirewallName(hcName string) string {
 	}
 	return hcName + firewallHcSuffix
 }
+
+// ClusterID returns cluster's id
+func (n *L4Namer) ClusterID() string {
+	return n.v2ClusterUID
+}


### PR DESCRIPTION
- Switch target of existing forwarding rule from target pool to regional
  backend service
- Clean up GCP resources used only by legacy service: target pool,
  health checks, firewall rules for health checks