### PR TITLE
Use namer.L4Firewall and namer.L4Backend instead of servicePort

### DIFF
--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -83,7 +83,7 @@ func TestEnsureL4NetLoadBalancer(t *testing.T) {
 }
 
 func checkAnnotations(result *L4NetLBSyncResult, l4netlb *L4NetLB) error {
-	expBackendName := l4netlb.ServicePort.BackendName()
+	expBackendName := l4netlb.namer.L4Backend(l4netlb.Service.Namespace, l4netlb.Service.Name)
 	if result.Annotations[annotations.BackendServiceKey] != expBackendName {
 		return fmt.Errorf("BackendServiceKey mismatch %v != %v", expBackendName, result.Annotations[annotations.BackendServiceKey])
 	}


### PR DESCRIPTION
It is better to have single source of naming, which is L4Namer in l4netlb
This PR changes getting Backend Service name and Firewall name with using namer, instead of ServicePort
This PR also helps to add DualStack implementation 

/assign @kl52752 