### PR TITLE
Create Health Checks Provider to interact with Google Cloud

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -26,7 +26,7 @@ import (
 	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
-	"k8s.io/ingress-gce/pkg/healthchecks"
+	"k8s.io/ingress-gce/pkg/healthchecksl4"
 	"k8s.io/ingress-gce/pkg/ingparams"
 	"k8s.io/ingress-gce/pkg/l4lb"
 	"k8s.io/ingress-gce/pkg/psc"
@@ -279,7 +279,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	fwc := firewalls.NewFirewallController(ctx, flags.F.NodePortRanges.Values())
 
-	healthchecks.InitializeL4(ctx.Cloud, ctx)
+	healthchecksl4.Initialize(ctx.Cloud, ctx)
 
 	if flags.F.RunL4Controller {
 		l4Controller := l4lb.NewILBController(ctx, stopCh)

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -17,15 +17,13 @@ limitations under the License.
 package healthchecks
 
 import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
-	"k8s.io/ingress-gce/pkg/utils/namer"
-
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 )
 
 // HealthCheckProvider is an interface to manage a single GCE health check.
@@ -57,20 +55,4 @@ type HealthChecker interface {
 	SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (string, error)
 	Delete(name string, scope meta.KeyType) error
 	Get(name string, version meta.Version, scope meta.KeyType) (*translator.HealthCheck, error)
-}
-
-// L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
-type L4HealthChecks interface {
-	// EnsureL4HealthCheck creates health check (and firewall rule) for l4 service
-	EnsureL4HealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult
-	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
-	DeleteHealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
-}
-
-type EnsureL4HealthCheckResult struct {
-	HCName             string
-	HCLink             string
-	HCFirewallRuleName string
-	GceResourceInError string
-	Err                error
 }

--- a/pkg/healthchecksl4/healthchecksl4_test.go
+++ b/pkg/healthchecksl4/healthchecksl4_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package healthchecks
+package healthchecksl4
 
 import (
 	"testing"
@@ -109,7 +109,7 @@ func TestCompareHealthChecks(t *testing.T) {
 	}
 }
 
-func TestCreateHealthCheck(t *testing.T) {
+func TestNewHealthCheck(t *testing.T) {
 	t.Parallel()
 	namespaceName := types.NamespacedName{Name: "svc", Namespace: "default"}
 

--- a/pkg/healthchecksl4/interfaces.go
+++ b/pkg/healthchecksl4/interfaces.go
@@ -1,0 +1,33 @@
+package healthchecksl4
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+)
+
+// L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
+type L4HealthChecks interface {
+	// EnsureHealthCheck creates health check (and firewall rule) for l4 service
+	EnsureHealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult
+	// DeleteHealthCheck deletes health check (and firewall rule) for l4 service
+	DeleteHealthCheck(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
+}
+
+type EnsureL4HealthCheckResult struct {
+	HCName             string
+	HCLink             string
+	HCFirewallRuleName string
+	GceResourceInError string
+	Err                error
+}
+
+type healthChecksProvider interface {
+	Get(name string, scope meta.KeyType) (*composite.HealthCheck, error)
+	Create(healthCheck *composite.HealthCheck) error
+	Update(name string, scope meta.KeyType, updatedHealthCheck *composite.HealthCheck) error
+	Delete(name string, scope meta.KeyType) error
+	SelfLink(name string, scope meta.KeyType) (string, error)
+}

--- a/pkg/healthchecksprovider/healthchecksprovider.go
+++ b/pkg/healthchecksprovider/healthchecksprovider.go
@@ -1,0 +1,86 @@
+package healthchecksprovider
+
+import (
+	"fmt"
+
+	cloudprovider "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+type HealthChecks struct {
+	cloud   *gce.Cloud
+	version meta.Version
+}
+
+func NewHealthChecks(cloud *gce.Cloud, version meta.Version) *HealthChecks {
+	return &HealthChecks{
+		cloud:   cloud,
+		version: version,
+	}
+}
+
+func (hc *HealthChecks) Get(name string, scope meta.KeyType) (*composite.HealthCheck, error) {
+	key, err := hc.createKey(name, scope)
+	if err != nil {
+		return nil, fmt.Errorf("hc.createKey(%s, %s) returned error %w, want nil", name, scope, err)
+	}
+	healthCheck, err := composite.GetHealthCheck(hc.cloud, key, hc.version)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("composite.GetHealthCheck(_, %v, %v) returned error %w, want nil", key, meta.VersionGA, err)
+	}
+	return healthCheck, nil
+}
+
+func (hc *HealthChecks) Create(healthCheck *composite.HealthCheck) error {
+	key, err := hc.createKey(healthCheck.Name, healthCheck.Scope)
+	if err != nil {
+		return fmt.Errorf("hc.createKey(%s, %s) returned error: %w, want nil", healthCheck.Name, healthCheck.Scope, err)
+	}
+
+	err = composite.CreateHealthCheck(hc.cloud, key, healthCheck)
+	if err != nil {
+		return fmt.Errorf("composite.CreateHealthCheck(_, %s, %v) returned error %w, want nil", key, healthCheck, err)
+	}
+	return nil
+}
+
+func (hc *HealthChecks) Update(name string, scope meta.KeyType, updatedHealthCheck *composite.HealthCheck) error {
+	key, err := hc.createKey(name, scope)
+	if err != nil {
+		return fmt.Errorf("hc.createKey(%s, %s) returned error: %w, want nil", name, scope, err)
+	}
+
+	err = composite.UpdateHealthCheck(hc.cloud, key, updatedHealthCheck)
+	if err != nil {
+		return fmt.Errorf("composite.UpdateHealthCheck(_, %s, %v) returned error %w, want nil", key, updatedHealthCheck, err)
+	}
+	return nil
+}
+
+func (hc *HealthChecks) Delete(name string, scope meta.KeyType) error {
+	key, err := hc.createKey(name, scope)
+	if err != nil {
+		return fmt.Errorf("hc.createKey(%s, %s) returned error %w, want nil", name, scope, err)
+	}
+
+	return utils.IgnoreHTTPNotFound(composite.DeleteHealthCheck(hc.cloud, key, hc.version))
+}
+
+func (hc *HealthChecks) SelfLink(name string, scope meta.KeyType) (string, error) {
+	key, err := hc.createKey(name, scope)
+	if err != nil {
+		return "", fmt.Errorf("hc.createKey(%s, %s) returned error %w, want nil", name, scope, err)
+	}
+
+	return cloudprovider.SelfLink(meta.VersionGA, hc.cloud.ProjectID(), "healthChecks", key), nil
+}
+
+func (hc *HealthChecks) createKey(name string, scope meta.KeyType) (*meta.Key, error) {
+	return composite.CreateKey(hc.cloud, name, scope)
+}

--- a/pkg/healthchecksprovider/healthchecksprovider_test.go
+++ b/pkg/healthchecksprovider/healthchecksprovider_test.go
@@ -1,0 +1,267 @@
+package healthchecksprovider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+func TestCreateHealthCheck(t *testing.T) {
+	testCases := []struct {
+		healthCheck *composite.HealthCheck
+		desc        string
+	}{
+		{
+			desc: "Create regional health check",
+			healthCheck: &composite.HealthCheck{
+				Name:  "regional-hc",
+				Scope: meta.Regional,
+			},
+		},
+		{
+			desc: "Create global health check",
+			healthCheck: &composite.HealthCheck{
+				Name:  "global-hc",
+				Scope: meta.Global,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			hc := NewHealthChecks(fakeGCE, meta.VersionGA)
+
+			err := hc.Create(tc.healthCheck)
+			if err != nil {
+				t.Fatalf("hc.Create(%v), returned error %v, want nil", tc.healthCheck, err)
+			}
+
+			err = verifyHealthCheckExists(fakeGCE, tc.healthCheck.Name, tc.healthCheck.Scope)
+			if err != nil {
+				t.Errorf("verifyHealthCheckExists(_, %s, %s) returned error %v, want nil", tc.healthCheck.Name, tc.healthCheck.Scope, err)
+			}
+		})
+	}
+}
+
+func TestGetHealthCheck(t *testing.T) {
+	regionalHealthCheck := &composite.HealthCheck{
+		Name:    "regional-hc",
+		Version: meta.VersionGA,
+		Scope:   meta.Regional,
+	}
+	globalHealthCheck := &composite.HealthCheck{
+		Name:    "global-hc",
+		Version: meta.VersionGA,
+		Scope:   meta.Global,
+	}
+
+	testCases := []struct {
+		existingHealthChecks []*composite.HealthCheck
+		getHCName            string
+		getHCScope           meta.KeyType
+		expectedHealthCheck  *composite.HealthCheck
+		desc                 string
+	}{
+		{
+			desc:                 "Get regional health check",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            regionalHealthCheck.Name,
+			getHCScope:           regionalHealthCheck.Scope,
+			expectedHealthCheck:  regionalHealthCheck,
+		},
+		{
+			desc:                 "Get global health check",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            globalHealthCheck.Name,
+			getHCScope:           globalHealthCheck.Scope,
+			expectedHealthCheck:  globalHealthCheck,
+		},
+		{
+			desc:                 "Get non existent global health check",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            "non-existent-hc",
+			getHCScope:           meta.Global,
+			expectedHealthCheck:  nil,
+		},
+		{
+			desc:                 "Get non existent regional health check",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            "non-existent-hc",
+			getHCScope:           meta.Regional,
+			expectedHealthCheck:  nil,
+		},
+		{
+			desc:                 "Get existent regional health check, but providing global scope",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            regionalHealthCheck.Name,
+			getHCScope:           meta.Global,
+			expectedHealthCheck:  nil,
+		},
+		{
+			desc:                 "Get existent global health check, but providing regional scope",
+			existingHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			getHCName:            globalHealthCheck.Name,
+			getHCScope:           meta.Regional,
+			expectedHealthCheck:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			mustCreateHealthChecks(t, fakeGCE, tc.existingHealthChecks)
+			hcp := NewHealthChecks(fakeGCE, meta.VersionGA)
+
+			hc, err := hcp.Get(tc.getHCName, tc.getHCScope)
+			if err != nil {
+				t.Fatalf("hcp.Get(%v), returned error %v, want nil", tc.getHCName, err)
+			}
+
+			// Scope field gets removed (but region added), after creating health check
+			ignoreFields := cmpopts.IgnoreFields(composite.HealthCheck{}, "SelfLink", "Region", "Scope")
+			if !cmp.Equal(hc, tc.expectedHealthCheck, ignoreFields) {
+				diff := cmp.Diff(hc, tc.expectedHealthCheck, ignoreFields)
+				t.Errorf("hcp.Get(s) returned %v, not equal to expectedHealthCheck %v, diff: %v", hc, tc.expectedHealthCheck, diff)
+			}
+		})
+	}
+}
+
+func TestDeleteHealthCheck(t *testing.T) {
+	regionalHealthCheck := &composite.HealthCheck{
+		Name:    "regional-hc",
+		Version: meta.VersionGA,
+		Scope:   meta.Regional,
+	}
+	globalHealthCheck := &composite.HealthCheck{
+		Name:    "global-hc",
+		Version: meta.VersionGA,
+		Scope:   meta.Global,
+	}
+
+	testCases := []struct {
+		existingHealthChecks        []*composite.HealthCheck
+		deleteHCName                string
+		deleteHCScope               meta.KeyType
+		shouldNotDeleteHealthChecks []*composite.HealthCheck
+		desc                        string
+	}{
+		{
+			desc:                        "Delete regional health check",
+			existingHealthChecks:        []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			deleteHCName:                regionalHealthCheck.Name,
+			deleteHCScope:               regionalHealthCheck.Scope,
+			shouldNotDeleteHealthChecks: []*composite.HealthCheck{globalHealthCheck},
+		},
+		{
+			desc:                        "Delete global health check",
+			existingHealthChecks:        []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			deleteHCName:                globalHealthCheck.Name,
+			deleteHCScope:               globalHealthCheck.Scope,
+			shouldNotDeleteHealthChecks: []*composite.HealthCheck{regionalHealthCheck},
+		},
+		{
+			desc:                        "Delete non existent healthCheck",
+			existingHealthChecks:        []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			deleteHCName:                "non-existent",
+			deleteHCScope:               meta.Regional,
+			shouldNotDeleteHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+		},
+		{
+			desc:                        "Delete global health check name, but using regional scope",
+			existingHealthChecks:        []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			deleteHCName:                globalHealthCheck.Name,
+			deleteHCScope:               meta.Regional,
+			shouldNotDeleteHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+		},
+		{
+			desc:                        "Delete regional health check name, but using global scope",
+			existingHealthChecks:        []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+			deleteHCName:                regionalHealthCheck.Name,
+			deleteHCScope:               meta.Global,
+			shouldNotDeleteHealthChecks: []*composite.HealthCheck{regionalHealthCheck, globalHealthCheck},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			mustCreateHealthChecks(t, fakeGCE, tc.existingHealthChecks)
+			hc := NewHealthChecks(fakeGCE, meta.VersionGA)
+
+			err := hc.Delete(tc.deleteHCName, tc.deleteHCScope)
+			if err != nil {
+				t.Fatalf("hc.Delete(%v), returned error %v, want nil", tc.deleteHCName, err)
+			}
+
+			err = verifyHealthCheckNotExists(fakeGCE, tc.deleteHCName, tc.deleteHCScope)
+			if err != nil {
+				t.Errorf("verifyHealthCheckNotExists(_, %s, %s) returned error %v", tc.deleteHCName, tc.deleteHCScope, err)
+			}
+			for _, hc := range tc.shouldNotDeleteHealthChecks {
+				err = verifyHealthCheckExists(fakeGCE, hc.Name, hc.Scope)
+				if err != nil {
+					t.Errorf("verifyHealthCheckExists(_, %s, %s) returned error %v", hc.Name, hc.Scope, err)
+				}
+			}
+		})
+	}
+}
+
+func verifyHealthCheckExists(cloud *gce.Cloud, name string, scope meta.KeyType) error {
+	return verifyHealthCheckShouldExist(cloud, name, scope, true)
+}
+
+func verifyHealthCheckNotExists(cloud *gce.Cloud, name string, scope meta.KeyType) error {
+	return verifyHealthCheckShouldExist(cloud, name, scope, false)
+}
+
+func verifyHealthCheckShouldExist(cloud *gce.Cloud, name string, scope meta.KeyType, shouldExist bool) error {
+	key, err := composite.CreateKey(cloud, name, scope)
+	if err != nil {
+		return fmt.Errorf("hailed to create key for fetching health check %s, err: %w", name, err)
+	}
+	_, err = composite.GetHealthCheck(cloud, key, meta.VersionGA)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			if shouldExist {
+				return fmt.Errorf("health check %s in scope %s was not found", name, scope)
+			}
+			return nil
+		}
+		return fmt.Errorf("composite.GetHealthCheck(_, %v, %v) returned error %w, want nil", key, meta.VersionGA, err)
+	}
+	if !shouldExist {
+		return fmt.Errorf("health Check %s in scope %s exists, expected to be not found", name, scope)
+	}
+	return nil
+}
+
+func mustCreateHealthChecks(t *testing.T, cloud *gce.Cloud, hcs []*composite.HealthCheck) {
+	t.Helper()
+
+	for _, hc := range hcs {
+		mustCreateHealthCheck(t, cloud, hc)
+	}
+}
+
+func mustCreateHealthCheck(t *testing.T, cloud *gce.Cloud, hc *composite.HealthCheck) {
+	t.Helper()
+
+	key, err := composite.CreateKey(cloud, hc.Name, hc.Scope)
+	if err != nil {
+		t.Fatalf("composite.CreateKey(_, %s, %s) returned error %v, want nil", hc.Name, hc.Scope, err)
+	}
+	err = composite.CreateHealthCheck(cloud, key, hc)
+	if err != nil {
+		t.Fatalf("composite.CreateHealthCheck(_, %s, %v) returned error %v, want nil", key, hc, err)
+	}
+}

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -23,8 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/ingress-gce/pkg/healthchecks"
-
+	"k8s.io/ingress-gce/pkg/healthchecksl4"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -71,7 +70,7 @@ func newServiceController(t *testing.T, fakeGCE *gce.Cloud) *L4Controller {
 	for _, n := range nodes {
 		ctx.NodeInformer.GetIndexer().Add(n)
 	}
-	healthchecks.FakeL4(ctx.Cloud, ctx)
+	healthchecksl4.Fake(ctx.Cloud, ctx)
 	return NewILBController(ctx, stopCh)
 }
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	ingctx "k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/healthchecks"
+	"k8s.io/ingress-gce/pkg/healthchecksl4"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -240,7 +240,7 @@ func newL4NetLBServiceController() *L4NetLBController {
 	for _, n := range nodes {
 		ctx.NodeInformer.GetIndexer().Add(n)
 	}
-	healthchecks.FakeL4(ctx.Cloud, ctx)
+	healthchecksl4.Fake(ctx.Cloud, ctx)
 	return NewL4NetLBController(ctx, stopCh)
 }
 
@@ -873,7 +873,7 @@ func TestHealthCheckWhenExternalTrafficPolicyWasUpdated(t *testing.T) {
 	// delete shared health check if is created, update service to Cluster and
 	// check that non-shared health check was created
 	hcNameShared := lc.namer.L4HealthCheck(svc.Namespace, svc.Name, true)
-	healthchecks.FakeL4(lc.ctx.Cloud, lc.ctx).DeleteHealthCheck(svc, lc.namer, true, meta.Regional, utils.XLB)
+	healthchecksl4.Fake(lc.ctx.Cloud, lc.ctx).DeleteHealthCheck(svc, lc.namer, true, meta.Regional, utils.XLB)
 	// Update ExternalTrafficPolicy to Cluster check if shared HC was created
 	err = updateAndAssertExternalTrafficPolicy(newSvc, lc, v1.ServiceExternalTrafficPolicyTypeCluster, hcNameShared)
 	if err != nil {

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -21,10 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/ingress-gce/pkg/firewalls"
-	"k8s.io/ingress-gce/pkg/flags"
-	"k8s.io/ingress-gce/pkg/healthchecks"
-
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
@@ -34,6 +30,9 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/healthchecksl4"
 	"k8s.io/ingress-gce/pkg/metrics"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -57,7 +56,7 @@ func TestEnsureL4NetLoadBalancer(t *testing.T) {
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 
 	l4netlb := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
-	l4netlb.healthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+	l4netlb.healthChecks = healthchecksl4.Fake(fakeGCE, &test.FakeRecorderSource{})
 
 	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -108,7 +107,7 @@ func TestDeleteL4NetLoadBalancer(t *testing.T) {
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 
 	l4NetLB := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
-	l4NetLB.healthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+	l4NetLB.healthChecks = healthchecksl4.Fake(fakeGCE, &test.FakeRecorderSource{})
 
 	if _, err := test.CreateAndInsertNodes(l4NetLB.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -211,7 +210,7 @@ func ensureLoadBalancer(port int, vals gce.TestClusterValues, fakeGCE *gce.Cloud
 	emptyNodes := []string{}
 
 	l4NetLB := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
-	l4NetLB.healthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+	l4NetLB.healthChecks = healthchecksl4.Fake(fakeGCE, &test.FakeRecorderSource{})
 
 	result := l4NetLB.EnsureFrontend(emptyNodes, svc)
 	if result.Error != nil {
@@ -354,7 +353,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw"))
 
 	l4netlb := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
-	l4netlb.healthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+	l4netlb.healthChecks = healthchecksl4.Fake(fakeGCE, &test.FakeRecorderSource{})
 
 	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)
@@ -401,7 +400,7 @@ func TestEnsureNetLBFirewallDestinations(t *testing.T) {
 	svc := test.NewL4NetLBRBSService(8080)
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 	l4netlb := NewL4NetLB(svc, fakeGCE, meta.Regional, namer, record.NewFakeRecorder(100))
-	l4netlb.healthChecks = healthchecks.FakeL4(fakeGCE, &test.FakeRecorderSource{})
+	l4netlb.healthChecks = healthchecksl4.Fake(fakeGCE, &test.FakeRecorderSource{})
 
 	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
 		t.Errorf("Unexpected error when adding nodes %v", err)


### PR DESCRIPTION
This separates business logic of managing L4 HealthChecks and interacting with Google Cloud API

We want to achieve following layered level logic
l4controller (handles workqueue for l4 services) -> l4 (for single service) -> l4healthchecks (health checks business logic) -> healthchecksprovider (no business logic, only interaction with gcp)

This makes composition better, testing and mocking should be also easier in the long run