### PR TITLE
use bash for verify scripts

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2022 The Kubernetes Authors.
 #

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2022 The Kubernetes Authors.
 #

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2022 The Kubernetes Authors.
 #

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2022 The Kubernetes Authors.
 #


### PR DESCRIPTION
otherwise the scripts fails because `pipefail` is a bash only thing

```
hack/verify-all.sh
hack/verify-all.sh: 19: set: Illegal option -o pipefail
make: *** [Makefile:68: verify] Error 2
+ EXIT_VALUE=2
```