### PR TITLE
Add metrics for endpointslice state

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -93,6 +93,7 @@ var (
 		WatchNamespace                   string
 		LeaderElection                   LeaderElectionConfiguration
 		MetricsExportInterval            time.Duration
+		NegMetricsExportInterval         time.Duration
 
 		// Feature flags should be named Enablexxx.
 		EnableASMConfigMapBasedConfig  bool
@@ -257,6 +258,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multiple unmanaged instance groups")
 	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)
+	flag.DurationVar(&F.NegMetricsExportInterval, "neg-metrics-export-interval", 5*time.Second, `Period for calculating and exporting internal neg controller metrics, not usage.`)
 }
 
 type RateLimitSpecs struct {

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -362,6 +362,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		wait.Until(c.gc, c.gcPeriod, stopCh)
 	}()
 	go c.reflector.Run(stopCh)
+	go c.syncerMetrics.Run(stopCh)
 	<-stopCh
 }
 

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -43,8 +43,10 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	svcnegv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/controller/translator"
-	usage "k8s.io/ingress-gce/pkg/metrics"
+	"k8s.io/ingress-gce/pkg/flags"
+	usageMetrics "k8s.io/ingress-gce/pkg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics"
+	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
@@ -99,8 +101,10 @@ type Controller struct {
 	// reflector handles NEG readiness gate and conditions for pods in NEG.
 	reflector readiness.Reflector
 
-	// collector collects NEG usage metrics
-	collector usage.NegMetricsCollector
+	// usageCollector collects NEG usage metrics
+	usageCollector usageMetrics.NegMetricsCollector
+
+	syncerMetrics *syncMetrics.SyncerMetrics
 
 	// runL4 indicates whether to run NEG controller that processes L4 ILB services
 	runL4 bool
@@ -123,7 +127,7 @@ func NewController(
 	destinationRuleInformer cache.SharedIndexInformer,
 	svcNegInformer cache.SharedIndexInformer,
 	hasSynced func() bool,
-	controllerMetrics *usage.ControllerMetrics,
+	controllerMetrics *usageMetrics.ControllerMetrics,
 	l4Namer namer2.L4ResourcesNamer,
 	defaultBackendService utils.ServicePort,
 	cloud negtypes.NetworkEndpointGroupCloud,
@@ -168,6 +172,8 @@ func NewController(
 		endpointIndexer = endpointInformer.GetIndexer()
 	}
 
+	syncerMetrics := metrics.NewNegMetricsCollector(flags.F.NegMetricsExportInterval, logger)
+
 	manager := newSyncerManager(
 		namer,
 		recorder,
@@ -181,6 +187,7 @@ func NewController(
 		endpointSliceIndexer,
 		nodeInformer.GetIndexer(),
 		svcNegInformer.GetIndexer(),
+		syncerMetrics,
 		enableNonGcpMode,
 		enableEndpointSlices,
 		logger)
@@ -217,7 +224,8 @@ func NewController(
 		nodeQueue:             workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		syncTracker:           utils.NewTimeTracker(),
 		reflector:             reflector,
-		collector:             controllerMetrics,
+		usageCollector:        controllerMetrics,
+		syncerMetrics:         syncerMetrics,
 		runL4:                 runL4Controller,
 		logger:                logger,
 	}
@@ -462,7 +470,7 @@ func (c *Controller) processService(key string) error {
 		return err
 	}
 	if !exists {
-		c.collector.DeleteNegService(key)
+		c.usageCollector.DeleteNegService(key)
 		c.manager.StopSyncer(namespace, name)
 		return nil
 	}
@@ -470,7 +478,7 @@ func (c *Controller) processService(key string) error {
 	if service == nil {
 		return fmt.Errorf("cannot convert to Service (%T)", obj)
 	}
-	negUsage := usage.NegServiceState{}
+	negUsage := usageMetrics.NegServiceState{}
 	svcPortInfoMap := make(negtypes.PortInfoMap)
 	if err := c.mergeDefaultBackendServicePortInfoMap(key, service, svcPortInfoMap); err != nil {
 		return err
@@ -510,12 +518,12 @@ func (c *Controller) processService(key string) error {
 			return fmt.Errorf("failed to merge service ports referenced by Istio:DestinationRule (%v): %w", destinationRulesPortInfoMap, err)
 		}
 		negUsage.SuccessfulNeg, negUsage.ErrorNeg, err = c.manager.EnsureSyncers(namespace, name, svcPortInfoMap)
-		c.collector.SetNegService(key, negUsage)
+		c.usageCollector.SetNegService(key, negUsage)
 		return err
 	}
 	// do not need Neg
 	c.logger.V(3).Info("Service does not need any NEG. Skipping", "service", key)
-	c.collector.DeleteNegService(key)
+	c.usageCollector.DeleteNegService(key)
 	// neg annotation is not found or NEG is not enabled
 	c.manager.StopSyncer(namespace, name)
 
@@ -547,7 +555,7 @@ func (c *Controller) mergeIngressPortInfo(service *apiv1.Service, name types.Nam
 }
 
 // mergeStandaloneNEGsPortInfo merge Standalone NEG PortInfo into portInfoMap
-func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usage.NegServiceState) error {
+func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usageMetrics.NegServiceState) error {
 	negAnnotation, foundNEGAnnotation, err := annotations.FromService(service).NEGAnnotation()
 	if err != nil {
 		return err
@@ -587,7 +595,7 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 }
 
 // mergeVmIpNEGsPortInfo merges the PortInfo for ILB services using GCE_VM_IP NEGs into portInfoMap
-func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usage.NegServiceState) error {
+func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *usageMetrics.NegServiceState) error {
 	if wantsILB, _ := annotations.WantsL4ILB(service); !wantsILB {
 		return nil
 	}
@@ -601,7 +609,7 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 
 	onlyLocal := helpers.RequestsOnlyLocalTraffic(service)
 	// Update usage metrics.
-	negUsage.VmIpNeg = usage.NewVmIpNegType(onlyLocal)
+	negUsage.VmIpNeg = usageMetrics.NewVmIpNegType(onlyLocal)
 
 	return portInfoMap.Merge(negtypes.NewPortInfoMapForVMIPNEG(name.Namespace, name.Name, c.l4Namer, onlyLocal))
 }

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -81,6 +81,9 @@ type syncerManager struct {
 	// syncerMap stores the NEG syncer
 	// key consists of service namespace, name and targetPort. Value is the corresponding syncer.
 	syncerMap map[negtypes.NegSyncerKey]negtypes.NegSyncer
+	// syncCollector collect sync related metrics
+	syncerMetrics *metrics.SyncerMetrics
+
 	// reflector handles NEG readiness gate and conditions for pods in NEG.
 	reflector readiness.Reflector
 	//svcNegClient handles lifecycle operations for NEG CRs
@@ -114,6 +117,7 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 	endpointSliceLister cache.Indexer,
 	nodeLister cache.Indexer,
 	svcNegLister cache.Indexer,
+	syncerMetrics *metrics.SyncerMetrics,
 	enableNonGcpMode bool,
 	enableEndpointSlices bool,
 	logger klog.Logger) *syncerManager {
@@ -135,6 +139,7 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 		svcNegLister:         svcNegLister,
 		svcPortMap:           make(map[serviceKey]negtypes.PortInfoMap),
 		syncerMap:            make(map[negtypes.NegSyncerKey]negtypes.NegSyncer),
+		syncerMetrics:        syncerMetrics,
 		svcNegClient:         svcNegClient,
 		kubeSystemUID:        kubeSystemUID,
 		enableNonGcpMode:     enableNonGcpMode,
@@ -227,6 +232,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				epc,
 				string(manager.kubeSystemUID),
 				manager.svcNegClient,
+				manager.syncerMetrics,
 				!manager.namer.IsNEG(portInfo.NegName),
 				manager.enableEndpointSlices,
 				manager.logger,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/types"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
@@ -91,6 +92,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 		testContext.EndpointSliceInformer.GetIndexer(),
 		testContext.NodeInformer.GetIndexer(),
 		testContext.SvcNegInformer.GetIndexer(),
+		metrics.FakeSyncerMetrics(),
 		false, //enableNonGcpMode
 		false, //enableEndpointSlices
 		klog.TODO(),

--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -139,6 +139,8 @@ func RegisterMetrics() {
 		prometheus.MustRegister(SyncerSyncLatency)
 		prometheus.MustRegister(LastSyncTimestamp)
 		prometheus.MustRegister(InitializationLatency)
+
+		RegisterSyncerMetrics()
 	})
 }
 

--- a/pkg/neg/metrics/neg_metrics_collector.go
+++ b/pkg/neg/metrics/neg_metrics_collector.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/klog/v2"
 )
@@ -28,9 +29,22 @@ import (
 const (
 	syncResultLabel = "result"
 	syncResultKey   = "sync_result"
+
+	syncerStatusLabel = "status"
+	syncerStatusKey   = "syncer_status"
 )
 
 var (
+	// syncerSyncerStatus tracks the count of syncer in different statuses
+	syncerSyncerStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: negControllerSubsystem,
+			Name:      syncerStatusKey,
+			Help:      "Current count of syncers in each status",
+		},
+		[]string{syncerStatusLabel},
+	)
+
 	// syncerSyncResult tracks the count for each sync result
 	syncerSyncResult = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -47,6 +61,8 @@ type SyncerMetricsCollector interface {
 }
 
 type SyncerMetrics struct {
+	// syncerStatusmap tracks the status of each syncer
+	syncerStatusMap map[negtypes.NegSyncerKey]string
 	// mu avoid race conditions and ensure correctness of metrics
 	mu sync.Mutex
 	// duration between metrics exports
@@ -58,6 +74,7 @@ type SyncerMetrics struct {
 // NewNEGMetricsCollector initializes SyncerMetrics and starts a go routine to compute and export metrics periodically.
 func NewNegMetricsCollector(exportInterval time.Duration, logger klog.Logger) *SyncerMetrics {
 	return &SyncerMetrics{
+		syncerStatusMap: make(map[negtypes.NegSyncerKey]string),
 		metricsInterval: exportInterval,
 		logger:          logger.WithName("NegMetricsCollector"),
 	}
@@ -70,9 +87,66 @@ func FakeSyncerMetrics() *SyncerMetrics {
 
 func RegisterSyncerMetrics() {
 	prometheus.MustRegister(syncerSyncResult)
+	prometheus.MustRegister(syncerSyncerStatus)
+}
+
+func (sm *SyncerMetrics) Run(stopCh <-chan struct{}) {
+	sm.logger.V(3).Info("Syncer Metrics initialized.", "exportInterval", sm.metricsInterval)
+	// Compute and export metrics periodically.
+	go func() {
+		time.Sleep(sm.metricsInterval)
+		wait.Until(sm.export, sm.metricsInterval, stopCh)
+	}()
+	<-stopCh
+}
+
+// export exports syncer metrics.
+func (sm *SyncerMetrics) export() {
+	statusCount, syncerCount := sm.computeSyncerStatusMetrics()
+	sm.logger.V(3).Info("Exporting syncer status metrics.", "Syncer count", syncerCount)
+	for syncerStatus, count := range statusCount {
+		syncerSyncerStatus.WithLabelValues(syncerStatus).Set(float64(count))
+	}
 }
 
 // UpdateSyncer updates the count of sync results based on the result/error of sync
 func (sm *SyncerMetrics) UpdateSyncer(key negtypes.NegSyncerKey, syncResult *negtypes.NegSyncResult) {
 	syncerSyncResult.WithLabelValues(syncResult.Result).Inc()
+	syncerStatus := negtypes.GetSyncerStatus(syncResult.Result)
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.syncerStatusMap == nil {
+		sm.syncerStatusMap = make(map[negtypes.NegSyncerKey]string)
+		sm.logger.V(3).Info("Syncer Metrics failed to initialize correctly, reinitializing syncerStatusMap: %v", sm.syncerStatusMap)
+	}
+	sm.syncerStatusMap[key] = syncerStatus
+}
+
+func (sm *SyncerMetrics) computeSyncerStatusMetrics() (map[string]int, int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.logger.V(3).Info("computing syncer status metrics")
+
+	statusCount := map[string]int{
+		negtypes.SyncerEPCountsDiffer:         0,
+		negtypes.SyncerEPMissingNodeName:      0,
+		negtypes.SyncerNodeNotFound:           0,
+		negtypes.SyncerEPMissingZone:          0,
+		negtypes.SyncerEPSEndpointCountZero:   0,
+		negtypes.SyncerEPCalculationCountZero: 0,
+		negtypes.SyncerInvalidEPAttach:        0,
+		negtypes.SyncerInvalidEPDetach:        0,
+		negtypes.SyncerNegNotFound:            0,
+		negtypes.SyncerCurrentEPNotFound:      0,
+		negtypes.SyncerEPSNotFound:            0,
+		negtypes.SyncerOtherError:             0,
+		negtypes.SyncerSuccess:                0,
+	}
+	syncerCount := 0
+	for _, syncerStatus := range sm.syncerStatusMap {
+		statusCount[syncerStatus] += 1
+		syncerCount += 1
+	}
+	return statusCount, syncerCount
 }

--- a/pkg/neg/metrics/neg_metrics_collector.go
+++ b/pkg/neg/metrics/neg_metrics_collector.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/klog/v2"
+)
+
+const (
+	syncResultLabel = "result"
+	syncResultKey   = "sync_result"
+)
+
+var (
+	// syncerSyncResult tracks the count for each sync result
+	syncerSyncResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: negControllerSubsystem,
+			Name:      syncResultKey,
+			Help:      "Current count for each sync result",
+		},
+		[]string{syncResultLabel},
+	)
+)
+
+type SyncerMetricsCollector interface {
+	UpdateSyncer(key negtypes.NegSyncerKey, result *negtypes.NegSyncResult)
+}
+
+type SyncerMetrics struct {
+	// mu avoid race conditions and ensure correctness of metrics
+	mu sync.Mutex
+	// duration between metrics exports
+	metricsInterval time.Duration
+	// logger logs message related to NegMetricsCollector
+	logger klog.Logger
+}
+
+// NewNEGMetricsCollector initializes SyncerMetrics and starts a go routine to compute and export metrics periodically.
+func NewNegMetricsCollector(exportInterval time.Duration, logger klog.Logger) *SyncerMetrics {
+	return &SyncerMetrics{
+		metricsInterval: exportInterval,
+		logger:          logger.WithName("NegMetricsCollector"),
+	}
+}
+
+// FakeSyncerMetrics creates new NegMetricsCollector with fixed 5 second metricsInterval, to be used in tests
+func FakeSyncerMetrics() *SyncerMetrics {
+	return NewNegMetricsCollector(5*time.Second, klog.TODO())
+}
+
+func RegisterSyncerMetrics() {
+	prometheus.MustRegister(syncerSyncResult)
+}
+
+// UpdateSyncer updates the count of sync results based on the result/error of sync
+func (sm *SyncerMetrics) UpdateSyncer(key negtypes.NegSyncerKey, syncResult *negtypes.NegSyncResult) {
+	syncerSyncResult.WithLabelValues(syncResult.Result).Inc()
+}

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -61,7 +61,7 @@ func (l *LocalL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, *types.SyncerEPStat, error) {
 	// List all nodes where the service endpoints are running. Get a subset of the desired count.
 	zoneNodeMap := make(map[string][]*v1.Node)
 	processedNodes := sets.String{}
@@ -101,12 +101,12 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 	}
 	if numEndpoints == 0 {
 		// Not having backends will cause clients to see connection timeout instead of an "ICMP ConnectionRefused".
-		return nil, nil, 0, nil
+		return nil, nil, types.NewSyncerEPStat(), nil
 	}
 	// Compute the networkEndpoints, with total endpoints count <= l.subsetSizeLimit
 	klog.V(2).Infof("Got zoneNodeMap as input for service", "zoneNodeMap", nodeMapToString(zoneNodeMap), "serviceID", l.svcId)
 	subsetMap, err := getSubsetPerZone(zoneNodeMap, l.subsetSizeLimit, l.svcId, currentMap, l.logger)
-	return subsetMap, nil, 0, err
+	return subsetMap, nil, types.NewSyncerEPStat(), err
 }
 
 // ClusterL4ILBEndpointGetter implements the NetworkEndpointsCalculator interface.
@@ -142,7 +142,7 @@ func (l *ClusterL4ILBEndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, *types.SyncerEPStat, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
 	nodes, _ := utils.ListWithPredicate(l.nodeLister, utils.CandidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes)
 
@@ -158,7 +158,7 @@ func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.Endpoints
 	klog.V(2).Infof("Got zoneNodeMap as input for service", "zoneNodeMap", nodeMapToString(zoneNodeMap), "serviceID", l.svcId)
 	// Compute the networkEndpoints, with total endpoints <= l.subsetSizeLimit.
 	subsetMap, err := getSubsetPerZone(zoneNodeMap, l.subsetSizeLimit, l.svcId, currentMap, l.logger)
-	return subsetMap, nil, 0, err
+	return subsetMap, nil, types.NewSyncerEPStat(), err
 }
 
 // L7EndpointsCalculator implements methods to calculate Network endpoints for VM_IP_PORT NEGs
@@ -188,7 +188,7 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, *types.SyncerEPStat, error) {
 	return toZoneNetworkEndpointMap(eds, l.zoneGetter, l.servicePortName, l.podLister, l.subsetLabels, l.networkEndpointType)
 }
 

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1477,7 +1477,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 		expect         *negtypes.NegSyncResult
 	}{
 		{
-			desc: "counts equal, endpointData has no duplicated endpoints",
+			desc: "counts equal, endpointData has no duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1549,7 +1549,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 			expect:         negtypes.NewNegSyncResult(nil, negtypes.ResultSuccess),
 		},
 		{
-			desc: "counts equal, endpointData has duplicated endpoints",
+			desc: "counts equal, endpointData has duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1603,7 +1603,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 							NodeName:  &instance1,
 							Addresses: []string{testIP2},
 							Ready:     true,
-						}, // this is a duplicated endpoint
+						}, // this is a duplicate endpoint
 						{
 							TargetRef: &corev1.ObjectReference{
 								Namespace: testServiceNamespace,
@@ -1630,7 +1630,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 			expect:         negtypes.NewNegSyncResult(nil, negtypes.ResultSuccess),
 		},
 		{
-			desc: "counts not equal, endpointData has no duplicated endpoints",
+			desc: "counts not equal, endpointData has no duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1693,7 +1693,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 			expect:         negtypes.NewNegSyncResult(negtypes.ErrEPCountsDiffer, negtypes.ResultEPCountsDiffer),
 		},
 		{
-			desc: "counts not equal, endpointData has duplicated endpoints",
+			desc: "counts not equal, endpointData has duplicate endpoints",
 			endpointsData: []negtypes.EndpointsData{
 				{
 					Meta: &metav1.ObjectMeta{
@@ -1738,7 +1738,7 @@ func TestCheckEndpointInfo(t *testing.T) {
 							NodeName:  &instance1,
 							Addresses: []string{testIP2},
 							Ready:     true,
-						}, // this is a duplicated endpoint
+						}, // this is a duplicate endpoint
 						{
 							TargetRef: &corev1.ObjectReference{
 								Namespace: testServiceNamespace,

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -17,7 +17,6 @@ limitations under the License.
 package syncers
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,12 +45,6 @@ const (
 	minRetryDelay = 5 * time.Second
 	maxRetryDelay = 600 * time.Second
 	separator     = "||"
-)
-
-var (
-	ErrEPMissingNodeName = errors.New("endpoint has empty nodeName field")
-	ErrNodeNotFound      = errors.New("failed to retrieve associated zone of node")
-	ErrEPMissingZone     = errors.New("endpoint has empty zone field")
 )
 
 // encodeEndpoint encodes ip and instance into a single string
@@ -266,7 +259,7 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 			}
 			if endpointAddress.NodeName == nil || len(*endpointAddress.NodeName) == 0 {
 				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not have an associated node. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
-				return nil, nil, dupCount, ErrEPMissingNodeName
+				return nil, nil, dupCount, negtypes.ErrEPMissingNodeName
 			}
 			if endpointAddress.TargetRef == nil {
 				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not have an associated pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
@@ -274,10 +267,10 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 			}
 			zone, err := zoneGetter.GetZoneForNode(*endpointAddress.NodeName)
 			if err != nil {
-				return nil, nil, dupCount, ErrNodeNotFound
+				return nil, nil, dupCount, negtypes.ErrNodeNotFound
 			}
 			if zone == "" {
-				return nil, nil, dupCount, ErrEPMissingZone
+				return nil, nil, dupCount, negtypes.ErrEPMissingZone
 			}
 			if zoneNetworkEndpointMap[zone] == nil {
 				zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()

--- a/pkg/neg/types/endpoint_stat.go
+++ b/pkg/neg/types/endpoint_stat.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type State string
+
+func (s State) String() string {
+	return string(s)
+}
+
+const (
+	EPMissingNodeName = State("endpointMissingNodeName")
+	EPMissingPod      = State("endpointMissingPod")
+	EPMissingZone     = State("endpointMissingZone")
+	EPMissingField    = State("endpointMissingField")
+	EPDuplicate       = State("endpointDuplicate")
+	EPTotal           = State("endpointTotal")
+)
+
+func StateForEP() []State {
+	return []State{EPMissingNodeName, EPMissingPod, EPMissingZone, EPMissingField, EPDuplicate, EPTotal}
+}
+
+// SyncerEPStat contains endpoint and endpointslice status related to a syncer
+type SyncerEPStat struct {
+	EndpointStateCount StateCountMap
+}
+
+// StateCountMap collect the count of instances in different states
+type StateCountMap map[State]int
+
+func NewSyncerEPStat() *SyncerEPStat {
+	return &SyncerEPStat{
+		EndpointStateCount: make(map[State]int),
+	}
+}

--- a/pkg/neg/types/endpoint_stat.go
+++ b/pkg/neg/types/endpoint_stat.go
@@ -26,15 +26,27 @@ const (
 	EPMissingField    = State("endpointMissingField")
 	EPDuplicate       = State("endpointDuplicate")
 	EPTotal           = State("endpointTotal")
+
+	EPSWithMissingNodeName = State("endpointsliceWithMissingNodeNameEP")
+	EPSWithMissingPod      = State("endpointsliceWithMissingPodEP")
+	EPSWithMissingZone     = State("endpointsliceWithMissingZoneEP")
+	EPSWithMissingField    = State("endpointsliceWithMissingFieldEP")
+	EPSWithDuplicate       = State("endpointsliceWithDuplicateEP")
+	EPSTotal               = State("endpointsliceTotal")
 )
 
 func StateForEP() []State {
 	return []State{EPMissingNodeName, EPMissingPod, EPMissingZone, EPMissingField, EPDuplicate, EPTotal}
 }
 
+func StateForEPS() []State {
+	return []State{EPSWithMissingNodeName, EPSWithMissingPod, EPSWithMissingZone, EPSWithMissingField, EPSWithDuplicate, EPSTotal}
+}
+
 // SyncerEPStat contains endpoint and endpointslice status related to a syncer
 type SyncerEPStat struct {
-	EndpointStateCount StateCountMap
+	EndpointStateCount      StateCountMap
+	EndpointSliceStateCount StateCountMap
 }
 
 // StateCountMap collect the count of instances in different states
@@ -42,6 +54,7 @@ type StateCountMap map[State]int
 
 func NewSyncerEPStat() *SyncerEPStat {
 	return &SyncerEPStat{
-		EndpointStateCount: make(map[State]int),
+		EndpointStateCount:      make(map[State]int),
+		EndpointSliceStateCount: make(map[State]int),
 	}
 }

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -84,7 +84,7 @@ type NegSyncerManager interface {
 type NetworkEndpointsCalculator interface {
 	// CalculateEndpoints computes the NEG endpoints based on service endpoints and the current NEG state and returns a
 	// map of zone name to network endpoint set
-	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, int, error)
+	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, *SyncerEPStat, error)
 	// Mode indicates the mode that the EndpointsCalculator is operating in.
 	Mode() EndpointsCalculatorMode
 }

--- a/pkg/neg/types/sync_results.go
+++ b/pkg/neg/types/sync_results.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "errors"
+
+var (
+	ResultEPCountsDiffer = "EPCountsDiffer"
+	ErrEPCountsDiffer    = errors.New("endpoint counts from endpointData and endpointPodMap differ")
+
+	ResultEPMissingNodeName = "EPMissingNodeName"
+	ErrEPMissingNodeName    = errors.New("endpoint has empty nodeName field")
+
+	ResultNodeNotFound = "NodeNotFound"
+	ErrNodeNotFound    = errors.New("failed to retrieve associated zone of node")
+
+	ResultEPMissingZone = "EPMissingZone"
+	ErrEPMissingZone    = errors.New("endpoint has empty zone field")
+
+	ResultEPSEndpointCountZero = "EPSEndpointCountZero"
+	ErrEPSEndpointCountZero    = errors.New("endpoint count from endpointData cannot be zero")
+
+	ResultEPCalculationCountZero = "EPCalculationCountZero"
+	ErrEPCalculationCountZero    = errors.New("endpoint count from endpointPodMap cannot be zero")
+
+	// these results have their own errors
+	ResultInvalidEPAttach   = "InvalidEPAttach"
+	ResultInvalidEPDetach   = "InvalidEPDetach"
+	ResultNegNotFound       = "NegNotFound"
+	ResultCurrentEPNotFound = "CurrentEPNotFound"
+	ResultEPSNotFound       = "EPSNotFound"
+	ResultOtherError        = "OtherError"
+	ResultSuccess           = "Success"
+)
+
+type NegSyncResult struct {
+	Error  error
+	Result string
+}
+
+func NewNegSyncResult(err error, result string) *NegSyncResult {
+	return &NegSyncResult{
+		Error:  err,
+		Result: result,
+	}
+}

--- a/pkg/neg/types/sync_results.go
+++ b/pkg/neg/types/sync_results.go
@@ -20,31 +20,50 @@ import "errors"
 
 var (
 	ResultEPCountsDiffer = "EPCountsDiffer"
+	SyncerEPCountsDiffer = "SyncerEPCountsDiffer"
 	ErrEPCountsDiffer    = errors.New("endpoint counts from endpointData and endpointPodMap differ")
 
 	ResultEPMissingNodeName = "EPMissingNodeName"
+	SyncerEPMissingNodeName = "SyncerEPMissingNodeName"
 	ErrEPMissingNodeName    = errors.New("endpoint has empty nodeName field")
 
 	ResultNodeNotFound = "NodeNotFound"
+	SyncerNodeNotFound = "SyncerNodeNotFound"
 	ErrNodeNotFound    = errors.New("failed to retrieve associated zone of node")
 
 	ResultEPMissingZone = "EPMissingZone"
+	SyncerEPMissingZone = "SyncerEPMissingZone"
 	ErrEPMissingZone    = errors.New("endpoint has empty zone field")
 
 	ResultEPSEndpointCountZero = "EPSEndpointCountZero"
+	SyncerEPSEndpointCountZero = "SyncerEPSEndpointCountZero"
 	ErrEPSEndpointCountZero    = errors.New("endpoint count from endpointData cannot be zero")
 
 	ResultEPCalculationCountZero = "EPCalculationCountZero"
+	SyncerEPCalculationCountZero = "SyncerEPCalculationCountZero"
 	ErrEPCalculationCountZero    = errors.New("endpoint count from endpointPodMap cannot be zero")
 
 	// these results have their own errors
-	ResultInvalidEPAttach   = "InvalidEPAttach"
-	ResultInvalidEPDetach   = "InvalidEPDetach"
-	ResultNegNotFound       = "NegNotFound"
+	ResultInvalidEPAttach = "InvalidEPAttach"
+	SyncerInvalidEPAttach = "SyncerInvalidEPAttach"
+
+	ResultInvalidEPDetach = "InvalidEPDetach"
+	SyncerInvalidEPDetach = "SyncerInvalidEPDetach"
+
+	ResultNegNotFound = "NegNotFound"
+	SyncerNegNotFound = "SyncerNegNotFound"
+
 	ResultCurrentEPNotFound = "CurrentEPNotFound"
-	ResultEPSNotFound       = "EPSNotFound"
-	ResultOtherError        = "OtherError"
-	ResultSuccess           = "Success"
+	SyncerCurrentEPNotFound = "SyncerCurrentEPNotFound"
+
+	ResultEPSNotFound = "EPSNotFound"
+	SyncerEPSNotFound = "SyncerEPSNotFound"
+
+	ResultOtherError = "OtherError"
+	SyncerOtherError = "SyncerOtherError"
+
+	ResultSuccess = "Success"
+	SyncerSuccess = "SyncerSuccess"
 )
 
 type NegSyncResult struct {
@@ -56,5 +75,36 @@ func NewNegSyncResult(err error, result string) *NegSyncResult {
 	return &NegSyncResult{
 		Error:  err,
 		Result: result,
+	}
+}
+
+func GetSyncerStatus(result string) string {
+	switch result {
+	case ResultEPCountsDiffer:
+		return SyncerEPCountsDiffer
+	case ResultEPMissingNodeName:
+		return SyncerEPMissingNodeName
+	case ResultNodeNotFound:
+		return SyncerNodeNotFound
+	case ResultEPMissingZone:
+		return SyncerEPMissingZone
+	case ResultEPSEndpointCountZero:
+		return SyncerEPSEndpointCountZero
+	case ResultEPCalculationCountZero:
+		return SyncerEPCalculationCountZero
+	case ResultInvalidEPAttach:
+		return SyncerInvalidEPAttach
+	case ResultInvalidEPDetach:
+		return SyncerInvalidEPDetach
+	case ResultNegNotFound:
+		return SyncerNegNotFound
+	case ResultCurrentEPNotFound:
+		return SyncerCurrentEPNotFound
+	case ResultEPSNotFound:
+		return SyncerEPSNotFound
+	case ResultSuccess:
+		return SyncerSuccess
+	default:
+		return SyncerOtherError
 	}
 }


### PR DESCRIPTION
Added metrics to collect the state of each endpointslice.

Example:
HELP neg_controller_neg_sync_endpoint_slice_state Current count of endpoint slices in each state
TYPE neg_controller_neg_sync_endpoint_slice_state gauge
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceTotal"} 3
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceWithDuplicateEP"} 0
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceWithMissingFieldEP"} 0
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceWithMissingNodeNameEP"} 0
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceWithMissingPodEP"} 0
neg_controller_neg_sync_endpoint_slice_state{endpoint_slice_label="endpointsliceWithMissingZoneEP"} 0