### PR TITLE
Flip the result of endpoint validation

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -244,7 +244,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		}
 		endpointsData := negtypes.EndpointsDataFromEndpointSlices(endpointSlices)
 		targetMap, endpointPodMap, dupCount, err = s.endpointsCalculator.CalculateEndpoints(endpointsData, currentMap)
-		if s.invalidEndpointInfo(endpointsData, endpointPodMap, dupCount) || s.isZoneMissing(targetMap) {
+		if !s.isValidEndpointInfo(endpointsData, endpointPodMap, dupCount) || s.isZoneMissing(targetMap) {
 			s.setErrorState()
 		}
 		if err != nil {
@@ -358,20 +358,20 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	return utilerrors.NewAggregate(errList)
 }
 
-// invalidEndpointInfo checks if endpoint information is correct.
-// It returns true if any of the following checks fails:
+// isValidEndpointInfo checks if endpoint information is correct.
+// It returns false if any of the following checks fails:
 //
 //  1. The endpoint count from endpointData doesn't equal to the one from endpointPodMap:
 //     endpiontPodMap removes the duplicated endpoints, and dupCount stores the number of duplicated it removed
 //     and we compare the endpoint counts with duplicates
 //  2. There is at least one endpoint in endpointData with missing nodeName
 //  3. The endpoint count from endpointData or the one from endpointPodMap is 0
-func (s *transactionSyncer) invalidEndpointInfo(eds []negtypes.EndpointsData, endpointPodMap negtypes.EndpointPodMap, dupCount int) bool {
+func (s *transactionSyncer) isValidEndpointInfo(eds []negtypes.EndpointsData, endpointPodMap negtypes.EndpointPodMap, dupCount int) bool {
 	// Endpoint count from EndpointPodMap
 	countFromPodMap := len(endpointPodMap) + dupCount
 	if countFromPodMap == 0 {
 		s.logger.Info("Detected endpoint count from endpointPodMap going to zero", "endpointPodMap", endpointPodMap)
-		return true
+		return false
 	}
 
 	// Endpoint count from EndpointData
@@ -382,20 +382,20 @@ func (s *transactionSyncer) invalidEndpointInfo(eds []negtypes.EndpointsData, en
 			nodeName := endpointAddress.NodeName
 			if nodeName == nil || len(*nodeName) == 0 {
 				s.logger.Info("Detected error when checking nodeName", "endpoint", endpointAddress, "endpointData", eds)
-				return true
+				return false
 			}
 		}
 	}
 	if countFromEndpointData == 0 {
 		s.logger.Info("Detected endpoint count from endpointData going to zero", "endpointData", eds)
-		return true
+		return false
 	}
 
 	if countFromEndpointData != countFromPodMap {
 		s.logger.Info("Detected error when comparing endpoint counts", "endpointData", eds, "endpointPodMap", endpointPodMap, "dupCount", dupCount)
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 // isZoneMissing returns true if there is invalid(empty) zone in zoneNetworkEndpointMap
@@ -407,18 +407,20 @@ func (s *transactionSyncer) isZoneMissing(zoneNetworkEndpointMap map[string]negt
 	return false
 }
 
-func (s *transactionSyncer) isInvalidEPBatch(err error, operation transactionOp, networkEndpoints []*composite.NetworkEndpoint) bool {
+// isValidEPBatch returns false if the returned error is not an instance of googleapi.Error
+// or the returned error has http.StatusBadRequest status code
+func (s *transactionSyncer) isValidEPBatch(err error, operation transactionOp, networkEndpoints []*composite.NetworkEndpoint) bool {
 	apiErr, ok := err.(*googleapi.Error)
 	if !ok {
-		s.logger.Info("Detected error when parsing batch request error", "operation", operation, "error", err)
-		return true
+		s.logger.Info("Detected error when parsing batch response error", "operation", operation, "error", err)
+		return false
 	}
 	errCode := apiErr.Code
 	if errCode == http.StatusBadRequest {
 		s.logger.Info("Detected error when sending endpoint batch information", "operation", operation, "errorCode", errCode)
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 // syncNetworkEndpoints spins off go routines to execute NEG operations
@@ -499,7 +501,7 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, zone stri
 		s.recordEvent(apiv1.EventTypeNormal, operation.String(), fmt.Sprintf("%s %d network endpoint(s) (NEG %q in zone %q)", operation.String(), len(networkEndpointMap), s.NegSyncerKey.NegName, zone))
 	} else {
 		s.recordEvent(apiv1.EventTypeWarning, operation.String()+"Failed", fmt.Sprintf("Failed to %s %d network endpoint(s) (NEG %q in zone %q): %v", operation.String(), len(networkEndpointMap), s.NegSyncerKey.NegName, zone, err))
-		if s.isInvalidEPBatch(err, operation, networkEndpoints) {
+		if !s.isValidEPBatch(err, operation, networkEndpoints) {
 			s.setErrorState()
 		}
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1412,7 +1412,7 @@ func TestUnknownNodes(t *testing.T) {
 	}
 }
 
-func TestInvalidEndpointInfo(t *testing.T) {
+func TestIsValidEndpointInfo(t *testing.T) {
 	t.Parallel()
 	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false, true)
 
@@ -1544,7 +1544,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         false,
+			expect:         true,
 		},
 		{
 			desc: "counts equal, endpointData has duplicated endpoints",
@@ -1625,7 +1625,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       1,
-			expect:         false,
+			expect:         true,
 		},
 		{
 			desc: "counts not equal, endpointData has no duplicated endpoints",
@@ -1688,7 +1688,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "counts not equal, endpointData has duplicated endpoints",
@@ -1760,7 +1760,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       1,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "no missing nodeNames",
@@ -1832,7 +1832,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         false,
+			expect:         true,
 		},
 		{
 			desc: "at least one endpoint is missing a nodeName",
@@ -1904,7 +1904,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "endpointData has zero endpoint",
@@ -1938,7 +1938,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "endpointPodMap has zero endpoint",
@@ -2010,7 +2010,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: map[negtypes.NetworkEndpoint]types.NamespacedName{},
 			dupCount:       0,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "endpointData and endpointPodMap both have zero endpoint",
@@ -2044,7 +2044,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: map[negtypes.NetworkEndpoint]types.NamespacedName{},
 			dupCount:       0,
-			expect:         true,
+			expect:         false,
 		},
 		{
 			desc: "endpointData and endpointPodMap both have non-zero endpoints",
@@ -2116,13 +2116,13 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			},
 			endpointPodMap: testEndpointPodMap,
 			dupCount:       0,
-			expect:         false,
+			expect:         true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := transactionSyncer.invalidEndpointInfo(tc.endpointsData, tc.endpointPodMap, tc.dupCount); got != tc.expect {
+			if got := transactionSyncer.isValidEndpointInfo(tc.endpointsData, tc.endpointPodMap, tc.dupCount); got != tc.expect {
 				t.Errorf("invalidEndpointInfo() = %t,  expected %t", got, tc.expect)
 			}
 		})
@@ -2203,7 +2203,7 @@ func TestIsZoneMissing(t *testing.T) {
 	}
 }
 
-func TestIsInvalidEPBatch(t *testing.T) {
+func TestIsValidEPBatch(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	fakeCloud := negtypes.NewAdapter(fakeGCE)
 	zone := "us-central1-a"
@@ -2217,12 +2217,12 @@ func TestIsInvalidEPBatch(t *testing.T) {
 		{
 			desc:           "NEG API call no error, status code 200",
 			HttpStatusCode: http.StatusOK,
-			expect:         false,
+			expect:         true,
 		},
 		{
 			desc:           "NEG API call error, status code 400",
 			HttpStatusCode: http.StatusBadRequest,
-			expect:         true,
+			expect:         false,
 		},
 	}
 
@@ -2237,7 +2237,7 @@ func TestIsInvalidEPBatch(t *testing.T) {
 			_, transactionSyncer := newTestTransactionSyncer(fakeCloud, negtypes.VmIpPortEndpointType, false, true)
 
 			err := transactionSyncer.cloud.AttachNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, networkEndpoints, transactionSyncer.NegSyncerKey.GetAPIVersion())
-			if got := transactionSyncer.isInvalidEPBatch(err, attachOp, networkEndpoints); got != tc.expect {
+			if got := transactionSyncer.isValidEPBatch(err, attachOp, networkEndpoints); got != tc.expect {
 				t.Errorf("isInvalidEPBatch() = %t, expected %t", got, tc.expect)
 			}
 		})


### PR DESCRIPTION
Flip the result of invalidEndpointInfo for better readability. Now the function returns true if endpoints are valid, false otherwise.