### PR TITLE
Fix RBS crash, when getting NodePorts for Services without ports

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -234,7 +234,7 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // isRBSBasedService checks if service has either RBS annotation, finalizer or RBSForwardingRule
 func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service) bool {
-	if svc == nil {
+	if !utils.IsLoadBalancerServiceType(svc) {
 		return false
 	}
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -1203,3 +1203,58 @@ func TestPreventTargetPoolToRBSMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRBSBasedServiceForNonLoadBalancersType(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		ports   []v1.ServicePort
+		svcType v1.ServiceType
+	}{
+		{
+			desc: "Service ClusterIP with ports should not be marked as RBS",
+			ports: []v1.ServicePort{
+				{Name: "testport", Port: 8080, Protocol: "TCP", NodePort: 32999},
+			},
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service ClusterIP with empty ports array should not be marked as RBS",
+			ports:   []v1.ServicePort{},
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service ClusterIP without ports should not be marked as RBS",
+			ports:   nil,
+			svcType: v1.ServiceTypeClusterIP,
+		},
+		{
+			desc:    "Service NodePort should not be marked as RBS",
+			svcType: v1.ServiceTypeNodePort,
+		},
+		{
+			desc:    "Service ExternalName should not be marked as RBS",
+			svcType: v1.ServiceTypeExternalName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Setup
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "example-svc",
+					Annotations: make(map[string]string),
+				},
+				Spec: v1.ServiceSpec{
+					Type:  tc.svcType,
+					Ports: tc.ports,
+				},
+			}
+			controller := newL4NetLBServiceController()
+
+			if controller.isRBSBasedService(svc) {
+				t.Errorf("isRBSBasedService(%v) = true, want false", svc)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -95,7 +95,7 @@ func NewL4NetLB(service *corev1.Service, cloud *gce.Cloud, scope meta.KeyType, n
 	l4netlb.ServicePort = utils.ServicePort{
 		ID:           portId,
 		BackendNamer: l4netlb.namer,
-		NodePort:     int64(service.Spec.Ports[0].NodePort),
+		NodePort:     utils.GetServiceNodePort(service),
 		L4RBSEnabled: true,
 	}
 	return l4netlb

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -242,8 +242,9 @@ func PrettyJson(data interface{}) (string, error) {
 
 // KeyName returns the name portion from a full or partial GCP resource URL.
 // Example:
-//  Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
-//  Output: my-backend
+//
+//	Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
+//	Output: my-backend
 func KeyName(url string) (string, error) {
 	id, err := cloud.ParseResourceURL(url)
 	if err != nil {
@@ -261,8 +262,9 @@ func KeyName(url string) (string, error) {
 // RelativeResourceName returns the project, location, resource, and name from a full/partial GCP
 // resource URL. This removes the endpoint prefix and version.
 // Example:
-//  Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
-//  Output: projects/my-project/global/backendServices/my-backend
+//
+//	Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
+//	Output: projects/my-project/global/backendServices/my-backend
 func RelativeResourceName(url string) (string, error) {
 	resID, err := cloud.ParseResourceURL(url)
 	if err != nil {
@@ -274,8 +276,9 @@ func RelativeResourceName(url string) (string, error) {
 // ResourcePath returns the location, resource and name portion from a
 // full or partial GCP resource URL. This removes the endpoint prefix, version, and project.
 // Example:
-//  Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
-//  Output: global/backendServices/my-backend
+//
+//	Input:  https://googleapis.com/v1/compute/projects/my-project/global/backendServices/my-backend
+//	Output: global/backendServices/my-backend
 func ResourcePath(url string) (string, error) {
 	resID, err := cloud.ParseResourceURL(url)
 	if err != nil {
@@ -781,4 +784,21 @@ func GetNetworkTier(service *api_v1.Service) (cloud.NetworkTier, bool) {
 	default:
 		return cloud.NetworkTierDefault, false
 	}
+}
+
+// IsLoadBalancerServiceType checks if kubernetes service is type of LoadBalancer.
+func IsLoadBalancerServiceType(service *api_v1.Service) bool {
+	if service == nil {
+		return false
+	}
+	return service.Spec.Type == api_v1.ServiceTypeLoadBalancer
+}
+
+// GetServiceNodePort safely gets service's first node port,
+// even if they are empty, which can happen for headless services
+func GetServiceNodePort(service *api_v1.Service) int64 {
+	if len(service.Spec.Ports) == 0 {
+		return 0
+	}
+	return int64(service.Spec.Ports[0].NodePort)
 }


### PR DESCRIPTION
This is mostly copied from here https://github.com/kubernetes/ingress-gce/pull/1773