### PR TITLE
missing argument to klog

### DIFF
--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) Shutdown() {
 func (c *Controller) sync(key string) error {
 	start := time.Now()
 	klog.V(4).Infof("Instance groups controller: Start processing %s", key)
-	defer klog.V(4).Infof("Instance groups controller: Processing key %s took %v", time.Since(start))
+	defer klog.V(4).Infof("Instance groups controller: Processing key %s took %v", key, time.Since(start))
 
 	nodeNames, err := utils.GetReadyNodeNames(listers.NewNodeLister(c.lister))
 	if err != nil {


### PR DESCRIPTION
the logs show

```
INFO 2023-02-27T08:15:32.449802444Z Instance groups controller: Processing key 145.404µs took %!v(MISSING)
  {
    "textPayload": "Instance groups controller: Processing key 145.404µs took %!v(MISSING)",
```