### PR TITLE
Add delay for retrying NEG polling for unhealthy pods

### DIFF
--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -19,16 +19,17 @@ package readiness
 import (
 	"context"
 	"fmt"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
-	"google.golang.org/api/compute/v1"
-	"k8s.io/apimachinery/pkg/util/clock"
-	"k8s.io/legacy-cloud-providers/gce"
 	"net"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
+	"google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/legacy-cloud-providers/gce"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/apimachinery/pkg/types"
@@ -387,14 +388,18 @@ func TestPoll(t *testing.T) {
 		},
 	}
 
-	pollAndValidate := func(desc string, expectErr bool, expectRetry bool, expectPatchCount int, stepClock bool) {
+	pollAndValidate := func(desc string, expectErr bool, expectRetry bool, expectPatchCount int, stepClock bool, healthStatusDelay bool) {
 		if stepClock {
 			go func() {
 				time.Sleep(2 * time.Second)
-				fakeClock.Step(retryDelay)
+				delay := retryDelay
+				if healthStatusDelay {
+					delay = minRetryDelay
+				}
+				fakeClock.Step(delay)
 			}()
 		}
-		retry, err := poller.Poll(key)
+		retry, err := poller.Poll(key, func() time.Duration { return retryDelay })
 		if expectErr && err == nil {
 			t.Errorf("For case %q, expect err, but got %v", desc, err)
 		} else if !expectErr && err != nil {
@@ -416,19 +421,19 @@ func TestPoll(t *testing.T) {
 		polling: true,
 	}
 
-	pollAndValidate(step, false, true, 0, false)
-	pollAndValidate(step, false, true, 0, false)
+	pollAndValidate(step, false, true, 0, false, false)
+	pollAndValidate(step, false, true, 0, false, false)
 
 	step = "unmark polling"
 	poller.pollMap[key].polling = false
-	pollAndValidate(step, true, true, 0, true)
-	pollAndValidate(step, true, true, 0, true)
+	pollAndValidate(step, true, true, 0, true, false)
+	pollAndValidate(step, true, true, 0, true, false)
 
 	step = "NEG exists, but with no endpoint"
 	// create NEG, but with no endpoint
 	negCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: zone, Version: meta.VersionGA}, zone)
-	pollAndValidate(step, false, true, 0, false)
-	pollAndValidate(step, false, true, 0, false)
+	pollAndValidate(step, false, true, 0, true, true)
+	pollAndValidate(step, false, true, 0, true, true)
 
 	step = "NE added to the NEG, but NE health status is empty"
 	ne := &composite.NetworkEndpoint{
@@ -446,8 +451,8 @@ func TestPoll(t *testing.T) {
 		},
 	})
 
-	pollAndValidate(step, false, false, 1, false)
-	pollAndValidate(step, false, false, 2, false)
+	pollAndValidate(step, false, false, 1, false, false)
+	pollAndValidate(step, false, false, 2, false, false)
 	patcherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), nil)
 
 	step = "NE health status is empty and there are other endpoint with health status in NEG"
@@ -458,8 +463,8 @@ func TestPoll(t *testing.T) {
 			Healths:         []*composite.HealthStatusForNetworkEndpoint{},
 		},
 	})
-	pollAndValidate(step, false, true, 2, false)
-	pollAndValidate(step, false, true, 2, false)
+	pollAndValidate(step, false, true, 2, true, true)
+	pollAndValidate(step, false, true, 2, true, true)
 
 	step = "NE has nonhealthy status"
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
@@ -475,8 +480,8 @@ func TestPoll(t *testing.T) {
 			},
 		},
 	})
-	pollAndValidate(step, false, true, 2, false)
-	pollAndValidate(step, false, true, 2, false)
+	pollAndValidate(step, false, true, 2, true, true)
+	pollAndValidate(step, false, true, 2, true, true)
 
 	step = "NE has nonhealthy status with irrelevant entry"
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
@@ -493,8 +498,8 @@ func TestPoll(t *testing.T) {
 			},
 		},
 	})
-	pollAndValidate(step, false, true, 2, false)
-	pollAndValidate(step, false, true, 2, false)
+	pollAndValidate(step, false, true, 2, true, true)
+	pollAndValidate(step, false, true, 2, true, true)
 
 	step = "NE has unsupported health"
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
@@ -510,8 +515,8 @@ func TestPoll(t *testing.T) {
 			},
 		},
 	})
-	pollAndValidate(step, false, false, 3, false)
-	pollAndValidate(step, false, false, 4, false)
+	pollAndValidate(step, false, false, 3, false, false)
+	pollAndValidate(step, false, false, 4, false, false)
 
 	step = "NE has healthy status"
 	bsName := "bar"
@@ -530,9 +535,9 @@ func TestPoll(t *testing.T) {
 		},
 		irrelevantEntry,
 	})
-	pollAndValidate(step, false, false, 5, false)
+	pollAndValidate(step, false, false, 5, false, false)
 	patcherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), meta.GlobalKey(bsName))
-	pollAndValidate(step, false, false, 6, false)
+	pollAndValidate(step, false, false, 6, false, false)
 	patcherTester.Eval(t, fmt.Sprintf("%v/%v", ns, podName), meta.ZonalKey(negName, zone), meta.GlobalKey(bsName))
 
 	step = "ListNetworkEndpoint return error response"
@@ -542,13 +547,15 @@ func TestPoll(t *testing.T) {
 		return nil, fmt.Errorf("random error from GCE")
 	}
 	poller.negCloud = negtypes.NewAdapter(fakeGCE)
-	pollAndValidate(step, true, true, 6, true)
-	pollAndValidate(step, true, true, 6, true)
+	pollAndValidate(step, true, true, 6, true, false)
+	pollAndValidate(step, true, true, 6, true, false)
 }
 
 func TestProcessHealthStatus(t *testing.T) {
 	t.Parallel()
 	poller := newFakePoller()
+	fakeClock := clock.NewFakeClock(time.Now())
+	poller.clock = fakeClock
 
 	// key was not in pollMap
 	key := negMeta{
@@ -559,6 +566,10 @@ func TestProcessHealthStatus(t *testing.T) {
 	res := []*composite.NetworkEndpointWithHealthStatus{}
 
 	// processHealthStatus should not crash when pollMap does not have corresponding key.
+	go func() {
+		time.Sleep(2 * time.Second)
+		fakeClock.Step(minRetryDelay)
+	}()
 	retry, err := poller.processHealthStatus(key, res)
 	if retry != false {
 		t.Errorf("expect retry == false, but got %v", retry)

--- a/pkg/neg/syncers/syncer.go
+++ b/pkg/neg/syncers/syncer.go
@@ -54,7 +54,7 @@ type syncer struct {
 	// sync signal and retry handling
 	syncCh  chan interface{}
 	clock   clock.Clock
-	backoff backoffHandler
+	backoff negtypes.BackoffHandler
 
 	logger klog.Logger
 }
@@ -68,7 +68,7 @@ func newSyncer(negSyncerKey negtypes.NegSyncerKey, serviceLister cache.Indexer, 
 		stopped:       true,
 		shuttingDown:  false,
 		clock:         clock.RealClock{},
-		backoff:       NewExponentialBackendOffHandler(maxRetries, minRetryDelay, maxRetryDelay),
+		backoff:       negtypes.NewExponentialBackendOffHandler(maxRetries, minRetryDelay, maxRetryDelay),
 		logger:        logger,
 	}
 }
@@ -91,7 +91,7 @@ func (s *syncer) Start() error {
 			if err != nil {
 				delay, retryErr := s.backoff.NextRetryDelay()
 				retryMsg := ""
-				if retryErr == ErrRetriesExceeded {
+				if retryErr == negtypes.ErrRetriesExceeded {
 					retryMsg = "(will not retry)"
 				} else {
 					retryCh = s.clock.After(delay)

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -170,7 +170,7 @@ func TestRetryOnSyncError(t *testing.T) {
 	if err := syncerTester.syncer.Start(); err != nil {
 		t.Fatalf("Failed to start syncer: %v", err)
 	}
-	syncerTester.syncer.(*syncer).backoff = NewExponentialBackendOffHandler(maxRetry, 0, 0)
+	syncerTester.syncer.(*syncer).backoff = negtypes.NewExponentialBackendOffHandler(maxRetry, 0, 0)
 
 	if err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
 		// In 5 seconds, syncer should be able to retry 3 times.

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -78,7 +78,7 @@ type transactionSyncer struct {
 	endpointsCalculator negtypes.NetworkEndpointsCalculator
 
 	// retry handles back off retry for NEG API operations
-	retry retryHandler
+	retry negtypes.RetryHandler
 
 	// reflector handles NEG readiness gate and conditions for pods in NEG.
 	reflector readiness.Reflector
@@ -153,7 +153,7 @@ func NewTransactionSyncer(
 	syncer := newSyncer(negSyncerKey, serviceLister, recorder, ts, logger)
 	// transactionSyncer needs syncer interface for internals
 	ts.syncer = syncer
-	ts.retry = NewDelayRetryHandler(func() { syncer.Sync() }, NewExponentialBackendOffHandler(maxRetries, minRetryDelay, maxRetryDelay))
+	ts.retry = negtypes.NewDelayRetryHandler(func() { syncer.Sync() }, negtypes.NewExponentialBackendOffHandler(maxRetries, minRetryDelay, maxRetryDelay))
 	return syncer
 }
 

--- a/pkg/neg/types/backoff.go
+++ b/pkg/neg/types/backoff.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package syncers
+package types
 
 import (
 	"fmt"
@@ -26,8 +26,8 @@ import (
 
 var ErrRetriesExceeded = fmt.Errorf("maximum retry exceeded")
 
-// backoffHandler handles delays for back off retry
-type backoffHandler interface {
+// BackoffHandler handles delays for back off retry
+type BackoffHandler interface {
 	// NextRetryDelay returns the delay for next retry or error if maximum number of retries exceeded.
 	NextRetryDelay() (time.Duration, error)
 	// ResetRetryDelay resets the retry delay

--- a/pkg/neg/types/backoff_test.go
+++ b/pkg/neg/types/backoff_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package syncers
+package types
 
 import (
 	"testing"

--- a/pkg/neg/types/retry_handler.go
+++ b/pkg/neg/types/retry_handler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package syncers
+package types
 
 import (
 	"fmt"
@@ -25,8 +25,8 @@ import (
 
 var ErrHandlerRetrying = fmt.Errorf("retry handler is retrying")
 
-// retryHandler encapsulates logic that handles retry
-type retryHandler interface {
+// RetryHandler encapsulates logic that handles retry
+type RetryHandler interface {
 	// Retry triggers retry
 	Retry() error
 	// Reset resets handler internals
@@ -43,13 +43,13 @@ type backoffRetryHandler struct {
 
 	// backoff delay handling
 	clock   clock.Clock
-	backoff backoffHandler
+	backoff BackoffHandler
 
 	// retryFunc called on retry
 	retryFunc func()
 }
 
-func NewDelayRetryHandler(retryFunc func(), backoff backoffHandler) *backoffRetryHandler {
+func NewDelayRetryHandler(retryFunc func(), backoff BackoffHandler) *backoffRetryHandler {
 	return &backoffRetryHandler{
 		retrying:  false,
 		clock:     clock.RealClock{},

--- a/pkg/neg/types/retry_handler_test.go
+++ b/pkg/neg/types/retry_handler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package syncers
+package types
 
 import (
 	"sync"


### PR DESCRIPTION
Add delay for retrying NEG polling for unhealthy pods and exponential backoff for GCE API errors