### PR TITLE
Endpoints Calculator should check the endpoint is ready

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -77,6 +77,10 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 				l.logger.V(2).Info("Address inside Endpoints does not have an associated pod. Skipping", "address", addr.Addresses, "endpoints", klog.KRef(ed.Meta.Namespace, ed.Meta.Name))
 				continue
 			}
+			if !addr.Ready {
+				l.logger.V(2).Info("Address inside Endpoints is not ready. Skipping", "address", addr.Addresses, "endpoints", klog.KRef(ed.Meta.Namespace, ed.Meta.Name))
+				continue
+			}
 			numEndpoints++
 			if processedNodes.Has(*addr.NodeName) {
 				continue

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1346,6 +1346,7 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 	instance2 := negtypes.TestInstance2
 	instance3 := negtypes.TestInstance3
 	instance4 := negtypes.TestInstance4
+	instance5 := negtypes.TestInstance5
 	notReady := false
 	emptyNamedPort := ""
 	testNamedPort := testNamedPort
@@ -1455,6 +1456,15 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 					TargetRef: &v1.ObjectReference{
 						Namespace: namespace,
 						Name:      "pod9",
+					},
+					Conditions: discovery.EndpointConditions{Ready: &notReady},
+				},
+				{
+					Addresses: []string{"10.100.4.5"},
+					NodeName:  &instance5,
+					TargetRef: &v1.ObjectReference{
+						Namespace: namespace,
+						Name:      "pod10",
 					},
 					Conditions: discovery.EndpointConditions{Ready: &notReady},
 				},


### PR DESCRIPTION
The fact that the endpointslice Conditions.Ready and Terminating
prevent that Unready endpoints are used, but this is a bit of a
fortunate coincidence, the endpoints calculator should verify
the endpoint is serving traffic.

You can run the test that is in a different commit to verify it fails without the fix

/assign @swetharepakula 