### PR TITLE
fix for get NodePort from service spec

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -234,7 +234,7 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // isRBSBasedService checks if service has either RBS annotation, finalizer or RBSForwardingRule
 func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service) bool {
-	if svc == nil {
+	if !utils.IsLoadBalancerService(svc) {
 		return false
 	}
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -1203,3 +1203,58 @@ func TestPreventTargetPoolToRBSMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRBSBasedServiceForNonLoadBalancersType(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		ports   []v1.ServicePort
+		svcType v1.ServiceType
+	}{
+		{
+			desc: "Service ClusterIP with ports should not be marked as RBS",
+			ports: []v1.ServicePort{
+				{Name: "testport", Port: 8080, Protocol: "TCP", NodePort: 32999},
+			},
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service ClusterIP with empty ports array should not be marked as RBS",
+			ports:   []v1.ServicePort{},
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service ClusterIP without ports should not be marked as RBS",
+			ports:   nil,
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service NodePort should not be marked as RBS",
+			svcType: v1.ServiceTypeNodePort,
+		},
+		{
+			desc:    "Service ExternalName should not be marked as RBS",
+			svcType: v1.ServiceTypeExternalName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Setup
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "example-svc",
+					Annotations: make(map[string]string),
+				},
+				Spec: v1.ServiceSpec{
+					Type:  tc.svcType,
+					Ports: tc.ports,
+				},
+			}
+			controller := newL4NetLBServiceController()
+
+			if controller.isRBSBasedService(svc) {
+				t.Errorf("isRBSBasedService(%v) = true, want false", svc)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -80,6 +80,13 @@ func (r *L4NetLBSyncResult) SetMetricsForSuccessfulServiceSync() {
 	r.MetricsState.InSuccess = true
 }
 
+func getNodePort(service *corev1.Service) int64 {
+	if len(service.Spec.Ports) == 0 {
+		return 0
+	}
+	return int64(service.Spec.Ports[0].NodePort)
+}
+
 // NewL4NetLB creates a new Handler for the given L4NetLB service.
 func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, namer namer.L4ResourcesNamer, recorder record.EventRecorder) *L4NetLB {
 	l4netlb := &L4NetLB{cloud: cloud,
@@ -95,7 +102,7 @@ func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, n
 	l4netlb.ServicePort = utils.ServicePort{
 		ID:           portId,
 		BackendNamer: l4netlb.namer,
-		NodePort:     int64(service.Spec.Ports[0].NodePort),
+		NodePort:     getNodePort(service),
 		L4RBSEnabled: true,
 	}
 	return l4netlb

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -782,3 +782,11 @@ func GetNetworkTier(service *api_v1.Service) (cloud.NetworkTier, bool) {
 		return cloud.NetworkTierDefault, false
 	}
 }
+
+// IsLoadBalancerService checks if kubernetes service is type of LoadBalancer.
+func IsLoadBalancerService(service *api_v1.Service) bool {
+	if service == nil {
+		return false
+	}
+	return service.Spec.Type == api_v1.ServiceTypeLoadBalancer
+}


### PR DESCRIPTION
service of type LoadBalancer has check that fields Spec.ports needs to be added but other type of services like ClusterIp does not have those requirements. To fix this issue we need to check is Spec.Ports array is not empty and it is good to check at the very beginning of `shouldProcess` that this service is of type LoadBalancer 