### PR TITLE
Add UserError Status to ILB DualStack metrics

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	l4metrics "k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
+	"k8s.io/ingress-gce/pkg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -233,6 +234,9 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service) *load
 			"Error syncing load balancer: %v", syncResult.Error)
 		if utils.IsUserError(syncResult.Error) {
 			syncResult.MetricsState.IsUserError = true
+			if l4c.enableDualStack {
+				syncResult.DualStackMetricsState.Status = metrics.StatusUserError
+			}
 		}
 		return syncResult
 	}

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -506,7 +506,7 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 			klog.V(6).Infof("Internal L4 Loadbalancer for Service %s deleted, removing its state from metrics cache", namespacedName)
 			l4c.ctx.ControllerMetrics.DeleteL4ILBService(namespacedName)
 			if l4c.enableDualStack {
-				klog.V(6).Infof("Internal L4 Loadbalancer for Service %s deleted, removing its state from metrics cache", namespacedName)
+				klog.V(6).Infof("Internal L4 DualStack LoadBalancer for Service %s deleted, removing its state from metrics cache", namespacedName)
 				l4c.ctx.ControllerMetrics.DeleteL4ILBDualStackService(namespacedName)
 			}
 		}

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -76,6 +76,7 @@ type L4ILBServiceState struct {
 type L4ILBDualStackServiceStateStatus string
 
 var StatusSuccess = L4ILBDualStackServiceStateStatus("Success")
+var StatusUserError = L4ILBDualStackServiceStateStatus("UserError")
 var StatusError = L4ILBDualStackServiceStateStatus("Error")
 
 // L4ILBDualStackServiceState defines ipFamilies, ipFamilyPolicy and status

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -75,9 +75,9 @@ type L4ILBServiceState struct {
 
 type L4ILBDualStackServiceStateStatus string
 
-var StatusSuccess = L4ILBDualStackServiceStateStatus("Success")
-var StatusUserError = L4ILBDualStackServiceStateStatus("UserError")
-var StatusError = L4ILBDualStackServiceStateStatus("Error")
+const StatusSuccess = L4ILBDualStackServiceStateStatus("Success")
+const StatusUserError = L4ILBDualStackServiceStateStatus("UserError")
+const StatusError = L4ILBDualStackServiceStateStatus("Error")
 
 // L4ILBDualStackServiceState defines ipFamilies, ipFamilyPolicy and status
 // of L4 ILB DualStack service


### PR DESCRIPTION
Currently all dual stack errors are not distinguished between user errors and controller failure. This is required to set up proper alerts

At first we should merge this https://github.com/kubernetes/ingress-gce/pull/1897