### PR TITLE
Add flag for Transparent Health Check

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -108,6 +108,7 @@ var (
 		EnablePSC                      bool
 		EnableIngressGAFields          bool
 		EnableTrafficScaling           bool
+		EnableTransparentHealthChecks  bool
 		EnablePinhole                  bool
 		EnableL4ILBDualStack           bool
 		EnableL4NetLBDualStack         bool
@@ -252,6 +253,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.GKEClusterHash, "gke-cluster-hash", "", "The cluster hash of the GKE cluster this Ingress Controller will be interacting with")
 	flag.StringVar(&F.GKEClusterType, "gke-cluster-type", "ZONAL", "The cluster type of the GKE cluster this Ingress Controller will be interacting with")
 	flag.BoolVar(&F.EnableTrafficScaling, "enable-traffic-scaling", false, "Enable support for Service {max-rate-per-endpoint, capacity-scaler}")
+	flag.BoolVar(&F.EnableTransparentHealthChecks, "enable-transparent-health-checks", false, "Enable Transparent Health Checks.")
 	flag.BoolVar(&F.EnablePinhole, "enable-pinhole", false, "Enable Pinhole firewall feature")
 	flag.BoolVar(&F.EnableL4ILBDualStack, "enable-l4ilb-dual-stack", false, "Enable Dual-Stack handling for L4 Internal Load Balancers")
 	flag.BoolVar(&F.EnableL4NetLBDualStack, "enable-l4netlb-dual-stack", false, "Enable Dual-Stack handling for L4 External Load Balancers")


### PR DESCRIPTION
This is a boolean feature flag to enable Transparent Health Checks (THC).

The purpose of the THC feature is to implement integration of

 * health checks in GCE called Unified Health Checks (UHC) and
 * health check mechanism in K8s,

so we can reflect K8s readiness status in UHC healthy status. The goal is to provide consistent health check results for GKE and UHC, showing the same status and operating on the same probers results.

K8s readiness status is a signal to enable the traffic flow for the POD. For GSLB, the health information is stored in the UHC configured for the BackendService. When those two signals are synchronized, there will be no disruption on traffic when the Backend will be marked as healthy. 

**Naming:** The THC health check mechanism is “transparent” from Kubernetes point of view because the actual K8s POD’s status is exposed to the GCE UHC system, visible for Users in GCE, and used by GSLB to route the traffic.

**Background:** In GKE the integration of Services with GCLB is built on top of GCE BackendServices. Backend Services are health checked using UHC and this health check signal is used to control traffic flow to the Backends (PODs). UHC healthy statuses are independent from Kubernetes health checks, which can create situations where both systems report different readiness values for the same backend and can lead to the discrepancy in marking backends ready to receive traffic. The K8s signal to receive the status is called POD’s readiness and UHC signal to start sending the traffic is called UHC healthy status.