### PR TITLE
Add Dual-Stack support to L4 ILB

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -199,6 +199,7 @@ func main() {
 		ASMConfigMapName:      flags.F.ASMConfigMapBasedConfigCMName,
 		EndpointSlicesEnabled: flags.F.EnableEndpointSlices,
 		MaxIGSize:             flags.F.MaxIGSize,
+		EnableL4ILBDualStack:  flags.F.EnableL4ILBDualStack,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, svcNegClient, ingParamsClient, svcAttachmentClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)

--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -73,6 +73,7 @@ const (
 	// ProtocolHTTP2 protocol for a service
 	ProtocolHTTP2 AppProtocol = "HTTP2"
 
+	IPv6Suffix = "-ipv6"
 	// ServiceStatusPrefix is the prefix used in annotations used to record
 	// debug information in the Service annotations. This is applicable to L4 ILB services.
 	ServiceStatusPrefix = "service.kubernetes.io"
@@ -82,24 +83,39 @@ const (
 	// UDPForwardingRuleKey is the annotation key used by l4 controller to record
 	// GCP UDP forwarding rule name.
 	UDPForwardingRuleKey = ServiceStatusPrefix + "/udp-" + ForwardingRuleResource
+	// TCPForwardingRuleIPv6Key is the annotation key used by l4 controller to record
+	// GCP IPv6 TCP forwarding rule name.
+	TCPForwardingRuleIPv6Key = TCPForwardingRuleKey + IPv6Suffix
+	// UDPForwardingRuleIPv6Key is the annotation key used by l4 controller to record
+	// GCP IPv6 UDP forwarding rule name.
+	UDPForwardingRuleIPv6Key = UDPForwardingRuleKey + IPv6Suffix
 	// BackendServiceKey is the annotation key used by l4 controller to record
 	// GCP Backend service name.
 	BackendServiceKey = ServiceStatusPrefix + "/" + BackendServiceResource
 	// FirewallRuleKey is the annotation key used by l4 controller to record
 	// GCP Firewall rule name.
 	FirewallRuleKey = ServiceStatusPrefix + "/" + FirewallRuleResource
+	// FirewallRuleIPv6Key is the annotation key used by l4 controller to record
+	// GCP IPv6 Firewall rule name.
+	FirewallRuleIPv6Key = FirewallRuleKey + IPv6Suffix
 	// HealthcheckKey is the annotation key used by l4 controller to record
 	// GCP Healthcheck name.
 	HealthcheckKey = ServiceStatusPrefix + "/" + HealthcheckResource
 	// FirewallRuleForHealthcheckKey is the annotation key used by l4 controller to record
 	// the firewall rule name that allows healthcheck traffic.
-	FirewallRuleForHealthcheckKey  = ServiceStatusPrefix + "/" + FirewallForHealthcheckResource
-	ForwardingRuleResource         = "forwarding-rule"
-	BackendServiceResource         = "backend-service"
-	FirewallRuleResource           = "firewall-rule"
-	HealthcheckResource            = "healthcheck"
-	FirewallForHealthcheckResource = "firewall-rule-for-hc"
-	AddressResource                = "address"
+	FirewallRuleForHealthcheckKey = ServiceStatusPrefix + "/" + FirewallForHealthcheckResource
+	// FirewallRuleForHealthcheckIPv6Key is the annotation key used by l4 controller to record
+	// the firewall rule name that allows IPv6 healthcheck traffic.
+	FirewallRuleForHealthcheckIPv6Key  = FirewallRuleForHealthcheckKey + IPv6Suffix
+	ForwardingRuleResource             = "forwarding-rule"
+	ForwardingRuleIPv6Resource         = ForwardingRuleResource + IPv6Suffix
+	BackendServiceResource             = "backend-service"
+	FirewallRuleResource               = "firewall-rule"
+	FirewallRuleIPv6Resource           = FirewallRuleResource + IPv6Suffix
+	HealthcheckResource                = "healthcheck"
+	FirewallForHealthcheckResource     = "firewall-rule-for-hc"
+	FirewallForHealthcheckIPv6Resource = FirewallRuleForHealthcheckKey + IPv6Suffix
+	AddressResource                    = "address"
 	// TODO(slavik): import this from gce_annotations when it will be merged in k8s
 	RBSAnnotationKey = "cloud.google.com/l4-rbs"
 	RBSEnabled       = "enabled"

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -136,6 +136,7 @@ type ControllerContextConfig struct {
 	ASMConfigMapName      string
 	EndpointSlicesEnabled bool
 	MaxIGSize             int
+	EnableL4ILBDualStack  bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -160,7 +160,6 @@ func ensureFirewall(svc *v1.Service, shared bool, params *FirewallParams, cloud 
 
 // EnsureL4LBFirewallForHc creates or updates firewall rule for shared or non-shared health check to nodes
 func EnsureL4LBFirewallForHc(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder) error {
-	params.SourceRanges = gce.L4LoadBalancerSrcRanges()
 	return ensureFirewall(svc, shared, params, cloud, recorder)
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -109,6 +109,7 @@ var (
 		EnableTrafficScaling           bool
 		EnableEndpointSlices           bool
 		EnablePinhole                  bool
+		EnableL4ILBDualStack           bool
 		EnableMultipleIGs              bool
 		MaxIGSize                      int
 	}{
@@ -252,6 +253,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableTrafficScaling, "enable-traffic-scaling", false, "Enable support for Service {max-rate-per-endpoint, capacity-scaler}")
 	flag.BoolVar(&F.EnableEndpointSlices, "enable-endpoint-slices", false, "Enable using Endpoint Slices API instead of Endpoints API")
 	flag.BoolVar(&F.EnablePinhole, "enable-pinhole", false, "Enable Pinhole firewall feature")
+	flag.BoolVar(&F.EnableL4ILBDualStack, "enable-l4ilb-dual-stack", false, "Enable Dual-Stack handling for L4 Internal Load Balancers")
 	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multiple unmanaged instance groups")
 	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)

--- a/pkg/healthchecksl4/healthchecksl4_test.go
+++ b/pkg/healthchecksl4/healthchecksl4_test.go
@@ -430,5 +430,4 @@ func TestNewHealthCheck(t *testing.T) {
 			t.Errorf("HealthCheck Scope mismatch! %v != %v", hc.Scope, v.scope)
 		}
 	}
-
 }

--- a/pkg/healthchecksl4/interfaces.go
+++ b/pkg/healthchecksl4/interfaces.go
@@ -10,18 +10,23 @@ import (
 
 // L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
 type L4HealthChecks interface {
-	// EnsureHealthCheckWithFirewall creates health check with firewall rule for l4 service.
-	EnsureHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult
-	// DeleteHealthCheckWithFirewall deletes health check with firewall rule for l4 service.
+	// EnsureHealthCheckWithFirewall creates health check (and firewall rule) for l4 service.
+	EnsureHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureHealthCheckResult
+	// EnsureHealthCheckWithDualStackFirewalls creates health check (and firewall rule) for l4 service. Handles both IPv4 and IPv6.
+	EnsureHealthCheckWithDualStackFirewalls(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string, needsIPv4 bool, needsIPv6 bool) *EnsureHealthCheckResult
+	// DeleteHealthCheckWithFirewall deletes health check (and firewall rule) for l4 service.
 	DeleteHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
+	// DeleteHealthCheckWithDualStackFirewalls deletes health check (and firewall rule) for l4 service, deletes IPv6 firewalls if asked.
+	DeleteHealthCheckWithDualStackFirewalls(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
 }
 
-type EnsureL4HealthCheckResult struct {
-	HCName             string
-	HCLink             string
-	HCFirewallRuleName string
-	GceResourceInError string
-	Err                error
+type EnsureHealthCheckResult struct {
+	HCName                 string
+	HCLink                 string
+	HCFirewallRuleName     string
+	HCFirewallRuleIPv6Name string
+	GceResourceInError     string
+	Err                    error
 }
 
 type healthChecksProvider interface {

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/ingress-gce/pkg/loadbalancers"
+	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -49,12 +50,19 @@ const (
 )
 
 var (
-	ilbAnnotationKeys = []string{
-		annotations.FirewallRuleKey,
+	ilbCommonAnnotationKeys = []string{
 		annotations.BackendServiceKey,
 		annotations.HealthcheckKey,
+	}
+	ilbIPv4AnnotationKeys = []string{
+		annotations.FirewallRuleKey,
 		annotations.TCPForwardingRuleKey,
 		annotations.FirewallRuleForHealthcheckKey,
+	}
+	ilbIPv6AnnotationKeys = []string{
+		annotations.FirewallRuleIPv6Key,
+		annotations.TCPForwardingRuleIPv6Key,
+		annotations.FirewallRuleForHealthcheckIPv6Key,
 	}
 )
 
@@ -127,6 +135,17 @@ func getKeyForSvc(svc *api_v1.Service, t *testing.T) string {
 	return key
 }
 
+func calculateExpectedAnnotationsKeys(svc *api_v1.Service) []string {
+	expectedAnnotations := ilbCommonAnnotationKeys
+	if utils.NeedsIPv4(svc) {
+		expectedAnnotations = append(expectedAnnotations, ilbIPv4AnnotationKeys...)
+	}
+	if utils.NeedsIPv6(svc) {
+		expectedAnnotations = append(expectedAnnotations, ilbIPv6AnnotationKeys...)
+	}
+	return expectedAnnotations
+}
+
 func verifyILBServiceProvisioned(t *testing.T, svc *api_v1.Service) {
 	t.Helper()
 
@@ -137,8 +156,9 @@ func verifyILBServiceProvisioned(t *testing.T, svc *api_v1.Service) {
 		t.Errorf("Invalid LoadBalancer status field in service - %+v", svc.Status.LoadBalancer)
 	}
 
+	expectedAnnotationsKeys := calculateExpectedAnnotationsKeys(svc)
 	var missingKeys []string
-	for _, key := range ilbAnnotationKeys {
+	for _, key := range expectedAnnotationsKeys {
 		if _, ok := svc.Annotations[key]; !ok {
 			missingKeys = append(missingKeys, key)
 		}
@@ -159,13 +179,14 @@ func verifyILBServiceNotProvisioned(t *testing.T, svc *api_v1.Service) {
 		t.Errorf("Expected LoadBalancer status to be empty, Got %v", svc.Status.LoadBalancer)
 	}
 
+	expectedAnnotationsKeys := calculateExpectedAnnotationsKeys(svc)
 	var missingKeys []string
-	for _, key := range ilbAnnotationKeys {
+	for _, key := range expectedAnnotationsKeys {
 		if _, ok := svc.Annotations[key]; !ok {
 			missingKeys = append(missingKeys, key)
 		}
 	}
-	if len(missingKeys) != len(ilbAnnotationKeys) {
+	if len(missingKeys) != len(expectedAnnotationsKeys) {
 		t.Errorf("Unexpected ILB annotations present, Got %v", svc.Annotations)
 	}
 }
@@ -616,6 +637,7 @@ func TestProcessServiceWithDelayedNEGAdd(t *testing.T) {
 }
 
 func TestProcessServiceOnError(t *testing.T) {
+	t.Parallel()
 	l4c := newServiceController(t, newFakeGCEWithInsertError())
 	prevMetrics, err := test.GetL4ILBErrorMetric()
 	if err != nil {
@@ -636,4 +658,87 @@ func TestProcessServiceOnError(t *testing.T) {
 		t.Errorf("Error getting L4 ILB error metrics err: %v", errMetrics)
 	}
 	prevMetrics.ValidateDiff(currMetrics, expectMetrics, t)
+}
+
+func TestCreateDeleteDualStackService(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		ipFamilies []api_v1.IPFamily
+	}{
+		{
+			desc:       "Create and delete IPv4 ILB",
+			ipFamilies: []api_v1.IPFamily{api_v1.IPv4Protocol},
+		},
+		{
+			desc:       "Create and delete IPv4 IPv6 ILB",
+			ipFamilies: []api_v1.IPFamily{api_v1.IPv4Protocol, api_v1.IPv6Protocol},
+		},
+		{
+			desc:       "Create and delete IPv6 ILB",
+			ipFamilies: []api_v1.IPFamily{api_v1.IPv6Protocol},
+		},
+		{
+			desc:       "Create and delete IPv6 IPv4 ILB",
+			ipFamilies: []api_v1.IPFamily{api_v1.IPv6Protocol, api_v1.IPv4Protocol},
+		},
+		{
+			desc:       "Create and delete ILB with empty IP families",
+			ipFamilies: []api_v1.IPFamily{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			l4c := newServiceController(t, newFakeGCE())
+			l4c.enableDualStack = true
+			prevMetrics, err := test.GetL4ILBLatencyMetric()
+			if err != nil {
+				t.Errorf("Error getting L4 ILB latency metrics err: %v", err)
+			}
+			newSvc := test.NewL4ILBDualStackService(8080, api_v1.ProtocolTCP, tc.ipFamilies, api_v1.ServiceExternalTrafficPolicyTypeCluster)
+			addILBService(l4c, newSvc)
+			addNEG(l4c, newSvc)
+			err = l4c.sync(getKeyForSvc(newSvc, t))
+			if err != nil {
+				t.Errorf("Failed to sync newly added service %s, err %v", newSvc.Name, err)
+			}
+			// List the service and ensure that it contains the finalizer as well as Status field.
+			newSvc, err = l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, err)
+			}
+			verifyILBServiceProvisioned(t, newSvc)
+			currMetrics, metricErr := test.GetL4ILBLatencyMetric()
+			if metricErr != nil {
+				t.Errorf("Error getting L4 ILB latency metrics err: %v", metricErr)
+			}
+			prevMetrics.ValidateDiff(currMetrics, &test.L4LBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
+
+			// Remove the Internal LoadBalancer annotation, this should trigger a cleanup.
+			delete(newSvc.Annotations, gce.ServiceAnnotationLoadBalancerType)
+			updateILBService(l4c, newSvc)
+			err = l4c.sync(getKeyForSvc(newSvc, t))
+			if err != nil {
+				t.Errorf("Failed to sync updated service %s, err %v", newSvc.Name, err)
+			}
+
+			// List the service and ensure that it doesn't contain the finalizer as well as Status field.
+			newSvc, err = l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, err)
+			}
+			verifyILBServiceNotProvisioned(t, newSvc)
+			currMetrics, metricErr = test.GetL4ILBLatencyMetric()
+			if metricErr != nil {
+				t.Errorf("Error getting L4 ILB latency metrics err: %v", metricErr)
+			}
+			prevMetrics.ValidateDiff(currMetrics, &test.L4LBLatencyMetricInfo{CreateCount: 1, DeleteCount: 1, UpperBoundSeconds: 1}, t)
+			newSvc.DeletionTimestamp = &v1.Time{}
+			updateILBService(l4c, newSvc)
+			key, _ := common.KeyFunc(newSvc)
+			if err = l4c.sync(key); err != nil {
+				t.Errorf("Failed to sync deleted service %s, err %v", key, err)
+			}
+		})
+	}
 }

--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -73,6 +73,16 @@ func updateL4ResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Servic
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
+// updateL4DualStackResourcesAnnotations this function checks if new annotations should be added to dual-stack service and patch service metadata if needed.
+func updateL4DualStackResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string) error {
+	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4DualStackResourceAnnotationKeys)
+	if newObjectMeta == nil {
+		return nil
+	}
+	klog.V(3).Infof("Patching annotations of service %v/%v", svc.Namespace, svc.Name)
+	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
+}
+
 // deleteL4RBSAnnotations deletes all annotations which could be added by L4 ELB RBS controller
 func deleteL4RBSAnnotations(ctx *context.ControllerContext, svc *v1.Service) error {
 	newObjectMeta := computeNewAnnotationsIfNeeded(svc, nil, loadbalancers.L4RBSAnnotations)

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -876,7 +876,7 @@ func TestHealthCheckWhenExternalTrafficPolicyWasUpdated(t *testing.T) {
 	// Update ExternalTrafficPolicy to Cluster check if shared HC was created
 	err = updateAndAssertExternalTrafficPolicy(newSvc, lc, v1.ServiceExternalTrafficPolicyTypeCluster, hcNameShared)
 	if err != nil {
-		t.Errorf("Error asserthing shared health check %v", err)
+		t.Errorf("Error asserting shared health check %v", err)
 	}
 	newSvc.DeletionTimestamp = &metav1.Time{}
 	updateNetLBService(lc, newSvc)

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options)
+	if err != nil {
+		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v) returned error %w, want nil", bsLink, options, err)
+	}
+
+	existingIPv6FwdRule, err := l4.forwardingRules.Get(expectedIPv6FwdRule.Name)
+	if err != nil {
+		return nil, fmt.Errorf("l4.forwardingRules.GetForwardingRule(%s) returned error %w, want nil", expectedIPv6FwdRule.Name, err)
+	}
+
+	if existingIPv6FwdRule != nil {
+		equal, err := EqualIPv6ForwardingRules(existingIPv6FwdRule, expectedIPv6FwdRule)
+		if err != nil {
+			return existingIPv6FwdRule, err
+		}
+		if equal {
+			klog.V(2).Infof("ensureIPv6ForwardingRule: Skipping update of unchanged ipv6 forwarding rule - %s", expectedIPv6FwdRule.Name)
+			return existingIPv6FwdRule, nil
+		}
+		err = l4.deleteChangedIPv6ForwardingRule(existingIPv6FwdRule, expectedIPv6FwdRule)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	klog.V(2).Infof("ensureIPv6ForwardingRule: Creating/Recreating forwarding rule - %s", expectedIPv6FwdRule.Name)
+	err = l4.forwardingRules.Create(expectedIPv6FwdRule)
+	if err != nil {
+		return nil, err
+	}
+
+	createdFr, err := l4.forwardingRules.Get(expectedIPv6FwdRule.Name)
+	return createdFr, err
+}
+
+func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+	frName := l4.getIPv6FRName()
+
+	frDesc, err := utils.MakeL4IPv6ForwardingRuleDescription(l4.Service)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute description for forwarding rule %s, err: %w", frName, err)
+	}
+
+	subnetworkURL := l4.cloud.SubnetworkURL()
+
+	if options.SubnetName != "" {
+		subnetworkURL, err = l4.getSubnetworkURLByName(options.SubnetName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	svcPorts := l4.Service.Spec.Ports
+	ports := utils.GetPorts(svcPorts)
+	protocol := utils.GetProtocol(svcPorts)
+
+	fr := &composite.ForwardingRule{
+		Name:                frName,
+		Description:         frDesc,
+		IPProtocol:          string(protocol),
+		Ports:               ports,
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      bsLink,
+		IpVersion:           "IPV6",
+		Network:             l4.cloud.NetworkURL(),
+		Subnetwork:          subnetworkURL,
+		AllowGlobalAccess:   options.AllowGlobalAccess,
+		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+	}
+	if len(ports) > maxL4ILBPorts {
+		fr.Ports = nil
+		fr.AllPorts = true
+	}
+
+	return fr, nil
+}
+
+func (l4 *L4) deleteChangedIPv6ForwardingRule(existingFwdRule *composite.ForwardingRule, expectedFwdRule *composite.ForwardingRule) error {
+	frDiff := cmp.Diff(existingFwdRule, expectedFwdRule, cmpopts.IgnoreFields(composite.ForwardingRule{}, "IPAddress"))
+	klog.V(2).Infof("IPv6 forwarding rule changed - Existing - %+v\n, New - %+v\n, Diff(-existing, +new) - %s\n. Deleting existing ipv6 forwarding rule.", existingFwdRule, expectedFwdRule, frDiff)
+
+	err := l4.forwardingRules.Delete(existingFwdRule.Name)
+	if err != nil {
+		return err
+	}
+	l4.recorder.Eventf(l4.Service, corev1.EventTypeNormal, events.SyncIngress, "ForwardingRule %q deleted", existingFwdRule.Name)
+	return nil
+}
+
+func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) {
+	id1, err := cloud.ParseResourceURL(fr1.BackendService)
+	if err != nil {
+		return false, fmt.Errorf("EqualIPv6ForwardingRules(): failed to parse backend resource URL from FR, err - %w", err)
+	}
+	id2, err := cloud.ParseResourceURL(fr2.BackendService)
+	if err != nil {
+		return false, fmt.Errorf("EqualIPv6ForwardingRules(): failed to parse resource URL from FR, err - %w", err)
+	}
+	return fr1.IPProtocol == fr2.IPProtocol &&
+		fr1.LoadBalancingScheme == fr2.LoadBalancingScheme &&
+		utils.EqualStringSets(fr1.Ports, fr2.Ports) &&
+		id1.Equal(id2) &&
+		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
+		fr1.AllPorts == fr2.AllPorts &&
+		fr1.Subnetwork == fr2.Subnetwork &&
+		fr1.NetworkTier == fr2.NetworkTier, nil
+}

--- a/pkg/loadbalancers/forwarding_rules_ipv6_test.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"k8s.io/ingress-gce/pkg/composite"
+)
+
+func TestIPv6ForwardingRulesEqual(t *testing.T) {
+	t.Parallel()
+
+	emptyAddressFwdRule := &composite.ForwardingRule{
+		Name:                "empty-ip-address-fwd-rule",
+		IPAddress:           "",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	tcpFwdRule := &composite.ForwardingRule{
+		Name:                "tcp-fwd-rule",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	tcpFwdRuleIP2 := &composite.ForwardingRule{
+		Name:                "tcp-fwd-rule-ipv2",
+		IPAddress:           "0::2/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	udpFwdRule := &composite.ForwardingRule{
+		Name:                "udp-fwd-rule",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "UDP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	globalAccessFwdRule := &composite.ForwardingRule{
+		Name:                "global-access-fwd-rule",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		AllowGlobalAccess:   true,
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	bsLink1FwdRule := &composite.ForwardingRule{
+		Name:                "fwd-rule-bs-link1",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://compute.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	bsLink2FwdRule := &composite.ForwardingRule{
+		Name:                "fwd-rule-bs-link2",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	udpAllPortsFwdRule := &composite.ForwardingRule{
+		Name:                "udp-fwd-rule-all-ports",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		AllPorts:            true,
+		IPProtocol:          "UDP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+	}
+	bsLink2StandardNetworkTierFwdRule := &composite.ForwardingRule{
+		Name:                "fwd-rule-bs-link2-standard-network-tier",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		NetworkTier:         string(cloud.NetworkTierStandard),
+	}
+	bsLink2PremiumNetworkTierFwdRule := &composite.ForwardingRule{
+		Name:                "fwd-rule-bs-link2-premium-network-tier",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+	}
+
+	testCases := []struct {
+		desc        string
+		oldFwdRule  *composite.ForwardingRule
+		newFwdRule  *composite.ForwardingRule
+		expectEqual bool
+	}{
+		{
+			desc:        "empty and non empty ip should be equal",
+			oldFwdRule:  emptyAddressFwdRule,
+			newFwdRule:  tcpFwdRule,
+			expectEqual: true,
+		},
+		{
+			desc:        "forwarding rules different only in ips should be equal",
+			oldFwdRule:  tcpFwdRule,
+			newFwdRule:  tcpFwdRuleIP2,
+			expectEqual: true,
+		},
+		{
+			desc:        "global access enabled",
+			oldFwdRule:  tcpFwdRule,
+			newFwdRule:  globalAccessFwdRule,
+			expectEqual: false,
+		},
+		{
+			desc:        "IP protocol changed",
+			oldFwdRule:  tcpFwdRule,
+			newFwdRule:  udpFwdRule,
+			expectEqual: false,
+		},
+		{
+			desc:        "same forwarding rule",
+			oldFwdRule:  udpFwdRule,
+			newFwdRule:  udpFwdRule,
+			expectEqual: true,
+		},
+		{
+			desc:        "same forwarding rule, different basepath",
+			oldFwdRule:  bsLink1FwdRule,
+			newFwdRule:  bsLink2FwdRule,
+			expectEqual: true,
+		},
+		{
+			desc:        "same forwarding rule, one uses ALL keyword for ports",
+			oldFwdRule:  udpFwdRule,
+			newFwdRule:  udpAllPortsFwdRule,
+			expectEqual: false,
+		},
+		{
+			desc:        "network tier mismatch",
+			oldFwdRule:  bsLink2PremiumNetworkTierFwdRule,
+			newFwdRule:  bsLink2StandardNetworkTierFwdRule,
+			expectEqual: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := EqualIPv6ForwardingRules(tc.oldFwdRule, tc.newFwdRule)
+			if err != nil {
+				t.Errorf("EqualIPv6ForwardingRules(_, _) returned error %v, want nil", err)
+			}
+			if got != tc.expectEqual {
+				t.Errorf("EqualIPv6ForwardingRules(_, _) = %t, want %t", got, tc.expectEqual)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -83,6 +83,7 @@ func TestGetEffectiveIP(t *testing.T) {
 		})
 	}
 }
+
 func TestForwardingRulesEqual(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+	"k8s.io/legacy-cloud-providers/gce"
+)
+
+// ensureIPv6Resources creates resources specific to IPv6 L4 Load Balancers:
+// - IPv6 Forwarding Rule
+// - IPv6 Firewall
+// it also adds IPv6 address to LB status
+func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string) {
+	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options)
+	if err != nil {
+		klog.Errorf("ensureIPv6Resources: Failed to create ipv6 forwarding rule - %v", err)
+		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
+		syncResult.Error = err
+		return
+	}
+
+	if ipv6fr.IPProtocol == string(corev1.ProtocolTCP) {
+		syncResult.Annotations[annotations.TCPForwardingRuleIPv6Key] = ipv6fr.Name
+	} else {
+		syncResult.Annotations[annotations.UDPForwardingRuleIPv6Key] = ipv6fr.Name
+	}
+
+	firewallName := l4.namer.L4IPv6Firewall(l4.Service.Namespace, l4.Service.Name)
+	err = l4.ensureIPv6Firewall(ipv6fr, firewallName, nodeNames)
+	if err != nil {
+		syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource
+		syncResult.Error = err
+		return
+	}
+	syncResult.Annotations[annotations.FirewallRuleIPv6Key] = firewallName
+
+	trimmedIPv6Address := strings.Split(ipv6fr.IPAddress, "/")[0]
+	syncResult.Status = utils.AddIPToLBStatus(syncResult.Status, trimmedIPv6Address)
+}
+
+// deleteIPv6ResourcesOnSync deletes resources specific to IPv6,
+// only if corresponding resource annotation exist on Service object.
+// This function is called only on Service update or periodic sync.
+// Checking for annotation saves us from emitting too much error logs "Resource not found".
+// If annotation was deleted, but resource still exists, it will be left till the Service deletion,
+// where we delete all resources, no matter if they exist in annotations.
+func (l4 *L4) deleteIPv6ResourcesOnSync(syncResult *L4ILBSyncResult) {
+	l4.deleteIPv6ResourcesAnnotationBased(syncResult, true)
+}
+
+// deleteIPv6ResourcesOnDelete deletes all resources specific to IPv6.
+// This function is called only on Service deletion.
+// During sync, we delete resources only that exist in annotations,
+// so they could be leaked, if annotation was deleted.
+// That's why on service deletion we delete all IPv4 resources, ignoring their existence in annotations
+func (l4 *L4) deleteIPv6ResourcesOnDelete(syncResult *L4ILBSyncResult) {
+	l4.deleteIPv6ResourcesAnnotationBased(syncResult, false)
+}
+
+// deleteIPv6ResourcesAnnotationBased deletes IPv6 only resources with checking,
+// if resource exists in Service annotation, if shouldIgnoreAnnotations not set to true
+// IPv6 Specific resources:
+// - IPv6 Forwarding Rule
+// - IPv6 Address
+// - IPv6 Firewall
+// This function does not delete Backend Service and Health Check, because they are shared between IPv4 and IPv6.
+// IPv6 Firewall Rule for Health Check also will not be deleted here, and will be left till the Service Deletion.
+func (l4 *L4) deleteIPv6ResourcesAnnotationBased(syncResult *L4ILBSyncResult, shouldCheckAnnotations bool) {
+	if !shouldCheckAnnotations || l4.hasAnnotation(annotations.TCPForwardingRuleIPv6Key) || l4.hasAnnotation(annotations.UDPForwardingRuleIPv6Key) {
+		err := l4.deleteIPv6ForwardingRule()
+		if err != nil {
+			klog.Errorf("Failed to delete ipv6 forwarding rule for internal loadbalancer service %s, err %v", l4.NamespacedName.String(), err)
+			syncResult.Error = err
+			syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
+		}
+	}
+
+	if !shouldCheckAnnotations || l4.hasAnnotation(annotations.FirewallRuleIPv6Key) {
+		err := l4.deleteIPv6Firewall()
+		if err != nil {
+			klog.Errorf("Failed to delete ipv6 firewall rule for internal loadbalancer service %s, err %v", l4.NamespacedName.String(), err)
+			syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource
+			syncResult.Error = err
+		}
+	}
+}
+
+func (l4 *L4) getIPv6FRName() string {
+	protocol := utils.GetProtocol(l4.Service.Spec.Ports)
+	return l4.getIPv6FRNameWithProtocol(string(protocol))
+}
+
+func (l4 *L4) getIPv6FRNameWithProtocol(protocol string) string {
+	return l4.namer.L4IPv6ForwardingRule(l4.Service.Namespace, l4.Service.Name, strings.ToLower(protocol))
+}
+
+func (l4 *L4) ensureIPv6Firewall(forwardingRule *composite.ForwardingRule, firewallName string, nodeNames []string) error {
+	svcPorts := l4.Service.Spec.Ports
+	portRanges := utils.GetServicePortRanges(svcPorts)
+	protocol := utils.GetProtocol(svcPorts)
+
+	ipv6nodesFWRParams := firewalls.FirewallParams{
+		PortRanges: portRanges,
+		// TODO(panslava): support .spec.loadBalancerSourceRanges
+		SourceRanges:      []string{"0::0/0"},
+		DestinationRanges: []string{forwardingRule.IPAddress},
+		Protocol:          string(protocol),
+		Name:              firewallName,
+		NodeNames:         nodeNames,
+		L4Type:            utils.ILB,
+	}
+
+	return firewalls.EnsureL4LBFirewallForNodes(l4.Service, &ipv6nodesFWRParams, l4.cloud, l4.recorder)
+}
+
+func (l4 *L4) deleteIPv6ForwardingRule() error {
+	ipv6FrName := l4.getIPv6FRName()
+	return l4.forwardingRules.Delete(ipv6FrName)
+}
+
+func (l4 *L4) deleteIPv6Firewall() error {
+	ipv6FirewallName := l4.namer.L4IPv6Firewall(l4.Service.Namespace, l4.Service.Name)
+	return l4.deleteFirewall(ipv6FirewallName)
+}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -157,7 +157,8 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 	} else {
 		result.Annotations[annotations.UDPForwardingRuleKey] = fr.Name
 	}
-	result.Status = &corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: fr.IPAddress}}}
+
+	result.Status = utils.AddIPToLBStatus(result.Status, fr.IPAddress)
 	result.MetricsState.IsPremiumTier = fr.NetworkTier == cloud.NetworkTierPremium.ToGCEValue()
 	result.MetricsState.IsManagedIP = ipAddrType == IPAddrManaged
 

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -151,7 +151,7 @@ func TestDeleteL4NetLoadBalancerWithSharedHC(t *testing.T) {
 		t.Errorf("UnexpectedError %v", err.Error)
 	}
 	// Health check is in used by second service
-	// we expect that firewall rule will not be deleted
+	// we expectEqual that firewall rule will not be deleted
 	hcFwName := l4NetLB.namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, true)
 	firewall, err := l4NetLB.cloud.GetFirewall(hcFwName)
 	if err != nil || firewall == nil {
@@ -201,7 +201,7 @@ func TestHealthCheckFirewallDeletionWithILB(t *testing.T) {
 		t.Errorf("UnexpectedError %v", err.Error)
 	}
 
-	// When ILB health check uses the same firewall rules we expect that hc firewall rule will not be deleted.
+	// When ILB health check uses the same firewall rules we expectEqual that hc firewall rule will not be deleted.
 	hcName := l4NetLB.namer.L4HealthCheck(l4NetLB.Service.Namespace, l4NetLB.Service.Name, true)
 	hcFwName := l4NetLB.namer.L4HealthCheckFirewall(l4NetLB.Service.Namespace, l4NetLB.Service.Name, true)
 	firewall, err := l4NetLB.cloud.GetFirewall(hcFwName)

--- a/pkg/loadbalancers/l4syncresult.go
+++ b/pkg/loadbalancers/l4syncresult.go
@@ -35,3 +35,11 @@ var L4LBResourceAnnotationKeys = []string{
 }
 
 var L4RBSAnnotations = append(L4LBResourceAnnotationKeys, annotations.RBSAnnotationKey)
+
+var l4IPv6AnnotationKeys = []string{
+	annotations.FirewallRuleIPv6Key,
+	annotations.FirewallRuleForHealthcheckIPv6Key,
+	annotations.TCPForwardingRuleIPv6Key,
+	annotations.UDPForwardingRuleIPv6Key,
+}
+var L4DualStackResourceAnnotationKeys = append(L4LBResourceAnnotationKeys, l4IPv6AnnotationKeys...)

--- a/pkg/loadbalancers/l7s_test.go
+++ b/pkg/loadbalancers/l7s_test.go
@@ -191,21 +191,21 @@ func TestGC(t *testing.T) {
 
 		err := l7sPool.GCv1(tc.ingressLBs)
 		if err != nil {
-			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+			t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 		}
 
 		// check if other LB are not deleted
 		for _, key := range otherKeys {
 			namer := otherFeNamerFactory.NamerForLoadBalancer(otherNamer.LoadBalancer(key))
 			if err := checkFakeLoadBalancer(cloud, namer, versions, defaultScope, true); err != nil {
-				t.Errorf("For case %q and key %q, do not expect err: %v", tc.desc, key, err)
+				t.Errorf("For case %q and key %q, do not expectEqual err: %v", tc.desc, key, err)
 			}
 		}
 
 		// check if the total number of url maps are expected
 		urlMaps, _ := l7sPool.cloud.ListURLMaps()
 		if len(urlMaps) != len(tc.expectLBs)+len(otherKeys) {
-			t.Errorf("For case %q, expect %d urlmaps, but got %d.", tc.desc, len(tc.expectLBs)+len(otherKeys), len(urlMaps))
+			t.Errorf("For case %q, expectEqual %d urlmaps, but got %d.", tc.desc, len(tc.expectLBs)+len(otherKeys), len(urlMaps))
 		}
 
 		// check if the ones that are expected to be GC is actually GCed.
@@ -213,7 +213,7 @@ func TestGC(t *testing.T) {
 		for _, key := range expectRemovedLBs.List() {
 			namer := namerFactory.NamerForLoadBalancer(v1NamerHelper.LoadBalancer(key))
 			if err := checkFakeLoadBalancer(cloud, namer, versions, defaultScope, false); err != nil {
-				t.Errorf("For case %q and key %q, do not expect err: %v", tc.desc, key, err)
+				t.Errorf("For case %q and key %q, do not expectEqual err: %v", tc.desc, key, err)
 			}
 		}
 
@@ -221,7 +221,7 @@ func TestGC(t *testing.T) {
 		for _, key := range tc.expectLBs {
 			namer := namerFactory.NamerForLoadBalancer(v1NamerHelper.LoadBalancer(key))
 			if err := checkFakeLoadBalancer(cloud, namer, versions, defaultScope, true); err != nil {
-				t.Errorf("For case %q and key %q, do not expect err: %v", tc.desc, key, err)
+				t.Errorf("For case %q and key %q, do not expectEqual err: %v", tc.desc, key, err)
 			}
 			removeFakeLoadBalancer(cloud, namer, versions, defaultScope)
 		}
@@ -253,15 +253,15 @@ func TestDoNotGCWantedLB(t *testing.T) {
 		createFakeLoadbalancer(l7sPool.cloud, namer, versions, defaultScope)
 		err := l7sPool.GCv1([]string{tc.key})
 		if err != nil {
-			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+			t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 		}
 
 		if err := checkFakeLoadBalancer(l7sPool.cloud, namer, versions, defaultScope, true); err != nil {
-			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+			t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 		}
 		urlMaps, _ := l7sPool.cloud.ListURLMaps()
 		if len(urlMaps) != 1+numOfExtraUrlMap {
-			t.Errorf("For case %q, expect %d urlmaps, but got %d.", tc.desc, 1+numOfExtraUrlMap, len(urlMaps))
+			t.Errorf("For case %q, expectEqual %d urlmaps, but got %d.", tc.desc, 1+numOfExtraUrlMap, len(urlMaps))
 		}
 		removeFakeLoadBalancer(l7sPool.cloud, namer, versions, defaultScope)
 	}
@@ -289,17 +289,17 @@ func TestGCToLeakLB(t *testing.T) {
 		createFakeLoadbalancer(l7sPool.cloud, namer, versions, defaultScope)
 		err := l7sPool.GCv1([]string{})
 		if err != nil {
-			t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+			t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 		}
 
 		if len(tc.key) >= resourceLeakLimit {
 			if err := checkFakeLoadBalancer(l7sPool.cloud, namer, versions, defaultScope, true); err != nil {
-				t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+				t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 			}
 			removeFakeLoadBalancer(l7sPool.cloud, namer, versions, defaultScope)
 		} else {
 			if err := checkFakeLoadBalancer(l7sPool.cloud, namer, versions, defaultScope, false); err != nil {
-				t.Errorf("For case %q, do not expect err: %v", tc.desc, err)
+				t.Errorf("For case %q, do not expectEqual err: %v", tc.desc, err)
 			}
 		}
 	}
@@ -668,7 +668,7 @@ func checkFakeLoadBalancer(cloud *gce.Cloud, namer namer_util.IngressFrontendNam
 		return err
 	}
 	if !expectPresent && (err == nil || err.(*googleapi.Error).Code != http.StatusNotFound) {
-		return fmt.Errorf("expect URLMap %q to not present: %v", key, err)
+		return fmt.Errorf("expectEqual URLMap %q to not present: %v", key, err)
 	}
 	return nil
 }
@@ -689,7 +689,7 @@ func checkFakeLoadBalancerWithProtocol(cloud *gce.Cloud, namer namer_util.Ingres
 		return err
 	}
 	if !expectPresent && (err == nil || err.(*googleapi.Error).Code != http.StatusNotFound) {
-		return fmt.Errorf("expect %s GlobalForwardingRule %q to not present: %v", protocol, key, err)
+		return fmt.Errorf("expectEqual %s GlobalForwardingRule %q to not present: %v", protocol, key, err)
 	}
 
 	key.Name = namer.TargetProxy(protocol)
@@ -702,7 +702,7 @@ func checkFakeLoadBalancerWithProtocol(cloud *gce.Cloud, namer namer_util.Ingres
 		return err
 	}
 	if !expectPresent && (err == nil || err.(*googleapi.Error).Code != http.StatusNotFound) {
-		return fmt.Errorf("expect Target%sProxy %q to not present: %v", protocol, key, err)
+		return fmt.Errorf("expectEqual Target%sProxy %q to not present: %v", protocol, key, err)
 	}
 	return nil
 }

--- a/pkg/loadbalancers/loadbalancers_test.go
+++ b/pkg/loadbalancers/loadbalancers_test.go
@@ -639,7 +639,7 @@ func TestUpgradeToNewCertNames(t *testing.T) {
 	if _, err := j.pool.Ensure(lbInfo); err != nil {
 		t.Fatalf("pool.Ensure() = err %v", err)
 	}
-	// We expect to see only the new cert linked to the proxy and available in the load balancer.
+	// We expectEqual to see only the new cert linked to the proxy and available in the load balancer.
 	expectCerts := map[string]string{newCertName: tlsCert.Cert}
 	verifyCertAndProxyLink(expectCerts, expectCerts, j, t)
 }
@@ -1833,7 +1833,7 @@ func TestResourceDeletionWithProtocol(t *testing.T) {
 
 			lb, err = j.pool.Ensure(lbInfo)
 			if tc.disableHTTP && tc.disableHTTPS {
-				// we expect an invalid ingress configuration error here.
+				// we expectEqual an invalid ingress configuration error here.
 				errMsg := errAllProtocolsDisabled.Error()
 				if err == nil || !strings.Contains(err.Error(), errMsg) {
 					t.Fatalf("pool.Ensure(%+v) = %v, want %s", lbInfo, err, errMsg)

--- a/pkg/loadbalancers/url_maps.go
+++ b/pkg/loadbalancers/url_maps.go
@@ -111,7 +111,7 @@ func (l7 *L7) ensureRedirectURLMap() error {
 		return err
 	}
 
-	// Do not expect to have a RedirectUrlMap
+	// Do not expectEqual to have a RedirectUrlMap
 	if expectedMap == nil {
 		// Check if we need to GC
 		status, ok := l7.ingress.Annotations[annotations.RedirectUrlMapKey]

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -97,6 +97,27 @@ func NewL4ILBService(onlyLocal bool, port int) *api_v1.Service {
 	return svc
 }
 
+// NewL4ILBDualStackService creates a Service of type LoadBalancer with the Internal annotation and provided ipFamilies and ipFamilyPolicy
+func NewL4ILBDualStackService(port int, protocol api_v1.Protocol, ipFamilies []api_v1.IPFamily, externalTrafficPolicy api_v1.ServiceExternalTrafficPolicyType) *api_v1.Service {
+	svc := &api_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:        testServiceName,
+			Namespace:   testServiceNamespace,
+			Annotations: map[string]string{gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal)},
+		},
+		Spec: api_v1.ServiceSpec{
+			Type:            api_v1.ServiceTypeLoadBalancer,
+			SessionAffinity: api_v1.ServiceAffinityClientIP,
+			Ports: []api_v1.ServicePort{
+				{Name: "testport", Port: int32(port), Protocol: protocol},
+			},
+			ExternalTrafficPolicy: externalTrafficPolicy,
+			IPFamilies:            ipFamilies,
+		},
+	}
+	return svc
+}
+
 func NewL4LegacyNetLBServiceWithoutPorts() *api_v1.Service {
 	svc := &api_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{

--- a/pkg/utils/ipfamily.go
+++ b/pkg/utils/ipfamily.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "k8s.io/api/core/v1"
+
+func NeedsIPv6(service *v1.Service) bool {
+	return supportsIPFamily(service, v1.IPv6Protocol)
+}
+
+func NeedsIPv4(service *v1.Service) bool {
+	if service == nil {
+		return false
+	}
+	// Should never happen, defensive coding if kube-api did not populate IPFamilies
+	if len(service.Spec.IPFamilies) == 0 {
+		return true
+	}
+
+	return supportsIPFamily(service, v1.IPv4Protocol)
+}
+
+func supportsIPFamily(service *v1.Service, ipFamily v1.IPFamily) bool {
+	if service == nil {
+		return false
+	}
+
+	ipFamilies := service.Spec.IPFamilies
+	for _, ipf := range ipFamilies {
+		if ipf == ipFamily {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/ipfamily_test.go
+++ b/pkg/utils/ipfamily_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestNeedsIPv6(t *testing.T) {
+	testCases := []struct {
+		service       *v1.Service
+		wantNeedsIPv6 bool
+		desc          string
+	}{
+		{
+			desc:          "Should return false for nil pointer",
+			service:       nil,
+			wantNeedsIPv6: false,
+		},
+		{
+			desc: "Should detect ipv6 for dual-stack ip families",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			}},
+			wantNeedsIPv6: true,
+		},
+		{
+			desc: "Should not detect ipv6 for only ipv4 families",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			}},
+			wantNeedsIPv6: false,
+		},
+		{
+			desc: "Should detect ipv6 for only ipv6 families",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+			}},
+			wantNeedsIPv6: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			needsIPv6 := NeedsIPv6(tc.service)
+
+			if needsIPv6 != tc.wantNeedsIPv6 {
+				t.Errorf("NeedsIPv6(%v) returned %t, not equal to expected wantNeedsIPv6 = %t", tc.service, needsIPv6, tc.wantNeedsIPv6)
+			}
+		})
+	}
+}
+
+func TestNeedsIPv4(t *testing.T) {
+	testCases := []struct {
+		service       *v1.Service
+		wantNeedsIPv4 bool
+		desc          string
+	}{
+		{
+			desc:          "Should return false for nil pointer",
+			service:       nil,
+			wantNeedsIPv4: false,
+		},
+		{
+			desc: "Should handle dual-stack ip families",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			}},
+			wantNeedsIPv4: true,
+		},
+		{
+			desc: "Should handle only ipv4 family",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			}},
+			wantNeedsIPv4: true,
+		},
+		{
+			desc: "Should not handle only ipv6 family",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+			}},
+			wantNeedsIPv4: false,
+		},
+		{
+			desc: "Empty families should be recognized as IPv4. Should never happen in real life",
+			service: &v1.Service{Spec: v1.ServiceSpec{
+				IPFamilies: []v1.IPFamily{},
+			}},
+			wantNeedsIPv4: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			needsIPv4 := NeedsIPv4(tc.service)
+
+			if needsIPv4 != tc.wantNeedsIPv4 {
+				t.Errorf("NeedsIPv4(%v) returned %t, not equal to expected wantNeedsIPv6 = %t", tc.service, needsIPv4, tc.wantNeedsIPv4)
+			}
+		})
+	}
+}

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -89,10 +89,16 @@ type L4ResourcesNamer interface {
 	L4ForwardingRule(namespace, name, protocol string) string
 	// L4Firewall returns the name of the firewall rule for the given service
 	L4Firewall(namespace, name string) string
+	// L4IPv6Firewall returns the name of the ipv6 firewall rule for the given service
+	L4IPv6Firewall(namespace, name string) string
 	// L4HealthCheck returns the names of the Healthcheck
 	L4HealthCheck(namespace, name string, shared bool) string
 	// L4HealthCheckFirewall returns the names of the Healthcheck Firewall
 	L4HealthCheckFirewall(namespace, name string, shared bool) string
+	// L4IPv6ForwardingRule returns the name of the IPv6 forwarding rule for the given service and protocol.
+	L4IPv6ForwardingRule(namespace, name, protocol string) string
+	// L4IPv6HealthCheckFirewall returns the name of the IPv6 L4 LB health check firewall rule.
+	L4IPv6HealthCheckFirewall(namespace, name string, shared bool) string
 	// IsNEG returns if the given name is a VM_IP_NEG name.
 	IsNEG(name string) bool
 }

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -10,16 +10,19 @@ func TestL4Namer(t *testing.T) {
 	longstring1 := "012345678901234567890123456789012345678901234567890123456789abc"
 	longstring2 := "012345678901234567890123456789012345678901234567890123456789pqr"
 	testCases := []struct {
-		desc           string
-		namespace      string
-		name           string
-		proto          string
-		sharedHC       bool
-		expectFRName   string
-		expectNEGName  string
-		expectFWName   string
-		expectHcFwName string
-		expectHcName   string
+		desc              string
+		namespace         string
+		name              string
+		proto             string
+		sharedHC          bool
+		expectFRName      string
+		expectIPv6FRName  string
+		expectNEGName     string
+		expectFWName      string
+		expectIPv6FWName  string
+		expectHcFwName    string
+		expectIPv6HcFName string
+		expectHcName      string
 	}{
 		{
 			"simple case",
@@ -28,9 +31,12 @@ func TestL4Namer(t *testing.T) {
 			"TCP",
 			false,
 			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x-ipv6",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x-ipv6",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x-fw",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x-fw-ipv6",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 		},
 		{
@@ -40,9 +46,12 @@ func TestL4Namer(t *testing.T) {
 			"TCP",
 			true,
 			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x-ipv6",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x-ipv6",
 			"k8s2-7kpbhpki-l4-shared-hc-fw",
+			"k8s2-7kpbhpki-l4-shared-hc-fw-ipv6",
 			"k8s2-7kpbhpki-l4-shared-hc",
 		},
 		{
@@ -52,9 +61,12 @@ func TestL4Namer(t *testing.T) {
 			"UDP",
 			false,
 			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
+			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm-ipv6",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm-ipv6",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm40-fw",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678--fw-ipv6",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 		},
 		{
@@ -64,9 +76,12 @@ func TestL4Namer(t *testing.T) {
 			"UDP",
 			true,
 			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
+			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm-ipv6",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm-ipv6",
 			"k8s2-7kpbhpki-l4-shared-hc-fw",
+			"k8s2-7kpbhpki-l4-shared-hc-fw-ipv6",
 			"k8s2-7kpbhpki-l4-shared-hc",
 		},
 	}
@@ -74,15 +89,21 @@ func TestL4Namer(t *testing.T) {
 	newNamer := NewL4Namer(kubeSystemUID, nil)
 	for _, tc := range testCases {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
+		ipv6FrName := newNamer.L4IPv6ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		negName := newNamer.L4Backend(tc.namespace, tc.name)
 		fwName := newNamer.L4Firewall(tc.namespace, tc.name)
+		ipv6FWName := newNamer.L4IPv6Firewall(tc.namespace, tc.name)
 		hcName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
 		hcFwName := newNamer.L4HealthCheckFirewall(tc.namespace, tc.name, tc.sharedHC)
-		if len(frName) > maxResourceNameLength || len(negName) > maxResourceNameLength || len(fwName) > maxResourceNameLength || len(hcName) > maxResourceNameLength || len(hcFwName) > maxResourceNameLength {
-			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, len(fwName) == %v, len(hcName) == %v, len(hcFwName) == %v want <= 63", tc.desc, len(frName), len(negName), len(fwName), len(hcName), len(hcFwName))
+		ipv6hcFwName := newNamer.L4IPv6HealthCheckFirewall(tc.namespace, tc.name, tc.sharedHC)
+		if len(frName) > maxResourceNameLength || len(ipv6FrName) > maxResourceNameLength || len(negName) > maxResourceNameLength || len(fwName) > maxResourceNameLength || len(ipv6FWName) > maxResourceNameLength || len(hcName) > maxResourceNameLength || len(hcFwName) > maxResourceNameLength || len(ipv6hcFwName) > maxResourceNameLength {
+			t.Errorf("%s: got len(frName) == %v, got len(ipv6FrName) == %v, len(negName) == %v, len(fwName) == %v, len(ipv6FWName) == %v, len(hcName) == %v, len(hcFwName) == %v, len(ipv6hcFwName) == %v want <= %d", tc.desc, len(frName), len(ipv6FrName), len(negName), len(fwName), len(ipv6FWName), len(hcName), len(hcFwName), len(ipv6hcFwName), maxResourceNameLength)
 		}
 		if frName != tc.expectFRName {
 			t.Errorf("%s ForwardingRuleName: got %q, want %q", tc.desc, frName, tc.expectFRName)
+		}
+		if ipv6FrName != tc.expectIPv6FRName {
+			t.Errorf("%s IPv6 ForwardingRuleName: got %q, want %q", tc.desc, ipv6FrName, tc.expectIPv6FRName)
 		}
 		if negName != tc.expectNEGName {
 			t.Errorf("%s VMIPNEGName: got %q, want %q", tc.desc, negName, tc.expectFRName)
@@ -90,8 +111,14 @@ func TestL4Namer(t *testing.T) {
 		if fwName != tc.expectFWName {
 			t.Errorf("%s FirewallName: got %q, want %q", tc.desc, fwName, tc.expectFWName)
 		}
+		if ipv6FWName != tc.expectIPv6FWName {
+			t.Errorf("%s IPv6 FirewallName: got %q, want %q", tc.desc, ipv6FWName, tc.expectIPv6FWName)
+		}
 		if hcFwName != tc.expectHcFwName {
 			t.Errorf("%s FirewallName For Healthcheck: got %q, want %q", tc.desc, hcFwName, tc.expectHcFwName)
+		}
+		if ipv6hcFwName != tc.expectIPv6HcFName {
+			t.Errorf("%s IPv6 FirewallName For Healthcheck: got %q, want %q", tc.desc, ipv6hcFwName, tc.expectIPv6HcFName)
 		}
 		if hcName != tc.expectHcName {
 			t.Errorf("%s HealthCheckName: got %q, want %q", tc.desc, hcName, tc.expectHcName)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -756,6 +756,10 @@ func MakeL4LBServiceDescription(svcName, ip string, version meta.Version, shared
 	return (&L4LBResourceDescription{ServiceName: svcName, ServiceIP: ip, APIVersion: version}).Marshal()
 }
 
+func MakeL4IPv6ForwardingRuleDescription(service *api_v1.Service) (string, error) {
+	return (&L4LBResourceDescription{ServiceName: ServiceKeyFunc(service.Namespace, service.Name)}).Marshal()
+}
+
 // NewStringPointer returns a pointer to the provided string literal
 func NewStringPointer(s string) *string {
 	return &s
@@ -818,4 +822,17 @@ func GetServiceNodePort(service *api_v1.Service) int64 {
 		return 0
 	}
 	return int64(service.Spec.Ports[0].NodePort)
+}
+
+func AddIPToLBStatus(status *api_v1.LoadBalancerStatus, ips ...string) *api_v1.LoadBalancerStatus {
+	if status == nil {
+		status = &api_v1.LoadBalancerStatus{
+			Ingress: []api_v1.LoadBalancerIngress{},
+		}
+	}
+
+	for _, ip := range ips {
+		status.Ingress = append(status.Ingress, api_v1.LoadBalancerIngress{IP: ip})
+	}
+	return status
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1522,3 +1522,47 @@ func TestGetServicePortRanges(t *testing.T) {
 		})
 	}
 }
+
+func TestAddIPToLBStatus(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		status         *api_v1.LoadBalancerStatus
+		ipsToAdd       []string
+		expectedStatus *api_v1.LoadBalancerStatus
+	}{
+		{
+			desc:           "Should create empty status ingress if no IPs provided",
+			status:         nil,
+			ipsToAdd:       []string{},
+			expectedStatus: &api_v1.LoadBalancerStatus{Ingress: []api_v1.LoadBalancerIngress{}},
+		},
+		{
+			desc:     "Should add IPs to the empty status",
+			status:   nil,
+			ipsToAdd: []string{"1.1.1.1", "0::0"},
+			expectedStatus: &api_v1.LoadBalancerStatus{Ingress: []api_v1.LoadBalancerIngress{
+				{IP: "1.1.1.1"}, {IP: "0::0"},
+			}},
+		},
+		{
+			desc: "Should add IP to the existing status",
+			status: &api_v1.LoadBalancerStatus{Ingress: []api_v1.LoadBalancerIngress{
+				{IP: "0::0"},
+			}},
+			ipsToAdd: []string{"1.1.1.1"},
+			expectedStatus: &api_v1.LoadBalancerStatus{Ingress: []api_v1.LoadBalancerIngress{
+				{IP: "0::0"}, {IP: "1.1.1.1"},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			newStatus := AddIPToLBStatus(tc.status, tc.ipsToAdd...)
+
+			if !reflect.DeepEqual(tc.expectedStatus, newStatus) {
+				t.Errorf("newStatus = %v, not equal to expectedStatus = %v", newStatus, tc.expectedStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support for `spec.ipFamilies` and `spec.ipFamiliyPolicy` in L4 ILB

- Add new feature-flag `--enable-l4ilb-dual-stack`, all the new logic is hidden behind it
- Support all the transitions between ipFamilies, controller sync will provide resources for required ipFamily and clean resources for not required, but only if they exist in annotations
- On service deletion, clean up all the resources, no matter if they exist in annotations 