### PR TITLE
Add IsSubnetworkMissingIPv6GCEError to User Errors

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -93,6 +93,7 @@ const (
 )
 
 var networkTierErrorRegexp = regexp.MustCompile(`The network tier of external IP is STANDARD|PREMIUM, that of Address must be the same.`)
+var subnetworkMissingIPv6ErrorRegexp = regexp.MustCompile("Subnetwork does not have an internal IPv6 IP space which is required for IPv6 L4 ILB forwarding rules.")
 
 // NetworkTierError is a struct to define error caused by User misconfiguration of Network Tier.
 type NetworkTierError struct {
@@ -201,6 +202,10 @@ func IsInUsedByError(err error) bool {
 	return strings.Contains(apiErr.Message, "being used by")
 }
 
+func IsSubnetworkMissingIPv6GCEError(err error) bool {
+	return subnetworkMissingIPv6ErrorRegexp.MatchString(err.Error())
+}
+
 // IsNetworkTierMismatchGCEError checks if error is a GCE network tier mismatch for external IP
 func IsNetworkTierMismatchGCEError(err error) bool {
 	return networkTierErrorRegexp.MatchString(err.Error())
@@ -237,7 +242,8 @@ func IsUserError(err error) bool {
 	return IsNetworkTierError(err) ||
 		IsIPConfigurationError(err) ||
 		IsInvalidLoadBalancerSourceRangesSpecError(err) ||
-		IsInvalidLoadBalancerSourceRangesAnnotationError(err)
+		IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
+		IsSubnetworkMissingIPv6GCEError(err)
 }
 
 // IsNotFoundError returns true if the resource does not exist


### PR DESCRIPTION
If user tries to create IPv6 ILB in subnetwork, which does not have internal IPv6 addresses, this call https://github.com/panslava/ingress-gce/blob/master/pkg/loadbalancers/forwarding_rules_ipv6.go#L67 will return following error


ensureIPv6Resources: Failed to ensure ipv6 forwarding rule - googleapi: Error 400: Invalid value for field 'resource.subnetwork': 'https://www.googleapis.com/compute/v1/projects/.../regions/us-west3/subnetworks/v6-ext-subnet'. Subnetwork does not have an internal IPv6 IP space which is required for IPv6 L4 ILB forwarding rules., invalid


We should count such errors as user ones

I also not really sure, if the approach I did is good -- checking string matching on the very end of sync loop. 
Alternatively, we could do this string matching checking straight after doing forwardingRules.Create call, and then construct new custom error type, but I am not sure exactly, what will be the benefits

/assign cezarygerard