### PR TITLE
Fix preventTargetPoolToRBSMigration. Properly delete annotation

### DIFF
--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -73,6 +73,17 @@ func updateAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBA
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
+func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotationKey string) error {
+	newObjectMeta := svc.ObjectMeta.DeepCopy()
+	if _, ok := newObjectMeta.Annotations[annotationKey]; !ok {
+		return nil
+	}
+
+	klog.V(3).Infof("Removing annotation %s from service %v/%v", annotationKey, svc.Namespace, svc.Name)
+	delete(newObjectMeta.Annotations, annotationKey)
+	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
+}
+
 // updateServiceStatus this faction checks if LoadBalancer status changed and patch service if needed.
 func updateServiceStatus(ctx *context.ControllerContext, svc *v1.Service, newStatus *v1.LoadBalancerStatus) error {
 	if helpers.LoadBalancerStatusEqual(&svc.Status.LoadBalancer, newStatus) {

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -287,8 +287,13 @@ func (lc *L4NetLBController) revertToTargetPool(service *v1.Service) {
 }
 
 func (lc *L4NetLBController) deleteRBSAnnotation(service *v1.Service) error {
+	err := deleteAnnotation(lc.ctx, service, annotations.RBSAnnotationKey)
+	if err != nil {
+		return fmt.Errorf("deleteAnnotation(_, %v, %s) returned error %v, want nil", service, annotations.RBSAnnotationKey, err)
+	}
+	// update current object annotations, so we do not treat it as RBS after
 	delete(service.Annotations, annotations.RBSAnnotationKey)
-	return updateAnnotations(lc.ctx, service, service.Annotations)
+	return nil
 }
 
 // hasRBSForwardingRule checks if services loadbalancer has forwarding rule pointing to backend service

--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -97,12 +97,12 @@ func DeleteHealthCheckResourceInUseErrorHook(ctx context.Context, key *meta.Key,
 }
 
 func GetLegacyForwardingRule(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, *compute.ForwardingRule, error) {
-	fwRule := compute.ForwardingRule{Target: "some_target", LoadBalancingScheme: string(cloud.SchemeExternal)}
+	fwRule := compute.ForwardingRule{Target: "some_target", LoadBalancingScheme: string(cloud.SchemeExternal), NetworkTier: cloud.NetworkTierDefault.ToGCEValue()}
 	return true, &fwRule, nil
 }
 
 func GetRBSForwardingRule(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, *compute.ForwardingRule, error) {
-	fwRule := compute.ForwardingRule{BackendService: "some_rbs", LoadBalancingScheme: string(cloud.SchemeExternal)}
+	fwRule := compute.ForwardingRule{BackendService: bsUrl, LoadBalancingScheme: string(cloud.SchemeExternal), NetworkTier: cloud.NetworkTierDefault.ToGCEValue()}
 	return true, &fwRule, nil
 }
 


### PR DESCRIPTION
Fixing bug introduces in PR #1740: RBS annotation was not deleted from Target Pool services