### PR TITLE
Add L4 ILB Dual-Stack Metrics

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -487,6 +487,10 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 	case loadbalancers.SyncTypeCreate, loadbalancers.SyncTypeUpdate:
 		klog.V(6).Infof("Internal L4 Loadbalancer for Service %s ensured, updating its state %v in metrics cache", namespacedName, result.MetricsState)
 		l4c.ctx.ControllerMetrics.SetL4ILBService(namespacedName, result.MetricsState)
+		if l4c.enableDualStack {
+			klog.V(6).Infof("Internal L4 DualStack Loadbalancer for Service %s ensured, updating its state %v in metrics cache", namespacedName, result.MetricsState)
+			l4c.ctx.ControllerMetrics.SetL4ILBDualStackService(namespacedName, result.DualStackMetricsState)
+		}
 		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime)
 
 	case loadbalancers.SyncTypeDelete:
@@ -494,6 +498,10 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 		if result.Error == nil {
 			klog.V(6).Infof("Internal L4 Loadbalancer for Service %s deleted, removing its state from metrics cache", namespacedName)
 			l4c.ctx.ControllerMetrics.DeleteL4ILBService(namespacedName)
+			if l4c.enableDualStack {
+				klog.V(6).Infof("Internal L4 Loadbalancer for Service %s deleted, removing its state from metrics cache", namespacedName)
+				l4c.ctx.ControllerMetrics.DeleteL4ILBDualStackService(namespacedName)
+			}
 		}
 		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime)
 	default:

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -71,6 +71,22 @@ type L4ILBServiceState struct {
 	InSuccess bool
 }
 
+type L4ILBDualStackServiceStateStatus string
+
+var StatusSuccess = L4ILBDualStackServiceStateStatus("Success")
+var StatusError = L4ILBDualStackServiceStateStatus("Error")
+
+// L4ILBDualStackServiceState defines ipFamilies, ipFamilyPolicy and status
+// of L4 ILB DualStack service
+type L4ILBDualStackServiceState struct {
+	// IPFamilies stores spec.ipFamilies of Service
+	IPFamilies string
+	// IPFamilyPolicy specifies spec.IPFamilyPolicy of Service
+	IPFamilyPolicy string
+	// Status specifies status of L4 ILB DualStack
+	Status L4ILBDualStackServiceStateStatus
+}
+
 // L4NetLBServiceState defines if network tier is premium and
 // if static ip address is managed bu controller
 // for an L4 NetLB service.


### PR DESCRIPTION
This PR adds counting service per ipFamilies, ipFamilyPolicy and Status for L4 ILB DualStack

Count will be stored in a map where key is struct 

```
type L4ILBDualStackServiceState struct {
	// IPFamilies stores spec.ipFamilies of Service
	IPFamilies string
	// IPFamilyPolicy specifies spec.IPFamilyPolicy of Service
	IPFamilyPolicy string
	// Status specifies status of L4 ILB DualStack
	Status L4ILBDualStackServiceStateStatus
}
```