### PR TITLE
Process IPv6 Endpoints 

### DIFF
--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	apiv1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -244,6 +245,10 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 		foundMatchingPort = true
 
 		for _, endpointAddress := range ed.Addresses {
+			if endpointAddress.AddressType != discovery.AddressTypeIPv4 {
+				klog.Infof("Skipping non IPv4 address: %q, in endpoint slice %s/%s", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				continue
+			}
 			if endpointAddress.NodeName == nil || len(*endpointAddress.NodeName) == 0 {
 				klog.V(2).Infof("Detected unexpected error when checking missing nodeName. Endpoint %q in Endpoints %s/%s does not have an associated node. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
 				return nil, nil, dupCount, negtypes.ErrEPMissingNodeName
@@ -306,6 +311,10 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			continue
 		}
 		for _, endpointAddress := range ed.Addresses {
+			if endpointAddress.AddressType != discovery.AddressTypeIPv4 {
+				klog.Infof("Skipping non IPv4 address in degraded mode: %q, in endpoint slice %s/%s", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				continue
+			}
 			if endpointAddress.TargetRef == nil {
 				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not have an associated pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
 				continue

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1698,5 +1698,49 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "-4",
+				Namespace: namespace,
+				Labels: map[string]string{
+					discovery.LabelServiceName: name,
+				},
+			},
+			AddressType: discovery.AddressTypeIPv6,
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"aa:aa"},
+					NodeName:  &instance3,
+					TargetRef: &v1.ObjectReference{
+						Namespace: namespace,
+						Name:      "pod10",
+					},
+				},
+				{
+					Addresses: []string{"aa:ab"},
+					NodeName:  &instance4,
+					TargetRef: &v1.ObjectReference{
+						Namespace: namespace,
+						Name:      "pod11",
+					},
+				},
+				{
+					Addresses: []string{"aa:ac"},
+					NodeName:  &instance4,
+					TargetRef: &v1.ObjectReference{
+						Namespace: namespace,
+						Name:      "pod12",
+					},
+					Conditions: discovery.EndpointConditions{Ready: &notReady},
+				},
+			},
+			Ports: []discovery.EndpointPort{
+				{
+					Name:     &emptyNamedPort,
+					Port:     &port80,
+					Protocol: &protocolTCP,
+				},
+			},
+		},
 	}
 }

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -308,10 +308,11 @@ type PortData struct {
 }
 
 type AddressData struct {
-	TargetRef *apiv1.ObjectReference
-	NodeName  *string
-	Addresses []string
-	Ready     bool
+	TargetRef   *apiv1.ObjectReference
+	NodeName    *string
+	Addresses   []string
+	Ready       bool
+	AddressType discovery.AddressType
 }
 
 // Converts API EndpointSlice list to the EndpointsData abstraction.
@@ -319,10 +320,6 @@ type AddressData struct {
 func EndpointsDataFromEndpointSlices(slices []*discovery.EndpointSlice) []EndpointsData {
 	result := make([]EndpointsData, 0, len(slices))
 	for _, slice := range slices {
-		if slice.AddressType != discovery.AddressTypeIPv4 {
-			// Neg Controller can only attach IPv4 endpoints
-			continue
-		}
 		ports := make([]PortData, 0)
 		addresses := make([]AddressData, 0)
 		for _, port := range slice.Ports {
@@ -343,7 +340,7 @@ func EndpointsDataFromEndpointSlices(slices []*discovery.EndpointSlice) []Endpoi
 				nodeNameFromTopology := ep.DeprecatedTopology[apiv1.LabelHostname]
 				nodeName = &nodeNameFromTopology
 			}
-			addresses = append(addresses, AddressData{TargetRef: ep.TargetRef, NodeName: nodeName, Addresses: ep.Addresses, Ready: ready})
+			addresses = append(addresses, AddressData{TargetRef: ep.TargetRef, NodeName: nodeName, Addresses: ep.Addresses, Ready: ready, AddressType: slice.AddressType})
 		}
 		result = append(result, EndpointsData{Meta: &slice.ObjectMeta, Ports: ports, Addresses: addresses})
 	}

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -595,20 +595,18 @@ func TestEndpointsDataFromEndpointSlices(t *testing.T) {
 
 	endpointsData := EndpointsDataFromEndpointSlices(endpointSlices)
 
-	if len(endpointsData) != 2 {
-		t.Errorf("Expected the same number of endpoints subsets and endpoints data, got %d endpoints data for 2 subsets", len(endpointsData))
+	if len(endpointsData) != 3 {
+		t.Errorf("Expected the same number of endpoints subsets and endpoints data, got %d endpoints data for 3 subsets", len(endpointsData))
 	}
 	// This test expects that all the valid EPS are at the beginning
 	for i, slice := range endpointSlices {
-		if slice.AddressType != discovery.AddressTypeIPv4 {
-			continue
-		}
+		addressType := slice.AddressType
 		for j, port := range slice.Ports {
 			ValidatePortData(endpointsData[i].Ports[j], *port.Port, *port.Name, t)
 		}
 		terminatingEndpointsNumber := 0
 		for _, endpoint := range slice.Endpoints {
-			found := CheckIfAddressIsPresentInData(endpointsData[i].Addresses, endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready, endpoint.Addresses[0], endpoint.TargetRef, endpoint.NodeName)
+			found := CheckIfAddressIsPresentInData(endpointsData[i].Addresses, endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready, endpoint.Addresses[0], endpoint.TargetRef, endpoint.NodeName, addressType)
 			if endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating {
 				terminatingEndpointsNumber++
 				if found {
@@ -732,9 +730,9 @@ func ValidatePortData(portData PortData, port int32, name string, t *testing.T) 
 	}
 }
 
-func CheckIfAddressIsPresentInData(addressData []AddressData, ready bool, address string, targetRef *v1.ObjectReference, nodeName *string) bool {
+func CheckIfAddressIsPresentInData(addressData []AddressData, ready bool, address string, targetRef *v1.ObjectReference, nodeName *string, addressType discovery.AddressType) bool {
 	for _, data := range addressData {
-		if data.Ready == ready && len(data.Addresses) == 1 && data.Addresses[0] == address && data.TargetRef == targetRef && data.NodeName == nodeName {
+		if data.Ready == ready && len(data.Addresses) == 1 && data.Addresses[0] == address && data.TargetRef == targetRef && data.NodeName == nodeName && data.AddressType == addressType {
 			return true
 		}
 	}

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -740,12 +740,3 @@ func CheckIfAddressIsPresentInData(addressData []AddressData, ready bool, addres
 	}
 	return false
 }
-
-func ValidateAddressDataForEndpointsAddresses(addressData []AddressData, addresses []v1.EndpointAddress, ready bool, t *testing.T) {
-	for _, addr := range addresses {
-		found := CheckIfAddressIsPresentInData(addressData, ready, addr.IP, addr.TargetRef, addr.NodeName)
-		if !found {
-			t.Errorf("Endpoint address %v couldn't be found in Address Data %v", addr, addressData)
-		}
-	}
-}


### PR DESCRIPTION
This PR moves the logic of skipping IPv6 endpoints to the individual endpoint calculators. This allows L4 to use the ipv6 endpoints and l7 to ignore them.