### PR TITLE
Add support for Cloud CDN dynamic compression

### DIFF
--- a/pkg/apis/backendconfig/v1/types.go
+++ b/pkg/apis/backendconfig/v1/types.go
@@ -97,6 +97,7 @@ type CDNConfig struct {
 	ServeWhileStale             *int64                        `json:"serveWhileStale,omitempty"`
 	SignedUrlCacheMaxAgeSec     *int64                        `json:"signedUrlCacheMaxAgeSec,omitempty"`
 	SignedUrlKeys               []*SignedUrlKey               `json:"signedUrlKeys,omitempty"`
+	CompressionMode             *string                       `json:"compressionMode,omitempty"`
 }
 
 // BypassCacheOnRequestHeader contains configuration for how requests containing specific request

--- a/pkg/apis/backendconfig/v1beta1/types.go
+++ b/pkg/apis/backendconfig/v1beta1/types.go
@@ -81,8 +81,9 @@ type OAuthClientCredentials struct {
 // CDNConfig contains configuration for CDN-enabled backends.
 // +k8s:openapi-gen=true
 type CDNConfig struct {
-	Enabled     bool            `json:"enabled"`
-	CachePolicy *CacheKeyPolicy `json:"cachePolicy,omitempty"`
+	Enabled         bool            `json:"enabled"`
+	CachePolicy     *CacheKeyPolicy `json:"cachePolicy,omitempty"`
+	CompressionMode *string         `json:"compressionMode,omitempty"`
 }
 
 // CacheKeyPolicy contains configuration for how requests to a CDN-enabled backend are cached.

--- a/pkg/backends/features/cdn.go
+++ b/pkg/backends/features/cdn.go
@@ -40,6 +40,8 @@ var defaultCdnPolicy = composite.BackendServiceCdnPolicy{
 	SignedUrlCacheMaxAgeSec: 0,
 }
 
+var defaultCompressionMode string = "DISABLED"
+
 // EnsureCDN reads the CDN configuration specified in the ServicePort.BackendConfig
 // and applies it to the BackendService. It returns true if there were existing
 // settings on the BackendService that were overwritten.
@@ -204,6 +206,12 @@ func renderConfig(sp utils.ServicePort) *composite.BackendService {
 	}
 	if len(bypassCacheOnRequestHeaders) > 0 {
 		be.CdnPolicy.BypassCacheOnRequestHeaders = bypassCacheOnRequestHeaders
+	}
+
+	if cdnConfig.CompressionMode != nil {
+		be.CompressionMode = *cdnConfig.CompressionMode
+	} else {
+		be.CompressionMode = defaultCompressionMode
 	}
 
 	return be

--- a/pkg/backends/features/cdn_test.go
+++ b/pkg/backends/features/cdn_test.go
@@ -31,9 +31,11 @@ import (
 )
 
 var (
-	cacheAllStatic   string = "CACHE_ALL_STATIC"
-	useOriginHeaders string = "USE_ORIGIN_HEADERS"
-	forceCacheAll    string = "FORCE_CACHE_ALL"
+	cacheAllStatic           string = "CACHE_ALL_STATIC"
+	useOriginHeaders         string = "USE_ORIGIN_HEADERS"
+	forceCacheAll            string = "FORCE_CACHE_ALL"
+	compressionModeAutomatic string = "AUTOMATIC"
+	compressionModeDisabled  string = "DISABLED"
 )
 
 func init() {
@@ -244,12 +246,14 @@ func TestEnsureCDN(t *testing.T) {
 								{HeaderName: "header"},
 							},
 							SignedUrlCacheMaxAgeSec: createInt64(3600),
+							CompressionMode:         &compressionModeDisabled,
 						},
 					},
 				},
 			},
 			be: &composite.BackendService{
-				EnableCDN: true,
+				EnableCDN:       true,
+				CompressionMode: compressionModeAutomatic,
 				CdnPolicy: &composite.BackendServiceCdnPolicy{
 					CacheKeyPolicy: &composite.CacheKeyPolicy{
 						IncludeHost:          true,
@@ -277,7 +281,8 @@ func TestEnsureCDN(t *testing.T) {
 			},
 			updateExpected: false,
 			beAfter: &composite.BackendService{
-				EnableCDN: true,
+				EnableCDN:       true,
+				CompressionMode: compressionModeAutomatic,
 				CdnPolicy: &composite.BackendServiceCdnPolicy{
 					CacheKeyPolicy: &composite.CacheKeyPolicy{
 						IncludeHost:          true,
@@ -363,6 +368,7 @@ func TestEnsureCDN(t *testing.T) {
 				cdn.ServeWhileStale = createInt64(defCdn.ServeWhileStale)
 				cdn.RequestCoalescing = createBool(defCdn.RequestCoalescing)
 				cdn.SignedUrlCacheMaxAgeSec = createInt64(defCdn.SignedUrlCacheMaxAgeSec)
+				cdn.CompressionMode = &defaultCompressionMode
 			}).build(),
 			be:             newDefaultBackendService().build(),
 			updateExpected: false,


### PR DESCRIPTION
Add support for [Cloud CDN dynamic compression](https://cloud.google.com/cdn/docs/dynamic-compression#console). 