### PR TITLE
Remove emitting Update event on top-level in L4 NetLB

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -107,7 +107,6 @@ func NewL4NetLBController(
 			svcKey := utils.ServiceKeyFunc(curSvc.Namespace, curSvc.Name)
 			if l4netLBc.shouldProcessService(curSvc, oldSvc) {
 				klog.V(3).Infof("L4 External LoadBalancer Service %s updated, enqueuing", svcKey)
-				l4netLBc.ctx.Recorder(curSvc.Namespace).Eventf(curSvc, v1.EventTypeNormal, "UPDATE", svcKey)
 				l4netLBc.svcQueue.Enqueue(curSvc)
 				l4netLBc.enqueueTracker.Track()
 				return


### PR DESCRIPTION
I've added this event in https://github.com/kubernetes/ingress-gce/pull/1845 thinking it will give more info,

but I found out that proper update event is emitted in needsUpdate function, emitting event on top level will spam events even on periodic enqueues, which we don't want