### PR TITLE
Add statusCodeHandler to 404-server-with-metrics which serves status code given in URL path

### DIFF
--- a/cmd/404-server-with-metrics/server-with-metrics.go
+++ b/cmd/404-server-with-metrics/server-with-metrics.go
@@ -254,7 +254,7 @@ func (s *server) notFoundHandler() http.HandlerFunc {
 // If URL path does not contain a valid status code, returns 404 (NotFound).
 func (s *server) statusCodeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-	        p := strings.TrimPrefix(r.URL.Path, statusCodePrefix)
+		p := strings.TrimPrefix(r.URL.Path, statusCodePrefix)
 		code, err := strconv.Atoi(p)
 		if err != nil {
 			code = http.StatusNotFound


### PR DESCRIPTION
Add to 404 server with metrics the functionality to return 500 status code (InternalServerError). The server returns 500 if request path is /servererror.  