### PR TITLE
don't use alpine for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ARCH ?= amd64
 ALL_ARCH := amd64
 
 # Image to use for building.
-BUILD_IMAGE ?= golang:1.18-alpine
+BUILD_IMAGE ?= golang:1.18
 # Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION).
 CONTAINER_PREFIX ?= ingress-gce
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/rules.mk
+++ b/build/rules.mk
@@ -40,22 +40,6 @@ SRC_DIRS := cmd pkg
 
 ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 NOBODY ?= nobody
-# Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-    BASEIMAGE?=alpine
-endif
-ifeq ($(ARCH),arm)
-    BASEIMAGE?=arm32v6/alpine
-endif
-ifeq ($(ARCH),arm64)
-    BASEIMAGE?=arm64v8/alpine
-endif
-ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=ppc64le/alpine
-endif
-ifeq ($(ARCH),s390x)
-    BASEIMAGE?=s390x/alpine
-endif
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.
@@ -141,7 +125,6 @@ define DOCKERFILE_RULE
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_BIN|$(BINARY)|g' \
 	    -e 's|ARG_REGISTRY|$(REGISTRY)|g' \
-	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
 	    -e 's|ARG_NOBODY|$(NOBODY)|g' \
 	    -e 's|ARG_VERSION|$(VERSION)|g' \
 	    $$< > $$@
@@ -154,7 +137,6 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(DOCKERFILE_RULE)))
 define CONTAINER_RULE
 .$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
 	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
-	@docker pull $(BASEIMAGE)
 	@docker build					\
 		$(DOCKER_BUILD_FLAGS)			\
 		-t $(CONTAINER_NAME):$(VERSION)		\

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
Alpine image doesn't have gcc installed, that is required if we want to test with the race detector.
It also uses muslc instead of libc, that use to be conflictive with network features.
Switching to the ubuntu images, we have to explicitly use `bash`, since ubuntu defaults `sh` to `dash`, that doesn't support some bashism like `set -o pipefail`

In addition, remove the BASEIMAGE variable that doesn't seem to be used anywhere, a `grep` with current state doesn't show any match.