### PR TITLE
NetLB: Treat LoadBalancer IP setup errors as user errors.

### DIFF
--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -65,6 +65,12 @@ func InsertForwardingRuleHook(ctx context.Context, key *meta.Key, obj *compute.F
 	return false, nil
 }
 
+func InsertForwardingRuleErrorHook(err error) func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules) (b bool, e error) {
+	return func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules) (b bool, e error) {
+		return true, err
+	}
+}
+
 func DeleteForwardingRulesErrorHook(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, error) {
 	return true, fmt.Errorf("DeleteForwardingRulesErrorHook")
 }
@@ -117,4 +123,8 @@ func InsertAddressErrorHook(ctx context.Context, key *meta.Key, obj *compute.Add
 
 func InsertAddressNetworkErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
 	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "The network tier of external IP is STANDARD, that of Address must be the same."}
+}
+
+func InsertAddressNotAllocatedToProjectErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Specified IP address is not allocated to the project or does not belong to the specified scope."}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,6 +110,20 @@ func NewNetworkTierErr(resourceInErr, desired, received string) *NetworkTierErro
 	return &NetworkTierError{resource: resourceInErr, desiredNT: desired, receivedNT: received}
 }
 
+// IPConfigurationError is a struct to define error caused by User misconfiguration the Load Balancer IP.
+type IPConfigurationError struct {
+	ip     string
+	reason string
+}
+
+func (e *IPConfigurationError) Error() string {
+	return fmt.Sprintf("IP configuration error: \"%s\" %s", e.ip, e.reason)
+}
+
+func NewIPConfigurationError(ip, reason string) *IPConfigurationError {
+	return &IPConfigurationError{ip: ip, reason: reason}
+}
+
 // L4LBType indicates if L4 LoadBalancer is Internal or External
 type L4LBType int
 
@@ -198,11 +212,17 @@ func IsNetworkTierError(err error) bool {
 	return errors.As(err, &netTierError)
 }
 
+// IsIPConfigurationError checks if wrapped error is an IP configuration error.
+func IsIPConfigurationError(err error) bool {
+	var ipConfigError *IPConfigurationError
+	return errors.As(err, &ipConfigError)
+}
+
 // IsUserError checks if given error is cause by User.
-// Right now User Error might be cause by Network Tier misconfiguration
-// but this list might get longer.
+// Right now User Error might be caused by Network Tier misconfiguration
+// or specifying non-existent or already used IP address.
 func IsUserError(err error) bool {
-	return IsNetworkTierError(err)
+	return IsNetworkTierError(err) || IsIPConfigurationError(err)
 }
 
 // IsNotFoundError returns true if the resource does not exist


### PR DESCRIPTION
Change the errors caused by user misconfiguring the Load Balancer IP in cases where:
- the requested LB external IP is not reserved in the project
- attempting to use an IP already used by another LB
- attempting to use a reserved IP of another type (internal IP).

This will affect numbers reported in the metrics, marking the above errors as user errors.