### PR TITLE
Change resync period to 10 minutes

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -206,7 +206,7 @@ values.`)
 the pod secrets for creating a Kubernetes client.`)
 	flag.StringVar(&F.KubeConfigFile, "kubeconfig", "",
 		`Path to kubeconfig file with authorization and master location information.`)
-	flag.DurationVar(&F.ResyncPeriod, "sync-period", 30*time.Second,
+	flag.DurationVar(&F.ResyncPeriod, "sync-period", 10*time.Minute,
 		`Relist and confirm cloud resources this often.`)
 	flag.DurationVar(&F.L4NetLBProvisionDeadline, "l4-netlb-provision-deadline", 20*time.Minute,
 		`Deadline latency for L4 NetLB provisioning.`)


### PR DESCRIPTION
With short resync period, when running locally, it is easy to miss bugs, when service update is not triggered, but service is quickly updated due to resync period (example https://github.com/kubernetes/ingress-gce/pull/1928) 

/assign cezarygerard
/assign aojea