### PR TITLE
Change e2e regional address to use full subnet path

### DIFF
--- a/pkg/e2e/fixtures.go
+++ b/pkg/e2e/fixtures.go
@@ -322,7 +322,8 @@ func NewGCPAddress(s *Sandbox, name string, region string) error {
 		addr.Purpose = "SHARED_LOADBALANCER_VIP"
 		// Regional addresses need a Subnet if the cluster network is not "default"
 		if s.f.Subnet != "" {
-			addr.Subnetwork = s.f.Subnet
+			subnetID := cloud.ResourceID{ProjectID: s.f.Project, Resource: "subnetworks", Key: meta.RegionalKey(s.f.Subnet, s.f.Region)}
+			addr.Subnetwork = subnetID.ResourcePath()
 		}
 		if err := s.f.Cloud.Addresses().Insert(context.Background(), meta.RegionalKey(addr.Name, region), addr); err != nil {
 			return err


### PR DESCRIPTION
This is a fix for a bug triggered by this PR: https://github.com/kubernetes/ingress-gce/pull/1867

The subnet needs to be provided as a full resource path.

```
--- PASS: TestILBStaticIP (2287.03s)
    --- PASS: TestILBStaticIP/ilb-static-ip (2287.03s)
        --- PASS: TestILBStaticIP/ilb-static-ip/Transition-0 (270.95s)
        --- PASS: TestILBStaticIP/ilb-static-ip/Transition-1 (31.01s)
        --- PASS: TestILBStaticIP/ilb-static-ip/Transition-2 (30.99s)
```

/assign @swetharepakula 