### PR TITLE
Add metric to report duplicated endpoints

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -362,7 +362,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 // It returns true if any of the following checks fails:
 //
 //  1. The endpoint count from endpointData doesn't equal to the one from endpointPodMap:
-//     endpiontPodMap removes the duplicated endpoints, and dupCount stores the number of duplicated it removed
+//     endpiontPodMap removes the duplicate endpoints, and dupCount stores the number of duplicate it removed
 //     and we compare the endpoint counts with duplicates
 //  2. There is at least one endpoint in endpointData with missing nodeName
 //  3. The endpoint count from endpointData or the one from endpointPodMap is 0

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1475,7 +1475,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 		expect         bool
 	}{
 		{
-			desc: "counts equal, endpointData has no duplicated endpoints",
+			desc: "counts equal, endpointData has no duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1547,7 +1547,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			expect:         false,
 		},
 		{
-			desc: "counts equal, endpointData has duplicated endpoints",
+			desc: "counts equal, endpointData has duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1601,7 +1601,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 							NodeName:  &instance1,
 							Addresses: []string{testIP2},
 							Ready:     true,
-						}, // this is a duplicated endpoint
+						}, // this is a duplicate endpoint
 						{
 							TargetRef: &corev1.ObjectReference{
 								Namespace: testServiceNamespace,
@@ -1628,7 +1628,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			expect:         false,
 		},
 		{
-			desc: "counts not equal, endpointData has no duplicated endpoints",
+			desc: "counts not equal, endpointData has no duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1691,7 +1691,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 			expect:         true,
 		},
 		{
-			desc: "counts not equal, endpointData has duplicated endpoints",
+			desc: "counts not equal, endpointData has duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1736,7 +1736,7 @@ func TestInvalidEndpointInfo(t *testing.T) {
 							NodeName:  &instance1,
 							Addresses: []string{testIP2},
 							Ready:     true,
-						}, // this is a duplicated endpoint
+						}, // this is a duplicate endpoint
 						{
 							TargetRef: &corev1.ObjectReference{
 								Namespace: testServiceNamespace,


### PR DESCRIPTION
Add metric to report the number of duplicated endpoints within each sync.

Example:
HELP neg_controller_neg_duplicated_endpoints Number of duplicated endpoints during one sync
TYPE neg_controller_neg_duplicated_endpoints gauge
neg_controller_neg_duplicated_endpoints{ep_type="DuplicatedEndpoints",neg_type="GCE_VM_IP_PORT"} 1
neg_controller_neg_duplicated_endpoints{ep_type="TotalEndpoints",neg_type="GCE_VM_IP_PORT"} 2