### PR TITLE
Add nil check for FrontendConfig in checkProxy()

### DIFF
--- a/pkg/loadbalancers/target_proxies.go
+++ b/pkg/loadbalancers/target_proxies.go
@@ -38,7 +38,10 @@ func (l7 *L7) checkProxy() (err error) {
 	// TODO(shance): move to translator
 	var umName string
 	if flags.F.EnableFrontendConfig {
-		if l7.redirectUm != nil && l7.runtimeInfo.FrontendConfig.Spec.RedirectToHttps != nil && l7.runtimeInfo.FrontendConfig.Spec.RedirectToHttps.Enabled {
+		if l7.redirectUm != nil &&
+			l7.runtimeInfo.FrontendConfig != nil &&
+			l7.runtimeInfo.FrontendConfig.Spec.RedirectToHttps != nil &&
+			l7.runtimeInfo.FrontendConfig.Spec.RedirectToHttps.Enabled {
 			umName = l7.redirectUm.Name
 		} else {
 			umName = l7.um.Name


### PR DESCRIPTION
If you delete the FrontendConfig before the redirectUm is cleaned up, the FrontendConfig will be nil and l7.redirectUm will not be, leading to an "unrecoverable" crash loop. The only fix is to manually update the target proxy's link to the original urlmap.