### PR TITLE
[Cherrypick #1733 into release-1.14] Do not return error if EndpointSlicesServiceKey func errors

### DIFF
--- a/pkg/utils/endpointslices/index.go
+++ b/pkg/utils/endpointslices/index.go
@@ -38,7 +38,8 @@ func EndpointSlicesByServiceFunc(obj interface{}) ([]string, error) {
 	}
 	key, err := EndpointSlicesServiceKey(es)
 	if err != nil {
-		return []string{}, err
+		// Do not return error, otherwise store will panic.
+		return []string{}, nil
 	}
 	return []string{key}, nil
 }

--- a/pkg/utils/endpointslices/index_test.go
+++ b/pkg/utils/endpointslices/index_test.go
@@ -28,7 +28,6 @@ func TestEndpointSlicesByServiceFunc(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		obj          interface{}
-		expectError  bool
 		expectedKeys []string
 	}{
 		{
@@ -44,7 +43,6 @@ func TestEndpointSlicesByServiceFunc(t *testing.T) {
 					Namespace: "nmspc",
 				},
 			},
-			expectError: true,
 		},
 		{
 			desc: "ReturnsKeyForProperSlices",
@@ -60,12 +58,9 @@ func TestEndpointSlicesByServiceFunc(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			keys, e := EndpointSlicesByServiceFunc(tc.obj)
-			if tc.expectError && e == nil {
-				t.Errorf("Expected error, got no error and keys %s", keys)
-			}
-			if !tc.expectError && e != nil {
-				t.Errorf("Incorrect error, got: %v, expected nil", e)
+			keys, err := EndpointSlicesByServiceFunc(tc.obj)
+			if err != nil {
+				t.Errorf("Unexpected error, got: %v, expected nil", err)
 			}
 			if len(keys) != len(tc.expectedKeys) || (len(tc.expectedKeys) == 1 && keys[0] != tc.expectedKeys[0]) {
 				t.Errorf("Incorrect keys, got: %s, expected %s", keys, tc.expectedKeys)


### PR DESCRIPTION
 * Service key may not be possible if EndpointSlice does not have all
   the expected labels set, namely the service label. This is a valid
   EPS and should be ignored when indexing. Returning an error causes
   the store to panic. Instead return empty list of keys and no error,
   so that the EPS is ignored.