### PR TITLE
don't consider ANY pod that is not terminating

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -187,7 +187,7 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
-	return toZoneNetworkEndpointMap(eds, l.zoneGetter, l.servicePortName, l.podLister, l.networkEndpointType)
+	return toZoneNetworkEndpointMap(eds, l.zoneGetter, l.servicePortName, l.networkEndpointType)
 }
 
 func nodeMapToString(nodeMap map[string][]*v1.Node) string {

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -225,7 +224,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 }
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
-func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, servicePortName string, podLister cache.Indexer, networkEndpointType negtypes.NetworkEndpointType) (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, int, error) {
+func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, servicePortName string, networkEndpointType negtypes.NetworkEndpointType) (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, int, error) {
 	zoneNetworkEndpointMap := map[string]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	dupCount := 0
@@ -271,12 +270,12 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 				zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()
 			}
 
-			// TODO: This check and EndpointsData.Ready field may be deleted once Endpoints support is removed.
-			// The purpose of this check is to handle endpoints in terminating state.
-			// The Endpoints API doesn't have terminating field. Terminating endpoints are marked as not ready.
-			// This check support this case. For not ready endpoints it checks if the endpoint is not yet ready or terminating.
-			// The EndpointSlices API has terminating field which solves this problem.
-			if endpointAddress.Ready || shouldPodBeInNeg(podLister, endpointAddress.TargetRef.Namespace, endpointAddress.TargetRef.Name) {
+			// Only consider endpoints that are Ready.
+			// TODO: In order to consider Terminating endpoints, the AddressData type should add a new field to
+			// carry this information based on the EndpointSlices Conditions Terminating = true and Serving = true.
+			// Terminating endpoints should only be used with ExternalTrafficPolicy = Local and if there are any
+			// other Ready endpoint in the same node.
+			if endpointAddress.Ready {
 				for _, address := range endpointAddress.Addresses {
 					networkEndpoint := negtypes.NetworkEndpoint{IP: address, Port: matchPort, Node: *endpointAddress.NodeName}
 					if networkEndpointType == negtypes.NonGCPPrivateEndpointType {
@@ -371,35 +370,4 @@ func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.N
 		}
 	}
 	return endpointBatch, nil
-}
-
-func keyFunc(namespace, name string) string {
-	return fmt.Sprintf("%s/%s", namespace, name)
-}
-
-// shouldPodBeInNeg returns true if pod is not in graceful termination state
-func shouldPodBeInNeg(podLister cache.Indexer, namespace, name string) bool {
-	if podLister == nil {
-		return false
-	}
-	key := keyFunc(namespace, name)
-	obj, exists, err := podLister.GetByKey(key)
-	if err != nil {
-		klog.Errorf("Failed to retrieve pod %s from pod lister: %v", key, err)
-		return false
-	}
-	if !exists {
-		return false
-	}
-	pod, ok := obj.(*v1.Pod)
-	if !ok {
-		klog.Errorf("Failed to convert obj %s to v1.Pod. The object type is %T", key, obj)
-		return false
-	}
-
-	// if pod has DeletionTimestamp, that means pod is in graceful termination state.
-	if pod.DeletionTimestamp != nil {
-		return false
-	}
-	return true
 }

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -441,34 +441,6 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false, false)
-	podLister := transactionSyncer.podLister
-
-	// add all pods in default endpoint into podLister
-	for i := 1; i <= 12; i++ {
-		podLister.Add(&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testServiceNamespace,
-				Name:      fmt.Sprintf("pod%v", i),
-			},
-		})
-	}
-	// pod6 is deleted
-	podLister.Update(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         testServiceNamespace,
-			Name:              "pod6",
-			DeletionTimestamp: &metav1.Time{},
-		},
-	})
-
-	podLister.Update(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         testServiceNamespace,
-			Name:              "pod12",
-			DeletionTimestamp: &metav1.Time{},
-		},
-	})
 
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	testCases := []struct {
@@ -492,8 +464,7 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
-					networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"),
-					networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80")),
+					networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80")),
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
@@ -502,7 +473,6 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 				networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
 				networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
 				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
 			},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -515,13 +485,11 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"),
 					networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"),
-					networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"),
-					networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81")),
+					networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081")),
 			},
 			expectMap: negtypes.EndpointPodMap{
 				networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod7"},
 				networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod8"},
-				networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod9"},
 				networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod10"},
 				networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod11"},
 			},
@@ -534,8 +502,7 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||||80"),
-					networkEndpointFromEncodedEndpoint("10.100.2.1||||80"),
-					networkEndpointFromEncodedEndpoint("10.100.1.3||||80")),
+					networkEndpointFromEncodedEndpoint("10.100.2.1||||80")),
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||||80")),
 			},
@@ -544,14 +511,13 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 				networkEndpointFromEncodedEndpoint("10.100.1.2||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
 				networkEndpointFromEncodedEndpoint("10.100.2.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
 				networkEndpointFromEncodedEndpoint("10.100.3.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
 			},
 			networkEndpointType: negtypes.NonGCPPrivateEndpointType,
 		},
 	}
 
 	for _, tc := range testCases {
-		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpoints(getDefaultEndpoint()), zoneGetter, tc.portName, podLister, tc.networkEndpointType)
+		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpoints(getDefaultEndpoint()), zoneGetter, tc.portName, tc.networkEndpointType)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
 		}
@@ -879,82 +845,6 @@ func TestMakeEndpointBatch(t *testing.T) {
 					}
 				}
 			}
-		}
-	}
-}
-
-func TestShouldPodBeInNeg(t *testing.T) {
-	t.Parallel()
-
-	_, transactionSyncer := newTestTransactionSyncer(negtypes.NewAdapter(gce.NewFakeGCECloud(gce.DefaultTestClusterValues())), negtypes.VmIpPortEndpointType, false, false)
-
-	podLister := transactionSyncer.podLister
-
-	namespace1 := "ns1"
-	namespace2 := "ns2"
-	name1 := "n1"
-	name2 := "n2"
-
-	podLister.Add(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace1,
-			Name:      name1,
-		},
-	})
-
-	// deleted pod
-	podLister.Add(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         namespace1,
-			Name:              name2,
-			DeletionTimestamp: &metav1.Time{},
-		},
-	})
-
-	podLister.Add(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace2,
-			Name:      name2,
-		},
-	})
-
-	for _, tc := range []struct {
-		desc      string
-		namespace string
-		name      string
-		expect    bool
-	}{
-		{
-			desc: "empty input",
-		},
-		{
-			desc:      "non exists pod",
-			namespace: "non exists",
-			name:      "non exists",
-			expect:    false,
-		},
-		{
-			desc:      "pod exists and not deleted",
-			namespace: namespace1,
-			name:      name1,
-			expect:    true,
-		},
-		{
-			desc:      "pod exists and deleted",
-			namespace: namespace1,
-			name:      name2,
-			expect:    false,
-		},
-		{
-			desc:      "pod exists and not deleted 2",
-			namespace: namespace2,
-			name:      name2,
-			expect:    true,
-		},
-	} {
-		ret := shouldPodBeInNeg(podLister, tc.namespace, tc.name)
-		if ret != tc.expect {
-			t.Errorf("For test case %q, endpointSets output = %+v, but got %+v", tc.desc, tc.expect, ret)
 		}
 	}
 }


### PR DESCRIPTION
The neg syncer was doing some wrong assumptions:

1. Endpoints that are not Ready can have Pods with deletionTimestamp not nil.
The Endpoint and EndpointSlice controller will remove the Pod from the corresponding object once it gets deleted (DeletionTimestamp != nil)

2. Any pod with deletionTimestamp == nil is valid, this is the most dangerous assumption, since a pod can be Unready and be used.

/kind bug
/assign @swetharepakula @bowei 