### PR TITLE
Extract to separate function L4HealthCheckFirewall from L4 namer L4HealthCheck

### DIFF
--- a/pkg/healthchecks/healthchecks_l4.go
+++ b/pkg/healthchecks/healthchecks_l4.go
@@ -78,7 +78,7 @@ func InitializeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) {
 	klog.V(3).Infof("Initialized L4 Healthchecks")
 }
 
-// FakeL4 creates instance of l4HealthChecks> USe for test only.
+// FakeL4 creates instance of l4HealthChecks. Use for test only.
 func FakeL4(cloud *gce.Cloud, recorderFactory events.RecorderProducer) *l4HealthChecks {
 	instance = &l4HealthChecks{
 		cloud:           cloud,
@@ -106,7 +106,8 @@ func L4() *l4HealthChecks {
 func (l4hc *l4HealthChecks) EnsureL4HealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureL4HealthCheckResult {
 	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 
-	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	hcName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	hcFwName := namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, sharedHC)
 	hcPath, hcPort := helpers.GetServiceHealthCheckPathPort(svc)
 	klog.V(3).Infof("Ensuring L4 healthcheck: %s and firewall rule %s from service %s, shared: %v.", hcName, hcFwName, namespacedName.String(), sharedHC)
 
@@ -143,8 +144,8 @@ func (l4hc *l4HealthChecks) EnsureL4HealthCheck(svc *corev1.Service, namer namer
 
 // DeleteHealthCheck deletes health check (and firewall rule) for l4 service. Checks if shared resources are safe to delete.
 func (l4hc *l4HealthChecks) DeleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error) {
-
-	hcName, hcFwName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	hcName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
+	hcFwName := namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, sharedHC)
 	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	klog.V(3).Infof("Trying to delete L4 healthcheck: %s and firewall rule %s from service %s, shared: %v", hcName, hcFwName, namespacedName.String(), sharedHC)
 	if sharedHC {

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -19,13 +19,13 @@ package l4lb
 import (
 	context2 "context"
 	"fmt"
-	"k8s.io/ingress-gce/pkg/healthchecks"
+	"net/http"
 	"testing"
 	"time"
 
-	"k8s.io/ingress-gce/pkg/loadbalancers"
+	"k8s.io/ingress-gce/pkg/healthchecks"
 
-	"net/http"
+	"k8s.io/ingress-gce/pkg/loadbalancers"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -250,7 +250,7 @@ func TestProcessCreateOrUpdate(t *testing.T) {
 		t.Errorf("Failed to sync deleted service %s, err %v", key, err)
 	}
 	for _, isShared := range []bool{true, false} {
-		hcName, _ := l4c.namer.L4HealthCheck(newSvc.Namespace, newSvc.Name, isShared)
+		hcName := l4c.namer.L4HealthCheck(newSvc.Namespace, newSvc.Name, isShared)
 		if !isHealthCheckDeleted(l4c.ctx.Cloud, hcName) {
 			t.Errorf("Health check %s should be deleted", hcName)
 		}
@@ -293,7 +293,7 @@ func TestProcessUpdateExternalTrafficPolicy(t *testing.T) {
 	validateSvcStatus(svc, true, t)
 	// Verify that both health checks were created.
 	for _, isShared := range []bool{true, false} {
-		hcName, _ := l4c.namer.L4HealthCheck(svc.Namespace, svc.Name, isShared)
+		hcName := l4c.namer.L4HealthCheck(svc.Namespace, svc.Name, isShared)
 		if isHealthCheckDeleted(l4c.ctx.Cloud, hcName) {
 			t.Errorf("Health check %s should be created", hcName)
 		}
@@ -307,7 +307,7 @@ func TestProcessUpdateExternalTrafficPolicy(t *testing.T) {
 	}
 	// Verify that both health checks were deleted.
 	for _, isShared := range []bool{true, false} {
-		hcName, _ := l4c.namer.L4HealthCheck(svc.Namespace, svc.Name, isShared)
+		hcName := l4c.namer.L4HealthCheck(svc.Namespace, svc.Name, isShared)
 		if !isHealthCheckDeleted(l4c.ctx.Cloud, hcName) {
 			t.Errorf("Health check %s should be deleted", hcName)
 		}

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -865,14 +865,14 @@ func TestHealthCheckWhenExternalTrafficPolicyWasUpdated(t *testing.T) {
 	}
 
 	// Update ExternalTrafficPolicy to Local check if nonshared HC was created
-	hcNameNonShared, _ := lc.namer.L4HealthCheck(svc.Namespace, svc.Name, false)
+	hcNameNonShared := lc.namer.L4HealthCheck(svc.Namespace, svc.Name, false)
 	err = updateAndAssertExternalTrafficPolicy(newSvc, lc, v1.ServiceExternalTrafficPolicyTypeLocal, hcNameNonShared)
 	if err != nil {
 		t.Errorf("Error asserthing nonshared health check %v", err)
 	}
 	// delete shared health check if is created, update service to Cluster and
 	// check that non-shared health check was created
-	hcNameShared, _ := lc.namer.L4HealthCheck(svc.Namespace, svc.Name, true)
+	hcNameShared := lc.namer.L4HealthCheck(svc.Namespace, svc.Name, true)
 	healthchecks.FakeL4(lc.ctx.Cloud, lc.ctx).DeleteHealthCheck(svc, lc.namer, true, meta.Regional, utils.XLB)
 	// Update ExternalTrafficPolicy to Cluster check if shared HC was created
 	err = updateAndAssertExternalTrafficPolicy(newSvc, lc, v1.ServiceExternalTrafficPolicyTypeCluster, hcNameShared)

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -294,7 +294,7 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 	fakeGCE.CreateFirewall(existingFirewall)
 
 	sharedHealthCheck := !servicehelper.RequestsOnlyLocalTraffic(svc)
-	hcName, _ := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHealthCheck)
+	hcName := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHealthCheck)
 
 	// Create a healthcheck with an incomplete fields
 	existingHC := &composite.HealthCheck{Name: hcName}
@@ -464,7 +464,7 @@ func TestEnsureInternalLoadBalancerHealthCheckConfigurable(t *testing.T) {
 		t.Errorf("Unexpected error when creating key - %v", err)
 	}
 	sharedHealthCheck := !servicehelper.RequestsOnlyLocalTraffic(svc)
-	hcName, _ := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHealthCheck)
+	hcName := l.namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHealthCheck)
 
 	// Create a healthcheck with an incorrect threshold, default value is 8s.
 	existingHC := &composite.HealthCheck{Name: hcName, CheckIntervalSec: 6000}
@@ -581,7 +581,7 @@ func TestEnsureInternalLoadBalancerDeletedWithSharedHC(t *testing.T) {
 		t.Errorf("Unexpected error %v", result.Error)
 	}
 	// When health check is shared we expect that hc firewall rule will not be deleted.
-	_, hcFwName := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	hcFwName := l.namer.L4HealthCheckFirewall(l.Service.Namespace, l.Service.Name, true)
 	firewall, err := l.cloud.GetFirewall(hcFwName)
 	if err != nil || firewall == nil {
 		t.Errorf("Expected firewall exists err: %v, fwR: %v", err, firewall)
@@ -625,7 +625,8 @@ func TestHealthCheckFirewallDeletionWithNetLB(t *testing.T) {
 	}
 
 	// When NetLB health check uses the same firewall rules we expect that hc firewall rule will not be deleted.
-	haName, hcFwName := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	hcName := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	hcFwName := l.namer.L4HealthCheckFirewall(l.Service.Namespace, l.Service.Name, true)
 	firewall, err := l.cloud.GetFirewall(hcFwName)
 	if err != nil {
 		t.Errorf("Expected error: firewall exists, got %v", err)
@@ -635,7 +636,7 @@ func TestHealthCheckFirewallDeletionWithNetLB(t *testing.T) {
 	}
 
 	// The healthcheck itself should be deleted.
-	healthcheck, err := l.cloud.GetHealthCheck(haName)
+	healthcheck, err := l.cloud.GetHealthCheck(hcName)
 	if err == nil || healthcheck != nil {
 		t.Errorf("Expected error when looking up shared healthcheck after deletion")
 	}
@@ -1287,7 +1288,8 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 	}
 	proto := utils.GetProtocol(apiService.Spec.Ports)
 	expectedAnnotations := make(map[string]string)
-	hcName, hcFwName := l.namer.L4HealthCheck(apiService.Namespace, apiService.Name, sharedHC)
+	hcName := l.namer.L4HealthCheck(apiService.Namespace, apiService.Name, sharedHC)
+	hcFwName := l.namer.L4HealthCheckFirewall(apiService.Namespace, apiService.Name, sharedHC)
 	// hcDesc is the resource description for healthcheck and firewall rule allowing healthcheck.
 	hcDesc := resourceDesc
 	if sharedHC {
@@ -1403,8 +1405,10 @@ func assertInternalLbResources(t *testing.T, apiService *v1.Service, l *L4, node
 func assertInternalLbResourcesDeleted(t *testing.T, apiService *v1.Service, firewallsDeleted bool, l *L4) {
 	frName := l.GetFRName()
 	resourceName, _ := l.namer.L4Backend(l.Service.Namespace, l.Service.Name)
-	hcNameShared, hcFwNameShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
-	hcNameNonShared, hcFwNameNonShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, false)
+	hcNameShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, true)
+	hcFwNameShared := l.namer.L4HealthCheckFirewall(l.Service.Namespace, l.Service.Name, true)
+	hcNameNonShared := l.namer.L4HealthCheck(l.Service.Namespace, l.Service.Name, false)
+	hcFwNameNonShared := l.namer.L4HealthCheckFirewall(l.Service.Namespace, l.Service.Name, false)
 
 	if firewallsDeleted {
 		// Check that Firewalls are deleted for the LoadBalancer and the HealthCheck

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -87,8 +87,10 @@ type L4ResourcesNamer interface {
 	BackendNamer
 	// L4ForwardingRule returns the name of the forwarding rule for the given service and protocol.
 	L4ForwardingRule(namespace, name, protocol string) string
-	// L4HealthCheck returns the names of the Healthcheck and HC-firewall rule.
-	L4HealthCheck(namespace, name string, shared bool) (string, string)
+	// L4HealthCheck returns the names of the Healthcheck
+	L4HealthCheck(namespace, name string, shared bool) string
+	// L4HealthCheckFirewall returns the names of the Healthcheck Firewall
+	L4HealthCheckFirewall(namespace, name string, shared bool) string
 	// IsNEG returns if the given name is a VM_IP_NEG name.
 	IsNEG(name string) bool
 }

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -74,14 +74,22 @@ func (namer *L4Namer) L4ForwardingRule(namespace, name, protocol string) string 
 	return strings.Join([]string{namer.v2Prefix, protocol, namer.v2ClusterUID, truncNamespace, truncName, namer.suffix(namespace, name)}, "-")
 }
 
-// L4HealthCheck returns the name of the L4 LB Healthcheck and the associated firewall rule.
-func (namer *L4Namer) L4HealthCheck(namespace, name string, shared bool) (string, string) {
+// L4HealthCheck returns the name of the L4 LB Healthcheck
+func (namer *L4Namer) L4HealthCheck(namespace, name string, shared bool) string {
+	if shared {
+		return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedHcSuffix}, "-")
+	}
+	l4Name, _ := namer.L4Backend(namespace, name)
+	return l4Name
+}
+
+// L4HealthCheckFirewall returns the name of the L4 LB Healthcheck Firewall
+func (namer *L4Namer) L4HealthCheckFirewall(namespace, name string, shared bool) string {
 	if !shared {
 		l4Name, _ := namer.L4Backend(namespace, name)
-		return l4Name, namer.hcFirewallName(l4Name)
+		return namer.hcFirewallName(l4Name)
 	}
-	return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedHcSuffix}, "-"),
-		strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedFirewallHcSuffix}, "-")
+	return strings.Join([]string{namer.v2Prefix, namer.v2ClusterUID, sharedFirewallHcSuffix}, "-")
 }
 
 // IsNEG indicates if the given name is a NEG following the L4 naming convention.

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -70,7 +70,8 @@ func TestL4Namer(t *testing.T) {
 	for _, tc := range testCases {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		negName, ok := newNamer.L4Backend(tc.namespace, tc.name)
-		hcName, hcFwName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
+		hcName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
+		hcFwName := newNamer.L4HealthCheckFirewall(tc.namespace, tc.name, tc.sharedHC)
 		if !ok {
 			t.Errorf("Namer does not support VMIPNEG")
 		}


### PR DESCRIPTION
Before we used single function to get L4 Health Check and L4 Health Check Firewall name

It is better to split it to separate functions