### PR TITLE
Add metrics for missing field endpoints

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -18,6 +18,7 @@ package syncers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -244,7 +245,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		}
 		endpointsData := negtypes.EndpointsDataFromEndpointSlices(endpointSlices)
 		targetMap, endpointPodMap, dupCount, err = s.endpointsCalculator.CalculateEndpoints(endpointsData, currentMap)
-		if s.invalidEndpointInfo(endpointsData, endpointPodMap, dupCount) || s.isZoneMissing(targetMap) {
+		if s.isZoneMissing(err) || s.invalidEndpointInfo(endpointsData, endpointPodMap, dupCount) {
 			s.setErrorState()
 		}
 		if err != nil {
@@ -398,10 +399,10 @@ func (s *transactionSyncer) invalidEndpointInfo(eds []negtypes.EndpointsData, en
 	return false
 }
 
-// isZoneMissing returns true if there is invalid(empty) zone in zoneNetworkEndpointMap
-func (s *transactionSyncer) isZoneMissing(zoneNetworkEndpointMap map[string]negtypes.NetworkEndpointSet) bool {
-	if _, isPresent := zoneNetworkEndpointMap[""]; isPresent {
-		s.logger.Info("Detected error when checking missing zone", "zoneNetworkEndpointMap", zoneNetworkEndpointMap)
+// isZoneMissing returns true if the error returned from CalculateEndpoint is ErrEPMissingZone
+func (s *transactionSyncer) isZoneMissing(err error) bool {
+	if errors.Is(err, ErrEPMissingZone) {
+		s.logger.Info("Detected unexpected error when checking missing zone", "error", err)
 		return true
 	}
 	return false

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package syncers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -45,6 +46,11 @@ const (
 	minRetryDelay = 5 * time.Second
 	maxRetryDelay = 600 * time.Second
 	separator     = "||"
+)
+
+var (
+	ErrNodeNotFound  = errors.New("failed to retrieve associated zone of node")
+	ErrEPMissingZone = errors.New("endpoint has empty zone field")
 )
 
 // encodeEndpoint encodes ip and instance into a single string
@@ -257,7 +263,7 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 					continue
 				}
 			}
-			if endpointAddress.NodeName == nil {
+			if endpointAddress.NodeName == nil || len(*endpointAddress.NodeName) == 0 {
 				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not have an associated node. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
 				continue
 			}
@@ -267,7 +273,10 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 			}
 			zone, err := zoneGetter.GetZoneForNode(*endpointAddress.NodeName)
 			if err != nil {
-				return nil, nil, dupCount, fmt.Errorf("failed to retrieve associated zone of node %q: %w", *endpointAddress.NodeName, err)
+				return nil, nil, dupCount, ErrNodeNotFound
+			}
+			if zone == "" {
+				return nil, nil, dupCount, ErrEPMissingZone
 			}
 			if zoneNetworkEndpointMap[zone] == nil {
 				zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()


### PR DESCRIPTION
Add metrics to report the number of occurrence of missing field endpoints.

Example:
HELP neg_controller_neg_missing_field_endpoints Number of missing field endpoints during one sync
TYPE neg_controller_neg_missing_field_endpoints gauge
neg_controller_neg_missing_field_endpoints{ep_type="MissingNodeNameEndpoints",neg_type="GCE_VM_IP_PORT"} 0
neg_controller_neg_missing_field_endpoints{ep_type="MissingPodEndpoints",neg_type="GCE_VM_IP_PORT"} 2
neg_controller_neg_missing_field_endpoints{ep_type="MissingZoneEndpoints",neg_type="GCE_VM_IP_PORT"} 0
neg_controller_neg_missing_field_endpoints{ep_type="MissingFieldEndpoints",neg_type="GCE_VM_IP_PORT"} 2
neg_controller_neg_missing_field_endpoints{ep_type="TotalEndpoints",neg_type="GCE_VM_IP_PORT"} 2