### PR TITLE
Fix L4 NetLB RBS cleanup when Service Type changed

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -238,10 +238,6 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // isRBSBasedService checks if service has either RBS annotation, finalizer or RBSForwardingRule
 func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service) bool {
-	if !utils.IsLoadBalancerServiceType(svc) {
-		return false
-	}
-
 	return lc.hasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || lc.hasRBSForwardingRule(svc)
 }
 


### PR DESCRIPTION
This fixes issue, that on switching Service Type from LoadBalancer to ClusterIP or NodePort, RBS resources were not cleaned up