### PR TITLE
Increase timeouts to reflect GCE API

### DIFF
--- a/cmd/e2e-test/draining_test.go
+++ b/cmd/e2e-test/draining_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	drainingTransitionPollTimeout = 10 * time.Minute
+	drainingTransitionPollTimeout = 15 * time.Minute
 	drainingTansitionPollInterval = 30 * time.Second
 )
 

--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -71,7 +71,7 @@ const (
 
 	negPollInterval  = 5 * time.Second
 	negPollTimeout   = 3 * time.Minute
-	negGCPollTimeout = 5 * time.Minute
+	negGCPollTimeout = 6 * time.Minute
 
 	k8sApiPoolInterval = 10 * time.Second
 	k8sApiPollTimeout  = 30 * time.Minute
@@ -84,6 +84,9 @@ const (
 	backendConfigCRDName            = "backendconfigs.cloud.google.com"
 
 	redirectURLMapPollTimeout = 10 * time.Minute
+
+	// timeout for ILB creation + SA creation
+	saPollTimeout = 10 * time.Minute
 
 	healthyState = "HEALTHY"
 )
@@ -962,7 +965,7 @@ func DeleteNegCR(s *Sandbox, negName string) error {
 // created and properly configured
 func WaitForServiceAttachment(s *Sandbox, saName string) (string, error) {
 	var gceSAURL string
-	err := wait.Poll(negPollInterval, negPollTimeout, func() (bool, error) {
+	err := wait.Poll(negPollInterval, saPollTimeout, func() (bool, error) {
 		saCR, err := s.f.SAClient.Get(s.Namespace, saName)
 		if saCR == nil || err != nil {
 			return false, fmt.Errorf("failed to get service attachment %s/%s: %v", s.Namespace, saName, err)


### PR DESCRIPTION
 * Extend NEG GC timeout since regional cluster GC loops take longer
 * Extend draining timeout as propagation latency can be greater than 10
   minutes
 * Create a ServiceAttachment specific timeout since ServiceAttachment
   requires load balancer to come up as well as a service attachment and
   may take longer than the NEG timeout