### PR TITLE
[Cherry pick #1907] to release 1.20 Remove using node ports for L4 NetLB RBS Services

### DIFF
--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -122,7 +122,7 @@ func (i *Instances) ensureInstanceGroupAndPorts(name, zone string, ports []int64
 			return nil, err
 		}
 	} else {
-		klog.V(5).Infof("Instance group %v/%v already exists.", zone, name)
+		klog.V(2).Infof("Instance group %v/%v already exists.", zone, name)
 	}
 
 	// Build map of existing ports

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -650,18 +650,16 @@ func TestProcessServiceCreationFailed(t *testing.T) {
 		addMockFunc   func(*cloud.MockGCE)
 		expectedError string
 	}{{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.GetHook = test.GetErrorInstanceGroupHook },
-		expectedError: "GetErrorInstanceGroupHook"},
+		expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error GetErrorInstanceGroupHook"},
 		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.ListHook = test.ListErrorHook },
 			expectedError: "ListErrorHook"},
 		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.InsertHook = test.InsertErrorHook },
-			expectedError: "InsertErrorHook"},
+			expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error InsertErrorHook"},
 
 		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.AddInstancesHook = test.AddInstancesErrorHook },
 			expectedError: "AddInstances: [AddInstancesErrorHook]"},
 		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.ListInstancesHook = test.ListInstancesWithErrorHook },
 			expectedError: "ListInstancesWithErrorHook"},
-		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.SetNamedPortsHook = test.SetNamedPortsErrorHook },
-			expectedError: "SetNamedPortsErrorHook"},
 	} {
 		lc := newL4NetLBServiceController()
 		param.addMockFunc((lc.ctx.Cloud.Compute().(*cloud.MockGCE)))


### PR DESCRIPTION
[Cherry pick #1907] to release 1.20 Remove using node ports for L4 NetLB RBS Services

NodePorts are not needed for NetLB RBS and were copied from legacy implementation. They were also slowing down our controller, because we were updating same instance group with node port for every service