### PR TITLE
Rework the health check for the loadbalancer controller

### DIFF
--- a/cmd/glbc/app/clients.go
+++ b/cmd/glbc/app/clients.go
@@ -110,7 +110,11 @@ func NewGCEClient() *gce.Cloud {
 			// user has no need for Ingress in this case. If they grant
 			// permissions to the node they will have to restart the controller
 			// manually to re-create the client.
-			// TODO: why do we bail with success out if there is a permission error???
+			//
+			// Our aim here is not to validate if we have an IAM permission but just
+			// to ensure that gce client is working properly and able to make API
+			// calls. The choice of fetching BackendServices below is completely
+			// arbitrary.
 			if _, err = cloud.ListGlobalBackendServices(); err == nil || utils.IsHTTPErrorCode(err, http.StatusForbidden) {
 				return cloud
 			}


### PR DESCRIPTION
## _Why do we need this?_
There have been several bug reports about customers concerned about API calls to `k8s-ingress-svc-acct-permission-check-probe` returning 404s -- this was also flagged out by partner teams since it results in lots of RESOURCE_NOT_FOUND errors within GCE APIs. 

https://github.com/kubernetes/ingress-gce/pull/1104 is an earlier related change (accompanied by the addition to the public documentation at https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#implementation_details). This change was an improvement over the earlier approach of probing backend service called `foo`.  

**We can improve this further by probing using an API call which does not error out.**

## _What does this PR propose?_

* We can use the `GCE Regions.Get` call (https://cloud.google.com/compute/docs/reference/rest/v1/regions/get) in place of fetching a random backend service. The benefit being:
    - The call won't error out
    - It uses regional APIs for improved compliance.
* We only call the GCE API after 60 seconds from the previous successful call. 
    - This avoids spikes in API calls to GCE, which can result because of issues with the k8s liveness probe or if the liveness probe is configured to be too frequent.
    - Note that we still do not independently ping GCE API "every" 60 seconds but only lazily ping when the health check is invoked. This is because having a totally independent pinging frequency would only have been helpful if we were utilizing the results of the ping outside the health check -- since they are only used within the health check, we should just ensure that they are "atleast" 60 seconds apart and avoid unnecessary pings.

## _Is this change safe?_
It's reasonable to think that the reason for using the `BackendService.GET` call could be to check if we have the associated IAM permission. But that does not seem to be the case because of the following reasons:

* We can see from the **existing code** here https://github.com/kubernetes/ingress-gce/blob/091ae8b07bd92d6781ce036ea67acb19d48e14a2/pkg/controller/controller.go#L306-L309 that we pass the health check even in case of a permissions error -- meaning even right now we don't care if we have the permission or not.
* Taking a look at how this code evolved, the original reason for making this API call was stated in the following comment https://github.com/kubernetes/ingress-gce/blob/73afef4bec27a6539da13f6cf93ae09d832c6dde/controllers/gce/controller/cluster_manager.go#L77-L79 but the comment got lost in the refactoring done in https://github.com/kubernetes/ingress-gce/pull/424. This comment further solidifies the reasoning that this API call was to check if gce client is able to make API calls.