### PR TITLE
Fix creation of NEGs in the new zone when cluster spans to the new zone

### DIFF
--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1459,7 +1459,7 @@ func TestSyncNodesConditions(t *testing.T) {
 		},
 		{
 			desc:       "vm ip neg, zones are the same",
-			expectSync: true,
+			expectSync: false,
 			negType:    negtypes.VmIpEndpointType,
 		},
 		{

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -435,6 +435,14 @@ func EndpointsDataFromEndpointSlices(slices []*discovery.EndpointSlice) []Endpoi
 func NodePredicateForEndpointCalculatorMode(mode EndpointsCalculatorMode) utils.NodeConditionPredicate {
 	// VM_IP NEGs can include unready and upgrading nodes.
 	if mode == L4ClusterMode || mode == L4LocalMode {
+		return NodePredicateForNetworkEndpointType(VmIpEndpointType)
+	}
+	return NodePredicateForNetworkEndpointType(VmIpPortEndpointType)
+}
+
+// NodePredicateForNetworkEndpointType returns the predicate function to select candidate nodes, given the NEG type.
+func NodePredicateForNetworkEndpointType(negType NetworkEndpointType) utils.NodeConditionPredicate {
+	if negType == VmIpEndpointType {
 		return utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes
 	}
 	return utils.CandidateNodesPredicate


### PR DESCRIPTION
* Propagate node update events for both NEG types (GCE_VM_IP_PORT + GCE_VM_IP)

* Configure separate zoneMaps for the NEG types (`vmIpZoneMap` and `vmIpPortZoneMap`). These zoneMaps will be updated using the same predicate function that is eventually used inside `transactionSyncer.isZoneChange()` for the respective NEG types.

* Introduce a new function `NodePredicateForNetworkEndpointType` that will be the source of truth for the type of predicate function to be used for a given NEG type.
  

For future reference, here's another related PR: https://github.com/kubernetes/ingress-gce/pull/1600

/assign @swetharepakula 