### PR TITLE
[Cherrypick #1895] Cherrypick extending the number_of_l4_ilbs with us…

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -220,6 +220,9 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(key string, service *v1.Se
 	if syncResult.Error != nil {
 		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
 			"Error syncing load balancer: %v", syncResult.Error)
+		if utils.IsUserError(syncResult.Error) {
+			syncResult.MetricsState.IsUserError = true
+		}
 		return syncResult
 	}
 	if syncResult.Status == nil {

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/googleapi"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -93,6 +94,13 @@ func newFakeGCEWithInsertError() *gce.Cloud {
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := gce.NewFakeGCECloud(vals)
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockForwardingRules.InsertHook = mock.InsertForwardingRulesInternalErrHook
+	return fakeGCE
+}
+
+func newFakeGCEWithUserInsertError() *gce.Cloud {
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := gce.NewFakeGCECloud(vals)
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(&googleapi.Error{Code: http.StatusConflict, Message: "IP_IN_USE_BY_ANOTHER_RESOURCE - IP '1.1.1.1' is already being used by another resource."})
 	return fakeGCE
 }
 
@@ -636,4 +644,22 @@ func TestProcessServiceOnError(t *testing.T) {
 		t.Errorf("Error getting L4 ILB error metrics err: %v", errMetrics)
 	}
 	prevMetrics.ValidateDiff(currMetrics, expectMetrics, t)
+}
+
+func TestProcessServiceOnUserError(t *testing.T) {
+	t.Parallel()
+	l4c := newServiceController(t, newFakeGCEWithUserInsertError())
+	newSvc := test.NewL4ILBService(false, 8080)
+	addILBService(l4c, newSvc)
+	addNEG(l4c, newSvc)
+	syncResult := l4c.processServiceCreateOrUpdate("svc_key", newSvc)
+	if syncResult.Error == nil {
+		t.Fatalf("Failed to generate error when syncing service %s", newSvc.Name)
+	}
+	if !syncResult.MetricsState.IsUserError {
+		t.Errorf("syncResult.MetricsState.IsUserError should be true, got false")
+	}
+	if syncResult.MetricsState.InSuccess {
+		t.Errorf("syncResult.MetricsState.InSuccess should be false, got true")
+	}
 }

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -40,9 +40,12 @@ import (
 const (
 	// maxL4ILBPorts is the maximum number of ports that can be specified in an L4 ILB Forwarding Rule
 	maxL4ILBPorts = 5
-	// addressAlreadyInUseMessage is the error message string returned by the compute API
-	// when creating a forwarding rule that uses a conflicting IP address.
-	addressAlreadyInUseMessage = "Specified IP address is in-use and would result in a conflict."
+	// addressAlreadyInUseMessageExternal is the error message string returned by the compute API
+	// when creating an external forwarding rule that uses a conflicting IP address.
+	addressAlreadyInUseMessageExternal = "Specified IP address is in-use and would result in a conflict."
+	// addressAlreadyInUseMessageInternal is the error message string returned by the compute API
+	// when creating an internal forwarding rule that uses a conflicting IP address.
+	addressAlreadyInUseMessageInternal = "IP_IN_USE_BY_ANOTHER_RESOURCE"
 )
 
 func (l7 *L7) checkHttpForwardingRule() (err error) {
@@ -300,6 +303,9 @@ func (l4 *L4) ensureForwardingRule(bsLink string, options gce.ILBOptions, existi
 	}
 	klog.V(2).Infof("ensureForwardingRule: Creating/Recreating forwarding rule - %s", fr.Name)
 	if err = l4.forwardingRules.Create(fr); err != nil {
+		if isAddressAlreadyInUseError(err) {
+			return nil, utils.NewIPConfigurationError(fr.IPAddress, err.Error())
+		}
 		return nil, err
 	}
 
@@ -406,7 +412,7 @@ func (l4netlb *L4NetLB) ensureExternalForwardingRule(bsLink string) (*composite.
 	klog.V(2).Infof("ensureExternalForwardingRule: Creating/Recreating forwarding rule - %s", fr.Name)
 	if err = l4netlb.forwardingRules.Create(fr); err != nil {
 		if isAddressAlreadyInUseError(err) {
-			return nil, IPAddrUndefined, utils.NewIPConfigurationError(fr.IPAddress, addressAlreadyInUseMessage)
+			return nil, IPAddrUndefined, utils.NewIPConfigurationError(fr.IPAddress, addressAlreadyInUseMessageExternal)
 		}
 		return nil, IPAddrUndefined, err
 	}
@@ -469,5 +475,9 @@ func l4lbIPToUse(svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSu
 }
 
 func isAddressAlreadyInUseError(err error) bool {
-	return utils.IsHTTPErrorCode(err, http.StatusBadRequest) && strings.Contains(err.Error(), addressAlreadyInUseMessage)
+	// Bad request HTTP status (400) is returned for external Forwarding Rules.
+	alreadyInUseExternal := utils.IsHTTPErrorCode(err, http.StatusBadRequest) && strings.Contains(err.Error(), addressAlreadyInUseMessageExternal)
+	// Conflict HTTP status (409) is returned for internal Forwarding Rules.
+	alreadyInUseInternal := utils.IsHTTPErrorCode(err, http.StatusConflict) && strings.Contains(err.Error(), addressAlreadyInUseMessageInternal)
+	return alreadyInUseExternal || alreadyInUseInternal
 }

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/legacy-cloud-providers/gce"
 )
 
@@ -263,6 +264,37 @@ func TestL4CreateExternalForwardingRuleAddressAlreadyInUse(t *testing.T) {
 	insertError := &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.IPAddress': '1.1.1.1'. Specified IP address is in-use and would result in a conflict., invalid"}
 	fakeGCE.Compute().(*cloud.MockGCE).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(insertError)
 	_, _, err := l4.ensureExternalForwardingRule("link")
+
+	require.Error(t, err)
+	assert.True(t, utils.IsIPConfigurationError(err))
+}
+
+func TestL4EnsureIPv4ForwardingRuleAddressAlreadyInUse(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	targetIP := "1.1.1.1"
+	l4 := L4{
+		cloud:           fakeGCE,
+		forwardingRules: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional),
+		namer:           namer.NewL4Namer("test", namer.NewNamer("testCluster", "testFirewall")),
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "testService", Namespace: "default", UID: types.UID("1")},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port: 8080,
+					},
+				},
+				Type:           "LoadBalancer",
+				LoadBalancerIP: targetIP,
+			},
+		},
+	}
+
+	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(cloud.SchemeInternal)}
+	fakeGCE.ReserveRegionAddress(addr, fakeGCE.Region())
+	insertError := &googleapi.Error{Code: http.StatusConflict, Message: "IP_IN_USE_BY_ANOTHER_RESOURCE - IP '10.107.116.14' is already being used by another resource."}
+	fakeGCE.Compute().(*cloud.MockGCE).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(insertError)
+	_, err := l4.ensureForwardingRule("link", gce.ILBOptions{}, nil)
 
 	require.Error(t, err)
 	assert.True(t, utils.IsIPConfigurationError(err))

--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -112,6 +112,8 @@ const (
 	// l4ILBInInError feature specifies that an error had occurred while creating/
 	// updating GCE Load Balancer.
 	l4ILBInError = feature("L4ILBInError")
+	// l4ILBInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
+	l4ILBInUserError = feature("L4ILBInUserError")
 
 	l4NetLBService = feature("L4NetLBService")
 	// l4NetLBPremiumNetworkTier feature specifies that NetLB VIP is configured in Premium Network Tier.

--- a/pkg/metrics/l4metrics_test.go
+++ b/pkg/metrics/l4metrics_test.go
@@ -55,12 +55,13 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 0,
 				l4ILBInSuccess:    0,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "one l4 ilb service",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess),
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      1,
@@ -68,12 +69,13 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 0,
 				l4ILBInSuccess:    1,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "l4 ilb service in error state",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      1,
@@ -81,12 +83,27 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 0,
 				l4ILBInSuccess:    0,
 				l4ILBInError:      1,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "l4 ilb service in user error state",
+			serviceStates: []L4ILBServiceState{
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, isUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    0,
+				l4ILBInError:      0,
+				l4ILBInUserError:  1,
 			},
 		},
 		{
 			desc: "global access for l4 ilb service enabled",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      1,
@@ -94,12 +111,13 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 0,
 				l4ILBInSuccess:    1,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "custom subnet for l4 ilb service enabled",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      1,
@@ -107,12 +125,13 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 1,
 				l4ILBInSuccess:    1,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "both global access and custom subnet for l4 ilb service enabled",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      1,
@@ -120,15 +139,16 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 1,
 				l4ILBInSuccess:    1,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "many l4 ilb services",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess),
-				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess),
-				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess),
-				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess),
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
 			},
 			expectL4ILBCount: map[feature]int{
 				l4ILBService:      4,
@@ -136,24 +156,27 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 				l4ILBCustomSubnet: 2,
 				l4ILBInSuccess:    4,
 				l4ILBInError:      0,
+				l4ILBInUserError:  0,
 			},
 		},
 		{
 			desc: "many l4 ilb services with some in error state",
 			serviceStates: []L4ILBServiceState{
-				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess),
-				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError),
-				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess),
-				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess),
-				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isError),
-				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess),
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isError, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isError, isUserError),
 			},
 			expectL4ILBCount: map[feature]int{
-				l4ILBService:      6,
+				l4ILBService:      7,
 				l4ILBGlobalAccess: 2,
 				l4ILBCustomSubnet: 2,
 				l4ILBInSuccess:    4,
 				l4ILBInError:      2,
+				l4ILBInUserError:  1,
 			},
 		},
 	} {
@@ -172,11 +195,12 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 	}
 }
 
-func newL4ILBServiceState(globalAccess, customSubnet, inSuccess bool) L4ILBServiceState {
+func newL4ILBServiceState(globalAccess bool, customSubnet bool, inSuccess bool, isUserError bool) L4ILBServiceState {
 	return L4ILBServiceState{
 		EnabledGlobalAccess: globalAccess,
 		EnabledCustomSubnet: customSubnet,
 		InSuccess:           inSuccess,
+		IsUserError:         isUserError,
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -497,13 +497,18 @@ func (im *ControllerMetrics) computeL4ILBMetrics() map[feature]int {
 		l4ILBCustomSubnet: 0,
 		l4ILBInSuccess:    0,
 		l4ILBInError:      0,
+		l4ILBInUserError:  0,
 	}
 
 	for key, state := range im.l4ILBServiceMap {
 		klog.V(6).Infof("ILB Service %s has EnabledGlobalAccess: %t, EnabledCustomSubnet: %t, InSuccess: %t", key, state.EnabledGlobalAccess, state.EnabledCustomSubnet, state.InSuccess)
 		counts[l4ILBService]++
 		if !state.InSuccess {
-			counts[l4ILBInError]++
+			if state.IsUserError {
+				counts[l4ILBInUserError]++
+			} else {
+				counts[l4ILBInError]++
+			}
 			// Skip counting other features if the service is in error state.
 			continue
 		}

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -69,6 +69,8 @@ type L4ILBServiceState struct {
 	EnabledCustomSubnet bool
 	// InSuccess specifies if the ILB service VIP is configured.
 	InSuccess bool
+	// IsUserError specifies if the error was caused by User misconfiguration.
+	IsUserError bool
 }
 
 // L4NetLBServiceState defines if network tier is premium and


### PR DESCRIPTION
…er errors.

ILB: Extend the number_of_l4_ilbs metric to track user errors and treat ILB IP setup errors as these errors.

(cherry picked from commit e7ea3c15c01873e51aecf01c504cbf8eb8cf19b3)