### PR TITLE
Add an environment variable for disabling the instance group controller

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -358,14 +358,16 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	ctx.Start(stopCh)
 
-	igControllerParams := &instancegroups.ControllerConfig{
-		NodeInformer: ctx.NodeInformer,
-		IGManager:    ctx.InstancePool,
-		HasSynced:    ctx.HasSynced,
-		StopCh:       stopCh,
+	if flags.F.RunInstanceGroupController {
+		igControllerParams := &instancegroups.ControllerConfig{
+			NodeInformer: ctx.NodeInformer,
+			IGManager:    ctx.InstancePool,
+			HasSynced:    ctx.HasSynced,
+			StopCh:       stopCh,
+		}
+		igController := instancegroups.NewController(igControllerParams)
+		go igController.Run()
 	}
-	igController := instancegroups.NewController(igControllerParams)
-	go igController.Run()
 
 	// The L4NetLbController will be run when RbsMode flag is Set
 	if flags.F.RunL4NetLBController {

--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -358,7 +359,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 
 	ctx.Start(stopCh)
 
-	if flags.F.RunInstanceGroupController {
+	if strings.ToLower(os.Getenv("EXPERIMENTAL_ONLY_FOR_TESTING_DISABLE_INSTANCE_GROUP_CONTROLLER")) != "true" {
 		igControllerParams := &instancegroups.ControllerConfig{
 			NodeInformer: ctx.NodeInformer,
 			IGManager:    ctx.InstancePool,

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -87,7 +87,6 @@ var (
 		NumL4NetLBWorkers                int
 		NumIngressWorkers                int
 		RunIngressController             bool
-		RunInstanceGroupController       bool
 		RunL4Controller                  bool
 		RunL4NetLBController             bool
 		Version                          bool
@@ -243,7 +242,6 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
 	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
-	flag.BoolVar(&F.RunInstanceGroupController, "run-instance-group-controller", true, "Optional, whether or not to run InstanceGroupController as part of glbc. If set to false, changes in the instance group will not be processed.")
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, f enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableBackendConfigHealthCheck, "enable-backendconfig-healthcheck", false, "Enable configuration of HealthChecks from the BackendConfig")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -87,6 +87,7 @@ var (
 		NumL4NetLBWorkers                int
 		NumIngressWorkers                int
 		RunIngressController             bool
+		RunInstanceGroupController       bool
 		RunL4Controller                  bool
 		RunL4NetLBController             bool
 		Version                          bool
@@ -242,6 +243,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
 	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
+	flag.BoolVar(&F.RunInstanceGroupController, "run-instance-group-controller", true, "Optional, whether or not to run InstanceGroupController as part of glbc. If set to false, changes in the instance group will not be processed.")
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, f enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableBackendConfigHealthCheck, "enable-backendconfig-healthcheck", false, "Enable configuration of HealthChecks from the BackendConfig")


### PR DESCRIPTION
This PR proposes a new environment variable `EXPERIMENTAL_ONLY_FOR_TESTING_DISABLE_INSTANCE_GROUP_CONTROLLER` for disabling the instance group controller for the testing env.

When we are doing a test or dev on non-GCP, the instance group controller is not needed, so this env var provides the way to turn off the instance group controller. Please note that it is disabled only when the env var has the value `true` (case insensitive). 
