### PR TITLE
Add L4Firewall to namer, instead of using L4Backend

### DIFF
--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -87,6 +87,8 @@ type L4ResourcesNamer interface {
 	BackendNamer
 	// L4ForwardingRule returns the name of the forwarding rule for the given service and protocol.
 	L4ForwardingRule(namespace, name, protocol string) string
+	// L4Firewall returns the name of the firewall rule for the given service
+	L4Firewall(namespace, name string) string
 	// L4HealthCheck returns the names of the Healthcheck
 	L4HealthCheck(namespace, name string, shared bool) string
 	// L4HealthCheckFirewall returns the names of the Healthcheck Firewall

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -60,6 +60,17 @@ func (namer *L4Namer) L4Backend(namespace, name string) string {
 	}, "-")
 }
 
+// L4Firewall returns the gce Firewall name based on the service namespace and name
+// Naming convention:
+//
+//	k8s2-{uid}-{ns}-{name}-{suffix}
+//
+// Output name is at most 63 characters.
+// This name is identical to L4Backend.
+func (namer *L4Namer) L4Firewall(namespace, name string) string {
+	return namer.L4Backend(namespace, name)
+}
+
 // L4ForwardingRule returns the name of the L4 forwarding rule name based on the service namespace, name and protocol.
 // Naming convention:
 //

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -17,6 +17,7 @@ func TestL4Namer(t *testing.T) {
 		sharedHC       bool
 		expectFRName   string
 		expectNEGName  string
+		expectFWName   string
 		expectHcFwName string
 		expectHcName   string
 	}{
@@ -27,6 +28,7 @@ func TestL4Namer(t *testing.T) {
 			"TCP",
 			false,
 			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x-fw",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
@@ -39,6 +41,7 @@ func TestL4Namer(t *testing.T) {
 			true,
 			"k8s2-tcp-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-namespace-name-956p2p7x",
+			"k8s2-7kpbhpki-namespace-name-956p2p7x",
 			"k8s2-7kpbhpki-l4-shared-hc-fw",
 			"k8s2-7kpbhpki-l4-shared-hc",
 		},
@@ -49,6 +52,7 @@ func TestL4Namer(t *testing.T) {
 			"UDP",
 			false,
 			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm40-fw",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
@@ -61,6 +65,7 @@ func TestL4Namer(t *testing.T) {
 			true,
 			"k8s2-udp-7kpbhpki-012345678901234567-01234567890123456-hwm400mg",
 			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
+			"k8s2-7kpbhpki-01234567890123456789-0123456789012345678-hwm400mg",
 			"k8s2-7kpbhpki-l4-shared-hc-fw",
 			"k8s2-7kpbhpki-l4-shared-hc",
 		},
@@ -70,16 +75,20 @@ func TestL4Namer(t *testing.T) {
 	for _, tc := range testCases {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		negName := newNamer.L4Backend(tc.namespace, tc.name)
+		fwName := newNamer.L4Firewall(tc.namespace, tc.name)
 		hcName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)
 		hcFwName := newNamer.L4HealthCheckFirewall(tc.namespace, tc.name, tc.sharedHC)
-		if len(frName) > maxResourceNameLength || len(negName) > maxResourceNameLength || len(hcName) > maxResourceNameLength || len(hcFwName) > maxResourceNameLength {
-			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, len(hcName) == %v, len(hcFwName) == %v want <= 63", tc.desc, len(frName), len(negName), len(hcName), len(hcFwName))
+		if len(frName) > maxResourceNameLength || len(negName) > maxResourceNameLength || len(fwName) > maxResourceNameLength || len(hcName) > maxResourceNameLength || len(hcFwName) > maxResourceNameLength {
+			t.Errorf("%s: got len(frName) == %v, len(negName) == %v, len(fwName) == %v, len(hcName) == %v, len(hcFwName) == %v want <= 63", tc.desc, len(frName), len(negName), len(fwName), len(hcName), len(hcFwName))
 		}
 		if frName != tc.expectFRName {
 			t.Errorf("%s ForwardingRuleName: got %q, want %q", tc.desc, frName, tc.expectFRName)
 		}
 		if negName != tc.expectNEGName {
 			t.Errorf("%s VMIPNEGName: got %q, want %q", tc.desc, negName, tc.expectFRName)
+		}
+		if fwName != tc.expectFWName {
+			t.Errorf("%s FirewallName: got %q, want %q", tc.desc, fwName, tc.expectFWName)
 		}
 		if hcFwName != tc.expectHcFwName {
 			t.Errorf("%s FirewallName For Healthcheck: got %q, want %q", tc.desc, hcFwName, tc.expectHcFwName)


### PR DESCRIPTION
Currently, we using everywhere L4Backend() as a name for Firewall. It is a bit confusing, and can be handled on the level of namer, so this PR adds L4Firewall which returns result from L4Backend

I can not easily find and fix all the places in the test, where we still use L4Backend as name for Firewall, but I think it is not a big problem, and we will gradually fix it