### PR TITLE
Adds Subnet field to e2e-test

### DIFF
--- a/cmd/e2e-test/main_test.go
+++ b/cmd/e2e-test/main_test.go
@@ -45,6 +45,7 @@ var (
 		project             string
 		region              string
 		network             string
+		subnet              string
 		seed                int64
 		destroySandboxes    bool
 		handleSIGINT        bool
@@ -67,6 +68,7 @@ func init() {
 	flag.StringVar(&flags.project, "project", "", "GCP project")
 	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
 	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default)")
+	flag.StringVar(&flags.subnet, "subnet", "", "Optional GCP subnet name.  Parsed from custom metadata key 'cluster-subnet'")
 	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
 	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
 	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
@@ -125,6 +127,7 @@ func TestMain(m *testing.M) {
 		Project:             flags.project,
 		Region:              flags.region,
 		Network:             flags.network,
+		Subnet:              flags.subnet,
 		Seed:                flags.seed,
 		DestroySandboxes:    flags.destroySandboxes,
 		GceEndpointOverride: flags.gceEndpointOverride,

--- a/cmd/e2e-test/run.sh
+++ b/cmd/e2e-test/run.sh
@@ -81,6 +81,25 @@ if [[ -z "${NETWORK}" ]]; then
 fi
 echo "Using Network: ${NETWORK}"
 
+# Get subnet  information
+# We expect the custom metadata field 'cluster-subnet' on all VMs.
+for ATTEMPT in $(seq 60); do
+  SUBNET=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-subnet)
+  if [[ -n "${SUBNET}" ]]; then
+    break
+  fi
+  echo "Error: could not get subnet from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${SUBNET}" ]]; then
+  echo "Error: could not get subnet"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Subnet: ${SUBNET}"
+
+
 echo
 echo ==============================================================================
 echo "PROJECT: ${PROJECT}"

--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -320,6 +320,10 @@ func NewGCPAddress(s *Sandbox, name string, region string) error {
 	} else {
 		addr.AddressType = "INTERNAL"
 		addr.Purpose = "SHARED_LOADBALANCER_VIP"
+		// Regional addresses need a Subnet if the cluster network is not "default"
+		if s.f.Subnet != "" {
+			addr.Subnetwork = s.f.Subnet
+		}
 		if err := s.f.Cloud.Addresses().Insert(context.Background(), meta.RegionalKey(addr.Name, region), addr); err != nil {
 			return err
 		}

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -52,6 +52,7 @@ type Options struct {
 	Project             string
 	Region              string
 	Network             string
+	Subnet              string
 	Seed                int64
 	DestroySandboxes    bool
 	GceEndpointOverride string
@@ -103,6 +104,7 @@ func NewFramework(config *rest.Config, options Options) *Framework {
 		Project:              options.Project,
 		Region:               options.Region,
 		Network:              options.Network,
+		Subnet:               options.Subnet,
 		Cloud:                theCloud,
 		Rand:                 rand.New(rand.NewSource(options.Seed)),
 		destroySandboxes:     options.DestroySandboxes,
@@ -147,6 +149,7 @@ type Framework struct {
 	Project               string
 	Region                string
 	Network               string
+	Subnet                string
 	Cloud                 cloud.Cloud
 	Rand                  *rand.Rand
 	statusManager         *StatusManager


### PR DESCRIPTION
This is an optional field that is necessary for ILB tests running in clusters that are not using the "default" network and subnet.

Tested in an example VM.