### PR TITLE
Memoryless healthchecks

### DIFF
--- a/pkg/healthchecks/healthcheck.go
+++ b/pkg/healthchecks/healthcheck.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
 	"k8s.io/ingress-gce/pkg/translator"
 )
 
@@ -36,7 +35,7 @@ func (c *fieldDiffs) add(field, oldv, newv string) {
 func (c *fieldDiffs) String() string { return strings.Join(c.f, ", ") }
 func (c *fieldDiffs) hasDiff() bool  { return len(c.f) > 0 }
 
-func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCheckConfig) *fieldDiffs {
+func calculateDiff(old, new *translator.HealthCheck) *fieldDiffs {
 	var changes fieldDiffs
 
 	if old.Protocol() != new.Protocol() {
@@ -45,72 +44,31 @@ func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCh
 	if old.PortSpecification != new.PortSpecification {
 		changes.add("PortSpecification", old.PortSpecification, new.PortSpecification)
 	}
-
-	// TODO(bowei): why don't we check Port, timeout etc.
-
-	if c == nil {
-		return &changes
-	}
-
-	// This code assumes that the changes wrt to `c` has been applied to `new`.
-	if c.CheckIntervalSec != nil && old.CheckIntervalSec != new.CheckIntervalSec {
+	if old.CheckIntervalSec != new.CheckIntervalSec {
 		changes.add("CheckIntervalSec", strconv.FormatInt(old.CheckIntervalSec, 10), strconv.FormatInt(new.CheckIntervalSec, 10))
 	}
-	if c.TimeoutSec != nil && old.TimeoutSec != new.TimeoutSec {
+	if old.TimeoutSec != new.TimeoutSec {
 		changes.add("TimeoutSec", strconv.FormatInt(old.TimeoutSec, 10), strconv.FormatInt(new.TimeoutSec, 10))
 	}
-	if c.HealthyThreshold != nil && old.HealthyThreshold != new.HealthyThreshold {
+	if old.HealthyThreshold != new.HealthyThreshold {
 		changes.add("HeathyThreshold", strconv.FormatInt(old.HealthyThreshold, 10), strconv.FormatInt(new.HealthyThreshold, 10))
 	}
-	if c.UnhealthyThreshold != nil && old.UnhealthyThreshold != new.UnhealthyThreshold {
+	if old.UnhealthyThreshold != new.UnhealthyThreshold {
 		changes.add("UnhealthyThreshold", strconv.FormatInt(old.UnhealthyThreshold, 10), strconv.FormatInt(new.UnhealthyThreshold, 10))
 	}
 	// c.Type is handled by Protocol above.
-	if c.RequestPath != nil && old.RequestPath != new.RequestPath {
+	if old.RequestPath != new.RequestPath {
 		changes.add("RequestPath", old.RequestPath, new.RequestPath)
 	}
-	if c.Port != nil && old.Port != new.Port {
+	if old.Port != new.Port {
 		changes.add("Port", strconv.FormatInt(old.Port, 10), strconv.FormatInt(new.Port, 10))
 	}
-
-	// TODO(bowei): Host seems to be missing.
+	if old.Host != new.Host {
+		changes.add("Host", old.Host, new.Host)
+	}
+	if old.Description != new.Description {
+		changes.add("Description", old.Description, new.Description)
+	}
 
 	return &changes
-}
-
-// mergeUserSettings merges old health check configuration that the user may
-// have customized. This is to preserve the existing health check setting as
-// much as possible.
-//
-// TODO(bowei) -- fix below.
-// WARNING: if a service backend is converted from IG mode to NEG mode,
-// the existing health check setting will be preserved, although it may not
-// suit the customer needs.
-//
-// TODO(bowei): this is very unstable in combination with Probe, we do not
-// have a clear signal as to where the settings are coming from. Once a
-// healthcheck is created, it will basically not change.
-func mergeUserSettings(existing, newHC *translator.HealthCheck) *translator.HealthCheck {
-	hc := *newHC // return a copy
-
-	hc.HTTPHealthCheck = existing.HTTPHealthCheck
-	hc.HealthCheck.CheckIntervalSec = existing.HealthCheck.CheckIntervalSec
-	hc.HealthCheck.HealthyThreshold = existing.HealthCheck.HealthyThreshold
-	hc.HealthCheck.TimeoutSec = existing.HealthCheck.TimeoutSec
-	hc.HealthCheck.UnhealthyThreshold = existing.HealthCheck.UnhealthyThreshold
-
-	if existing.HealthCheck.LogConfig != nil {
-		l := *existing.HealthCheck.LogConfig
-		hc.HealthCheck.LogConfig = &l
-	}
-
-	// Cannot specify both portSpecification and port field.
-	if hc.ForNEG {
-		hc.HTTPHealthCheck.Port = 0
-		hc.PortSpecification = newHC.PortSpecification
-	} else {
-		hc.PortSpecification = ""
-		hc.Port = newHC.Port
-	}
-	return &hc
 }

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -217,6 +217,7 @@ func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckCon
 		// This override is necessary regardless of type
 		hc.PortSpecification = "USE_FIXED_PORT"
 	}
+	hc.Description = "Kubernetes L7 health check generated with BackendConfig CRD."
 }
 
 // DefaultHealthCheck simply returns the default health check.
@@ -327,4 +328,7 @@ func ApplyProbeSettingsToHC(p *v1.Probe, hc *HealthCheck) {
 	}
 
 	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
+
+	hc.HealthyThreshold = int64(p.SuccessThreshold)
+	hc.UnhealthyThreshold = int64(p.FailureThreshold)
 }


### PR DESCRIPTION
Main goal:
 * make the configuration of health checks independent from the history of previously used parameters (readiness probes or BackendConfig).

Related bug fixes:
 * update health check Description when a BackendConfig is used,
 * propagate SuccessThreshold to HealthyThreshold and FailureThreshold to UnhealthyThreshold from readiness probe config to health check config.

Currently (see this [commit message](https://github.com/kubernetes/ingress-gce/commit/581313450edce8462a0ff094e27bf6330d15ed3f)), health checks remember their previous configuration and only partially update it in specific cases. The intention of this behaviour was to respect manual adjustments in health checks configuration. However, the outcome is that
 * the configuration is not updated when a readiness probe is removed,
 *  only Port and Port Specification are updated when a BackendConfig is removed.

That is, the current solution sacrifices the correct (or at least expected) behaviour in basic use cases in order to support hacky adjustments. This PR intends to modify this legacy behaviour.