### PR TITLE
Extend transition timeout to 15 min

### DIFF
--- a/cmd/e2e-test/affinity_test.go
+++ b/cmd/e2e-test/affinity_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	transitionPollTimeout  = 10 * time.Minute
+	transitionPollTimeout  = 15 * time.Minute
 	transitionPollInterval = 30 * time.Second
 )
 


### PR DESCRIPTION
 * tests are flaky because GCLB is taking over 10 minutes to apply the new
   configuration