### PR TITLE
Adjust health check Description when BackendConfig used

### DIFF
--- a/pkg/healthchecks/healthcheck.go
+++ b/pkg/healthchecks/healthcheck.go
@@ -72,6 +72,9 @@ func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCh
 	if c.Port != nil && old.Port != new.Port {
 		changes.add("Port", strconv.FormatInt(old.Port, 10), strconv.FormatInt(new.Port, 10))
 	}
+	if old.Description != new.Description {
+		changes.add("Description", old.Description, new.Description)
+	}
 
 	// TODO(bowei): Host seems to be missing.
 

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -65,6 +65,12 @@ const (
 	// used for health checking.
 	useServingPortSpecification = "USE_SERVING_PORT"
 
+	DescriptionForDefaultHealthChecks            = "Default kubernetes L7 Loadbalancing health check."
+	DescriptionForDefaultNEGHealthChecks         = "Default kubernetes L7 Loadbalancing health check for NEG."
+	DescriptionForDefaultILBHealthChecks         = "Default kubernetes L7 Loadbalancing health check for ILB."
+	DescriptionForHealthChecksFromReadinessProbe = "Kubernetes L7 health check generated with readiness probe settings."
+	DescriptionForHealthChecksFromBackendConfig  = "Kubernetes L7 health check generated with BackendConfig CRD."
+
 	// TODO: revendor the GCE API go client so that this error will not be hit.
 	newHealthCheckErrorMessageTemplate = "the %v health check configuration on the existing health check %v is nil. " +
 		"This is usually caused by an application protocol change on the k8s service spec. " +
@@ -217,6 +223,8 @@ func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckCon
 		// This override is necessary regardless of type
 		hc.PortSpecification = "USE_FIXED_PORT"
 	}
+
+	hc.Description = DescriptionForHealthChecksFromBackendConfig
 }
 
 // DefaultHealthCheck simply returns the default health check.
@@ -231,7 +239,7 @@ func DefaultHealthCheck(port int64, protocol annotations.AppProtocol) *HealthChe
 		HealthyThreshold: defaultHealthyThreshold,
 		// Number of healthchecks to fail before the vm is deemed unhealthy.
 		UnhealthyThreshold: defaultUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check.",
+		Description:        DescriptionForDefaultHealthChecks,
 		Type:               string(protocol),
 	}
 	return &HealthCheck{
@@ -255,7 +263,7 @@ func DefaultNEGHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
 		HealthyThreshold: defaultHealthyThreshold,
 		// Number of healthchecks to fail before the vm is deemed unhealthy.
 		UnhealthyThreshold: defaultNEGUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check for NEG.",
+		Description:        DescriptionForDefaultNEGHealthChecks,
 		Type:               string(protocol),
 	}
 	return &HealthCheck{
@@ -278,7 +286,7 @@ func DefaultILBHealthCheck(protocol annotations.AppProtocol) *HealthCheck {
 		HealthyThreshold: defaultHealthyThreshold,
 		// Number of healthchecks to fail before the vm is deemed unhealthy.
 		UnhealthyThreshold: defaultNEGUnhealthyThreshold,
-		Description:        "Default kubernetes L7 Loadbalancing health check for ILB.",
+		Description:        DescriptionForDefaultILBHealthChecks,
 		Type:               string(protocol),
 	}
 
@@ -326,5 +334,5 @@ func ApplyProbeSettingsToHC(p *v1.Probe, hc *HealthCheck) {
 		hc.CheckIntervalSec = int64(p.PeriodSeconds) + int64(defaultHealthCheckInterval.Seconds())
 	}
 
-	hc.Description = "Kubernetes L7 health check generated with readiness probe settings."
+	hc.Description = DescriptionForHealthChecksFromReadinessProbe
 }


### PR DESCRIPTION
This is the first preparatory PR in a series of two. The intention of the second PR is to detect the removal of `BackendConfig` CRD and to update health check configuration according to the existing input (rather than keep the existing configuration from `BackendConfig`).

The present PR updates the health check `Description` when `BackendConfig` is used. Additionally, test cases are modified to verify health check `Description`s.