### PR TITLE
Update e2e.EnsureIngress() to check Annotations in addition to Spec

### DIFF
--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -159,7 +159,7 @@ func TestILBStaticIP(t *testing.T) {
 			}
 		}
 
-		_, err := e2e.CreateEchoService(s, "service-1", nil)
+		_, err := e2e.CreateEchoService(s, "service-1", negAnnotation)
 		if err != nil {
 			t.Fatalf("e2e.CreateEchoService(s, service-1, nil) = _, %v; want _, nil", err)
 		}

--- a/cmd/e2e-test/ilb_test.go
+++ b/cmd/e2e-test/ilb_test.go
@@ -191,9 +191,7 @@ func TestILBStaticIP(t *testing.T) {
 		var gclb *fuzz.GCLB
 		for i, testIng := range []*v1.Ingress{testIngDisabled, testIngEnabled, testIngDisabled} {
 			t.Run(fmt.Sprintf("Transition-%d", i), func(t *testing.T) {
-				newIng := ing.DeepCopy()
-				newIng.Spec = testIng.Spec
-				ing, err = crud.Patch(ing, newIng)
+				ing, err = e2e.EnsureIngress(s, testIng)
 				if err != nil {
 					t.Fatalf("error patching Ingress spec: %v", err)
 				}

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -283,8 +283,10 @@ func EnsureIngress(s *Sandbox, ing *networkingv1.Ingress) (*networkingv1.Ingress
 	if currentIng == nil || err != nil {
 		return crud.Create(ing)
 	}
-	// Update ingress spec if they are not equal
-	if !reflect.DeepEqual(ing.Spec, currentIng.Spec) {
+
+	// Update ingress spec if they are not equal.
+	// Comparing annotations will almost always result in a diff due to the status annotations added by the controller.
+	if !reflect.DeepEqual(ing.Spec, currentIng.Spec) || !reflect.DeepEqual(ing.Annotations, currentIng.Annotations) {
 		newIng := currentIng.DeepCopy()
 		newIng.Spec = ing.Spec
 		return crud.Patch(currentIng, newIng)


### PR DESCRIPTION
In addition to fixing the e2e func, the following fixes are included in the addl. commits:
* Fix TestILBStaticIP bug where the annotations were not being applied by using the newly fixed EnsureIngress() func instead.
* Fix a missing negAnnotation in the ILB e2e test.