### PR TITLE
Refactor instances package, move node controller out of l7

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
 	"k8s.io/ingress-gce/pkg/ingparams"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/l4lb"
 	"k8s.io/ingress-gce/pkg/psc"
 	"k8s.io/ingress-gce/pkg/serviceattachment"
@@ -357,8 +358,14 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	ctx.Start(stopCh)
 
-	nodeController := controller.NewNodeController(ctx, stopCh)
-	go nodeController.Run()
+	igControllerParams := &instancegroups.ControllerConfig{
+		NodeInformer: ctx.NodeInformer,
+		IGManager:    ctx.InstancePool,
+		HasSynced:    ctx.HasSynced,
+		StopCh:       stopCh,
+	}
+	igController := instancegroups.NewController(igControllerParams)
+	go igController.Run()
 
 	// The L4NetLbController will be run when RbsMode flag is Set
 	if flags.F.RunL4NetLBController {

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends/features"
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
@@ -38,7 +38,7 @@ import (
 
 const defaultZone = "zone-a"
 
-func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instances.NodePool) *instanceGroupLinker {
+func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instancegroups.Manager) *instanceGroupLinker {
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.
@@ -50,10 +50,10 @@ func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instances.NodePool) *i
 }
 
 func TestLink(t *testing.T) {
-	fakeIGs := instances.NewEmptyFakeInstanceGroups()
+	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(&instances.NodePoolConfig{
+	fakeZL := &instancegroups.FakeZoneLister{Zones: []string{defaultZone}}
+	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      fakeIGs,
 		Namer:      defaultNamer,
 		Recorders:  &test.FakeRecorderSource{},
@@ -88,10 +88,10 @@ func TestLink(t *testing.T) {
 }
 
 func TestLinkWithCreationModeError(t *testing.T) {
-	fakeIGs := instances.NewEmptyFakeInstanceGroups()
+	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeNodePool := instances.NewNodePool(&instances.NodePoolConfig{
+	fakeZL := &instancegroups.FakeZoneLister{Zones: []string{defaultZone}}
+	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      fakeIGs,
 		Namer:      defaultNamer,
 		Recorders:  &test.FakeRecorderSource{},
@@ -175,7 +175,7 @@ func TestBackendsForIG(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := backendsForIGs(tc.igLinks, Rate, &tc.sp)
+			got := backendsForIGs(tc.igLinks, Rate)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("backendsForIGs(_), diff(-tc.want +got) = %s", diff)
 			}

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -28,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/healthchecks"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
 type Jig struct {
-	fakeInstancePool instances.NodePool
+	fakeInstancePool instancegroups.Manager
 	linker           Linker
 	syncer           Syncer
 	pool             Pool
@@ -45,9 +45,9 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
-	fakeIGs := instances.NewEmptyFakeInstanceGroups()
-	fakeZL := &instances.FakeZoneLister{Zones: []string{defaultZone}}
-	fakeInstancePool := instances.NewNodePool(&instances.NodePoolConfig{
+	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
+	fakeZL := &instancegroups.FakeZoneLister{Zones: []string{defaultZone}}
+	fakeInstancePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      fakeIGs,
 		Namer:      defaultNamer,
 		Recorders:  &test.FakeRecorderSource{},

--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -19,18 +19,18 @@ import (
 	cloudprovider "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
 // RegionalInstanceGroupLinker handles linking backends to InstanceGroups.
 type RegionalInstanceGroupLinker struct {
-	instancePool instances.NodePool
+	instancePool instancegroups.Manager
 	backendPool  Pool
 }
 
-func NewRegionalInstanceGroupLinker(instancePool instances.NodePool, backendPool Pool) *RegionalInstanceGroupLinker {
+func NewRegionalInstanceGroupLinker(instancePool instancegroups.Manager, backendPool Pool) *RegionalInstanceGroupLinker {
 	return &RegionalInstanceGroupLinker{
 		instancePool: instancePool,
 		backendPool:  backendPool,

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -44,9 +44,9 @@ func linkerTestClusterValues() gce.TestClusterValues {
 }
 
 func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
-	fakeIGs := instances.NewEmptyFakeInstanceGroups()
-	fakeZL := &instances.FakeZoneLister{Zones: []string{uscentralzone}}
-	fakeInstancePool := instances.NewNodePool(&instances.NodePoolConfig{
+	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
+	fakeZL := &instancegroups.FakeZoneLister{Zones: []string{uscentralzone}}
+	fakeInstancePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      fakeIGs,
 		Namer:      l4Namer,
 		Recorders:  &test.FakeRecorderSource{},

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -50,7 +50,7 @@ import (
 	informerfrontendconfig "k8s.io/ingress-gce/pkg/frontendconfig/client/informers/externalversions/frontendconfig/v1beta1"
 	ingparamsclient "k8s.io/ingress-gce/pkg/ingparams/client/clientset/versioned"
 	informeringparams "k8s.io/ingress-gce/pkg/ingparams/client/informers/externalversions/ingparams/v1beta1"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/metrics"
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
 	informerserviceattachment "k8s.io/ingress-gce/pkg/serviceattachment/client/informers/externalversions/serviceattachment/v1"
@@ -117,7 +117,7 @@ type ControllerContext struct {
 	// controller logic and should only be used for providing additional information to the user.
 	RegionalCluster bool
 
-	InstancePool instances.NodePool
+	InstancePool instancegroups.Manager
 	Translator   *translator.Translator
 }
 
@@ -210,7 +210,7 @@ func NewControllerContext(
 		context.UseEndpointSlices,
 		context.KubeClient,
 	)
-	context.InstancePool = instances.NewNodePool(&instances.NodePoolConfig{
+	context.InstancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      context.Cloud,
 		Namer:      context.ClusterNamer,
 		Recorders:  context,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/frontendconfig"
 	"k8s.io/ingress-gce/pkg/healthchecks"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/metrics"
@@ -77,7 +77,7 @@ type LoadBalancerController struct {
 	hasSynced func() bool
 
 	// Resource pools.
-	instancePool instances.NodePool
+	instancePool instancegroups.Manager
 	l7Pool       loadbalancers.LoadBalancerPool
 
 	// syncer implementation for backends

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/events"
 	"k8s.io/ingress-gce/pkg/flags"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/translator"
@@ -61,7 +61,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	fakeZL := &instances.FakeZoneLister{Zones: []string{fakeZone}}
+	fakeZL := &instancegroups.FakeZoneLister{Zones: []string{fakeZone}}
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockGlobalForwardingRules.InsertHook = loadbalancers.InsertGlobalForwardingRuleHook
 	namer := namer_util.NewNamer(clusterUID, "")
 
@@ -75,8 +75,8 @@ func newLoadBalancerController() *LoadBalancerController {
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
 	lbc := NewLoadBalancerController(ctx, stopCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
-	lbc.instancePool = instances.NewNodePool(&instances.NodePoolConfig{
-		Cloud:      instances.NewEmptyFakeInstanceGroups(),
+	lbc.instancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
+		Cloud:      instancegroups.NewEmptyFakeInstanceGroups(),
 		Namer:      namer,
 		Recorders:  &test.FakeRecorderSource{},
 		BasePath:   utils.GetBasePath(fakeGCE),

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	compute "google.golang.org/api/compute/v1"
-	api_v1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -56,16 +55,6 @@ func uniq(svcPorts []utils.ServicePort) []utils.ServicePort {
 		svcPorts = append(svcPorts, sp)
 	}
 	return svcPorts
-}
-
-func nodeStatusChanged(old, cur *api_v1.Node) bool {
-	if old.Spec.Unschedulable != cur.Spec.Unschedulable {
-		return true
-	}
-	if utils.NodeIsReady(old) != utils.NodeIsReady(cur) {
-		return true
-	}
-	return false
 }
 
 func convert(ings []*v1.Ingress) (retVal []interface{}) {

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -158,51 +158,6 @@ func TestAddInstanceGroupsAnnotation(t *testing.T) {
 	}
 }
 
-func TestNodeStatusChanged(t *testing.T) {
-	testCases := []struct {
-		desc   string
-		mutate func(node *api_v1.Node)
-		expect bool
-	}{
-		{
-			"no change",
-			func(node *api_v1.Node) {},
-			false,
-		},
-		{
-			"unSchedulable changes",
-			func(node *api_v1.Node) {
-				node.Spec.Unschedulable = true
-			},
-			true,
-		},
-		{
-			"readiness changes",
-			func(node *api_v1.Node) {
-				node.Status.Conditions[0].Status = api_v1.ConditionFalse
-				node.Status.Conditions[0].LastTransitionTime = meta_v1.NewTime(time.Now())
-			},
-			true,
-		},
-		{
-			"new heartbeat",
-			func(node *api_v1.Node) {
-				node.Status.Conditions[0].LastHeartbeatTime = meta_v1.NewTime(time.Now())
-			},
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		node := testNode()
-		tc.mutate(node)
-		res := nodeStatusChanged(testNode(), node)
-		if res != tc.expect {
-			t.Fatalf("Test case %q got: %v, expected: %v", tc.desc, res, tc.expect)
-		}
-	}
-}
-
 func TestUniq(t *testing.T) {
 	testCases := []struct {
 		desc   string
@@ -365,31 +320,6 @@ func TestGetNodePortsUsedByIngress(t *testing.T) {
 		}
 	}
 
-}
-
-func testNode() *api_v1.Node {
-	return &api_v1.Node{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: "ns",
-			Name:      "node",
-			Annotations: map[string]string{
-				"key1": "value1",
-			},
-		},
-		Spec: api_v1.NodeSpec{
-			Unschedulable: false,
-		},
-		Status: api_v1.NodeStatus{
-			Conditions: []api_v1.NodeCondition{
-				{
-					Type:               api_v1.NodeReady,
-					Status:             api_v1.ConditionTrue,
-					LastHeartbeatTime:  meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
-					LastTransitionTime: meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
-				},
-			},
-		},
-	}
 }
 
 func testServicePort(namespace, name, port string, servicePort, nodePort int, enableNEG bool) utils.ServicePort {

--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package instancegroups
 
 import (
 	"time"
@@ -22,21 +22,19 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/instances"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
-// NodeController synchronizes the state of the nodes to the unmanaged instance
+// Controller synchronizes the state of the nodes to the unmanaged instance
 // groups.
-type NodeController struct {
+type Controller struct {
 	// lister is a cache of the k8s Node resources.
 	lister cache.Indexer
 	// queue is the TaskQueue used to manage the node worker updates.
 	queue utils.TaskQueue
-	// instancePool is a NodePool to manage kubernetes nodes.
-	instancePool instances.NodePool
+	// igManager is an interface to manage instance groups.
+	igManager Manager
 	// hasSynced returns true if relevant caches have done their initial
 	// synchronization.
 	hasSynced func() bool
@@ -44,17 +42,24 @@ type NodeController struct {
 	stopCh chan struct{}
 }
 
-// NewNodeController returns a new node update controller.
-func NewNodeController(ctx *context.ControllerContext, stopCh chan struct{}) *NodeController {
-	c := &NodeController{
-		lister:       ctx.NodeInformer.GetIndexer(),
-		instancePool: ctx.InstancePool,
-		hasSynced:    ctx.HasSynced,
-		stopCh:       stopCh,
+type ControllerConfig struct {
+	NodeInformer cache.SharedIndexInformer
+	IGManager    Manager
+	HasSynced    func() bool
+	StopCh       chan struct{}
+}
+
+// NewController returns a new node update controller.
+func NewController(config *ControllerConfig) *Controller {
+	c := &Controller{
+		lister:    config.NodeInformer.GetIndexer(),
+		igManager: config.IGManager,
+		hasSynced: config.HasSynced,
+		stopCh:    config.StopCh,
 	}
 	c.queue = utils.NewPeriodicTaskQueue("", "nodes", c.sync)
 
-	ctx.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	config.NodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Enqueue(obj)
 		},
@@ -72,7 +77,7 @@ func NewNodeController(ctx *context.ControllerContext, stopCh chan struct{}) *No
 
 // Run the queue to process updates for the controller. This must be run in a
 // separate goroutine (method will block until queue shutdown).
-func (c *NodeController) Run() {
+func (c *Controller) Run() {
 	start := time.Now()
 	for !c.hasSynced() {
 		klog.V(2).Infof("Waiting for hasSynced (%s elapsed)", time.Now().Sub(start))
@@ -84,15 +89,29 @@ func (c *NodeController) Run() {
 	c.Shutdown()
 }
 
+func nodeStatusChanged(old, cur *apiv1.Node) bool {
+	if old.Spec.Unschedulable != cur.Spec.Unschedulable {
+		return true
+	}
+	if utils.NodeIsReady(old) != utils.NodeIsReady(cur) {
+		return true
+	}
+	return false
+}
+
 // Shutdown shuts down the goroutine that processes node updates.
-func (c *NodeController) Shutdown() {
+func (c *Controller) Shutdown() {
 	c.queue.Shutdown()
 }
 
-func (c *NodeController) sync(key string) error {
+func (c *Controller) sync(key string) error {
+	start := time.Now()
+	klog.V(4).Infof("Instance groups controller: Start processing %s", key)
+	defer klog.V(4).Infof("Instance groups controller: Processing key %s took %v", time.Since(start))
+
 	nodeNames, err := utils.GetReadyNodeNames(listers.NewNodeLister(c.lister))
 	if err != nil {
 		return err
 	}
-	return c.instancePool.Sync(nodeNames)
+	return c.igManager.Sync(nodeNames)
 }

--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -1,0 +1,81 @@
+package instancegroups
+
+import (
+	"testing"
+	"time"
+
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodeStatusChanged(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		mutate func(node *api_v1.Node)
+		expect bool
+	}{
+		{
+			"no change",
+			func(node *api_v1.Node) {},
+			false,
+		},
+		{
+			"unSchedulable changes",
+			func(node *api_v1.Node) {
+				node.Spec.Unschedulable = true
+			},
+			true,
+		},
+		{
+			"readiness changes",
+			func(node *api_v1.Node) {
+				node.Status.Conditions[0].Status = api_v1.ConditionFalse
+				node.Status.Conditions[0].LastTransitionTime = meta_v1.NewTime(time.Now())
+			},
+			true,
+		},
+		{
+			"new heartbeat",
+			func(node *api_v1.Node) {
+				node.Status.Conditions[0].LastHeartbeatTime = meta_v1.NewTime(time.Now())
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			node := testNode()
+			tc.mutate(node)
+			res := nodeStatusChanged(testNode(), node)
+			if res != tc.expect {
+				t.Fatalf("Test case %q got: %v, expected: %v", tc.desc, res, tc.expect)
+			}
+		})
+	}
+}
+
+func testNode() *api_v1.Node {
+	return &api_v1.Node{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "node",
+			Annotations: map[string]string{
+				"key1": "value1",
+			},
+		},
+		Spec: api_v1.NodeSpec{
+			Unschedulable: false,
+		},
+		Status: api_v1.NodeStatus{
+			Conditions: []api_v1.NodeCondition{
+				{
+					Type:               api_v1.NodeReady,
+					Status:             api_v1.ConditionTrue,
+					LastHeartbeatTime:  meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
+					LastTransitionTime: meta_v1.NewTime(time.Date(2000, 01, 1, 1, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+}

--- a/pkg/instancegroups/fakes.go
+++ b/pkg/instancegroups/fakes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package instances
+package instancegroups
 
 import (
 	"fmt"

--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package instances
+package instancegroups
 
 import (
 	"fmt"
@@ -39,9 +39,9 @@ const (
 	allInstances = "ALL"
 )
 
-// Instances implements NodePool.
-type Instances struct {
-	cloud InstanceGroups
+// manager implements Manager.
+type manager struct {
+	cloud Provider
 	ZoneLister
 	namer              namer.BackendNamer
 	recorder           record.EventRecorder
@@ -53,10 +53,10 @@ type recorderSource interface {
 	Recorder(ns string) record.EventRecorder
 }
 
-// NodePoolConfig is used for NodePool constructor.
-type NodePoolConfig struct {
-	// Cloud implements InstanceGroups, used to sync Kubernetes nodes with members of the cloud InstanceGroup.
-	Cloud      InstanceGroups
+// ManagerConfig is used for Manager constructor.
+type ManagerConfig struct {
+	// Cloud implements Provider, used to sync Kubernetes nodes with members of the cloud InstanceGroup.
+	Cloud      Provider
 	Namer      namer.BackendNamer
 	Recorders  recorderSource
 	BasePath   string
@@ -64,9 +64,9 @@ type NodePoolConfig struct {
 	MaxIGSize  int
 }
 
-// NewNodePool creates a new node pool using NodePoolConfig.
-func NewNodePool(config *NodePoolConfig) NodePool {
-	return &Instances{
+// NewManager creates a new node pool using ManagerConfig.
+func NewManager(config *ManagerConfig) Manager {
+	return &manager{
 		cloud:              config.Cloud,
 		namer:              config.Namer,
 		recorder:           config.Recorders.Recorder(""), // No namespace
@@ -79,15 +79,15 @@ func NewNodePool(config *NodePoolConfig) NodePool {
 // EnsureInstanceGroupsAndPorts creates or gets an instance group if it doesn't exist
 // and adds the given ports to it. Returns a list of one instance group per zone,
 // all of which have the exact same named ports.
-func (i *Instances) EnsureInstanceGroupsAndPorts(name string, ports []int64) (igs []*compute.InstanceGroup, err error) {
+func (m *manager) EnsureInstanceGroupsAndPorts(name string, ports []int64) (igs []*compute.InstanceGroup, err error) {
 	// Instance groups need to be created only in zones that have ready nodes.
-	zones, err := i.ListZones(utils.CandidateNodesPredicate)
+	zones, err := m.ListZones(utils.CandidateNodesPredicate)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, zone := range zones {
-		ig, err := i.ensureInstanceGroupAndPorts(name, zone, ports)
+		ig, err := m.ensureInstanceGroupAndPorts(name, zone, ports)
 		if err != nil {
 			return nil, err
 		}
@@ -97,9 +97,10 @@ func (i *Instances) EnsureInstanceGroupsAndPorts(name string, ports []int64) (ig
 	return igs, nil
 }
 
-func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64) (*compute.InstanceGroup, error) {
+func (m *manager) ensureInstanceGroupAndPorts(name, zone string, ports []int64) (*compute.InstanceGroup, error) {
 	klog.V(3).Infof("Ensuring instance group %s in zone %s. Ports: %v", name, zone, ports)
-	ig, err := i.Get(name, zone)
+
+	ig, err := m.Get(name, zone)
 	if err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
 		klog.Errorf("Failed to get instance group %v/%v, err: %v", zone, name, err)
 		return nil, err
@@ -107,9 +108,9 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 
 	if ig == nil {
 		klog.V(3).Infof("Creating instance group %v/%v.", zone, name)
-		if err = i.cloud.CreateInstanceGroup(&compute.InstanceGroup{Name: name}, zone); err != nil {
+		if err = m.cloud.CreateInstanceGroup(&compute.InstanceGroup{Name: name}, zone); err != nil {
 			// Error may come back with StatusConflict meaning the instance group was created by another controller
-			// possibly the Service Controller for internal load balancers.
+			// possibly the Service Manager for internal load balancers.
 			if utils.IsHTTPErrorCode(err, http.StatusConflict) {
 				klog.Warningf("Failed to create instance group %v/%v due to conflict status, but continuing sync. err: %v", zone, name, err)
 			} else {
@@ -117,7 +118,7 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 				return nil, err
 			}
 		}
-		ig, err = i.cloud.GetInstanceGroup(name, zone)
+		ig, err = m.Get(name, zone)
 		if err != nil {
 			klog.Errorf("Failed to get instance group %v/%v after ensuring existence, err: %v", zone, name, err)
 			return nil, err
@@ -145,12 +146,12 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 	// Build slice of NamedPorts for adding
 	var newNamedPorts []*compute.NamedPort
 	for _, port := range newPorts {
-		newNamedPorts = append(newNamedPorts, &compute.NamedPort{Name: i.namer.NamedPort(port), Port: port})
+		newNamedPorts = append(newNamedPorts, &compute.NamedPort{Name: m.namer.NamedPort(port), Port: port})
 	}
 
 	if len(newNamedPorts) > 0 {
 		klog.V(3).Infof("Instance group %v/%v does not have ports %+v, adding them now.", zone, name, newPorts)
-		if err := i.cloud.SetNamedPortsOfInstanceGroup(ig.Name, zone, append(ig.NamedPorts, newNamedPorts...)); err != nil {
+		if err := m.cloud.SetNamedPortsOfInstanceGroup(ig.Name, zone, append(ig.NamedPorts, newNamedPorts...)); err != nil {
 			return nil, err
 		}
 	}
@@ -159,15 +160,15 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 }
 
 // DeleteInstanceGroup deletes the given IG by name, from all zones.
-func (i *Instances) DeleteInstanceGroup(name string) error {
-	errs := []error{}
+func (m *manager) DeleteInstanceGroup(name string) error {
+	var errs []error
 
-	zones, err := i.ListZones(utils.AllNodesPredicate)
+	zones, err := m.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return err
 	}
 	for _, zone := range zones {
-		if err := i.cloud.DeleteInstanceGroup(name, zone); err != nil {
+		if err := m.cloud.DeleteInstanceGroup(name, zone); err != nil {
 			if utils.IsNotFoundError(err) {
 				klog.V(3).Infof("Instance group %v in zone %v did not exist", name, zone)
 			} else if utils.IsInUsedByError(err) {
@@ -185,16 +186,16 @@ func (i *Instances) DeleteInstanceGroup(name string) error {
 	return fmt.Errorf("%v", errs)
 }
 
-// list lists all instances in all zones.
-func (i *Instances) list(name string) (sets.String, error) {
+// listIGInstances lists all instances of provided instance group name in all zones.
+func (m *manager) listIGInstances(name string) (sets.String, error) {
 	nodeNames := sets.NewString()
-	zones, err := i.ListZones(utils.AllNodesPredicate)
+	zones, err := m.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return nodeNames, err
 	}
 
 	for _, zone := range zones {
-		instances, err := i.cloud.ListInstancesInInstanceGroup(name, zone, allInstances)
+		instances, err := m.cloud.ListInstancesInInstanceGroup(name, zone, allInstances)
 		if err != nil {
 			return nodeNames, err
 		}
@@ -210,8 +211,8 @@ func (i *Instances) list(name string) (sets.String, error) {
 }
 
 // Get returns the Instance Group by name.
-func (i *Instances) Get(name, zone string) (*compute.InstanceGroup, error) {
-	ig, err := i.cloud.GetInstanceGroup(name, zone)
+func (m *manager) Get(name, zone string) (*compute.InstanceGroup, error) {
+	ig, err := m.cloud.GetInstanceGroup(name, zone)
 	if err != nil {
 		return nil, err
 	}
@@ -219,17 +220,17 @@ func (i *Instances) Get(name, zone string) (*compute.InstanceGroup, error) {
 	return ig, nil
 }
 
-// List lists the names of all InstanceGroups belonging to this cluster.
-func (i *Instances) List() ([]string, error) {
+// List lists the names of all Instance Groups belonging to this cluster.
+func (m *manager) List() ([]string, error) {
 	var igs []*compute.InstanceGroup
 
-	zones, err := i.ListZones(utils.AllNodesPredicate)
+	zones, err := m.ListZones(utils.AllNodesPredicate)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, zone := range zones {
-		igsForZone, err := i.cloud.ListInstanceGroups(zone)
+		igsForZone, err := m.cloud.ListInstanceGroups(zone)
 		if err != nil {
 			return nil, err
 		}
@@ -241,7 +242,7 @@ func (i *Instances) List() ([]string, error) {
 
 	var names []string
 	for _, ig := range igs {
-		if i.namer.NameBelongsToCluster(ig.Name) {
+		if m.namer.NameBelongsToCluster(ig.Name) {
 			names = append(names, ig.Name)
 		}
 	}
@@ -251,10 +252,10 @@ func (i *Instances) List() ([]string, error) {
 
 // splitNodesByZones takes a list of node names and returns a map of zone:node names.
 // It figures out the zones by asking the zoneLister.
-func (i *Instances) splitNodesByZone(names []string) map[string][]string {
+func (m *manager) splitNodesByZone(names []string) map[string][]string {
 	nodesByZone := map[string][]string{}
 	for _, name := range names {
-		zone, err := i.GetZoneForNode(name)
+		zone, err := m.GetZoneForNode(name)
 		if err != nil {
 			klog.Errorf("Failed to get zones for %v: %v, skipping", name, err)
 			continue
@@ -269,20 +270,20 @@ func (i *Instances) splitNodesByZone(names []string) map[string][]string {
 
 // getInstanceReferences creates and returns the instance references by generating the
 // expected instance URLs
-func (i *Instances) getInstanceReferences(zone string, nodeNames []string) (refs []*compute.InstanceReference) {
+func (m *manager) getInstanceReferences(zone string, nodeNames []string) (refs []*compute.InstanceReference) {
 	for _, nodeName := range nodeNames {
-		refs = append(refs, &compute.InstanceReference{Instance: fmt.Sprintf(i.instanceLinkFormat, zone, canonicalizeInstanceName(nodeName))})
+		refs = append(refs, &compute.InstanceReference{Instance: fmt.Sprintf(m.instanceLinkFormat, zone, canonicalizeInstanceName(nodeName))})
 	}
 	return refs
 }
 
 // Add adds the given instances to the appropriately zoned Instance Group.
-func (i *Instances) Add(groupName string, names []string) error {
-	events.GlobalEventf(i.recorder, core.EventTypeNormal, events.AddNodes, "Adding %s to InstanceGroup %q", events.TruncatedStringList(names), groupName)
+func (m *manager) add(groupName string, names []string) error {
+	events.GlobalEventf(m.recorder, core.EventTypeNormal, events.AddNodes, "Adding %s to InstanceGroup %q", events.TruncatedStringList(names), groupName)
 	var errs []error
-	for zone, nodeNames := range i.splitNodesByZone(names) {
+	for zone, nodeNames := range m.splitNodesByZone(names) {
 		klog.V(1).Infof("Adding nodes %v to %v in zone %v", nodeNames, groupName, zone)
-		if err := i.cloud.AddInstancesToInstanceGroup(groupName, zone, i.getInstanceReferences(zone, nodeNames)); err != nil {
+		if err := m.cloud.AddInstancesToInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames)); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -291,17 +292,17 @@ func (i *Instances) Add(groupName string, names []string) error {
 	}
 
 	err := fmt.Errorf("AddInstances: %v", errs)
-	events.GlobalEventf(i.recorder, core.EventTypeWarning, events.AddNodes, "Error adding %s to InstanceGroup %q: %v", events.TruncatedStringList(names), groupName, err)
+	events.GlobalEventf(m.recorder, core.EventTypeWarning, events.AddNodes, "Error adding %s to InstanceGroup %q: %v", events.TruncatedStringList(names), groupName, err)
 	return err
 }
 
 // Remove removes the given instances from the appropriately zoned Instance Group.
-func (i *Instances) Remove(groupName string, names []string) error {
-	events.GlobalEventf(i.recorder, core.EventTypeNormal, events.RemoveNodes, "Removing %s from InstanceGroup %q", events.TruncatedStringList(names), groupName)
+func (m *manager) remove(groupName string, names []string) error {
+	events.GlobalEventf(m.recorder, core.EventTypeNormal, events.RemoveNodes, "Removing %s from InstanceGroup %q", events.TruncatedStringList(names), groupName)
 	var errs []error
-	for zone, nodeNames := range i.splitNodesByZone(names) {
+	for zone, nodeNames := range m.splitNodesByZone(names) {
 		klog.V(1).Infof("Removing nodes %v from %v in zone %v", nodeNames, groupName, zone)
-		if err := i.cloud.RemoveInstancesFromInstanceGroup(groupName, zone, i.getInstanceReferences(zone, nodeNames)); err != nil {
+		if err := m.cloud.RemoveInstancesFromInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames)); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -310,12 +311,12 @@ func (i *Instances) Remove(groupName string, names []string) error {
 	}
 
 	err := fmt.Errorf("RemoveInstances: %v", errs)
-	events.GlobalEventf(i.recorder, core.EventTypeWarning, events.RemoveNodes, "Error removing nodes %s from InstanceGroup %q: %v", events.TruncatedStringList(names), groupName, err)
+	events.GlobalEventf(m.recorder, core.EventTypeWarning, events.RemoveNodes, "Error removing nodes %s from InstanceGroup %q: %v", events.TruncatedStringList(names), groupName, err)
 	return err
 }
 
 // Sync nodes with the instances in the instance group.
-func (i *Instances) Sync(nodes []string) (err error) {
+func (m *manager) Sync(nodes []string) (err error) {
 	klog.V(2).Infof("Syncing nodes %v", nodes)
 
 	defer func() {
@@ -331,7 +332,7 @@ func (i *Instances) Sync(nodes []string) (err error) {
 		}
 	}()
 
-	pool, err := i.List()
+	pool, err := m.List()
 	if err != nil {
 		klog.Errorf("List error: %v", err)
 		return err
@@ -339,7 +340,7 @@ func (i *Instances) Sync(nodes []string) (err error) {
 
 	for _, igName := range pool {
 		gceNodes := sets.NewString()
-		gceNodes, err = i.list(igName)
+		gceNodes, err = m.listIGInstances(igName)
 		if err != nil {
 			klog.Errorf("list(%q) error: %v", igName, err)
 			return err
@@ -348,7 +349,7 @@ func (i *Instances) Sync(nodes []string) (err error) {
 
 		// Individual InstanceGroup has a limit for 1000 instances in it.
 		// As a result, it's not possible to add more to it.
-		if len(kubeNodes) > i.maxIGSize {
+		if len(kubeNodes) > m.maxIGSize {
 			// List() will return a sorted list so the kubeNodesList truncation will have a stable set of nodes.
 			kubeNodesList := kubeNodes.List()
 
@@ -361,8 +362,8 @@ func (i *Instances) Sync(nodes []string) (err error) {
 				return nodes[:maxLogsSampleSize]
 			}
 
-			klog.Warningf("Total number of kubeNodes: %d, truncating to maximum Instance Group size = %d. Instance group name: %s. First truncated instances: %v", len(kubeNodesList), i.maxIGSize, igName, truncateForLogs(nodes[i.maxIGSize:]))
-			kubeNodes = sets.NewString(kubeNodesList[:i.maxIGSize]...)
+			klog.Warningf("Total number of kubeNodes: %d, truncating to maximum Instance Group size = %d. Instance group name: %s. First truncated instances: %v", len(kubeNodesList), m.maxIGSize, igName, truncateForLogs(nodes[m.maxIGSize:]))
+			kubeNodes = sets.NewString(kubeNodesList[:m.maxIGSize]...)
 		}
 
 		// A node deleted via kubernetes could still exist as a gce vm. We don't
@@ -376,7 +377,7 @@ func (i *Instances) Sync(nodes []string) (err error) {
 
 		start := time.Now()
 		if len(removeNodes) != 0 {
-			err = i.Remove(igName, removeNodes)
+			err = m.remove(igName, removeNodes)
 			klog.V(2).Infof("Remove(%q, _) = %v (took %s); nodes = %v", igName, err, time.Now().Sub(start), removeNodes)
 			if err != nil {
 				return err
@@ -385,7 +386,7 @@ func (i *Instances) Sync(nodes []string) (err error) {
 
 		start = time.Now()
 		if len(addNodes) != 0 {
-			err = i.Add(igName, addNodes)
+			err = m.add(igName, addNodes)
 			klog.V(2).Infof("Add(%q, _) = %v (took %s); nodes = %v", igName, err, time.Now().Sub(start), addNodes)
 			if err != nil {
 				return err

--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package instances
+package instancegroups
 
 import (
 	"fmt"
@@ -34,8 +34,8 @@ const (
 
 var defaultNamer = namer.NewNamer("uid1", "fw1")
 
-func newNodePool(f *FakeInstanceGroups, zone string, maxIGSize int) NodePool {
-	pool := NewNodePool(&NodePoolConfig{
+func newNodePool(f *FakeInstanceGroups, zone string, maxIGSize int) Manager {
+	pool := NewManager(&ManagerConfig{
 		Cloud:      f,
 		Namer:      defaultNamer,
 		Recorders:  &test.FakeRecorderSource{},
@@ -213,7 +213,7 @@ func TestGetInstanceReferences(t *testing.T) {
 		},
 	}
 	pool := newNodePool(NewFakeInstanceGroups(zonesToIGs, maxIGSize), defaultZone, maxIGSize)
-	instances := pool.(*Instances)
+	instances := pool.(*manager)
 
 	nodeNames := []string{"node-1", "node-2", "node-3", "node-4.region.zone"}
 

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
-	"k8s.io/ingress-gce/pkg/instances"
+	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -58,7 +58,7 @@ type L4NetLBController struct {
 	syncTracker utils.TimeTracker
 
 	backendPool     *backends.Backends
-	instancePool    instances.NodePool
+	instancePool    instancegroups.Manager
 	igLinker        *backends.RegionalInstanceGroupLinker
 	forwardingRules ForwardingRulesGetter
 }


### PR DESCRIPTION
- Rename instances package -> instancegroups. This package controls instance groups, not "instances" themselves, similar to "neg" package
- Move controller/node.go out of l7 controller, but to instancegroups package (cause it is used not only for l7, but also for l4)
- Unexport only internal methods, rename functions for clarity