### PR TITLE
WIP: Implement migration from L4 Legacy Target Pool based services to L4 RBS

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -26,6 +26,7 @@ import (
 	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
+	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/ingparams"
 	"k8s.io/ingress-gce/pkg/l4lb"
 	"k8s.io/ingress-gce/pkg/psc"
@@ -273,6 +274,8 @@ func runControllers(ctx *ingctx.ControllerContext) {
 	}
 
 	fwc := firewalls.NewFirewallController(ctx, flags.F.NodePortRanges.Values())
+
+	healthchecks.InitializeL4(ctx.Cloud, ctx)
 
 	if flags.F.RunL4Controller {
 		l4Controller := l4lb.NewILBController(ctx, stopCh)

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -300,11 +300,11 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 	}
 	expectedBS := &composite.BackendService{
 		Name:                name,
-		Protocol:            string(protocol),
+		Protocol:            protocol,
 		Description:         desc,
 		HealthChecks:        []string{hcLink},
 		SessionAffinity:     utils.TranslateAffinityType(sessionAffinity),
-		LoadBalancingScheme: string(scheme),
+		LoadBalancingScheme: scheme,
 	}
 	if protocol == string(api_v1.ProtocolTCP) {
 		expectedBS.ConnectionDraining = &composite.ConnectionDraining{DrainingTimeoutSec: DefaultConnectionDrainingTimeoutSeconds}

--- a/pkg/composite/composite.go
+++ b/pkg/composite/composite.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
-// SetUrlMapForTargetHttpsProxy() sets the UrlMap for a target https proxy
+// SetUrlMapForTargetHttpsProxy sets the UrlMap for a target https proxy
 func SetUrlMapForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpsProxy *TargetHttpsProxy, urlMapLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
@@ -68,7 +68,7 @@ func SetUrlMapForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttp
 	}
 }
 
-// SetSslCertificateForTargetHttpsProxy() sets the SSL Certificate for a target https proxy
+// SetSslCertificateForTargetHttpsProxy sets the SSL Certificate for a target https proxy
 func SetSslCertificateForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpsProxy *TargetHttpsProxy, sslCertURLs []string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
@@ -109,7 +109,7 @@ func SetSslCertificateForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, ta
 	}
 }
 
-// SetSslPolicyForTargetHttpsProxy() sets the url map for a target proxy
+// SetSslPolicyForTargetHttpsProxy sets the url map for a target proxy
 func SetSslPolicyForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpsProxy *TargetHttpsProxy, SslPolicyLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
@@ -147,7 +147,7 @@ func SetSslPolicyForTargetHttpsProxy(gceCloud *gce.Cloud, key *meta.Key, targetH
 	}
 }
 
-// SetUrlMapForTargetHttpProxy() sets the url map for a target proxy
+// SetUrlMapForTargetHttpProxy sets the url map for a target proxy
 func SetUrlMapForTargetHttpProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpProxy *TargetHttpProxy, urlMapLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
@@ -185,8 +185,8 @@ func SetUrlMapForTargetHttpProxy(gceCloud *gce.Cloud, key *meta.Key, targetHttpP
 	}
 }
 
-// SetProxyForForwardingRule() sets the target proxy for a forwarding rule
-func SetProxyForForwardingRule(gceCloud *gce.Cloud, key *meta.Key, forwardingRule *ForwardingRule, targetProxyLink string) error {
+// SetTargetForForwardingRule sets the target proxy for a forwarding rule
+func SetTargetForForwardingRule(gceCloud *gce.Cloud, key *meta.Key, forwardingRule *ForwardingRule, targetProxyLink string) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 	mc := metrics.NewMetricContext("ForwardingRule", "set_proxy", key.Region, key.Zone, string(forwardingRule.Version))

--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -47,31 +47,35 @@ const (
 )
 
 var (
-	// instance is a sinngleton instance, created by InitializeL4
+	// instanceLock to prevent duplicate initialization.
+	instanceLock = &sync.Mutex{}
+	// instance is a singleton instance, created by InitializeL4
 	instance *l4HealthChecks
-	// mutex for preventing multiple initialization
-	initLock = &sync.Mutex{}
 )
 
 type l4HealthChecks struct {
-	mutex           sync.Mutex
-	cloud           *gce.Cloud
-	recorderFactory events.RecorderProducer
+	// sharedResourceLock serializes operations on the healthcheck and firewall
+	// resources shared across multiple Services.
+	sharedResourcesLock sync.Mutex
+	cloud               *gce.Cloud
+	recorderFactory     events.RecorderProducer
 }
 
-// InitializeL4 creates singleton instance, must be run before GetL4() func
+// InitializeL4 creates singleton instance, must be run before L4() func
 func InitializeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) {
-	if instance == nil {
-		initLock.Lock()
-		defer initLock.Unlock()
+	instanceLock.Lock()
+	defer instanceLock.Unlock()
 
-		if instance == nil {
-			instance = &l4HealthChecks{
-				cloud:           cloud,
-				recorderFactory: recorderFactory,
-			}
-		}
+	if instance != nil {
+		klog.Error("Multiple L4 Healthchecks initialization attempts")
+		return
 	}
+
+	instance = &l4HealthChecks{
+		cloud:           cloud,
+		recorderFactory: recorderFactory,
+	}
+	klog.V(3).Infof("Initialized L4 Healthchecks")
 }
 
 // FakeL4 creates instance of l4HealthChecks> USe for test only.
@@ -83,68 +87,91 @@ func FakeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) *l4Health
 	return instance
 }
 
-// GetL4 returns singleton instance, must be run after InitializeL4
-func GetL4() *l4HealthChecks {
+// L4 returns singleton instance, must be run after InitializeL4
+func L4() *l4HealthChecks {
 	return instance
 }
 
-// EnsureL4HealthCheck creates a new HTTP health check for an L4 LoadBalancer service, and the firewall rule required
-// for the healthcheck. If healthcheck is shared (external traffic policy 'cluster') then firewall rules will be shared
-// regardless of scope param.
-// If the healthcheck already exists, it is updated as needed.
-func (l4hc *l4HealthChecks) EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) (string, string, string, string, error) {
+// EnsureL4HealthCheck and firewall rules exist for the L4
+// LoadBalancer Service.
+//
+// The healthcheck and firewall will be shared between different K8s
+// Services for ExternalTrafficPolicy = Cluster, as the same
+// configuration is used across all Services of this type.
+//
+// Firewall rules are always created at in the Global scope (vs
+// Regional). This means that one Firewall rule is created for
+// Services of different scope (Global vs Regional).
+
+func (l4hc *l4HealthChecks) EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult {
+	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+
 	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 	hcPath, hcPort := helpers.GetServiceHealthCheckPathPort(svc)
+	klog.V(3).Infof("Ensuring L4 healthcheck: %s and firewall rule %s from service %s, shared: %v.", hcName, hcFwName, namespacedName.String(), sharedHC)
+
 	if sharedHC {
 		hcPath, hcPort = gce.GetNodesHealthCheckPath(), gce.GetNodesHealthCheckPort()
-		// lock out entire EnsureL4HealthCheck process
-		l4hc.mutex.Lock()
-		defer l4hc.mutex.Unlock()
+		// We need to acquire a controller-wide mutex to ensure that in the case of a healthcheck shared between loadbalancers that the sync of the GCE resources is not performed in parallel.
+		l4hc.sharedResourcesLock.Lock()
+		defer l4hc.sharedResourcesLock.Unlock()
 	}
+	klog.V(3).Infof("L4 Healthcheck %s, path: %q, port %d", hcName, hcPath, hcPort)
 
-	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	_, hcLink, err := l4hc.ensureL4HealthCheckInternal(hcName, namespacedName, sharedHC, hcPath, hcPort, scope, l4Type)
 	if err != nil {
-		return "", "", "", annotations.HealthcheckResource, err
-	}
-	err = l4hc.ensureFirewall(svc, hcFwName, hcPort, sharedHC, nodeNames)
-	if err != nil {
-		return "", "", "", annotations.FirewallForHealthcheckResource, err
+		return &EnsureL4HealthCheckResult{
+			GceResourceInError: annotations.HealthcheckResource,
+			Err:                err,
+		}
 	}
 
-	return hcLink, hcFwName, hcName, "", err
+	klog.V(3).Infof("Healthcheck created, ensuring firewall rule %s", hcFwName)
+	err = l4hc.ensureFirewall(svc, hcFwName, hcPort, sharedHC, nodeNames)
+	if err != nil {
+		return &EnsureL4HealthCheckResult{
+			GceResourceInError: annotations.HealthcheckResource,
+			Err:                err,
+		}
+	}
+	return &EnsureL4HealthCheckResult{
+		HCName:             hcName,
+		HCLink:             hcLink,
+		HCFirewallRuleName: hcFwName,
+	}
 }
 
 // DeleteHealthCheck deletes health check (and firewall rule) for l4 service. Checks if shared resources are safe to delete.
 func (l4hc *l4HealthChecks) DeleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error) {
-	if sharedHC {
-		// lock out entire DeleteHealthCheck process
-		l4hc.mutex.Lock()
-		defer l4hc.mutex.Unlock()
-	}
 
 	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+	klog.V(3).Infof("Trying to delete L4 healthcheck: %s and firewall rule %s from service %s, shared: %v", hcName, hcFwName, namespacedName.String(), sharedHC)
+	if sharedHC {
+		// We need to acquire a controller-wide mutex to ensure that in the case of a healthcheck shared between loadbalancers that the sync of the GCE resources is not performed in parallel.
+		l4hc.sharedResourcesLock.Lock()
+		defer l4hc.sharedResourcesLock.Unlock()
+	}
+
 	err := utils.IgnoreHTTPNotFound(l4hc.deleteHealthCheck(hcName, scope))
 	if err != nil {
+		// Ignore deletion error due to health check in use by another resource.
 		if !utils.IsInUsedByError(err) {
 			klog.Errorf("Failed to delete healthcheck for service %s - %v", namespacedName.String(), err)
 			return annotations.HealthcheckResource, err
 		}
-		// Ignore deletion error due to health check in use by another resource.
-		// This will be hit if this is a shared healthcheck.
-		klog.V(2).Infof("Failed to delete healthcheck %s: health check in use.", hcName)
+		klog.V(2).Infof("Failed to delete healthcheck %s: shared health check in use.", hcName)
 		return "", nil
 	}
 	// Health check deleted, now delete the firewall rule
 	return l4hc.deleteHealthCheckFirewall(svc, hcName, hcFwName, sharedHC, l4Type)
 }
 
-func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(name string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType) (*composite.HealthCheck, string, error) {
+func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(hcName string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType) (*composite.HealthCheck, string, error) {
 	selfLink := ""
-	key, err := composite.CreateKey(l4hc.cloud, name, scope)
+	key, err := composite.CreateKey(l4hc.cloud, hcName, scope)
 	if err != nil {
-		return nil, selfLink, fmt.Errorf("Failed to create key for healthcheck with name %s for service %s", name, svcName.String())
+		return nil, selfLink, fmt.Errorf("Failed to create key for healthcheck with name %s for service %s", hcName, svcName.String())
 	}
 	hc, err := composite.GetHealthCheck(l4hc.cloud, key, meta.VersionGA)
 	if err != nil {
@@ -156,10 +183,11 @@ func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(name string, svcName typ
 	if scope == meta.Regional {
 		region = l4hc.cloud.Region()
 	}
-	expectedHC := NewL4HealthCheck(name, svcName, shared, path, port, l4Type, scope, region)
+	expectedHC := newL4HealthCheck(hcName, svcName, shared, path, port, l4Type, scope, region)
+
 	if hc == nil {
 		// Create the healthcheck
-		klog.V(2).Infof("Creating healthcheck %s for service %s, shared = %v", name, svcName, shared)
+		klog.V(2).Infof("Creating healthcheck %s for service %s, shared = %v. Expected healthcheck: %v", hcName, svcName, shared, expectedHC)
 		err = composite.CreateHealthCheck(l4hc.cloud, key, expectedHC)
 		if err != nil {
 			return nil, selfLink, err
@@ -170,10 +198,11 @@ func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(name string, svcName typ
 	selfLink = hc.SelfLink
 	if !needToUpdateHealthChecks(hc, expectedHC) {
 		// nothing to do
+		klog.V(3).Infof("Healthcheck %v already exists", hcName)
 		return hc, selfLink, nil
 	}
 	mergeHealthChecks(hc, expectedHC)
-	klog.V(2).Infof("Updating healthcheck %s for service %s", name, svcName)
+	klog.V(2).Infof("Updating healthcheck %s for service %s, updated healthcheck: %v", hcName, svcName, expectedHC)
 	err = composite.UpdateHealthCheck(l4hc.cloud, key, expectedHC)
 	if err != nil {
 		return nil, selfLink, err
@@ -181,9 +210,10 @@ func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(name string, svcName typ
 	return expectedHC, selfLink, err
 }
 
-// ensureFirewall rule for L4 service.
-// The firewall rules are the same for ILB and NetLB that use external traffic policy 'local' (sharedHC == true)
-// despite healthchecks have different scopes (global vs regional)
+// ensureFirewall rule for `svc`.
+//
+// L4 ILB and L4 NetLB Services with ExternalTrafficPolicy=Cluster use the same firewall
+// rule at global scope.
 func (l4hc *l4HealthChecks) ensureFirewall(svc *corev1.Service, hcFwName string, hcPort int32, sharedHC bool, nodeNames []string) error {
 	// Add firewall rule for healthchecks to nodes
 	hcFWRParams := firewalls.FirewallParams{
@@ -213,13 +243,14 @@ func (l4hc *l4HealthChecks) deleteHealthCheckFirewall(svc *corev1.Service, hcNam
 		return annotations.HealthcheckResource, err
 	}
 	if !safeToDelete {
-		klog.V(2).Infof("Failed to delete health check firewall rule %s: health check in use.", hcName)
+		klog.V(3).Infof("Failed to delete health check firewall rule %s: health check in use.", hcName)
 		return "", nil
 	}
+	klog.V(3).Infof("Deleting healthcheck firewall rule named: %s", hcFwName)
 	// Delete healthcheck firewall rule if no healthcheck uses the firewall rule.
 	err = l4hc.deleteFirewall(hcFwName, svc)
 	if err != nil {
-		klog.Errorf("Failed to delete firewall rule %s for internal loadbalancer service %s, err %v", hcFwName, namespacedName.String(), err)
+		klog.Errorf("Failed to delete firewall rule %s for loadbalancer service %s, err %v", hcFwName, namespacedName.String(), err)
 		return annotations.FirewallForHealthcheckResource, err
 	}
 	return "", nil
@@ -244,18 +275,19 @@ func (l4hc *l4HealthChecks) healthCheckFirewallSafeToDelete(hcName string, share
 
 func (l4hc *l4HealthChecks) deleteFirewall(name string, svc *corev1.Service) error {
 	err := firewalls.EnsureL4FirewallRuleDeleted(l4hc.cloud, name)
-	if err != nil {
-		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
-			recorder := l4hc.recorderFactory.Recorder(svc.Namespace)
-			recorder.Eventf(svc, corev1.EventTypeNormal, "XPN", fwErr.Message)
-			return nil
-		}
-		return err
+	if err == nil {
+		return nil
 	}
-	return nil
+	// Suppress Firewall XPN error, as this is no retryable and requires action by security admin
+	if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
+		recorder := l4hc.recorderFactory.Recorder(svc.Namespace)
+		recorder.Eventf(svc, corev1.EventTypeNormal, "XPN", fwErr.Message)
+		return nil
+	}
+	return err
 }
 
-func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32, l4Type utils.L4LBType, scope meta.KeyType, region string) *composite.HealthCheck {
+func newL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32, l4Type utils.L4LBType, scope meta.KeyType, region string) *composite.HealthCheck {
 	httpSettings := composite.HTTPHealthCheck{
 		Port:        int64(port),
 		RequestPath: path,
@@ -282,7 +314,7 @@ func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, pa
 
 // mergeHealthChecks reconciles HealthCheck config to be no smaller than
 // the default values. newHC is assumed to have defaults,
-// since it is created by the NewL4HealthCheck call.
+// since it is created by the newL4HealthCheck call.
 // E.g. old health check interval is 2s, new has the default of 8.
 // The HC interval will be reconciled to 8 seconds.
 // If the existing health check values are larger than the default interval,

--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -18,13 +18,18 @@ package healthchecks
 
 import (
 	"fmt"
+	"strconv"
+	"sync"
 
 	cloudprovider "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider/service/helpers"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
@@ -32,7 +37,6 @@ import (
 )
 
 const (
-
 	// L4 Load Balancer parameters
 	gceHcCheckIntervalSeconds = int64(8)
 	gceHcTimeoutSeconds       = int64(1)
@@ -42,26 +46,107 @@ const (
 	gceHcUnhealthyThreshold = int64(3)
 )
 
-// EnsureL4HealthCheck creates a new HTTP health check for an L4 LoadBalancer service, based on the parameters provided.
-// If the healthcheck already exists, it is updated as needed.
-func EnsureL4HealthCheck(cloud *gce.Cloud, svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, string, int32, string, error) {
-	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
-	hcPath, hcPort := gce.GetNodesHealthCheckPath(), gce.GetNodesHealthCheckPort()
-	if !sharedHC {
-		hcPath, hcPort = helpers.GetServiceHealthCheckPathPort(svc)
-	}
-	nn := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
-	_, hcLink, err := ensureL4HealthCheckInternal(cloud, hcName, nn, sharedHC, hcPath, hcPort, scope, l4Type)
-	return hcLink, hcFwName, hcPort, hcName, err
+var (
+	// instance is a sinngleton instance, created by InitializeL4
+	instance *l4HealthChecks
+	// mutex for preventing multiple initialization
+	initLock = &sync.Mutex{}
+)
+
+type l4HealthChecks struct {
+	mutex           sync.Mutex
+	cloud           *gce.Cloud
+	recorderFactory events.RecorderProducer
 }
 
-func ensureL4HealthCheckInternal(cloud *gce.Cloud, name string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType) (*composite.HealthCheck, string, error) {
-	selfLink := ""
-	key, err := composite.CreateKey(cloud, name, scope)
-	if err != nil {
-		return nil, selfLink, fmt.Errorf("Failed to create composite key for healthcheck %s - %w", name, err)
+// InitializeL4 creates singleton instance, must be run before GetL4() func
+func InitializeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) {
+	if instance == nil {
+		initLock.Lock()
+		defer initLock.Unlock()
+
+		if instance == nil {
+			instance = &l4HealthChecks{
+				cloud:           cloud,
+				recorderFactory: recorderFactory,
+			}
+		}
 	}
-	hc, err := composite.GetHealthCheck(cloud, key, meta.VersionGA)
+}
+
+// FakeL4 creates instance of l4HealthChecks> USe for test only.
+func FakeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) *l4HealthChecks {
+	instance = &l4HealthChecks{
+		cloud:           cloud,
+		recorderFactory: recorderFactory,
+	}
+	return instance
+}
+
+// GetL4 returns singleton instance, must be run after InitializeL4
+func GetL4() *l4HealthChecks {
+	return instance
+}
+
+// EnsureL4HealthCheck creates a new HTTP health check for an L4 LoadBalancer service, and the firewall rule required
+// for the healthcheck. If healthcheck is shared (external traffic policy 'cluster') then firewall rules will be shared
+// regardless of scope param.
+// If the healthcheck already exists, it is updated as needed.
+func (l4hc *l4HealthChecks) EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) (string, string, string, string, error) {
+	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	hcPath, hcPort := helpers.GetServiceHealthCheckPathPort(svc)
+	if sharedHC {
+		hcPath, hcPort = gce.GetNodesHealthCheckPath(), gce.GetNodesHealthCheckPort()
+		// lock out entire EnsureL4HealthCheck process
+		l4hc.mutex.Lock()
+		defer l4hc.mutex.Unlock()
+	}
+
+	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+	_, hcLink, err := l4hc.ensureL4HealthCheckInternal(hcName, namespacedName, sharedHC, hcPath, hcPort, scope, l4Type)
+	if err != nil {
+		return "", "", "", annotations.HealthcheckResource, err
+	}
+	err = l4hc.ensureFirewall(svc, hcFwName, hcPort, sharedHC, nodeNames)
+	if err != nil {
+		return "", "", "", annotations.FirewallForHealthcheckResource, err
+	}
+
+	return hcLink, hcFwName, hcName, "", err
+}
+
+// DeleteHealthCheck deletes health check (and firewall rule) for l4 service. Checks if shared resources are safe to delete.
+func (l4hc *l4HealthChecks) DeleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error) {
+	if sharedHC {
+		// lock out entire DeleteHealthCheck process
+		l4hc.mutex.Lock()
+		defer l4hc.mutex.Unlock()
+	}
+
+	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+	err := utils.IgnoreHTTPNotFound(l4hc.deleteHealthCheck(hcName, scope))
+	if err != nil {
+		if !utils.IsInUsedByError(err) {
+			klog.Errorf("Failed to delete healthcheck for service %s - %v", namespacedName.String(), err)
+			return annotations.HealthcheckResource, err
+		}
+		// Ignore deletion error due to health check in use by another resource.
+		// This will be hit if this is a shared healthcheck.
+		klog.V(2).Infof("Failed to delete healthcheck %s: health check in use.", hcName)
+		return "", nil
+	}
+	// Health check deleted, now delete the firewall rule
+	return l4hc.deleteHealthCheckFirewall(svc, hcName, hcFwName, sharedHC, l4Type)
+}
+
+func (l4hc *l4HealthChecks) ensureL4HealthCheckInternal(name string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType) (*composite.HealthCheck, string, error) {
+	selfLink := ""
+	key, err := composite.CreateKey(l4hc.cloud, name, scope)
+	if err != nil {
+		return nil, selfLink, fmt.Errorf("Failed to create key for healthcheck with name %s for service %s", name, svcName.String())
+	}
+	hc, err := composite.GetHealthCheck(l4hc.cloud, key, meta.VersionGA)
 	if err != nil {
 		if !utils.IsNotFoundError(err) {
 			return nil, selfLink, err
@@ -69,17 +154,17 @@ func ensureL4HealthCheckInternal(cloud *gce.Cloud, name string, svcName types.Na
 	}
 	var region string
 	if scope == meta.Regional {
-		region = cloud.Region()
+		region = l4hc.cloud.Region()
 	}
 	expectedHC := NewL4HealthCheck(name, svcName, shared, path, port, l4Type, scope, region)
 	if hc == nil {
 		// Create the healthcheck
 		klog.V(2).Infof("Creating healthcheck %s for service %s, shared = %v", name, svcName, shared)
-		err = composite.CreateHealthCheck(cloud, key, expectedHC)
+		err = composite.CreateHealthCheck(l4hc.cloud, key, expectedHC)
 		if err != nil {
 			return nil, selfLink, err
 		}
-		selfLink = cloudprovider.SelfLink(meta.VersionGA, cloud.ProjectID(), "healthChecks", key)
+		selfLink = cloudprovider.SelfLink(meta.VersionGA, l4hc.cloud.ProjectID(), "healthChecks", key)
 		return expectedHC, selfLink, nil
 	}
 	selfLink = hc.SelfLink
@@ -89,19 +174,85 @@ func ensureL4HealthCheckInternal(cloud *gce.Cloud, name string, svcName types.Na
 	}
 	mergeHealthChecks(hc, expectedHC)
 	klog.V(2).Infof("Updating healthcheck %s for service %s", name, svcName)
-	err = composite.UpdateHealthCheck(cloud, key, expectedHC)
+	err = composite.UpdateHealthCheck(l4hc.cloud, key, expectedHC)
 	if err != nil {
 		return nil, selfLink, err
 	}
 	return expectedHC, selfLink, err
 }
 
-func DeleteHealthCheck(cloud *gce.Cloud, name string, scope meta.KeyType) error {
-	key, err := composite.CreateKey(cloud, name, scope)
+// ensureFirewall rule for L4 service.
+// The firewall rules are the same for ILB and NetLB that use external traffic policy 'local' (sharedHC == true)
+// despite healthchecks have different scopes (global vs regional)
+func (l4hc *l4HealthChecks) ensureFirewall(svc *corev1.Service, hcFwName string, hcPort int32, sharedHC bool, nodeNames []string) error {
+	// Add firewall rule for healthchecks to nodes
+	hcFWRParams := firewalls.FirewallParams{
+		PortRanges:   []string{strconv.Itoa(int(hcPort))},
+		SourceRanges: gce.L4LoadBalancerSrcRanges(),
+		Protocol:     string(corev1.ProtocolTCP),
+		Name:         hcFwName,
+		NodeNames:    nodeNames,
+	}
+	return firewalls.EnsureL4LBFirewallForHc(svc, sharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorderFactory.Recorder(svc.Namespace))
+}
+
+func (l4hc *l4HealthChecks) deleteHealthCheck(name string, scope meta.KeyType) error {
+	key, err := composite.CreateKey(l4hc.cloud, name, scope)
 	if err != nil {
 		return fmt.Errorf("Failed to create composite key for healthcheck %s - %w", name, err)
 	}
-	return composite.DeleteHealthCheck(cloud, key, meta.VersionGA)
+	return composite.DeleteHealthCheck(l4hc.cloud, key, meta.VersionGA)
+}
+
+func (l4hc *l4HealthChecks) deleteHealthCheckFirewall(svc *corev1.Service, hcName, hcFwName string, sharedHC bool, l4Type utils.L4LBType) (string, error) {
+	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+
+	safeToDelete, err := l4hc.healthCheckFirewallSafeToDelete(hcName, sharedHC, l4Type)
+	if err != nil {
+		klog.Errorf("Failed to delete health check firewall rule %s for service %s - %v", hcFwName, namespacedName.String(), err)
+		return annotations.HealthcheckResource, err
+	}
+	if !safeToDelete {
+		klog.V(2).Infof("Failed to delete health check firewall rule %s: health check in use.", hcName)
+		return "", nil
+	}
+	// Delete healthcheck firewall rule if no healthcheck uses the firewall rule.
+	err = l4hc.deleteFirewall(hcFwName, svc)
+	if err != nil {
+		klog.Errorf("Failed to delete firewall rule %s for internal loadbalancer service %s, err %v", hcFwName, namespacedName.String(), err)
+		return annotations.FirewallForHealthcheckResource, err
+	}
+	return "", nil
+}
+
+func (l4hc *l4HealthChecks) healthCheckFirewallSafeToDelete(hcName string, sharedHC bool, l4Type utils.L4LBType) (bool, error) {
+	if !sharedHC {
+		return true, nil
+	}
+	var scopeToCheck meta.KeyType
+	scopeToCheck = meta.Regional
+	if l4Type == utils.XLB {
+		scopeToCheck = meta.Global
+	}
+	key, err := composite.CreateKey(l4hc.cloud, hcName, scopeToCheck)
+	if err != nil {
+		return false, fmt.Errorf("Failed to create composite key for healthcheck %s - %w", hcName, err)
+	}
+	_, err = composite.GetHealthCheck(l4hc.cloud, key, meta.VersionGA)
+	return utils.IsNotFoundError(err), nil
+}
+
+func (l4hc *l4HealthChecks) deleteFirewall(name string, svc *corev1.Service) error {
+	err := firewalls.EnsureL4FirewallRuleDeleted(l4hc.cloud, name)
+	if err != nil {
+		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
+			recorder := l4hc.recorderFactory.Recorder(svc.Namespace)
+			recorder.Eventf(svc, corev1.EventTypeNormal, "XPN", fwErr.Message)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func NewL4HealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32, l4Type utils.L4LBType, scope meta.KeyType, region string) *composite.HealthCheck {

--- a/pkg/healthchecks/healthchecks_l4_test.go
+++ b/pkg/healthchecks/healthchecks_l4_test.go
@@ -50,7 +50,7 @@ func TestMergeHealthChecks(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			// healthcheck intervals and thresholds are common for Global and Regional healthchecks. Hence testing only Global case.
-			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
+			wantHC := newL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
 			hc := &composite.HealthCheck{
 				CheckIntervalSec:   tc.checkIntervalSec,
 				TimeoutSec:         tc.timeoutSec,
@@ -97,8 +97,8 @@ func TestCompareHealthChecks(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			// healthcheck intervals and thresholds are common for Global and Regional healthchecks. Hence testing only Global case.
-			hc := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
-			wantHC := NewL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
+			hc := newL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
+			wantHC := newL4HealthCheck("hc", types.NamespacedName{Name: "svc", Namespace: "default"}, false, "/", 12345, utils.ILB, meta.Global, "")
 			if tc.modifier != nil {
 				tc.modifier(hc)
 			}
@@ -120,7 +120,7 @@ func TestCreateHealthCheck(t *testing.T) {
 		{meta.Global, ""},
 		{meta.Regional, "us-central1"},
 	} {
-		hc := NewL4HealthCheck("hc", namespaceName, false, "/", 12345, utils.ILB, v.scope, v.region)
+		hc := newL4HealthCheck("hc", namespaceName, false, "/", 12345, utils.ILB, v.scope, v.region)
 		if hc.Region != v.region {
 			t.Errorf("HealthCheck Region mismatch! %v != %v", hc.Region, v.region)
 		}

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -65,6 +65,8 @@ type L4HealthChecks interface {
 	EnsureL4HealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult
 	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
 	DeleteHealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
+	// DeleteLegacyHealthCheck deletes legacy http health check (and firewall rule) for l4 service
+	DeleteLegacyHealthCheck(svc *v1.Service, hcName, clusterID, loadBalancerName string) error
 }
 
 type EnsureL4HealthCheckResult struct {

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 )
@@ -56,4 +57,20 @@ type HealthChecker interface {
 	SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (string, error)
 	Delete(name string, scope meta.KeyType) error
 	Get(name string, version meta.Version, scope meta.KeyType) (*translator.HealthCheck, error)
+}
+
+// L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
+type L4HealthChecks interface {
+	// EnsureL4HealthCheck creates health check (and firewall rule) for l4 service
+	EnsureL4HealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult
+	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
+	DeleteHealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
+}
+
+type EnsureL4HealthCheckResult struct {
+	HCName             string
+	HCLink             string
+	HCFirewallRuleName string
+	GceResourceInError string
+	Err                error
 }

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -188,7 +188,7 @@ func (l4c *L4Controller) shouldProcessService(service *v1.Service, l4 *loadbalan
 // processServiceCreateOrUpdate ensures load balancer resources for the given service, as needed.
 // Returns an error if processing the service update failed.
 func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Service) *loadbalancers.L4ILBSyncResult {
-	l4 := loadbalancers.NewL4Handler(service, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(service.Namespace), &l4c.sharedResourcesLock)
+	l4 := loadbalancers.NewL4Handler(service, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(service.Namespace))
 	if !l4c.shouldProcessService(service, l4) {
 		return nil
 	}
@@ -241,7 +241,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Se
 }
 
 func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service) *loadbalancers.L4ILBSyncResult {
-	l4 := loadbalancers.NewL4Handler(svc, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(svc.Namespace), &l4c.sharedResourcesLock)
+	l4 := loadbalancers.NewL4Handler(svc, l4c.ctx.Cloud, meta.Regional, l4c.namer, l4c.ctx.Recorder(svc.Namespace))
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)
 	result := l4.EnsureInternalLoadBalancerDeleted(svc)
 	if result.Error != nil {

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -19,6 +19,7 @@ package l4lb
 import (
 	context2 "context"
 	"fmt"
+	"k8s.io/ingress-gce/pkg/healthchecks"
 	"testing"
 	"time"
 
@@ -70,6 +71,7 @@ func newServiceController(t *testing.T, fakeGCE *gce.Cloud) *L4Controller {
 	for _, n := range nodes {
 		ctx.NodeInformer.GetIndexer().Add(n)
 	}
+	healthchecks.FakeL4(ctx.Cloud, ctx)
 	return NewILBController(ctx, stopCh)
 }
 

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -18,9 +18,6 @@ package l4lb
 
 import (
 	"fmt"
-	"reflect"
-	"sync"
-
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +35,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
+	"reflect"
 )
 
 const l4NetLBControllerName = "l4netlb-controller"
@@ -54,8 +52,7 @@ type L4NetLBController struct {
 	// enqueueTracker tracks the latest time an update was enqueued
 	enqueueTracker utils.TimeTracker
 	// syncTracker tracks the latest time an enqueued service was synced
-	syncTracker         utils.TimeTracker
-	sharedResourcesLock sync.Mutex
+	syncTracker utils.TimeTracker
 
 	backendPool  *backends.Backends
 	instancePool instances.NodePool
@@ -236,7 +233,7 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // hasRBSForwardingRule checks if services loadbalancer has forwarding rule pointing to backend service
 func (lc *L4NetLBController) hasRBSForwardingRule(svc *v1.Service) bool {
-	l4netlb := loadbalancers.NewL4NetLB(svc, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(svc.Namespace), &lc.sharedResourcesLock)
+	l4netlb := loadbalancers.NewL4NetLB(svc, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(svc.Namespace))
 	frName := l4netlb.GetFRName()
 	// to optimize number of api calls, at first, check if forwarding rule exists in annotation
 	if lc.hasForwardingRuleAnnotation(svc, frName) {
@@ -322,7 +319,7 @@ func (lc *L4NetLBController) sync(key string) error {
 // syncInternal ensures load balancer resources for the given service, as needed.
 // Returns an error if processing the service update failed.
 func (lc *L4NetLBController) syncInternal(service *v1.Service) *loadbalancers.L4NetLBSyncResult {
-	l4netlb := loadbalancers.NewL4NetLB(service, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(service.Namespace), &lc.sharedResourcesLock)
+	l4netlb := loadbalancers.NewL4NetLB(service, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(service.Namespace))
 	// check again that rbs is enabled.
 	if !lc.isRBSBasedService(service) {
 		klog.Infof("Skipping syncInternal. Service %s does not have RBS enabled", service.Name)
@@ -400,7 +397,7 @@ func (lc *L4NetLBController) ensureInstanceGroups(service *v1.Service, nodeNames
 
 // garbageCollectRBSNetLB cleans-up all gce resources related to service and removes NetLB finalizer
 func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service) *loadbalancers.L4NetLBSyncResult {
-	l4netLB := loadbalancers.NewL4NetLB(svc, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(svc.Namespace), &lc.sharedResourcesLock)
+	l4netLB := loadbalancers.NewL4NetLB(svc, lc.ctx.Cloud, meta.Regional, lc.namer, lc.ctx.Recorder(svc.Namespace))
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer",
 		"Deleting L4 External LoadBalancer for %s", key)
 

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -18,6 +18,8 @@ package l4lb
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
@@ -35,7 +37,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
-	"reflect"
 )
 
 const l4NetLBControllerName = "l4netlb-controller"
@@ -343,37 +344,38 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service) *loadbalancers.L4
 
 	// Use the same function for both create and updates. If controller crashes and restarts,
 	// all existing services will show up as Service Adds.
-	syncResult := l4netlb.EnsureFrontend(nodeNames, service)
-	if syncResult.Error != nil {
+	l4netlb.EnsureFrontend(nodeNames)
+	if l4netlb.SyncResult.Error != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
-			"Error ensuring Resource for L4 External LoadBalancer, err: %v", syncResult.Error)
-		return syncResult
+			"Error ensuring Resource for L4 External LoadBalancer, err: %v", l4netlb.SyncResult.Error)
+		return l4netlb.SyncResult
 	}
 
 	if err = lc.ensureBackendLinking(l4netlb.ServicePort); err != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Error linking instance groups to backend service, err: %v", err)
-		syncResult.Error = err
-		return syncResult
+		l4netlb.SyncResult.Error = err
+		return l4netlb.SyncResult
 	}
 
-	err = updateServiceStatus(lc.ctx, service, syncResult.Status)
+	err = updateServiceStatus(lc.ctx, service, l4netlb.SyncResult.Status)
 	if err != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Error updating L4 External LoadBalancer, err: %v", err)
-		syncResult.Error = err
-		return syncResult
+		l4netlb.SyncResult.Error = err
+		return l4netlb.SyncResult
 	}
 	lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
 		"Successfully ensured L4 External LoadBalancer resources")
-	if err = updateAnnotations(lc.ctx, service, syncResult.Annotations); err != nil {
+
+	if err = updateAnnotations(lc.ctx, service, l4netlb.SyncResult.Annotations); err != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Failed to update annotations for load balancer, err: %v", err)
-		syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-		return syncResult
+		l4netlb.SyncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
+		return l4netlb.SyncResult
 	}
-	syncResult.MetricsState.InSuccess = true
-	return syncResult
+	l4netlb.SyncResult.MetricsState.InSuccess = true
+	return l4netlb.SyncResult
 }
 
 func (lc *L4NetLBController) ensureBackendLinking(port utils.ServicePort) error {
@@ -385,9 +387,7 @@ func (lc *L4NetLBController) ensureBackendLinking(port utils.ServicePort) error 
 }
 
 func (lc *L4NetLBController) ensureInstanceGroups(service *v1.Service, nodeNames []string) error {
-	// TODO(kl52752) Move instance creation and deletion logic to NodeController
-	// to avoid race condition between controllers
-	_, _, nodePorts, _ := utils.GetPortsAndProtocol(service.Spec.Ports)
+	nodePorts := utils.GetNodePorts(service.Spec.Ports)
 	_, err := lc.instancePool.EnsureInstanceGroupsAndPorts(lc.ctx.ClusterNamer.InstanceGroup(), nodePorts)
 	if err != nil {
 		return err
@@ -401,33 +401,33 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service)
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer",
 		"Deleting L4 External LoadBalancer for %s", key)
 
-	result := l4netLB.EnsureLoadBalancerDeleted(svc)
-	if result.Error != nil {
+	l4netLB.EnsureLoadBalancerDeleted()
+	if l4netLB.SyncResult.Error != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
-			"Error deleting L4 External LoadBalancer, err: %v", result.Error)
-		return result
+			"Error deleting L4 External LoadBalancer, err: %v", l4netLB.SyncResult.Error)
+		return l4netLB.SyncResult
 	}
 
 	if err := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{}); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error reseting L4 External LoadBalancer status to empty, err: %v", err)
-		result.Error = fmt.Errorf("Failed to reset L4 External LoadBalancer status, err: %w", err)
-		return result
+		l4netLB.SyncResult.Error = fmt.Errorf("Failed to reset L4 External LoadBalancer status, err: %w", err)
+		return l4netLB.SyncResult
 	}
 
 	// Remove LB annotations from the Service when processing the finalizer.
 	if err := updateAnnotations(lc.ctx, svc, nil); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error removing resource annotations: %v: %v", err)
-		result.Error = fmt.Errorf("Failed to reset resource annotations, err: %w", err)
-		return result
+		l4netLB.SyncResult.Error = fmt.Errorf("Failed to reset resource annotations, err: %w", err)
+		return l4netLB.SyncResult
 	}
 
 	if err := common.EnsureDeleteServiceFinalizer(svc, common.NetLBFinalizerV2, lc.ctx.KubeClient); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
 			"Error removing finalizer from L4 External LoadBalancer, err: %v", err)
-		result.Error = fmt.Errorf("Failed to remove L4 External LoadBalancer finalizer, err: %w", err)
-		return result
+		l4netLB.SyncResult.Error = fmt.Errorf("Failed to remove L4 External LoadBalancer finalizer, err: %w", err)
+		return l4netLB.SyncResult
 	}
 
 	// Try to delete instance group, instancePool.DeleteInstanceGroup ignores errors if resource is in use or not found.
@@ -435,12 +435,12 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service)
 	if err := lc.instancePool.DeleteInstanceGroup(lc.namer.InstanceGroup()); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteInstanceGroupFailed",
 			"Error deleting delete Instance Group from L4 External LoadBalancer, err: %v", err)
-		result.Error = fmt.Errorf("Failed to delete Instance Group, err: %w", err)
-		return result
+		l4netLB.SyncResult.Error = fmt.Errorf("Failed to delete Instance Group, err: %w", err)
+		return l4netLB.SyncResult
 	}
 
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletedLoadBalancer", "Deleted L4 External LoadBalancer")
-	return result
+	return l4netLB.SyncResult
 }
 
 // publishMetrics sets controller metrics for NetLB services and pushes NetLB metrics based on sync type.

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -242,7 +242,6 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 		}()
 	}
 
-	ports, _, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
 	// Create the forwarding rule
 	frDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(l.Service.Namespace, l.Service.Name), ipToUse,
 		version, false, utils.ILB)
@@ -254,8 +253,8 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 	fr := &composite.ForwardingRule{
 		Name:                loadBalancerName,
 		IPAddress:           ipToUse,
-		Ports:               ports,
-		IPProtocol:          string(protocol),
+		Ports:               utils.GetStringPorts(l.Service.Spec.Ports),
+		IPProtocol:          string(utils.GetProtocol(l.Service.Spec.Ports)),
 		LoadBalancingScheme: string(cloud.SchemeInternal),
 		Subnetwork:          subnetworkURL,
 		Network:             l.cloud.NetworkURL(),
@@ -265,7 +264,7 @@ func (l *L4) ensureForwardingRule(loadBalancerName, bsLink string, options gce.I
 		AllowGlobalAccess:   options.AllowGlobalAccess,
 		Description:         frDesc,
 	}
-	if len(ports) > maxL4ILBPorts {
+	if len(l.Service.Spec.Ports) > maxL4ILBPorts {
 		fr.Ports = nil
 		fr.AllPorts = true
 	}

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -216,7 +216,7 @@ func TestForwardingRulesEqual(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := Equal(tc.oldFwdRule, tc.newFwdRule)
+			got, err := equal(tc.oldFwdRule, tc.newFwdRule)
 			if err != nil {
 				t.Errorf("forwardingRulesEqual(_, _) = %v, want nil error", err)
 			}

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -18,10 +18,7 @@ package loadbalancers
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
-	"k8s.io/ingress-gce/pkg/utils"
-	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
 // LoadBalancerPool is an interface to manage the cloud resources associated
@@ -39,12 +36,4 @@ type LoadBalancerPool interface {
 	Shutdown(ings []*v1.Ingress) error
 	// HasUrlMap returns true if an URL map exists in GCE for given ingress.
 	HasUrlMap(ing *v1.Ingress) (bool, error)
-}
-
-// L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
-type L4HealthChecks interface {
-	// EnsureL4HealthCheck creates health check (and firewall rule) for l4 service
-	EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) (string, string, string, string, error)
-	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
-	DeleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
 }

--- a/pkg/loadbalancers/interfaces.go
+++ b/pkg/loadbalancers/interfaces.go
@@ -18,7 +18,10 @@ package loadbalancers
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
 // LoadBalancerPool is an interface to manage the cloud resources associated
@@ -36,4 +39,12 @@ type LoadBalancerPool interface {
 	Shutdown(ings []*v1.Ingress) error
 	// HasUrlMap returns true if an URL map exists in GCE for given ingress.
 	HasUrlMap(ing *v1.Ingress) (bool, error)
+}
+
+// L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
+type L4HealthChecks interface {
+	// EnsureL4HealthCheck creates health check (and firewall rule) for l4 service
+	EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) (string, string, string, string, error)
+	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
+	DeleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
 }

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -170,7 +170,7 @@ func (l *L4) deleteFirewall(name string) error {
 // This appends the protocol to the forwarding rule name, which will help supporting multiple protocols in the same ILB
 // service.
 func (l *L4) GetFRName() string {
-	_, _, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
+	protocol := utils.GetProtocol(l.Service.Spec.Ports)
 	return l.getFRNameWithProtocol(string(protocol))
 }
 
@@ -212,8 +212,7 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service)
 		return result
 	}
 	result.Annotations[annotations.HealthcheckKey] = hcResult.HCName
-
-	_, portRanges, _, protocol := utils.GetPortsAndProtocol(l.Service.Spec.Ports)
+	protocol := utils.GetProtocol(l.Service.Spec.Ports)
 
 	// ensure firewalls
 	sourceRanges, err := helpers.GetLoadBalancerSourceRanges(l.Service)
@@ -223,7 +222,7 @@ func (l *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service)
 	}
 	// Add firewall rule for ILB traffic to nodes
 	nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:   portRanges,
+		PortRanges:   utils.GetPortRanges(l.Service.Spec.Ports),
 		SourceRanges: sourceRanges.StringSlice(),
 		Protocol:     string(protocol),
 		Name:         name,

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -609,7 +609,7 @@ func TestHealthCheckFirewallDeletionWithNetLB(t *testing.T) {
 	l4NetLB.l4HealthChecks = l.l4HealthChecks
 
 	// create netlb resources
-	l4NetLB.EnsureFrontend(nodeNames)
+	ensureFrontend(l4NetLB, nodeNames)
 	if l4NetLB.SyncResult.Error != nil {
 		t.Errorf("Failed to ensure loadBalancer, err %v", l4NetLB.SyncResult.Error)
 	}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -220,12 +220,12 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 
 	// Create the expected resources necessary for an Internal Load Balancer
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(svc)
-	hcLink, _, _, _, err := l.l4HealthChecks.EnsureL4HealthCheck(l.Service, l.namer, sharedHC, meta.Global, utils.ILB, []string{})
+	hcResult := l.l4HealthChecks.EnsureL4HealthCheck(l.Service, l.namer, sharedHC, meta.Global, utils.ILB, []string{})
 
-	if err != nil {
-		t.Errorf("Failed to create healthcheck, err %v", err)
+	if hcResult.Err != nil {
+		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err = l.backendPool.EnsureL4BackendService(lbName, hcLink, "TCP", string(l.Service.Spec.SessionAffinity),
+	_, err := l.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l.Service.Spec.SessionAffinity),
 		string(cloud.SchemeInternal), l.NamespacedName, meta.VersionGA)
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -19,9 +19,9 @@ limitations under the License.
 import (
 	"context"
 	"fmt"
+	"k8s.io/ingress-gce/pkg/healthchecks"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 
 	"google.golang.org/api/compute/v1"
@@ -37,7 +37,6 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/test"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/legacy-cloud-providers/gce"
@@ -65,9 +64,12 @@ func getFakeGCECloud(vals gce.TestClusterValues) *gce.Cloud {
 func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	t.Parallel()
 	fakeGCE := getFakeGCECloud(gce.DefaultTestClusterValues())
+
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	bsName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	_, err := l.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l.NamespacedName, meta.VersionGA)
 	if err != nil {
@@ -116,7 +118,9 @@ func TestEnsureInternalLoadBalancer(t *testing.T) {
 
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -171,7 +175,9 @@ func TestEnsureInternalLoadBalancerTypeChange(t *testing.T) {
 
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -202,7 +208,10 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	fakeGCE := getFakeGCECloud(vals)
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -211,16 +220,8 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 
 	// Create the expected resources necessary for an Internal Load Balancer
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(svc)
-	ensureHCFunc := func() (string, string, int32, string, error) {
-		if sharedHC {
-			// Take the lock when creating the shared healthcheck
-			l.sharedResourcesLock.Lock()
-			defer l.sharedResourcesLock.Unlock()
-		}
-		return healthchecks.EnsureL4HealthCheck(l.cloud, l.Service, l.namer, sharedHC, meta.Global, utils.ILB)
-	}
+	hcLink, _, _, _, err := l.l4HealthChecks.EnsureL4HealthCheck(l.Service, l.namer, sharedHC, meta.Global, utils.ILB, []string{})
 
-	hcLink, _, _, _, err := ensureHCFunc()
 	if err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", err)
 	}
@@ -248,9 +249,12 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 
 	fakeGCE := getFakeGCECloud(vals)
+
 	svc := test.NewL4ILBService(true, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	_, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName)
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -365,9 +369,12 @@ func TestUpdateResourceLinks(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 
 	fakeGCE := getFakeGCECloud(vals)
+
 	svc := test.NewL4ILBService(true, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	_, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName)
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -440,9 +447,12 @@ func TestEnsureInternalLoadBalancerHealthCheckConfigurable(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 
 	fakeGCE := getFakeGCECloud(vals)
+
 	svc := test.NewL4ILBService(true, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	_, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName)
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -479,10 +489,13 @@ func TestEnsureInternalLoadBalancerDeleted(t *testing.T) {
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -508,10 +521,13 @@ func TestEnsureInternalLoadBalancerDeletedTwiceDoesNotError(t *testing.T) {
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -544,6 +560,7 @@ func TestEnsureInternalLoadBalancerDeletedWithSharedHC(t *testing.T) {
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockHealthChecks.DeleteHook = test.DeleteHealthCheckResourceInUseErrorHook
 	nodeNames := []string{"test-node-1"}
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
@@ -570,9 +587,64 @@ func TestEnsureInternalLoadBalancerDeletedWithSharedHC(t *testing.T) {
 	}
 }
 
+func TestHealthCheckFirewallDeletionWithNetLB(t *testing.T) {
+	t.Parallel()
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	nodeNames := []string{"test-node-1"}
+	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
+
+	// Create ILB Service
+	ilbSvc, l, result := ensureService(fakeGCE, namer, nodeNames, vals.ZoneName, 8081, t)
+	if result != nil && result.Error != nil {
+		t.Fatalf("Error ensuring service err: %v", result.Error)
+	}
+
+	// Create NetLB Service
+	netlbSvc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := NewL4NetLB(netlbSvc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	// make sure both ilb and netlb use the same l4 healtcheck instance
+	l4NetLB.l4HealthChecks = l.l4HealthChecks
+
+	// create netlb resources
+	xlbResult := l4NetLB.EnsureFrontend(nodeNames, netlbSvc)
+	if xlbResult.Error != nil {
+		t.Errorf("Failed to ensure loadBalancer, err %v", xlbResult.Error)
+	}
+	if len(xlbResult.Status.Ingress) == 0 {
+		t.Errorf("Got empty loadBalancer status using handler %v", l4NetLB)
+	}
+	assertNetLbResources(t, netlbSvc, l4NetLB, nodeNames)
+
+	// Delete the ILB loadbalancer
+	result = l.EnsureInternalLoadBalancerDeleted(ilbSvc)
+	if result.Error != nil {
+		t.Errorf("Unexpected error %v", result.Error)
+	}
+
+	// When NetLB health check uses the same firewall rules we expect that hc firewall rule will not be deleted.
+	haName, hcFwName := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	firewall, err := l.cloud.GetFirewall(hcFwName)
+	if err != nil {
+		t.Errorf("Expected error: firewall exists, got %v", err)
+	}
+	if firewall == nil {
+		t.Error("Healthcheck Firewall should still exist, got nil")
+	}
+
+	// The healthcheck itself should be deleted.
+	healthcheck, err := l.cloud.GetHealthCheck(haName)
+	if err == nil || healthcheck != nil {
+		t.Errorf("Expected error when looking up shared healthcheck after deletion")
+	}
+}
+
 func ensureService(fakeGCE *gce.Cloud, namer *namer_util.L4Namer, nodeNames []string, zoneName string, port int, t *testing.T) (*v1.Service, *L4, *L4ILBSyncResult) {
 	svc := test.NewL4ILBService(false, 8080)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, zoneName); err != nil {
 		return nil, nil, &L4ILBSyncResult{Error: fmt.Errorf("Unexpected error when adding nodes %v", err)}
 	}
@@ -591,10 +663,13 @@ func ensureService(fakeGCE *gce.Cloud, namer *namer_util.L4Namer, nodeNames []st
 func TestEnsureInternalLoadBalancerWithSpecialHealthCheck(t *testing.T) {
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -691,14 +766,17 @@ func TestEnsureInternalLoadBalancerErrors(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			fakeGCE := getFakeGCECloud(gce.DefaultTestClusterValues())
 			nodeNames := []string{"test-node-1"}
 			params = newEnsureILBParams()
 			if tc.adjustParams != nil {
 				tc.adjustParams(params)
 			}
 			namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-			l := NewL4Handler(params.service, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+			fakeGCE := getFakeGCECloud(gce.DefaultTestClusterValues())
+
+			l := NewL4Handler(params.service, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+			l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 			//lbName := l.namer.L4Backend(params.service.Namespace, params.service.Name)
 			frName := l.GetFRName()
 			key, err := composite.CreateKey(l.cloud, frName, meta.Regional)
@@ -779,7 +857,9 @@ func TestEnsureInternalLoadBalancerEnableGlobalAccess(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -859,7 +939,9 @@ func TestEnsureInternalLoadBalancerCustomSubnet(t *testing.T) {
 
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -952,9 +1034,12 @@ func TestEnsureInternalLoadBalancerCustomSubnet(t *testing.T) {
 func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	fwName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	tc := struct {
 		Input  []int
@@ -980,7 +1065,6 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 		PortRanges:   utils.GetPortRanges(tc.Input),
 		NodeNames:    nodeNames,
 		Protocol:     string(v1.ProtocolTCP),
-		L4Type:       utils.ILB,
 		IP:           "1.2.3.4",
 	}
 	firewalls.EnsureL4FirewallRule(l.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false)
@@ -1002,11 +1086,14 @@ func TestEnsureInternalLoadBalancerModifyProtocol(t *testing.T) {
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	c := fakeGCE.Compute().(*cloud.MockGCE)
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	_, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName)
 	if err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -1092,10 +1179,13 @@ func TestEnsureInternalLoadBalancerAllPorts(t *testing.T) {
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := getFakeGCECloud(vals)
+
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
-	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100), &sync.Mutex{})
+	l := NewL4Handler(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
+	l.l4HealthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+
 	if _, err := test.CreateAndInsertNodes(l.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
 	}
@@ -1185,6 +1275,8 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 	sharedHC := !servicehelper.RequestsOnlyLocalTraffic(apiService)
 	resourceName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
 	resourceDesc, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, false, utils.ILB)
+	// todo fix this shit.
+	//firewallDesc, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(apiService.Namespace, apiService.Name), "", meta.VersionGA, false, utils.ILB)
 	if err != nil {
 		t.Errorf("Failed to create description for resources, err %v", err)
 	}
@@ -1200,6 +1292,7 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 	if sharedHC {
 		hcDesc = sharedResourceDesc
 	}
+
 	type nameAndDesc struct {
 		fwName string
 		fwDesc string
@@ -1224,7 +1317,7 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 		if len(firewall.SourceRanges) == 0 {
 			t.Fatalf("Unexpected empty source range for firewall rule %v", firewall)
 		}
-		if firewall.Description != info.fwDesc {
+		if !sharedHC && firewall.Description != info.fwDesc {
 			t.Errorf("Unexpected description in firewall %q - Expected %s, Got %s", info.fwName, firewall.Description, info.fwDesc)
 		}
 	}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -18,8 +18,6 @@ package loadbalancers
 
 import (
 	"fmt"
-	"strconv"
-	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -47,11 +45,11 @@ type L4NetLB struct {
 	scope       meta.KeyType
 	namer       namer.L4ResourcesNamer
 	// recorder is used to generate k8s Events.
-	recorder            record.EventRecorder
-	Service             *corev1.Service
-	ServicePort         utils.ServicePort
-	NamespacedName      types.NamespacedName
-	sharedResourcesLock *sync.Mutex
+	recorder       record.EventRecorder
+	Service        *corev1.Service
+	ServicePort    utils.ServicePort
+	NamespacedName types.NamespacedName
+	l4HealthChecks L4HealthChecks
 }
 
 // L4NetLBSyncResult contains information about the outcome of an L4 NetLB sync. It stores the list of resource name annotations,
@@ -67,15 +65,15 @@ type L4NetLBSyncResult struct {
 }
 
 // NewL4NetLB creates a new Handler for the given L4NetLB service.
-func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, namer namer.L4ResourcesNamer, recorder record.EventRecorder, lock *sync.Mutex) *L4NetLB {
+func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, namer namer.L4ResourcesNamer, recorder record.EventRecorder) *L4NetLB {
 	l4netlb := &L4NetLB{cloud: cloud,
-		scope:               scope,
-		namer:               namer,
-		recorder:            recorder,
-		Service:             service,
-		sharedResourcesLock: lock,
-		NamespacedName:      types.NamespacedName{Name: service.Name, Namespace: service.Namespace},
-		backendPool:         backends.NewPool(cloud, namer),
+		scope:          scope,
+		namer:          namer,
+		recorder:       recorder,
+		Service:        service,
+		NamespacedName: types.NamespacedName{Name: service.Name, Namespace: service.Namespace},
+		backendPool:    backends.NewPool(cloud, namer),
+		l4HealthChecks: healthchecks.GetL4(),
 	}
 	portId := utils.ServicePortID{Service: l4netlb.NamespacedName}
 	l4netlb.ServicePort = utils.ServicePort{
@@ -108,25 +106,19 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 	}
 
 	l4netlb.Service = svc
+
 	sharedHC := !helpers.RequestsOnlyLocalTraffic(svc)
-	ensureHCFunc := func() (string, string, int32, string, error) {
-		if sharedHC {
-			// Take the lock when creating the shared healthcheck
-			l4netlb.sharedResourcesLock.Lock()
-			defer l4netlb.sharedResourcesLock.Unlock()
-		}
-		return healthchecks.EnsureL4HealthCheck(l4netlb.cloud, l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB)
-	}
-	hcLink, hcFwName, hcPort, hcName, err := ensureHCFunc()
+	hcLink, hcFwName, hcName, resourceInErr, err := l4netlb.l4HealthChecks.EnsureL4HealthCheck(l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB, nodeNames)
+
 	if err != nil {
-		result.GCEResourceInError = annotations.HealthcheckResource
+		result.GCEResourceInError = resourceInErr
 		result.Error = fmt.Errorf("Failed to ensure health check %s - %w", hcName, err)
 		return result
 	}
 	result.Annotations[annotations.HealthcheckKey] = hcName
 
 	name := l4netlb.ServicePort.BackendName()
-	protocol, res := l4netlb.createFirewalls(name, hcLink, hcFwName, hcPort, nodeNames, sharedHC)
+	protocol, res := l4netlb.createFirewalls(name, nodeNames)
 	if res.Error != nil {
 		return res
 	}
@@ -184,19 +176,7 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *L4NetLBS
 		result.GCEResourceInError = annotations.AddressResource
 	}
 
-	deleteFwFunc := func(name string) error {
-		err := firewalls.EnsureL4FirewallRuleDeleted(l4netlb.cloud, name)
-		if err != nil {
-			if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
-				l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
-				return nil
-			}
-			return err
-		}
-		return nil
-	}
-	// delete firewall rule allowing load balancer source ranges
-	err = deleteFwFunc(name)
+	err = l4netlb.deleteFirewall(name)
 	if err != nil {
 		klog.Errorf("Failed to delete firewall rule %s for service %s - %v", name, l4netlb.NamespacedName.String(), err)
 		result.GCEResourceInError = annotations.FirewallRuleResource
@@ -209,43 +189,33 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *L4NetLBS
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err
 	}
+
 	// Delete healthcheck
 	// We don't delete health check during service update so
 	// it is possible that there might be some health check leak
 	// when externalTrafficPolicy is changed from Local to Cluster and new a health check was created.
 	// When service is deleted we need to check both health checks shared and non-shared
 	// and delete them if needed.
-	deleteHcFunc := func(sharedHC bool) {
-		hcName, hcFwName := l4netlb.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
-		if sharedHC {
-			l4netlb.sharedResourcesLock.Lock()
-			defer l4netlb.sharedResourcesLock.Unlock()
-		}
-		err = utils.IgnoreHTTPNotFound(healthchecks.DeleteHealthCheck(l4netlb.cloud, hcName, meta.Regional))
-		if err != nil {
-			if !utils.IsInUsedByError(err) {
-				klog.Errorf("Failed to delete healthcheck for service %s - %v", l4netlb.NamespacedName.String(), err)
-				result.GCEResourceInError = annotations.HealthcheckResource
-				result.Error = err
-				return
-			}
-			// Ignore deletion error due to health check in use by another resource.
-			// This will be hit if this is a shared healthcheck.
-			klog.V(2).Infof("Failed to delete healthcheck %s: health check in use.", hcName)
-		} else {
-			// Delete healthcheck firewall rule if healthcheck deletion is successful.
-			err = deleteFwFunc(hcFwName)
-			if err != nil {
-				klog.Errorf("Failed to delete firewall rule %s for service %s - %v", hcFwName, l4netlb.NamespacedName.String(), err)
-				result.GCEResourceInError = annotations.FirewallForHealthcheckResource
-				result.Error = err
-			}
-		}
-	}
 	for _, isShared := range []bool{true, false} {
-		deleteHcFunc(isShared)
+		resourceInError, err := l4netlb.l4HealthChecks.DeleteHealthCheck(svc, l4netlb.namer, isShared, meta.Regional, utils.XLB)
+		if err != nil {
+			result.GCEResourceInError = resourceInError
+			result.Error = err
+		}
 	}
 	return result
+}
+
+func (l4netlb *L4NetLB) deleteFirewall(name string) error {
+	err := firewalls.EnsureL4FirewallRuleDeleted(l4netlb.cloud, name)
+	if err != nil {
+		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
+			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // GetFRName returns the name of the forwarding rule for the given L4 External LoadBalancer service.
@@ -255,7 +225,7 @@ func (l4netlb *L4NetLB) GetFRName() string {
 	return utils.LegacyForwardingRuleName(l4netlb.Service)
 }
 
-func (l4netlb *L4NetLB) createFirewalls(name, hcLink, hcFwName string, hcPort int32, nodeNames []string, sharedHC bool) (string, *L4NetLBSyncResult) {
+func (l4netlb *L4NetLB) createFirewalls(name string, nodeNames []string) (string, *L4NetLBSyncResult) {
 	_, portRanges, _, protocol := utils.GetPortsAndProtocol(l4netlb.Service.Spec.Ports)
 	result := &L4NetLBSyncResult{}
 	sourceRanges, err := helpers.GetLoadBalancerSourceRanges(l4netlb.Service)
@@ -272,26 +242,12 @@ func (l4netlb *L4NetLB) createFirewalls(name, hcLink, hcFwName string, hcPort in
 		Name:         name,
 		IP:           l4netlb.Service.Spec.LoadBalancerIP,
 		NodeNames:    nodeNames,
-		L4Type:       utils.XLB,
 	}
 	result.Error = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &nodesFWRParams, l4netlb.cloud, l4netlb.recorder)
 	if result.Error != nil {
 		result.GCEResourceInError = annotations.FirewallRuleResource
 		result.Error = err
 		return "", result
-	}
-	// Add firewall rule for healthchecks to nodes
-	hcFWRParams := firewalls.FirewallParams{
-		PortRanges:   []string{strconv.Itoa(int(hcPort))},
-		SourceRanges: gce.L4LoadBalancerSrcRanges(),
-		Protocol:     string(corev1.ProtocolTCP),
-		Name:         hcFwName,
-		NodeNames:    nodeNames,
-		L4Type:       utils.XLB,
-	}
-	result.Error = firewalls.EnsureL4LBFirewallForHc(l4netlb.Service, sharedHC, &hcFWRParams, l4netlb.cloud, l4netlb.sharedResourcesLock, l4netlb.recorder)
-	if result.Error != nil {
-		result.GCEResourceInError = annotations.FirewallForHealthcheckResource
 	}
 	return string(protocol), result
 }

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -43,6 +43,9 @@ const (
 	LegacyNetLBFinalizer = "gke.networking.io/l4-netlb-v1"
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
+	// LegacyL4CleanupFinalizer is the finalizer used to indicate,
+	// that Ingress-GCE should clean up GCE resources used for Legacy L4 Target-Pool based Service
+	LegacyL4CleanupFinalizer = "gke.networking.io/legacy-l4-cleanup"
 )
 
 // IsDeletionCandidate is true if the passed in meta contains an ingress finalizer.

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -91,6 +91,8 @@ type L4ResourcesNamer interface {
 	L4HealthCheck(namespace, name string, shared bool) (string, string)
 	// IsNEG returns if the given name is a VM_IP_NEG name.
 	IsNEG(name string) bool
+	// ClusterID returns cluster's id
+	ClusterID() string
 }
 
 type ServiceAttachmentNamer interface {

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -101,3 +101,8 @@ func (n *L4Namer) hcFirewallName(hcName string) string {
 	}
 	return hcName + firewallHcSuffix
 }
+
+// ClusterID returns cluster's id
+func (n *L4Namer) ClusterID() string {
+	return n.v2ClusterUID
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -722,6 +722,13 @@ func (d *L4LBResourceDescription) Unmarshal(desc string) error {
 	return json.Unmarshal([]byte(desc), d)
 }
 
+func MakeL4LBFirewallDescription(svcName, ip string, version meta.Version, shared bool) (string, error) {
+	if shared {
+		return (&L4LBResourceDescription{APIVersion: version, ResourceDescription: fmt.Sprintf(L4LBSharedResourcesDesc, "")}).Marshal()
+	}
+	return (&L4LBResourceDescription{ServiceName: svcName, ServiceIP: ip, APIVersion: version}).Marshal()
+}
+
 func MakeL4LBServiceDescription(svcName, ip string, version meta.Version, shared bool, lbType L4LBType) (string, error) {
 	if shared {
 		return (&L4LBResourceDescription{APIVersion: version, ResourceDescription: fmt.Sprintf(L4LBSharedResourcesDesc, lbType.ToString())}).Marshal()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -581,8 +581,8 @@ func EqualStringSets(x, y []string) bool {
 	return xString.Equal(yString)
 }
 
-// GetPortRanges returns a list of port ranges, given a list of ports.
-func GetPortRanges(ports []int) (ranges []string) {
+// ConvertPortsToRanges returns a list of port ranges, given a list of ports.
+func ConvertPortsToRanges(ports []int) (ranges []string) {
 	if len(ports) < 1 {
 		return ranges
 	}
@@ -624,22 +624,42 @@ func GetPortRanges(ports []int) (ranges []string) {
 	return ranges
 }
 
-// GetPortsAndProtocol returns the list of ports, list of port ranges and the protocol given the list of k8s port info.
-func GetPortsAndProtocol(svcPorts []api_v1.ServicePort) (ports []string, portRanges []string, nodePorts []int64, protocol api_v1.Protocol) {
-	if len(svcPorts) == 0 {
-		return []string{}, []string{}, []int64{}, api_v1.ProtocolTCP
+// GetProtocol returns protocol given the list of k8s port info.
+func GetProtocol(servicePorts []api_v1.ServicePort) api_v1.Protocol {
+	if len(servicePorts) == 0 {
+		return api_v1.ProtocolTCP
 	}
 
 	// GCP doesn't support multiple protocols for a single load balancer
-	protocol = svcPorts[0].Protocol
-	portInts := []int{}
-	for _, p := range svcPorts {
+	return servicePorts[0].Protocol
+}
+
+// GetStringPorts returns string list of ports given the list of k8s port info.
+func GetStringPorts(servicePorts []api_v1.ServicePort) []string {
+	var ports []string
+	for _, p := range servicePorts {
 		ports = append(ports, strconv.Itoa(int(p.Port)))
-		portInts = append(portInts, int(p.Port))
-		nodePorts = append(nodePorts, int64(p.NodePort))
 	}
 
-	return ports, GetPortRanges(portInts), nodePorts, protocol
+	return ports
+}
+
+// GetPortRanges returns string list of ports given the list of k8s port info.
+func GetPortRanges(servicePorts []api_v1.ServicePort) []string {
+	var ports []int
+	for _, p := range servicePorts {
+		ports = append(ports, int(p.Port))
+	}
+	return ConvertPortsToRanges(ports)
+}
+
+// GetNodePorts returns list of node ports given the list of k8s port info.
+func GetNodePorts(servicePorts []api_v1.ServicePort) []int64 {
+	var nodePorts []int64
+	for _, p := range servicePorts {
+		nodePorts = append(nodePorts, int64(p.NodePort))
+	}
+	return nodePorts
 }
 
 func minMaxPort(svcPorts []api_v1.ServicePort) (int32, int32) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -713,6 +713,19 @@ func HasL4NetLBFinalizerV2(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV2, nil)
 }
 
+// HasLegacyL4CleanupFinalizer returns true if the given Service has LegacyL4CleanupFinalizer
+func HasLegacyL4CleanupFinalizer(svc *api_v1.Service) bool {
+	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.LegacyL4CleanupFinalizer, nil)
+}
+
+// HasRBSAnnotation return true if the given service has RBS Annotation equals to "enabled"
+func HasRBSAnnotation(svc *api_v1.Service) bool {
+	if val, ok := svc.Annotations[annotations.RBSAnnotationKey]; ok && val == annotations.RBSEnabled {
+		return true
+	}
+	return false
+}
+
 func LegacyForwardingRuleName(svc *api_v1.Service) string {
 	return cloudprovider.DefaultLoadBalancerName(svc)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,11 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
-
-	"net/http"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/compute/v1"
@@ -992,7 +991,7 @@ func TestIsLegacyL4ILBService(t *testing.T) {
 	}
 }
 
-func TestGetPortRanges(t *testing.T) {
+func TestConvertPortToRanges(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		Desc   string
@@ -1010,9 +1009,9 @@ func TestGetPortRanges(t *testing.T) {
 		{Desc: "One value", Input: []int{12}, Result: []string{"12"}},
 		{Desc: "Empty", Input: []int{}, Result: nil},
 	} {
-		result := GetPortRanges(tc.Input)
+		result := ConvertPortsToRanges(tc.Input)
 		if diff := cmp.Diff(result, tc.Result); diff != "" {
-			t.Errorf("GetPortRanges(%s) mismatch, (-want +got): \n%s", tc.Desc, diff)
+			t.Errorf("ConvertPortsToRanges(%s) mismatch, (-want +got): \n%s", tc.Desc, diff)
 		}
 	}
 }


### PR DESCRIPTION
- Switch target of existing forwarding rule from target pool to regional
  backend service
- Clean up GCP resources used only by legacy service: target pool,
  health checks, firewall rules for health checks