### PR TITLE
Add Dual-Stack support to L4 NetLB

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -188,19 +188,20 @@ func main() {
 	cloud := app.NewGCEClient()
 	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)
 	ctxConfig := ingctx.ControllerContextConfig{
-		Namespace:             flags.F.WatchNamespace,
-		ResyncPeriod:          flags.F.ResyncPeriod,
-		NumL4Workers:          flags.F.NumL4Workers,
-		NumL4NetLBWorkers:     flags.F.NumL4NetLBWorkers,
-		DefaultBackendSvcPort: defaultBackendServicePort,
-		HealthCheckPath:       flags.F.HealthCheckPath,
-		FrontendConfigEnabled: flags.F.EnableFrontendConfig,
-		EnableASMConfigMap:    flags.F.EnableASMConfigMapBasedConfig,
-		ASMConfigMapNamespace: flags.F.ASMConfigMapBasedConfigNamespace,
-		ASMConfigMapName:      flags.F.ASMConfigMapBasedConfigCMName,
-		EndpointSlicesEnabled: flags.F.EnableEndpointSlices,
-		MaxIGSize:             flags.F.MaxIGSize,
-		EnableL4ILBDualStack:  flags.F.EnableL4ILBDualStack,
+		Namespace:              flags.F.WatchNamespace,
+		ResyncPeriod:           flags.F.ResyncPeriod,
+		NumL4Workers:           flags.F.NumL4Workers,
+		NumL4NetLBWorkers:      flags.F.NumL4NetLBWorkers,
+		DefaultBackendSvcPort:  defaultBackendServicePort,
+		HealthCheckPath:        flags.F.HealthCheckPath,
+		FrontendConfigEnabled:  flags.F.EnableFrontendConfig,
+		EnableASMConfigMap:     flags.F.EnableASMConfigMapBasedConfig,
+		ASMConfigMapNamespace:  flags.F.ASMConfigMapBasedConfigNamespace,
+		ASMConfigMapName:       flags.F.ASMConfigMapBasedConfigCMName,
+		EndpointSlicesEnabled:  flags.F.EnableEndpointSlices,
+		MaxIGSize:              flags.F.MaxIGSize,
+		EnableL4ILBDualStack:   flags.F.EnableL4ILBDualStack,
+		EnableL4NetLBDualStack: flags.F.EnableL4NetLBDualStack,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, svcNegClient, ingParamsClient, svcAttachmentClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -118,15 +118,16 @@ type ControllerContextConfig struct {
 	NumL4Workers      int
 	NumL4NetLBWorkers int
 	// DefaultBackendSvcPortID is the ServicePort for the system default backend.
-	DefaultBackendSvcPort utils.ServicePort
-	HealthCheckPath       string
-	FrontendConfigEnabled bool
-	EnableASMConfigMap    bool
-	ASMConfigMapNamespace string
-	ASMConfigMapName      string
-	EndpointSlicesEnabled bool
-	MaxIGSize             int
-	EnableL4ILBDualStack  bool
+	DefaultBackendSvcPort  utils.ServicePort
+	HealthCheckPath        string
+	FrontendConfigEnabled  bool
+	EnableASMConfigMap     bool
+	ASMConfigMapNamespace  string
+	ASMConfigMapName       string
+	EndpointSlicesEnabled  bool
+	MaxIGSize              int
+	EnableL4ILBDualStack   bool
+	EnableL4NetLBDualStack bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -110,6 +110,7 @@ var (
 		EnableEndpointSlices           bool
 		EnablePinhole                  bool
 		EnableL4ILBDualStack           bool
+		EnableL4NetLBDualStack         bool
 		EnableMultipleIGs              bool
 		MaxIGSize                      int
 	}{
@@ -254,6 +255,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableEndpointSlices, "enable-endpoint-slices", false, "Enable using Endpoint Slices API instead of Endpoints API")
 	flag.BoolVar(&F.EnablePinhole, "enable-pinhole", false, "Enable Pinhole firewall feature")
 	flag.BoolVar(&F.EnableL4ILBDualStack, "enable-l4ilb-dual-stack", false, "Enable Dual-Stack handling for L4 Internal Load Balancers")
+	flag.BoolVar(&F.EnableL4NetLBDualStack, "enable-l4netlb-dual-stack", false, "Enable Dual-Stack handling for L4 External Load Balancers")
 	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multiple unmanaged instance groups")
 	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)

--- a/pkg/healthchecksl4/healthchecksl4.go
+++ b/pkg/healthchecksl4/healthchecksl4.go
@@ -208,9 +208,10 @@ func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.Names
 // L4 ILB and L4 NetLB Services with ExternalTrafficPolicy=Cluster use the same firewall
 // rule at global scope.
 func (l4hc *l4HealthChecks) ensureIPv4Firewall(svc *corev1.Service, namer namer.L4ResourcesNamer, hcPort int32, isSharedHC bool, nodeNames []string, hcResult *EnsureHealthCheckResult) {
+	start := time.Now()
+
 	hcFwName := namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
 
-	start := time.Now()
 	klog.V(2).Infof("Ensuring IPv4 Firewall for health check %s for service %s/%s, health check port %d, shared health check: %t, len(nodeNames): %d", hcFwName, svc.Namespace, svc.Name, hcPort, isSharedHC, len(nodeNames))
 	defer func() {
 		klog.V(2).Infof("Finished ensuring IPv4 firewall for health check %s for service %s/%s, time taken %v", hcFwName, svc.Namespace, svc.Name, time.Since(start))
@@ -302,9 +303,10 @@ func (l4hc *l4HealthChecks) deleteHealthCheckWithDualStackFirewalls(svc *corev1.
 }
 
 func (l4hc *l4HealthChecks) deleteHealthCheck(svc *corev1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType) (bool, error) {
+	start := time.Now()
+
 	hcName := namer.L4HealthCheck(svc.Namespace, svc.Name, sharedHC)
 
-	start := time.Now()
 	klog.V(3).Infof("Deleting L4 healthcheck %s for service %s/%s, shared: %v, scope: %v", hcName, svc.Namespace, svc.Name, sharedHC, scope)
 	defer func() {
 		klog.V(3).Infof("Finished deleting L4 healthcheck %s for service %s/%s, time taken: %v", hcName, svc.Namespace, svc.Name, time.Since(start))
@@ -337,10 +339,11 @@ func (l4hc *l4HealthChecks) deleteIPv4HealthCheckFirewall(svc *corev1.Service, n
 }
 
 func (l4hc *l4HealthChecks) deleteIPv6HealthCheckFirewall(svc *corev1.Service, namer namer.L4ResourcesNamer, isSharedHC bool, l4type utils.L4LBType) (string, error) {
+	start := time.Now()
+
 	hcName := namer.L4HealthCheck(svc.Namespace, svc.Name, isSharedHC)
 	ipv6hcFwName := namer.L4IPv6HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
 
-	start := time.Now()
 	klog.V(3).Infof("Deleting IPv6 Firewall %s for health check %s", ipv6hcFwName, hcName)
 	defer func() {
 		klog.V(3).Infof("Finished deleting IPv6 Firewall %s for health check %s, time taken: %v", ipv6hcFwName, hcName, time.Since(start))

--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -95,6 +95,16 @@ func deleteL4RBSAnnotations(ctx *context.ControllerContext, svc *v1.Service) err
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
+// deleteL4RBSDualStackAnnotations deletes all annotations which could be added by L4 ELB RBS controller
+func deleteL4RBSDualStackAnnotations(ctx *context.ControllerContext, svc *v1.Service) error {
+	newObjectMeta := computeNewAnnotationsIfNeeded(svc, nil, loadbalancers.L4DualStackResourceRBSAnnotationKeys)
+	if newObjectMeta == nil {
+		return nil
+	}
+	klog.V(3).Infof("Deleting all DualStack annotations for L4 ELB RBS service %v/%v", svc.Namespace, svc.Name)
+	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
+}
+
 func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotationKey string) error {
 	newObjectMeta := svc.ObjectMeta.DeepCopy()
 	if _, ok := newObjectMeta.Annotations[annotationKey]; !ok {

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -207,11 +207,12 @@ func (l7 *L7) getEffectiveIP() (string, bool, error) {
 // ensureIPv4ForwardingRule creates a forwarding rule with the given name, if it does not exist. It updates the existing
 // forwarding rule if needed.
 func (l4 *L4) ensureIPv4ForwardingRule(bsLink string, options gce.ILBOptions, existingFwdRule *composite.ForwardingRule, subnetworkURL, ipToUse string) (*composite.ForwardingRule, error) {
+	start := time.Now()
+
 	// version used for creating the existing forwarding rule.
 	version := meta.VersionGA
 	frName := l4.GetFRName()
 
-	start := time.Now()
 	klog.V(2).Infof("Ensuring internal forwarding rule %s for L4 ILB Service %s/%s, backend service link: %s", frName, l4.Service.Namespace, l4.Service.Name, bsLink)
 	defer func() {
 		klog.V(2).Infof("Finished ensuring internal forwarding rule %s for L4 ILB Service %s/%s, time taken: %v", frName, l4.Service.Namespace, l4.Service.Name, time.Since(start))

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -32,12 +32,13 @@ import (
 )
 
 func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+	start := time.Now()
+
 	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options)
 	if err != nil {
 		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v) returned error %w, want nil", bsLink, options, err)
 	}
 
-	start := time.Now()
 	klog.V(2).Infof("Ensuring internal ipv6 forwarding rule %s for L4 ILB Service %s/%s, backend service link: %s", expectedIPv6FwdRule.Name, l4.Service.Namespace, l4.Service.Name, bsLink)
 	defer func() {
 		klog.V(2).Infof("Finished ensuring internal ipv6 forwarding rule %s for L4 ILB Service %s/%s, time taken: %v", expectedIPv6FwdRule.Name, l4.Service.Namespace, l4.Service.Name, time.Since(start))
@@ -128,10 +129,17 @@ func (l4 *L4) deleteChangedIPv6ForwardingRule(existingFwdRule *composite.Forward
 }
 
 func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.ForwardingRule, error) {
+	start := time.Now()
+
 	expectedIPv6FwdRule, err := l4netlb.buildExpectedIPv6ForwardingRule(bsLink)
 	if err != nil {
 		return nil, fmt.Errorf("l4netlb.buildExpectedIPv6ForwardingRule(%s) returned error %w, want nil", bsLink, err)
 	}
+
+	klog.V(2).Infof("Ensuring external ipv6 forwarding rule %s for L4 NetLB Service %s/%s, backend service link: %s", expectedIPv6FwdRule.Name, l4netlb.Service.Namespace, l4netlb.Service.Name, bsLink)
+	defer func() {
+		klog.V(2).Infof("Finished ensuring external ipv6 forwarding rule %s for L4 NetLB Service %s/%s, time taken: %v", expectedIPv6FwdRule.Name, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
 
 	existingIPv6FwdRule, err := l4netlb.forwardingRules.Get(expectedIPv6FwdRule.Name)
 	if err != nil {

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -264,7 +264,7 @@ func TestL4CreateExternalForwardingRuleAddressAlreadyInUse(t *testing.T) {
 	fakeGCE.ReserveRegionAddress(addr, fakeGCE.Region())
 	insertError := &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.IPAddress': '1.1.1.1'. Specified IP address is in-use and would result in a conflict., invalid"}
 	fakeGCE.Compute().(*cloud.MockGCE).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(insertError)
-	_, _, err := l4.ensureExternalForwardingRule("link")
+	_, _, err := l4.ensureIPv4ForwardingRule("link")
 
 	require.Error(t, err)
 	assert.True(t, utils.IsIPConfigurationError(err))

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -217,9 +217,10 @@ func (l4 *L4) deleteIPv4ResourcesAnnotationBased(result *L4ILBSyncResult, should
 }
 
 func (l4 *L4) deleteIPv4ForwardingRule() error {
+	start := time.Now()
+
 	frName := l4.GetFRName()
 
-	start := time.Now()
 	klog.Infof("Deleting IPv4 forwarding rule %s for L4 ILB Service %s/%s", frName, l4.Service.Namespace, l4.Service.Name)
 	defer func() {
 		klog.Infof("Finished deleting IPv4 forwarding rule %s for L4 ILB Service %s/%s, time taken: %v", frName, l4.Service.Namespace, l4.Service.Name, time.Since(start))
@@ -241,9 +242,10 @@ func (l4 *L4) deleteIPv4Address() error {
 }
 
 func (l4 *L4) deleteIPv4NodesFirewall() error {
+	start := time.Now()
+
 	firewallName := l4.namer.L4Firewall(l4.Service.Namespace, l4.Service.Name)
 
-	start := time.Now()
 	klog.Infof("Deleting IPv4 nodes firewall %s for L4 ILB Service %s/%s", firewallName, l4.Service.Namespace, l4.Service.Name)
 	defer func() {
 		klog.Infof("Finished deleting IPv4 nodes firewall %s for L4 ILB Service %s/%s, time taken: %v", firewallName, l4.Service.Namespace, l4.Service.Name, time.Since(start))

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -680,6 +680,7 @@ func TestHealthCheckFirewallDeletionWithNetLB(t *testing.T) {
 	if len(xlbResult.Status.Ingress) == 0 {
 		t.Errorf("Got empty loadBalancer status using handler %v", l4NetLB)
 	}
+	l4NetLB.Service.Annotations = xlbResult.Annotations
 	assertNetLBResources(t, l4NetLB, nodeNames)
 
 	// Delete the ILB loadbalancer
@@ -1801,7 +1802,7 @@ func TestDualStackLoadBalancerTransitions(t *testing.T) {
 	}
 }
 
-func TestDualStackLBCleansOnlyAnnotationResources(t *testing.T) {
+func TestDualStackILBCleansOnlyAnnotationResources(t *testing.T) {
 	t.Parallel()
 	nodeNames := []string{"test-node-1"}
 	vals := gce.DefaultTestClusterValues()

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -156,9 +156,10 @@ func (l4 *L4) ensureIPv6NodesFirewall(forwardingRule *composite.ForwardingRule, 
 }
 
 func (l4 *L4) deleteIPv6ForwardingRule() error {
+	start := time.Now()
+
 	ipv6FrName := l4.getIPv6FRName()
 
-	start := time.Now()
 	klog.V(2).Infof("Deleting IPv6 forwarding rule %s for L4 ILB Service %s/%s", ipv6FrName, l4.Service.Namespace, l4.Service.Name)
 	defer func() {
 		klog.V(2).Infof("Finished deleting IPv6 forwarding rule %s for L4 ILB Service %s/%s, time taken: %v", ipv6FrName, l4.Service.Namespace, l4.Service.Name, time.Since(start))

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -83,7 +83,6 @@ func (l4 *L4) deleteIPv6ResourcesOnDelete(syncResult *L4ILBSyncResult) {
 // if resource exists in Service annotation, if shouldIgnoreAnnotations not set to true
 // IPv6 Specific resources:
 // - IPv6 Forwarding Rule
-// - IPv6 Address
 // - IPv6 Firewall
 // This function does not delete Backend Service and Health Check, because they are shared between IPv4 and IPv6.
 // IPv6 Firewall Rule for Health Check also will not be deleted here, and will be left till the Service Deletion.

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -355,9 +355,10 @@ func (l4netlb *L4NetLB) deleteIPv4ResourcesAnnotationBased(result *L4NetLBSyncRe
 }
 
 func (l4netlb *L4NetLB) deleteIPv4ForwardingRule() error {
+	start := time.Now()
+
 	frName := l4netlb.frName()
 
-	start := time.Now()
 	klog.V(2).Infof("Deleting IPv4 external forwarding rule %s for L4 NetLB Service %s/%s", frName, l4netlb.Service.Namespace, l4netlb.Service.Name)
 	defer func() {
 		klog.V(2).Infof("Finished deleting IPv4 external forwarding rule %s for L4 NetLB Service %s/%s, time taken: %v", frName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
@@ -379,9 +380,10 @@ func (l4netlb *L4NetLB) deleteIPv4Address() error {
 }
 
 func (l4netlb *L4NetLB) deleteIPv4NodesFirewall() error {
+	start := time.Now()
+
 	firewallName := l4netlb.namer.L4Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
 
-	start := time.Now()
 	klog.V(2).Infof("Deleting IPv4 nodes firewall %s for L4 NetLB Service %s/%s", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name)
 	defer func() {
 		klog.V(2).Infof("Finished deleting IPv4 nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -51,6 +51,7 @@ type L4NetLB struct {
 	NamespacedName  types.NamespacedName
 	healthChecks    healthchecksl4.L4HealthChecks
 	forwardingRules ForwardingRulesProvider
+	enableDualStack bool
 }
 
 // L4NetLBSyncResult contains information about the outcome of an L4 NetLB sync. It stores the list of resource name annotations,
@@ -82,10 +83,11 @@ func (r *L4NetLBSyncResult) SetMetricsForSuccessfulServiceSync() {
 }
 
 type L4NetLBParams struct {
-	Service  *corev1.Service
-	Cloud    *gce.Cloud
-	Namer    namer.L4ResourcesNamer
-	Recorder record.EventRecorder
+	Service          *corev1.Service
+	Cloud            *gce.Cloud
+	Namer            namer.L4ResourcesNamer
+	Recorder         record.EventRecorder
+	DualStackEnabled bool
 }
 
 // NewL4NetLB creates a new Handler for the given L4NetLB service.
@@ -100,6 +102,7 @@ func NewL4NetLB(params *L4NetLBParams) *L4NetLB {
 		backendPool:     backends.NewPool(params.Cloud, params.Namer),
 		healthChecks:    healthchecksl4.NewL4HealthChecks(params.Cloud, params.Recorder),
 		forwardingRules: forwardingrules.New(params.Cloud, meta.VersionGA, meta.Regional),
+		enableDualStack: params.DualStackEnabled,
 	}
 	return l4netlb
 }
@@ -115,7 +118,6 @@ func (l4netlb *L4NetLB) createKey(name string) (*meta.Key, error) {
 // This function does not link instances to Backend Service.
 func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) *L4NetLBSyncResult {
 	result := NewL4SyncResult(SyncTypeCreate)
-
 	// If service already has an IP assigned, treat it as an update instead of a new Loadbalancer.
 	if len(svc.Status.LoadBalancer.Ingress) > 0 {
 		result.SyncType = SyncTypeUpdate
@@ -124,54 +126,156 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 
 	l4netlb.Service = svc
 
-	sharedHC := !helpers.RequestsOnlyLocalTraffic(svc)
+	hcLink := l4netlb.provideHealthChecks(nodeNames, result)
+	if result.Error != nil {
+		return result
+	}
+
+	bsLink := l4netlb.provideBackendService(result, hcLink)
+	if result.Error != nil {
+		return result
+	}
+
+	if l4netlb.enableDualStack {
+		l4netlb.ensureDualStackResources(result, nodeNames, bsLink)
+	} else {
+		l4netlb.ensureIPv4Resources(result, nodeNames, bsLink)
+	}
+
+	return result
+}
+
+func (l4netlb *L4NetLB) provideHealthChecks(nodeNames []string, result *L4NetLBSyncResult) string {
+	if l4netlb.enableDualStack {
+		return l4netlb.provideDualStackHealthChecks(nodeNames, result)
+	}
+	return l4netlb.provideIPv4HealthChecks(nodeNames, result)
+}
+
+func (l4netlb *L4NetLB) provideDualStackHealthChecks(nodeNames []string, result *L4NetLBSyncResult) string {
+	sharedHC := !helpers.RequestsOnlyLocalTraffic(l4netlb.Service)
+	hcResult := l4netlb.healthChecks.EnsureHealthCheckWithDualStackFirewalls(l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB, nodeNames, utils.NeedsIPv4(l4netlb.Service), utils.NeedsIPv6(l4netlb.Service))
+	if hcResult.Err != nil {
+		result.GCEResourceInError = hcResult.GceResourceInError
+		result.Error = hcResult.Err
+		return ""
+	}
+
+	if hcResult.HCFirewallRuleName != "" {
+		result.Annotations[annotations.FirewallRuleForHealthcheckKey] = hcResult.HCFirewallRuleName
+	}
+	if hcResult.HCFirewallRuleIPv6Name != "" {
+		result.Annotations[annotations.FirewallRuleForHealthcheckIPv6Key] = hcResult.HCFirewallRuleIPv6Name
+	}
+	result.Annotations[annotations.HealthcheckKey] = hcResult.HCName
+	return hcResult.HCLink
+}
+
+func (l4netlb *L4NetLB) provideIPv4HealthChecks(nodeNames []string, result *L4NetLBSyncResult) string {
+	sharedHC := !helpers.RequestsOnlyLocalTraffic(l4netlb.Service)
 	hcResult := l4netlb.healthChecks.EnsureHealthCheckWithFirewall(l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB, nodeNames)
 	if hcResult.Err != nil {
 		result.GCEResourceInError = hcResult.GceResourceInError
-		result.Error = fmt.Errorf("Failed to ensure health check %s - %w", hcResult.HCName, hcResult.Err)
-		return result
+		result.Error = hcResult.Err
+		return ""
 	}
 	result.Annotations[annotations.HealthcheckKey] = hcResult.HCName
 	result.Annotations[annotations.FirewallRuleForHealthcheckKey] = hcResult.HCFirewallRuleName
+	return hcResult.HCLink
+}
 
+func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcLink string) string {
 	bsName := l4netlb.namer.L4Backend(l4netlb.Service.Namespace, l4netlb.Service.Name)
 	servicePorts := l4netlb.Service.Spec.Ports
 	protocol := utils.GetProtocol(servicePorts)
-	bs, err := l4netlb.backendPool.EnsureL4BackendService(bsName, hcResult.HCLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName)
+	bs, err := l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName)
 	if err != nil {
-		result.GCEResourceInError = annotations.BackendServiceResource
-		result.Error = fmt.Errorf("Failed to ensure backend service %s - %w", bsName, err)
-		return result
+		syncResult.GCEResourceInError = annotations.BackendServiceResource
+		syncResult.Error = fmt.Errorf("Failed to ensure backend service %s - %w", bsName, err)
+		return ""
 	}
-	result.Annotations[annotations.BackendServiceKey] = bsName
+	syncResult.Annotations[annotations.BackendServiceKey] = bsName
+	return bs.SelfLink
+}
 
-	fr, ipAddrType, err := l4netlb.ensureExternalForwardingRule(bs.SelfLink)
+func (l4netlb *L4NetLB) ensureDualStackResources(result *L4NetLBSyncResult, nodeNames []string, bsLink string) {
+	if utils.NeedsIPv4(l4netlb.Service) {
+		l4netlb.ensureIPv4Resources(result, nodeNames, bsLink)
+	} else {
+		l4netlb.deleteIPv4ResourcesOnSync(result)
+	}
+	if utils.NeedsIPv6(l4netlb.Service) {
+		l4netlb.ensureIPv6Resources(result, nodeNames, bsLink)
+	} else {
+		l4netlb.deleteIPv6ResourcesOnSync(result)
+	}
+}
+
+// ensureIPv4Resources creates resources specific to IPv4 L4 Load Balancers:
+// - IPv4 Forwarding Rule
+// - IPv4 Firewall
+func (l4netlb *L4NetLB) ensureIPv4Resources(result *L4NetLBSyncResult, nodeNames []string, bsLink string) {
+	fr, ipAddrType, err := l4netlb.ensureIPv4ForwardingRule(bsLink)
 	if err != nil {
 		// User can misconfigure the forwarding rule if Network Tier will not match service level Network Tier.
 		result.MetricsState.IsUserError = utils.IsUserError(err)
 		result.GCEResourceInError = annotations.ForwardingRuleResource
-		result.Error = fmt.Errorf("Failed to ensure forwarding rule - %w", err)
-		return result
+		result.Error = fmt.Errorf("failed to ensure forwarding rule - %w", err)
+		return
 	}
 	if fr.IPProtocol == string(corev1.ProtocolTCP) {
 		result.Annotations[annotations.TCPForwardingRuleKey] = fr.Name
 	} else {
 		result.Annotations[annotations.UDPForwardingRuleKey] = fr.Name
 	}
+	result.MetricsState.IsManagedIP = ipAddrType == IPAddrManaged
+	result.MetricsState.IsPremiumTier = fr.NetworkTier == cloud.NetworkTierPremium.ToGCEValue()
+
+	l4netlb.ensureIPv4NodesFirewall(nodeNames, fr.IPAddress, result)
+	if result.Error != nil {
+		klog.Errorf("ensureIPv4Resources: Failed to ensure nodes firewall for L4 NetLB Service %s/%s, error: %v", l4netlb.Service.Namespace, l4netlb.Service.Name, err)
+		return
+	}
 
 	result.Status = utils.AddIPToLBStatus(result.Status, fr.IPAddress)
-	result.MetricsState.IsPremiumTier = fr.NetworkTier == cloud.NetworkTierPremium.ToGCEValue()
-	result.MetricsState.IsManagedIP = ipAddrType == IPAddrManaged
+}
+
+func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, result *L4NetLBSyncResult) {
+	start := time.Now()
 
 	firewallName := l4netlb.namer.L4Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
+	servicePorts := l4netlb.Service.Spec.Ports
 	portRanges := utils.GetServicePortRanges(servicePorts)
-	res := l4netlb.ensureNodesFirewall(firewallName, nodeNames, fr.IPAddress, portRanges, string(protocol))
-	if res.Error != nil {
-		return res
+	protocol := utils.GetProtocol(servicePorts)
+
+	klog.V(2).Infof("Ensuring nodes firewall %s for L4 NetLB Service %s/%s, ipAddress: %s, protocol: %s, len(nodeNames): %v, portRanges: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, ipAddress, protocol, len(nodeNames), portRanges)
+	defer func() {
+		klog.V(2).Infof("Finished ensuring nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
+
+	sourceRanges, err := utils.IPv4ServiceSourceRanges(l4netlb.Service)
+	if err != nil {
+		result.Error = err
+		return
+	}
+
+	// Add firewall rule for L4 External LoadBalancer traffic to nodes
+	nodesFWRParams := firewalls.FirewallParams{
+		PortRanges:        portRanges,
+		SourceRanges:      sourceRanges,
+		DestinationRanges: []string{ipAddress},
+		Protocol:          string(protocol),
+		Name:              firewallName,
+		IP:                l4netlb.Service.Spec.LoadBalancerIP,
+		NodeNames:         nodeNames,
+	}
+	result.Error = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &nodesFWRParams, l4netlb.cloud, l4netlb.recorder)
+	if result.Error != nil {
+		result.GCEResourceInError = annotations.FirewallRuleResource
+		result.Error = err
+		return
 	}
 	result.Annotations[annotations.FirewallRuleKey] = firewallName
-
-	return result
 }
 
 // EnsureLoadBalancerDeleted performs a cleanup of all GCE resources for the given loadbalancer service.
@@ -180,53 +284,122 @@ func (l4netlb *L4NetLB) EnsureLoadBalancerDeleted(svc *corev1.Service) *L4NetLBS
 	result := NewL4SyncResult(SyncTypeDelete)
 	l4netlb.Service = svc
 
-	// If any resource deletion fails, log the error and continue cleanup.
-	l4netlb.deleteExternalForwardingRule(result)
-	l4netlb.deleteAddress(result)
-	l4netlb.deleteNodesFirewall(result)
+	l4netlb.deleteIPv4ResourcesOnDelete(result)
+	if l4netlb.enableDualStack {
+		l4netlb.deleteIPv6ResourcesOnDelete(result)
+	}
+
 	l4netlb.deleteBackendService(result)
 	l4netlb.deleteHealthChecksWithFirewall(result)
 
 	return result
 }
 
-func (l4netlb *L4NetLB) deleteNodesFirewall(result *L4NetLBSyncResult) {
+// deleteIPv4ResourcesOnSync deletes resources specific to IPv4,
+// only if corresponding resource annotation exist on Service object.
+// This function is called only on Service update or periodic sync.
+// Checking for annotation saves us from emitting too much error logs "Resource not found".
+// If annotation was deleted, but resource still exists, it will be left till the Service deletion,
+// where we delete all resources, no matter if they exist in annotations.
+func (l4netlb *L4NetLB) deleteIPv4ResourcesOnSync(result *L4NetLBSyncResult) {
+	klog.Infof("Deleting IPv4 resources for L4 NetLB Service %s/%s on sync, with checking for existence in annotation", l4netlb.Service.Namespace, l4netlb.Service.Name)
+	l4netlb.deleteIPv4ResourcesAnnotationBased(result, false)
+}
+
+// deleteIPv4ResourcesOnDelete deletes all resources specific to IPv4.
+// This function is called only on Service deletion.
+// During sync, we delete resources only that exist in annotations,
+// so they could be leaked, if annotation was deleted.
+// That's why on service deletion we delete all IPv4 resources, ignoring their existence in annotations
+func (l4netlb *L4NetLB) deleteIPv4ResourcesOnDelete(result *L4NetLBSyncResult) {
+	klog.Infof("Deleting IPv4 resources for L4 NetLB Service %s/%s on delete, without checking for existence in annotation", l4netlb.Service.Namespace, l4netlb.Service.Name)
+	l4netlb.deleteIPv4ResourcesAnnotationBased(result, true)
+}
+
+// deleteIPv4ResourcesAnnotationBased deletes IPv4 only resources with checking,
+// if resource exists in Service annotation, if shouldIgnoreAnnotations not set to true
+// IPv4 Specific resources:
+// - IPv4 Forwarding Rule
+// - IPv4 Address
+// - IPv4 Firewall
+// This function does not delete Backend Service and Health Check, because they are shared between IPv4 and IPv6.
+// IPv4 Firewall Rule for Health Check also will not be deleted here, and will be left till the Service Deletion.
+func (l4netlb *L4NetLB) deleteIPv4ResourcesAnnotationBased(result *L4NetLBSyncResult, shouldIgnoreAnnotations bool) {
+	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.TCPForwardingRuleKey) || l4netlb.hasAnnotation(annotations.UDPForwardingRuleKey) {
+		err := l4netlb.deleteIPv4ForwardingRule()
+		if err != nil {
+			klog.Errorf("Failed to delete forwarding rule for NetLB RBS service %s, error: %v", l4netlb.NamespacedName.String(), err)
+			result.Error = err
+			result.GCEResourceInError = annotations.ForwardingRuleResource
+		}
+	}
+
+	// Deleting non-existent address do not print error audit logs, and we don't store address in annotations
+	// that's why we can delete it without checking annotation
+	err := l4netlb.deleteIPv4Address()
+	if err != nil {
+		klog.Errorf("Failed to delete address for NetLB RBS service %s, error: %v", l4netlb.NamespacedName.String(), err)
+		result.Error = err
+		result.GCEResourceInError = annotations.AddressResource
+	}
+
+	// delete firewall rule allowing load balancer source ranges
+	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.FirewallRuleKey) {
+		err = l4netlb.deleteIPv4NodesFirewall()
+		if err != nil {
+			klog.Errorf("Failed to delete firewall rule for NetLB RBS service %s, error: %v", l4netlb.NamespacedName.String(), err)
+			result.GCEResourceInError = annotations.FirewallRuleResource
+			result.Error = err
+		}
+	}
+}
+
+func (l4netlb *L4NetLB) deleteIPv4ForwardingRule() error {
+	frName := l4netlb.frName()
+
+	start := time.Now()
+	klog.V(2).Infof("Deleting IPv4 external forwarding rule %s for L4 NetLB Service %s/%s", frName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+	defer func() {
+		klog.V(2).Infof("Finished deleting IPv4 external forwarding rule %s for L4 NetLB Service %s/%s, time taken: %v", frName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
+
+	return l4netlb.forwardingRules.Delete(frName)
+}
+
+func (l4netlb *L4NetLB) deleteIPv4Address() error {
+	addressName := l4netlb.frName()
+
+	start := time.Now()
+	klog.V(2).Infof("Deleting IPv4 external static address %s for L4 NetLB service %s/%s", addressName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+	defer func() {
+		klog.V(2).Infof("Finished deleting IPv4 external static address %s for L4 NetLB service %s/%s, time taken: %v", addressName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
+
+	return ensureAddressDeleted(l4netlb.cloud, addressName, l4netlb.cloud.Region())
+}
+
+func (l4netlb *L4NetLB) deleteIPv4NodesFirewall() error {
 	firewallName := l4netlb.namer.L4Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
 
 	start := time.Now()
-	klog.V(2).Infof("Deleting nodes firewall %s for L4 NetLB Service %s/%s", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+	klog.V(2).Infof("Deleting IPv4 nodes firewall %s for L4 NetLB Service %s/%s", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name)
 	defer func() {
-		klog.V(2).Infof("Finished deleting nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+		klog.V(2).Infof("Finished deleting IPv4 nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
 	}()
 
+	return l4netlb.deleteFirewall(firewallName)
+}
+
+func (l4netlb *L4NetLB) deleteFirewall(firewallName string) error {
 	err := firewalls.EnsureL4FirewallRuleDeleted(l4netlb.cloud, firewallName)
 	if err != nil {
 		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
 			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
-			return
+			return nil
 		}
-
-		klog.Errorf("Failed to delete firewall rule %s for service %s - %v", firewallName, l4netlb.NamespacedName.String(), err)
-		result.GCEResourceInError = annotations.FirewallRuleResource
-		result.Error = err
+		return err
 	}
-}
-
-func (l4netlb *L4NetLB) deleteAddress(result *L4NetLBSyncResult) {
-	addressName := l4netlb.GetFRName()
-
-	start := time.Now()
-	klog.V(2).Infof("Deleting external static address %s for L4 NetLB service %s/%s", addressName, l4netlb.Service.Namespace, l4netlb.Service.Name)
-	defer func() {
-		klog.V(2).Infof("Finished deleting external static address %s for L4 NetLB service %s/%s, time taken: %v", addressName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
-	}()
-
-	err := ensureAddressDeleted(l4netlb.cloud, addressName, l4netlb.cloud.Region())
-	if err != nil {
-		klog.Errorf("Failed to delete address for service %s - %v", l4netlb.NamespacedName.String(), err)
-		result.Error = err
-		result.GCEResourceInError = annotations.AddressResource
-	}
+	return nil
 }
 
 func (l4netlb *L4NetLB) deleteBackendService(result *L4NetLBSyncResult) {
@@ -260,51 +433,34 @@ func (l4netlb *L4NetLB) deleteHealthChecksWithFirewall(result *L4NetLBSyncResult
 	// When service is deleted we need to check both health checks shared and non-shared
 	// and delete them if needed.
 	for _, isShared := range []bool{true, false} {
-		resourceInError, err := l4netlb.healthChecks.DeleteHealthCheckWithFirewall(l4netlb.Service, l4netlb.namer, isShared, meta.Regional, utils.XLB)
-		if err != nil {
-			result.GCEResourceInError = resourceInError
-			result.Error = err
-			// continue with deletion of the non-shared Healthcheck regardless of the error, both healthchecks may need to be deleted,
+		if l4netlb.enableDualStack {
+			resourceInError, err := l4netlb.healthChecks.DeleteHealthCheckWithDualStackFirewalls(l4netlb.Service, l4netlb.namer, isShared, meta.Regional, utils.XLB)
+			if err != nil {
+				result.GCEResourceInError = resourceInError
+				result.Error = err
+				// continue with deletion of the non-shared Healthcheck regardless of the error, both healthchecks may need to be deleted,
+			}
+		} else {
+			resourceInError, err := l4netlb.healthChecks.DeleteHealthCheckWithFirewall(l4netlb.Service, l4netlb.namer, isShared, meta.Regional, utils.XLB)
+			if err != nil {
+				result.GCEResourceInError = resourceInError
+				result.Error = err
+				// continue with deletion of the non-shared Healthcheck regardless of the error, both healthchecks may need to be deleted,
+			}
 		}
 	}
 }
 
-// GetFRName returns the name of the forwarding rule for the given L4 External LoadBalancer service.
-// This name should align with legacy forwarding rule name because we use forwarding rule to determine
-// which controller should process the service Ingress-GCE or k/k service controller.
-func (l4netlb *L4NetLB) GetFRName() string {
-	return utils.LegacyForwardingRuleName(l4netlb.Service)
+func (l4netlb *L4NetLB) hasAnnotation(annotationKey string) bool {
+	if _, ok := l4netlb.Service.Annotations[annotationKey]; ok {
+		return true
+	}
+	return false
 }
 
-func (l4netlb *L4NetLB) ensureNodesFirewall(name string, nodeNames []string, ipAddress string, portRanges []string, protocol string) *L4NetLBSyncResult {
-	start := time.Now()
-	klog.V(2).Infof("Ensuring nodes firewall %s for L4 NetLB Service %s/%s, ipAddress: %s, protocol: %s, len(nodeNames): %v, portRanges: %v", name, l4netlb.Service.Namespace, l4netlb.Service.Name, ipAddress, protocol, len(nodeNames), portRanges)
-	defer func() {
-		klog.V(2).Infof("Finished ensuring nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", name, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
-	}()
-
-	result := &L4NetLBSyncResult{}
-	sourceRanges, err := utils.IPv4ServiceSourceRanges(l4netlb.Service)
-	if err != nil {
-		result.Error = err
-		return result
-	}
-
-	// Add firewall rule for L4 External LoadBalancer traffic to nodes
-	nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:        portRanges,
-		SourceRanges:      sourceRanges,
-		DestinationRanges: []string{ipAddress},
-		Protocol:          protocol,
-		Name:              name,
-		IP:                l4netlb.Service.Spec.LoadBalancerIP,
-		NodeNames:         nodeNames,
-	}
-	result.Error = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &nodesFWRParams, l4netlb.cloud, l4netlb.recorder)
-	if result.Error != nil {
-		result.GCEResourceInError = annotations.FirewallRuleResource
-		result.Error = err
-		return result
-	}
-	return result
+// frName returns the name of the forwarding rule for the given L4 External LoadBalancer service.
+// This name should align with legacy forwarding rule name because we use forwarding rule to determine
+// which controller should process the service Ingress-GCE or k/k service controller.
+func (l4netlb *L4NetLB) frName() string {
+	return utils.LegacyForwardingRuleName(l4netlb.Service)
 }

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
+)
+
+const (
+	ipv6Suffix = "-ipv6"
+)
+
+// ensureIPv6Resources creates resources specific to IPv6 L4 NetLB Load Balancers:
+// - IPv6 Forwarding Rule
+// - IPv6 Firewall
+// it also adds IPv6 address to LB status
+func (l4netlb *L4NetLB) ensureIPv6Resources(syncResult *L4NetLBSyncResult, nodeNames []string, bsLink string) {
+	ipv6fr, err := l4netlb.ensureIPv6ForwardingRule(bsLink)
+	if err != nil {
+		klog.Errorf("ensureIPv6Resources: Failed to create ipv6 forwarding rule - %v", err)
+		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
+		syncResult.Error = err
+		return
+	}
+
+	if ipv6fr.IPProtocol == string(corev1.ProtocolTCP) {
+		syncResult.Annotations[annotations.TCPForwardingRuleIPv6Key] = ipv6fr.Name
+	} else {
+		syncResult.Annotations[annotations.UDPForwardingRuleIPv6Key] = ipv6fr.Name
+	}
+
+	l4netlb.ensureIPv6NodesFirewall(ipv6fr, nodeNames, syncResult)
+	if syncResult.Error != nil {
+		return
+	}
+
+	trimmedIPv6Address := strings.Split(ipv6fr.IPAddress, "/")[0]
+	syncResult.Status = utils.AddIPToLBStatus(syncResult.Status, trimmedIPv6Address)
+}
+
+// deleteIPv6ResourcesOnSync deletes resources specific to IPv6,
+// only if corresponding resource annotation exist on Service object.
+// This function is called only on Service update or periodic sync.
+// Checking for annotation saves us from emitting too much error logs "Resource not found".
+// If annotation was deleted, but resource still exists, it will be left till the Service deletion,
+// where we delete all resources, no matter if they exist in annotations.
+func (l4netlb *L4NetLB) deleteIPv6ResourcesOnSync(syncResult *L4NetLBSyncResult) {
+	l4netlb.deleteIPv6ResourcesAnnotationBased(syncResult, false)
+}
+
+// deleteIPv6ResourcesOnDelete deletes all resources specific to IPv6.
+// This function is called only on Service deletion.
+// During sync, we delete resources only that exist in annotations,
+// so they could be leaked, if annotation was deleted.
+// That's why on service deletion we delete all IPv4 resources, ignoring their existence in annotations
+func (l4netlb *L4NetLB) deleteIPv6ResourcesOnDelete(syncResult *L4NetLBSyncResult) {
+	l4netlb.deleteIPv6ResourcesAnnotationBased(syncResult, true)
+}
+
+// deleteIPv6ResourcesAnnotationBased deletes IPv6 only resources with checking,
+// if resource exists in Service annotation, if shouldIgnoreAnnotations not set to true
+// IPv6 Specific resources:
+// - IPv6 Forwarding Rule
+// - IPv6 Firewall
+// This function does not delete Backend Service and Health Check, because they are shared between IPv4 and IPv6.
+// IPv6 Firewall Rule for Health Check also will not be deleted here, and will be left till the Service Deletion.
+func (l4netlb *L4NetLB) deleteIPv6ResourcesAnnotationBased(syncResult *L4NetLBSyncResult, shouldIgnoreAnnotations bool) {
+	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.TCPForwardingRuleIPv6Key) || l4netlb.hasAnnotation(annotations.UDPForwardingRuleIPv6Key) {
+		l4netlb.deleteIPv6ForwardingRule(syncResult)
+	}
+
+	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.FirewallRuleIPv6Key) {
+		l4netlb.deleteIPv6NodesFirewall(syncResult)
+	}
+}
+
+func (l4netlb *L4NetLB) ipv6FRName() string {
+	return namer.GetSuffixedName(l4netlb.frName(), ipv6Suffix)
+}
+
+func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(forwardingRule *composite.ForwardingRule, nodeNames []string, syncResult *L4NetLBSyncResult) {
+	start := time.Now()
+
+	firewallName := l4netlb.namer.L4IPv6Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
+	svcPorts := l4netlb.Service.Spec.Ports
+	portRanges := utils.GetServicePortRanges(svcPorts)
+	protocol := utils.GetProtocol(svcPorts)
+
+	klog.V(2).Infof("Ensuring IPv6 nodes firewall %s for L4 ILB Service %s/%s, ipAddress: %s, protocol: %s, len(nodeNames): %v, portRanges: %v", firewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, forwardingRule.IPAddress, protocol, len(nodeNames), portRanges)
+	defer func() {
+		klog.V(2).Infof("Finished ensuring IPv6 nodes firewall %s for L4 ILB Service %s/%s, time taken: %v", l4netlb.Service.Namespace, l4netlb.Service.Name, firewallName, time.Since(start))
+	}()
+
+	// ensure firewalls
+	ipv6SourceRanges, err := utils.IPv6ServiceSourceRanges(l4netlb.Service)
+	if err != nil {
+		syncResult.Error = err
+		return
+	}
+
+	ipv6nodesFWRParams := firewalls.FirewallParams{
+		PortRanges:        portRanges,
+		SourceRanges:      ipv6SourceRanges,
+		DestinationRanges: []string{forwardingRule.IPAddress},
+		Protocol:          string(protocol),
+		Name:              firewallName,
+		NodeNames:         nodeNames,
+		L4Type:            utils.XLB,
+	}
+
+	err = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &ipv6nodesFWRParams, l4netlb.cloud, l4netlb.recorder)
+	if err != nil {
+		klog.Errorf("Failed to ensure ipv6 nodes firewall %s for L4 NetLB - %v", firewallName, err)
+		syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource
+		syncResult.Error = err
+		return
+	}
+	syncResult.Annotations[annotations.FirewallRuleIPv6Key] = firewallName
+}
+
+func (l4netlb *L4NetLB) deleteIPv6ForwardingRule(syncResult *L4NetLBSyncResult) {
+	ipv6FrName := l4netlb.ipv6FRName()
+
+	start := time.Now()
+	klog.V(2).Infof("Deleting IPv6 forwarding rule %s for L4 NetLB Service %s/%s", ipv6FrName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+	defer func() {
+		klog.V(2).Infof("Finished deleting IPv6 forwarding rule %s for L4 NetLB Service %s/%s, time taken: %v", ipv6FrName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
+
+	err := l4netlb.forwardingRules.Delete(ipv6FrName)
+	if err != nil {
+		klog.Errorf("Failed to delete ipv6 forwarding rule for external loadbalancer service %s, err %v", l4netlb.NamespacedName.String(), err)
+		syncResult.Error = err
+		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
+	}
+}
+
+func (l4netlb *L4NetLB) deleteIPv6NodesFirewall(syncResult *L4NetLBSyncResult) {
+	ipv6FirewallName := l4netlb.namer.L4IPv6Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
+
+	start := time.Now()
+	klog.V(2).Infof("Deleting IPv6 nodes firewall %s for L4 NetLB Service %s/%s", ipv6FirewallName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+	defer func() {
+		klog.V(2).Infof("Finished deleting IPv6 nodes firewall %s for L4 NetLB Service %s/%s, time taken: %v", ipv6FirewallName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
+	}()
+
+	err := l4netlb.deleteFirewall(ipv6FirewallName)
+	if err != nil {
+		klog.Errorf("Failed to delete ipv6 firewall rule for external loadbalancer service %s, err %v", l4netlb.NamespacedName.String(), err)
+		syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource
+		syncResult.Error = err
+	}
+}

--- a/pkg/loadbalancers/l4netlbipv6_test.go
+++ b/pkg/loadbalancers/l4netlbipv6_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/ingress-gce/pkg/test"
+)
+
+func TestIPv6FRName(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		svcUID             types.UID
+		expectedIPv6FRName string
+	}{
+		{
+			desc:               "Should add -ipv6 suffix to normal RBS forwarding rule name",
+			svcUID:             "09e0afadb26f4dccbc25d00f971b289",
+			expectedIPv6FRName: "a09e0afadb26f4dccbc25d00f971b289-ipv6",
+		},
+		{
+			// this test checks theoretical situation, in reality, we never have services with such a long UIDs
+			desc:               "Should trim and add -ipv6 suffix to normal RBS forwarding rule name",
+			svcUID:             "09e0afadb26f4dccbc25d00f971b289a09e0afadb26f4dccbc25d00f971b289",
+			expectedIPv6FRName: "a09e0afadb26f4dccbc25d00f971b289-ipv6",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := test.NewL4NetLBRBSService(8080)
+			svc.UID = tc.svcUID
+			l4NetLBParams := &L4NetLBParams{
+				Service: svc,
+			}
+			l4NetLB := NewL4NetLB(l4NetLBParams)
+
+			ipv6FRName := l4NetLB.ipv6FRName()
+			if ipv6FRName != tc.expectedIPv6FRName {
+				t.Errorf("Expecetd ipv6 forwarding rule name: %s, got %s", tc.expectedIPv6FRName, ipv6FRName)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/l4syncresult.go
+++ b/pkg/loadbalancers/l4syncresult.go
@@ -43,3 +43,4 @@ var l4IPv6AnnotationKeys = []string{
 	annotations.UDPForwardingRuleIPv6Key,
 }
 var L4DualStackResourceAnnotationKeys = append(L4LBResourceAnnotationKeys, l4IPv6AnnotationKeys...)
+var L4DualStackResourceRBSAnnotationKeys = append(L4DualStackResourceAnnotationKeys, annotations.RBSAnnotationKey)

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -154,11 +154,11 @@ func NewL4NetLBRBSService(port int) *api_v1.Service {
 }
 
 // NewL4NetLBRBSDualStackService creates a Service of type LoadBalancer with RBS Annotation and provided ipFamilies and ipFamilyPolicy
-func NewL4NetLBRBSDualStackService(port int, protocol api_v1.Protocol, ipFamilies []api_v1.IPFamily, externalTrafficPolicy api_v1.ServiceExternalTrafficPolicyType) *api_v1.Service {
+func NewL4NetLBRBSDualStackService(protocol api_v1.Protocol, ipFamilies []api_v1.IPFamily, externalTrafficPolicy api_v1.ServiceExternalTrafficPolicyType) *api_v1.Service {
 	svc := NewL4LegacyNetLBServiceWithoutPorts()
 	svc.ObjectMeta.Annotations[annotations.RBSAnnotationKey] = annotations.RBSEnabled
 	svc.Spec.Ports = []api_v1.ServicePort{
-		{Name: "testport", Port: int32(port), Protocol: protocol},
+		{Name: "testport", Port: int32(8080), Protocol: protocol},
 	}
 	svc.Spec.IPFamilies = ipFamilies
 	svc.Spec.ExternalTrafficPolicy = externalTrafficPolicy

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -153,6 +153,18 @@ func NewL4NetLBRBSService(port int) *api_v1.Service {
 	return svc
 }
 
+// NewL4NetLBRBSDualStackService creates a Service of type LoadBalancer with RBS Annotation and provided ipFamilies and ipFamilyPolicy
+func NewL4NetLBRBSDualStackService(port int, protocol api_v1.Protocol, ipFamilies []api_v1.IPFamily, externalTrafficPolicy api_v1.ServiceExternalTrafficPolicyType) *api_v1.Service {
+	svc := NewL4LegacyNetLBServiceWithoutPorts()
+	svc.ObjectMeta.Annotations[annotations.RBSAnnotationKey] = annotations.RBSEnabled
+	svc.Spec.Ports = []api_v1.ServicePort{
+		{Name: "testport", Port: int32(port), Protocol: protocol},
+	}
+	svc.Spec.IPFamilies = ipFamilies
+	svc.Spec.ExternalTrafficPolicy = externalTrafficPolicy
+	return svc
+}
+
 // NewL4NetLBRBSServiceMultiplePorts creates a Service of type LoadBalancer with multiple named ports.
 func NewL4NetLBRBSServiceMultiplePorts(name string, ports []int32) *api_v1.Service {
 	svc := NewL4LegacyNetLBServiceWithoutPorts()

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -79,7 +79,7 @@ func (namer *L4Namer) L4Firewall(namespace, name string) string {
 //
 // Output name is at most 63 characters.
 func (namer *L4Namer) L4IPv6Firewall(namespace, name string) string {
-	return getSuffixedName(namer.L4Backend(namespace, name), "-"+ipv6Suffix)
+	return GetSuffixedName(namer.L4Backend(namespace, name), "-"+ipv6Suffix)
 }
 
 // L4ForwardingRule returns the name of the L4 forwarding rule name based on the service namespace, name and protocol.
@@ -125,7 +125,7 @@ func (namer *L4Namer) L4HealthCheckFirewall(namespace, name string, shared bool)
 //
 // Output name is at most 63 characters.
 func (namer *L4Namer) L4IPv6ForwardingRule(namespace, name, protocol string) string {
-	return getSuffixedName(namer.L4ForwardingRule(namespace, name, protocol), "-"+ipv6Suffix)
+	return GetSuffixedName(namer.L4ForwardingRule(namespace, name, protocol), "-"+ipv6Suffix)
 }
 
 // L4IPv6HealthCheckFirewall returns the name of the IPv6 L4 LB health check firewall rule.
@@ -152,14 +152,14 @@ func (n *L4Namer) getClusterSuffix(namespace, name string) string {
 // hcFirewallName generates the firewall name for the given healthcheck.
 // It ensures that the name is at most 63 chars long.
 func (n *L4Namer) hcFirewallName(hcName, suffix string) string {
-	return getSuffixedName(hcName, firewallHcSuffix+suffix)
+	return GetSuffixedName(hcName, firewallHcSuffix+suffix)
 }
 
 func getTrimmedNamespacedName(namespace, name string, maxLength int) string {
 	return strings.Join(TrimFieldsEvenly(maxLength, namespace, name), "-")
 }
 
-func getSuffixedName(name string, suffix string) string {
+func GetSuffixedName(name string, suffix string) string {
 	return ensureSpaceForSuffix(name, suffix) + suffix
 }
 


### PR DESCRIPTION
Add support for `spec.ipFamilies` and `spec.ipFamiliyPolicy` in L4 NetLB

- Add new feature-flag `--enable-l4netlb-dual-stack`, all the new logic is hidden behind it
- Support all the transitions between ipFamilies, controller sync will provide resources for required ipFamily and clean resources for not required, but only if they exist in annotations
- On service deletion, clean up all the resources, no matter if they exist in annotations 