### PR TITLE
Add a new NetL4LB flag

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -191,6 +191,7 @@ func main() {
 		Namespace:             flags.F.WatchNamespace,
 		ResyncPeriod:          flags.F.ResyncPeriod,
 		NumL4Workers:          flags.F.NumL4Workers,
+		NumL4NetLBWorkers:     flags.F.NumL4NetLBWorkers,
 		DefaultBackendSvcPort: defaultBackendServicePort,
 		HealthCheckPath:       flags.F.HealthCheckPath,
 		FrontendConfigEnabled: flags.F.EnableFrontendConfig,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -123,9 +123,10 @@ type ControllerContext struct {
 
 // ControllerContextConfig encapsulates some settings that are tunable via command line flags.
 type ControllerContextConfig struct {
-	Namespace    string
-	ResyncPeriod time.Duration
-	NumL4Workers int
+	Namespace         string
+	ResyncPeriod      time.Duration
+	NumL4Workers      int
+	NumL4NetLBWorkers int
 	// DefaultBackendSvcPortID is the ServicePort for the system default backend.
 	DefaultBackendSvcPort utils.ServicePort
 	HealthCheckPath       string

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -84,6 +84,7 @@ var (
 		ResyncPeriod                     time.Duration
 		L4NetLBProvisionDeadline         time.Duration
 		NumL4Workers                     int
+		NumL4NetLBWorkers                int
 		NumIngressWorkers                int
 		RunIngressController             bool
 		RunL4Controller                  bool
@@ -209,7 +210,9 @@ the pod secrets for creating a Kubernetes client.`)
 	flag.DurationVar(&F.L4NetLBProvisionDeadline, "l4-netlb-provision-deadline", 20*time.Minute,
 		`Deadline latency for L4 NetLB provisioning.`)
 	flag.IntVar(&F.NumL4Workers, "num-l4-workers", 5,
-		`Number of parallel L4 Service worker goroutines.`)
+		`Number of parallel L4 Internal Load Balancer Service worker goroutines.`)
+	flag.IntVar(&F.NumL4NetLBWorkers, "num-l4-net-workers", 5,
+		`Number of parallel L4 External Load Balancer Service worker goroutines.`)
 	flag.IntVar(&F.NumIngressWorkers, "num-ingress-workers", 1,
 		`Number of Ingress sync-queue worker goroutines.`)
 	flag.StringVar(&F.WatchNamespace, "watch-namespace", v1.NamespaceAll,

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -76,7 +76,7 @@ type L4Controller struct {
 // NewILBController creates a new instance of the L4 ILB controller.
 func NewILBController(ctx *context.ControllerContext, stopCh chan struct{}) *L4Controller {
 	if ctx.NumL4Workers <= 0 {
-		klog.Infof("L4 Worker count has not been set, setting to 1")
+		klog.Infof("L4 Internal LB Service worker count has not been set, setting to 1")
 		ctx.NumL4Workers = 1
 	}
 	l4c := &L4Controller{

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -66,9 +66,9 @@ type L4NetLBController struct {
 func NewL4NetLBController(
 	ctx *context.ControllerContext,
 	stopCh chan struct{}) *L4NetLBController {
-	if ctx.NumL4Workers <= 0 {
-		klog.Infof("L4 Worker count has not been set, setting to 1")
-		ctx.NumL4Workers = 1
+	if ctx.NumL4NetLBWorkers <= 0 {
+		klog.Infof("External L4 worker count has not been set, setting to 1")
+		ctx.NumL4NetLBWorkers = 1
 	}
 
 	backendPool := backends.NewPool(ctx.Cloud, ctx.L4Namer)
@@ -84,7 +84,7 @@ func NewL4NetLBController(
 		igLinker:        backends.NewRegionalInstanceGroupLinker(ctx.InstancePool, backendPool),
 		forwardingRules: forwardingrules.New(ctx.Cloud, meta.VersionGA, meta.Regional),
 	}
-	l4netLBc.svcQueue = utils.NewPeriodicTaskQueueWithMultipleWorkers("l4netLB", "services", ctx.NumL4Workers, l4netLBc.sync)
+	l4netLBc.svcQueue = utils.NewPeriodicTaskQueueWithMultipleWorkers("l4netLB", "services", ctx.NumL4NetLBWorkers, l4netLBc.sync)
 
 	ctx.ServiceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -221,10 +221,10 @@ func buildContext(vals gce.TestClusterValues) *ingctx.ControllerContext {
 	namer := namer.NewNamer(clusterUID, "")
 
 	ctxConfig := ingctx.ControllerContextConfig{
-		Namespace:    v1.NamespaceAll,
-		ResyncPeriod: 1 * time.Minute,
-		NumL4Workers: 5,
-		MaxIGSize:    1000,
+		Namespace:         v1.NamespaceAll,
+		ResyncPeriod:      1 * time.Minute,
+		NumL4NetLBWorkers: 5,
+		MaxIGSize:         1000,
 	}
 	return ingctx.NewControllerContext(nil, kubeClient, nil, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 }


### PR DESCRIPTION
Before this change there was only one flag "num-l4-workers" to keep a count of internal and external L4 load balancer goroutines. It's better to have 2 separate flags so the new "num-net-l4-workers" flag was added.

Signed-off-by: Elina Akhmanova <elinka@google.com>