### PR TITLE
Fix DestinationRanges update when IP changes

### DIFF
--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -122,6 +122,10 @@ func firewallRuleEqual(a, b *compute.Firewall, skipDescription bool) bool {
 		}
 	}
 
+	if !utils.EqualStringSets(a.DestinationRanges, b.DestinationRanges) {
+		return false
+	}
+
 	if !utils.EqualStringSets(a.SourceRanges, b.SourceRanges) {
 		return false
 	}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1069,7 +1069,7 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 		Protocol:          string(v1.ProtocolTCP),
 		IP:                "1.2.3.4",
 	}
-	firewalls.EnsureL4FirewallRule(l.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false)
+	err = firewalls.EnsureL4FirewallRule(l.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false)
 	if err != nil {
 		t.Errorf("Unexpected error %v when ensuring firewall rule %s for svc %+v", err, fwName, svc)
 	}


### PR DESCRIPTION
L4 firewall's DestinationRanges was not being updated when the forwardingrule's IP was updated.