### PR TITLE
Inline dependency on legacy-cloud-providers

### DIFF
--- a/pkg/annotations/gce_annotations.go
+++ b/pkg/annotations/gce_annotations.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// LoadBalancerType defines a specific type for holding load balancer types (eg. Internal)
+type LoadBalancerType string
+
+const (
+	// ServiceAnnotationLoadBalancerType is annotated on a service with type LoadBalancer
+	// dictates what specific kind of GCP LB should be assembled.
+	// Currently, only "Internal" is supported.
+	ServiceAnnotationLoadBalancerType = "networking.gke.io/load-balancer-type"
+
+	// Deprecating the old-style naming of LoadBalancerType annotation
+	deprecatedServiceAnnotationLoadBalancerType = "cloud.google.com/load-balancer-type"
+
+	// LBTypeInternal is the constant for the official internal type.
+	LBTypeInternal LoadBalancerType = "Internal"
+
+	// Deprecating the lowercase spelling of Internal.
+	deprecatedTypeInternalLowerCase LoadBalancerType = "internal"
+)
+
+// GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.
+func GetLoadBalancerAnnotationType(service *v1.Service) LoadBalancerType {
+	var lbType LoadBalancerType
+	for _, ann := range []string{
+		ServiceAnnotationLoadBalancerType,
+		deprecatedServiceAnnotationLoadBalancerType,
+	} {
+		if v, ok := service.Annotations[ann]; ok {
+			lbType = LoadBalancerType(v)
+			break
+		}
+	}
+
+	switch lbType {
+	case LBTypeInternal, deprecatedTypeInternalLowerCase:
+		return LBTypeInternal
+	default:
+		return lbType
+	}
+}

--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/legacy-cloud-providers/gce"
 )
 
 const (
@@ -228,8 +227,8 @@ func WantsL4ILB(service *v1.Service) (bool, string) {
 	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false, fmt.Sprintf("Type : %s", service.Spec.Type)
 	}
-	ltype := gce.GetLoadBalancerAnnotationType(service)
-	if ltype == gce.LBTypeInternal {
+	ltype := GetLoadBalancerAnnotationType(service)
+	if ltype == LBTypeInternal {
 		return true, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
 	}
 	return false, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
@@ -243,8 +242,8 @@ func WantsL4NetLB(service *v1.Service) (bool, string) {
 	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false, fmt.Sprintf("Type : %s", service.Spec.Type)
 	}
-	ltype := gce.GetLoadBalancerAnnotationType(service)
-	return ltype != gce.LBTypeInternal, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
+	ltype := GetLoadBalancerAnnotationType(service)
+	return ltype != LBTypeInternal, fmt.Sprintf("Type : %s, LBType : %s", service.Spec.Type, ltype)
 }
 
 // OnlyStatusAnnotationsChanged returns true if the only annotation change between the 2 services is the NEG or ILB


### PR DESCRIPTION
Remove the dependency on legacy-cloud-providers for pkg/annotations/service.go
to facilitate import into google3 as this library does not exist in google3.