### PR TITLE
don't process unsupported LB Services with multiple protocoles

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -192,6 +192,10 @@ func (l4c *L4Controller) shouldProcessService(service *v1.Service) bool {
 		klog.Warningf("Ignoring update for service %s:%s managed by service controller", service.Namespace, service.Name)
 		return false
 	}
+	if utils.HasMultipleProtocols(service.Spec.Ports) {
+		klog.Warningf("Ignoring update for service %s:%s using different ports protocols", service.Namespace, service.Name)
+		return false
+	}
 	frName := utils.LegacyForwardingRuleName(service)
 	// Processing should continue if an external forwarding rule exists. This can happen if the service is transitioning from External to Internal.
 	// The external forwarding rule might not be deleted by the time this controller starts processing the service.

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -232,6 +232,10 @@ func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service) bo
 	if !(lc.isRBSBasedService(newSvc) || lc.isRBSBasedService(oldSvc)) {
 		return false
 	}
+	if utils.HasMultipleProtocols(newSvc.Spec.Ports) {
+		klog.Warningf("Ignoring update for service %s:%s using different ports protocols", newSvc.Namespace, newSvc.Name)
+		return false
+	}
 	if lc.needsAddition(newSvc, oldSvc) || lc.needsUpdate(newSvc, oldSvc) || lc.needsDeletion(newSvc) {
 		return true
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -668,6 +668,22 @@ func GetPortRanges(ports []int) (ranges []string) {
 	return ranges
 }
 
+func HasMultipleProtocols(svcPorts []api_v1.ServicePort) bool {
+	if len(svcPorts) == 0 {
+		return false
+	}
+
+	firstProtocol := svcPorts[0].Protocol
+	for _, port := range svcPorts[1:] {
+		if port.Protocol != firstProtocol {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO: This assumption is no longer true since 1.24, LoadBalancer Services may have multiple protocols
+// Ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1435-mixed-protocol-lb
 func GetProtocol(svcPorts []api_v1.ServicePort) api_v1.Protocol {
 	if len(svcPorts) == 0 {
 		return api_v1.ProtocolTCP

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1535,3 +1535,94 @@ func TestAddIPToLBStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestHasMultipleProtocols(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		ports       []api_v1.ServicePort
+		want        bool
+	}{
+		{
+			name:        "TCP",
+			annotations: make(map[string]string),
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     int32(8080),
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "UDP",
+			annotations: map[string]string{annotations.RBSAnnotationKey: "enabled"},
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     int32(8080),
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "TCP and UDP",
+			annotations: map[string]string{annotations.RBSAnnotationKey: "enabled"},
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     int32(53),
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     int32(53),
+				},
+			},
+			want: true,
+		},
+		{
+			name:        "TCP",
+			annotations: make(map[string]string),
+			ports: []api_v1.ServicePort{
+				{
+					Name:     "port80",
+					Protocol: api_v1.ProtocolTCP,
+					Port:     int32(80),
+				},
+				{
+					Name:     "port8080",
+					Protocol: api_v1.ProtocolTCP,
+					Port:     int32(8080),
+				},
+			},
+			want: false,
+		},
+		{
+			name:        "UDP",
+			annotations: map[string]string{annotations.RBSAnnotationKey: "enabled"},
+			ports: []api_v1.ServicePort{
+				{
+					Name:     "port80",
+					Protocol: api_v1.ProtocolUDP,
+					Port:     int32(80),
+				},
+				{
+					Name:     "port8080",
+					Protocol: api_v1.ProtocolUDP,
+					Port:     int32(8080),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasMultipleProtocols(tt.ports)
+			if tt.want != got {
+				t.Errorf("wanted %v got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since kubernetes 1.24 Kubernetes allot to configure LoadBalancer Services with multiplt protocols, typically UDP and TCP.

The ingress-gce L4 controllers assume that there is only one protocol, and is defined by the first port in the ServicePorts array.

We should not process these services because they work only for one protocol, causing confusion to users since they can see that it partially works, and is hard to find out what is the problem