### PR TITLE
make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,10 @@ include build/rules.mk
 # TODO(rramkumar): Find a way not to use "latest" as the tag.
 push-e2e:
 	@$(MAKE) --no-print-directory containers push
+
+# update generated code
+generate:
+	hack/update-codegen.sh
+# run linters, ensure generated code, etc.
+verify:
+	hack/verify-all.sh

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-
-# Copyright 2017 The Kubernetes Authors.
+#!/bin/sh
+#
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,30 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
-_tmp="$(mktemp -d -t "ingress-gce.XXXXXX")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &> /dev/null && pwd -P)"
+cd "${REPO_ROOT}"
 
-cleanup() {
- git worktree remove -f "${_tmp}"
-}
-
-trap "cleanup" EXIT SIGINT
-
-git worktree add -f -q "${_tmp}" HEAD
-cd "${_tmp}"
-
-# Update generated code
-hack/update-codegen.sh
-
-# Test for diffs
-diffs=$(git status --porcelain | wc -l)
-if [[ ${diffs} -gt 0 ]]; then
-  git status >&2
-  git diff >&2
-  echo "Generated files need to be updated" >&2
-  echo "Please run 'hack/update-codegen.sh'" >&2
-  exit 1
-fi
-
-echo "Generated files are up to date"
-echo
+hack/verify-gofmt.sh
+hack/verify-govet.sh
+hack/verify-lint.sh
+hack/verify-codegen.sh

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &> /dev/null && pwd -P)"
+cd "${REPO_ROOT}"
+
+echo -n "Checking gofmt: "
+
+function git_find() {
+    # Similar to find but faster and easier to understand.  We want to include
+    # modified and untracked files because this might be running against code
+    # which is not tracked by git yet.
+    git ls-files -cmo --exclude-standard \
+        ':!:vendor/*'        `# catches vendor/...` \
+        ':!:*/vendor/*'      `# catches any subdir/vendor/...` \
+        ':!:third_party/*'   `# catches third_party/...` \
+        ':!:*/third_party/*' `# catches third_party/...` \
+        ':(glob)**/*.go' \
+        "$@"
+}
+
+echo -n "Checking gofmt: "
+ERRS=$(git_find -z | xargs -0 gofmt -l 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL - the following files need to be gofmt'ed:"
+    for e in ${ERRS}; do
+        echo "    $e"
+    done
+    echo
+    exit 1
+fi
+echo "PASS"
+echo

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &> /dev/null && pwd -P)"
+cd "${REPO_ROOT}"
+
+# Set gobin here, install dependencies after this
+cd "hack/tools"
+export GOBIN=$PWD/bin
+export PATH=$GOBIN:$PATH
+# Install golangci-lint
+echo "Installing golangci-lint"
+echo
+go install github.com/golangci/golangci-lint/cmd/golangci-lint > /dev/null
+cd "../.."
+
+export GOLANGCI_LINT_CACHE=$PWD/.cache
+echo -n "Checking linters: "
+ERRS=$(golangci-lint run ./... 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL"
+    echo "${ERRS}"
+    echo
+    exit 1
+fi
+rm -rf $GOLANGCI_LINT_CACHE
+echo "PASS"
+echo

--- a/pkg/backends/features/customresponseheaders.go
+++ b/pkg/backends/features/customresponseheaders.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
It seems we were not running correctly the verify, this PR
- adds verify and update targets to the makefile
- split the verify options into different scripts to simplify its maintainnce
- fix one gofmt error


The generation still doesn't work, it will be fixed by https://github.com/kubernetes/ingress-gce/pull/1884 but this PR adds an option to verify the code generated is correct

Next step is to add a new job to run `make verify` on the CI https://github.com/kubernetes/test-infra/pull/28507
