### PR TITLE
Log if health check intended shared on deletion

### DIFF
--- a/pkg/healthchecksl4/healthchecksl4.go
+++ b/pkg/healthchecksl4/healthchecksl4.go
@@ -232,7 +232,7 @@ func (l4hc *l4HealthChecks) deleteHealthCheck(svc *corev1.Service, namer namer.L
 			klog.Errorf("Failed to delete healthcheck %s for service %s/%s - %v", hcName, svc.Namespace, svc.Name, err)
 			return false, err
 		}
-		klog.V(2).Infof("Failed to delete healthcheck %s: shared health check in use.", hcName)
+		klog.V(2).Infof("Failed to delete healthcheck %s is in use by other resource. Health check is shared in GKE = %t", hcName, sharedHC)
 		return false, nil
 	}
 	return true, nil


### PR DESCRIPTION
This improves debugging and logging

Some health checks are intended to be shared and will fail on deletion, but some can fail in the same way, even they were not intended to be shared, but user misconfigured it and attached to some resources, so it is useful to log if health check was intended to be shared