### PR TITLE
[Cherrypick #1890] Cherrypick metric user errors fix to release 1.20

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -18,6 +18,8 @@ package loadbalancers
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -35,8 +37,13 @@ import (
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
-// maxL4ILBPorts is the maximum number of ports that can be specified in an L4 ILB Forwarding Rule
-const maxL4ILBPorts = 5
+const (
+	// maxL4ILBPorts is the maximum number of ports that can be specified in an L4 ILB Forwarding Rule
+	maxL4ILBPorts = 5
+	// addressAlreadyInUseMessage is the error message string returned by the compute API
+	// when creating a forwarding rule that uses a conflicting IP address.
+	addressAlreadyInUseMessage = "Specified IP address is in-use and would result in a conflict."
+)
 
 func (l7 *L7) checkHttpForwardingRule() (err error) {
 	if l7.tp == nil {
@@ -398,6 +405,9 @@ func (l4netlb *L4NetLB) ensureExternalForwardingRule(bsLink string) (*composite.
 	}
 	klog.V(2).Infof("ensureExternalForwardingRule: Creating/Recreating forwarding rule - %s", fr.Name)
 	if err = l4netlb.forwardingRules.Create(fr); err != nil {
+		if isAddressAlreadyInUseError(err) {
+			return nil, IPAddrUndefined, utils.NewIPConfigurationError(fr.IPAddress, addressAlreadyInUseMessage)
+		}
 		return nil, IPAddrUndefined, err
 	}
 	createdFr, err := l4netlb.forwardingRules.Get(fr.Name)
@@ -456,4 +466,8 @@ func l4lbIPToUse(svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSu
 		return ""
 	}
 	return fwdRule.IPAddress
+}
+
+func isAddressAlreadyInUseError(err error) bool {
+	return utils.IsHTTPErrorCode(err, http.StatusBadRequest) && strings.Contains(err.Error(), addressAlreadyInUseMessage)
 }

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -1,11 +1,22 @@
 package loadbalancers
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+	"k8s.io/ingress-gce/pkg/test"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -225,4 +236,34 @@ func TestForwardingRulesEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestL4CreateExternalForwardingRuleAddressAlreadyInUse(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	targetIP := "1.1.1.1"
+	l4 := L4NetLB{
+		cloud:           fakeGCE,
+		forwardingRules: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional),
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "testService", Namespace: "default", UID: types.UID("1")},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port: 8080,
+					},
+				},
+				Type:           "LoadBalancer",
+				LoadBalancerIP: targetIP,
+			},
+		},
+	}
+
+	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(cloud.SchemeExternal)}
+	fakeGCE.ReserveRegionAddress(addr, fakeGCE.Region())
+	insertError := &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.IPAddress': '1.1.1.1'. Specified IP address is in-use and would result in a conflict., invalid"}
+	fakeGCE.Compute().(*cloud.MockGCE).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(insertError)
+	_, _, err := l4.ensureExternalForwardingRule("link")
+
+	require.Error(t, err)
+	assert.True(t, utils.IsIPConfigurationError(err))
 }

--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -65,6 +65,12 @@ func InsertForwardingRuleHook(ctx context.Context, key *meta.Key, obj *compute.F
 	return false, nil
 }
 
+func InsertForwardingRuleErrorHook(err error) func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules) (b bool, e error) {
+	return func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules) (b bool, e error) {
+		return true, err
+	}
+}
+
 func DeleteForwardingRulesErrorHook(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, error) {
 	return true, fmt.Errorf("DeleteForwardingRulesErrorHook")
 }
@@ -117,4 +123,8 @@ func InsertAddressErrorHook(ctx context.Context, key *meta.Key, obj *compute.Add
 
 func InsertAddressNetworkErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
 	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "The network tier of external IP is STANDARD, that of Address must be the same."}
+}
+
+func InsertAddressNotAllocatedToProjectErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Specified IP address is not allocated to the project or does not belong to the specified scope."}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,6 +110,20 @@ func NewNetworkTierErr(resourceInErr, desired, received string) *NetworkTierErro
 	return &NetworkTierError{resource: resourceInErr, desiredNT: desired, receivedNT: received}
 }
 
+// IPConfigurationError is a struct to define error caused by User misconfiguration the Load Balancer IP.
+type IPConfigurationError struct {
+	ip     string
+	reason string
+}
+
+func (e *IPConfigurationError) Error() string {
+	return fmt.Sprintf("IP configuration error: \"%s\" %s", e.ip, e.reason)
+}
+
+func NewIPConfigurationError(ip, reason string) *IPConfigurationError {
+	return &IPConfigurationError{ip: ip, reason: reason}
+}
+
 // L4LBType indicates if L4 LoadBalancer is Internal or External
 type L4LBType int
 
@@ -198,11 +212,17 @@ func IsNetworkTierError(err error) bool {
 	return errors.As(err, &netTierError)
 }
 
+// IsIPConfigurationError checks if wrapped error is an IP configuration error.
+func IsIPConfigurationError(err error) bool {
+	var ipConfigError *IPConfigurationError
+	return errors.As(err, &ipConfigError)
+}
+
 // IsUserError checks if given error is cause by User.
-// Right now User Error might be cause by Network Tier misconfiguration
-// but this list might get longer.
+// Right now User Error might be caused by Network Tier misconfiguration
+// or specifying non-existent or already used IP address.
 func IsUserError(err error) bool {
-	return IsNetworkTierError(err)
+	return IsNetworkTierError(err) || IsIPConfigurationError(err)
 }
 
 // IsNotFoundError returns true if the resource does not exist


### PR DESCRIPTION
[Cherrypick #1890] Cherrypick metric user errors fix to release 1.20
NetLB: Treat LoadBalancer IP setup errors as user errors.

(cherry picked from commit 810ebc9d33fa89d8a68a9adda0499087bfd38667)