### PR TITLE
Init first sync error time with transation start time

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -18,6 +18,8 @@ package l4lb
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
@@ -35,7 +37,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog"
-	"reflect"
 )
 
 const l4NetLBControllerName = "l4netlb-controller"
@@ -372,7 +373,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service) *loadbalancers.L4
 		syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
 		return syncResult
 	}
-	syncResult.SetMetricsForSuccessfulService()
+	syncResult.SetMetricsForSuccessfulServiceSync()
 	return syncResult
 }
 

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -87,6 +87,11 @@ type L4NetLBServiceState struct {
 	FirstSyncErrorTime *time.Time
 }
 
+// InitL4NetLBServiceState sets FirstSyncErrorTime
+func InitL4NetLBServiceState(syncTime *time.Time) L4NetLBServiceState {
+	return L4NetLBServiceState{FirstSyncErrorTime: syncTime}
+}
+
 // IngressMetricsCollector is an interface to update/delete ingress states in the cache
 // that is used for computing ingress usage metrics.
 type IngressMetricsCollector interface {


### PR DESCRIPTION
FirstSyncErrorTime was not set for failed synchronisation and while MetricController was exporting the metrics then it crashed because it tried to use nil value. 