### PR TITLE
NetLB controller: cleanup RBS resources in case service type changed

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -238,10 +238,6 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // isRBSBasedService checks if service has either RBS annotation, finalizer or RBSForwardingRule
 func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service) bool {
-	if !utils.IsLoadBalancerServiceType(svc) {
-		return false
-	}
-
 	return lc.hasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || lc.hasRBSForwardingRule(svc)
 }
 

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -128,7 +128,9 @@ func (lc *L4NetLBController) needsAddition(newSvc, oldSvc *v1.Service) bool {
 
 // needsDeletion return true if svc required deleting RBS based NetLB
 func (lc *L4NetLBController) needsDeletion(svc *v1.Service) bool {
-	if !lc.isRBSBasedService(svc) {
+	// Check if service has RBS related fields/resources
+	// this check differs from isRBSBasedService() func by checking also non load balancer type services
+	if !(lc.hasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || lc.hasRBSForwardingRule(svc)) {
 		return false
 	}
 	if svc.ObjectMeta.DeletionTimestamp != nil {
@@ -216,7 +218,7 @@ func (lc *L4NetLBController) needsUpdate(newSvc, oldSvc *v1.Service) bool {
 
 // shouldProcessService checks if given service should be process by controller
 func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service) bool {
-	if !lc.isRBSBasedService(newSvc) {
+	if !(lc.isRBSBasedService(newSvc) || lc.isRBSBasedService(oldSvc)) {
 		return false
 	}
 	if lc.needsAddition(newSvc, oldSvc) || lc.needsUpdate(newSvc, oldSvc) || lc.needsDeletion(newSvc) {
@@ -238,6 +240,11 @@ func (lc *L4NetLBController) hasForwardingRuleAnnotation(svc *v1.Service, frName
 
 // isRBSBasedService checks if service has either RBS annotation, finalizer or RBSForwardingRule
 func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service) bool {
+	// Check if the type=LoadBalancer, so we don't execute API calls o non-LB services
+	// this call is nil-safe
+	if !utils.IsLoadBalancerServiceType(svc) {
+		return false
+	}
 	return lc.hasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || lc.hasRBSForwardingRule(svc)
 }
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -522,12 +522,20 @@ func TestProcessRBSServiceTypeTransition(t *testing.T) {
 		finalType v1.ServiceType
 	}{
 		{
-			desc:      "Change RBS to ClusterIP should delete RBS resources",
+			desc:      "Change from RBS to ClusterIP should delete RBS resources",
 			finalType: v1.ServiceTypeClusterIP,
 		},
 		{
-			desc:      "Change RBS to NodePort should delete RBS resources",
+			desc:      "Change from RBS to NodePort should delete RBS resources",
 			finalType: v1.ServiceTypeNodePort,
+		},
+		{
+			desc:      "Change from RBS to ExternalName should delete RBS resources",
+			finalType: v1.ServiceTypeExternalName,
+		},
+		{
+			desc:      "Change from RBS to empty (default) type should delete RBS resources",
+			finalType: "",
 		},
 	}
 


### PR DESCRIPTION
NetLB RBS Controller: Change needsDeletion and shouldProcessService logic 

1) only process if old or new version of the service was/is RBS
2) only delete if service has RBS annotation/finalizer/forwarding rule, even if the type changed from LoadBalacer to other type

This will make controller cleanup RBS resources in case service type changed.

This PR builds on top of pull/1879 from @panslava 