### PR TITLE
ConfigMap informer should only watch --asm-configmap-based-config-nam…

### DIFF
--- a/pkg/cmconfig/controller.go
+++ b/pkg/cmconfig/controller.go
@@ -90,11 +90,13 @@ func (c *ConfigMapConfigController) DisableASM() {
 
 // SetASMReadyTrue update the ASMReady to True.
 func (c *ConfigMapConfigController) SetASMReadyTrue() {
+	klog.V(0).Info("SetASMReadyTrue")
 	c.updateASMReady(trueValue)
 }
 
 // SetASMReadyFalse update the ASMReady to False.
 func (c *ConfigMapConfigController) SetASMReadyFalse() {
+	klog.V(0).Info("SetASMReadyFalse")
 	c.updateASMReady(falseValue)
 }
 
@@ -125,10 +127,15 @@ func (c *ConfigMapConfigController) RegisterInformer(configMapInformer cache.Sha
 }
 
 func (c *ConfigMapConfigController) processItem(obj interface{}, cancel func()) {
+	klog.V(4).Infof("ConfigMapConfigController.processItem()")
+
 	configMap, ok := obj.(*v1.ConfigMap)
 	if !ok {
 		klog.Errorf("ConfigMapConfigController: failed to convert informer object to ConfigMap.")
 	}
+
+	klog.V(3).Infof("ConfigMapConfigController.processItem '%s.%s'", configMap.Namespace, configMap.Name)
+
 	if configMap.Namespace != c.configMapNamespace || configMap.Name != c.configMapName {
 		return
 	}


### PR DESCRIPTION
ConfigMap informer should only watch --asm-configmap-based-config-namespace

This avoids making total ConfigMap size part of the scalability
profile of the controller.

Testing: Manual

- hack/run-local-glbc.sh --enable-asm-config-map-config \
-v=3 --asm-configmap-based-config-namespace=default
- Created ConfigMaps in `default` namespace.
- Observed only updates to the default namespace ConfigMaps were being
observed in the controller.

Notes

One interesting thing to note is that watching kube-system has a
non-trivial amount of constant activity due to leader election leases.
This can cause CPU usage if there are a large number of components
running leader election using the same namespace.