### PR TITLE
Handle L4 ELB RBS controller race with legacy on service creation

### DIFF
--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -17,6 +17,8 @@ limitations under the License.
 package firewalls
 
 import (
+	"strings"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
@@ -24,7 +26,6 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog"
 	"k8s.io/legacy-cloud-providers/gce"
-	"strings"
 )
 
 // FirewallParams holds all data needed to create firewall for L4 LB
@@ -151,7 +152,7 @@ func EnsureL4LBFirewallForHc(svc *v1.Service, shared bool, params *FirewallParam
 	return ensureFirewall(svc, shared, params, cloud, recorder)
 }
 
-// EnsureFirewallForHc creates or updates firewall rule for LB traffic to nodes
+// EnsureL4LBFirewallForNodes creates or updates firewall rule for LB traffic to nodes
 func EnsureL4LBFirewallForNodes(svc *v1.Service, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder) error {
 	return ensureFirewall(svc /*shared = */, false, params, cloud, recorder)
 }

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -231,7 +231,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Se
 	}
 	l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
 		"Successfully ensured load balancer resources")
-	if err = updateAnnotations(l4c.ctx, service, syncResult.Annotations); err != nil {
+	if err = updateL4ResourcesAnnotations(l4c.ctx, service, syncResult.Annotations); err != nil {
 		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
 			"Failed to update annotations for load balancer, err: %v", err)
 		syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
@@ -258,7 +258,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service) *lo
 		return result
 	}
 	// Also remove any ILB annotations from the service metadata
-	if err := updateAnnotations(l4c.ctx, svc, nil); err != nil {
+	if err := updateL4ResourcesAnnotations(l4c.ctx, svc, nil); err != nil {
 		l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error resetting resource annotations for load balancer: %v", err)
 		result.Error = fmt.Errorf("failed to reset resource annotations, err: %w", err)

--- a/pkg/loadbalancers/l4syncresult.go
+++ b/pkg/loadbalancers/l4syncresult.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,4 +31,7 @@ var L4LBResourceAnnotationKeys = []string{
 	annotations.UDPForwardingRuleKey,
 	annotations.HealthcheckKey,
 	annotations.FirewallRuleKey,
-	annotations.FirewallRuleForHealthcheckKey}
+	annotations.FirewallRuleForHealthcheckKey,
+}
+
+var L4RBSAnnotations = append(L4LBResourceAnnotationKeys, annotations.RBSAnnotationKey)


### PR DESCRIPTION
Clean up RBS resources if we found rbs finalizer and target pool
attached to the service

This expected to only happen during service creation, if user quickly adds rbs annotation after creating the legacy service, before target pool was provisioned