### PR TITLE
Add metrics for degraded mode correctness

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -355,6 +355,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 		flags.F.RunL4Controller,
 		flags.F.EnableNonGCPMode,
 		enableAsm,
+		flags.F.EnableDegradedMode,
 		asmServiceNEGSkipNamespaces,
 		lpConfig,
 		klog.TODO(), // TODO(#1761): Replace this with a top level logger configuration once one is available.

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -128,6 +128,7 @@ func NewController(
 	runL4Controller bool,
 	enableNonGcpMode bool,
 	enableAsm bool,
+	enableDegradedMode bool,
 	asmServiceNEGSkipNamespaces []string,
 	lpConfig negtypes.PodLabelPropagationConfig,
 	logger klog.Logger,
@@ -168,6 +169,7 @@ func NewController(
 		svcNegInformer.GetIndexer(),
 		syncerMetrics,
 		enableNonGcpMode,
+		enableDegradedMode,
 		numGCWorkers,
 		lpConfig,
 		logger)

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -139,6 +139,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		runL4,     //runL4Controller
 		false,     //enableNonGcpMode
 		enableASM, //enableAsm
+		false,     // enableDegradedMode
 		[]string{},
 		negtypes.PodLabelPropagationConfig{},
 		klog.TODO(),

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -93,6 +93,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 		testContext.SvcNegInformer.GetIndexer(),
 		metrics.FakeSyncerMetrics(),
 		false, //enableNonGcpMode
+		false, // enableDegradedMode
 		testContext.NumGCWorkers,
 		negtypes.PodLabelPropagationConfig{},
 		klog.TODO(),

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -199,7 +199,7 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
-	return toZoneNetworkEndpointMap(eds, l.zoneGetter, l.servicePortName, l.networkEndpointType, l.lpConfig)
+	return toZoneNetworkEndpointMap(eds, l.podLister, l.zoneGetter, l.servicePortName, l.networkEndpointType, l.lpConfig)
 }
 
 func nodeMapToString(nodeMap map[string][]*v1.Node) string {

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -106,7 +106,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	ec := NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
 	for _, tc := range testCases {
 		createNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeReadyStatusMap, transactionSyncer.nodeLister)
-		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
+		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil, false)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
 		}
@@ -198,7 +198,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	ec := NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
 	for _, tc := range testCases {
 		createNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeReadyStatusMap, transactionSyncer.nodeLister)
-		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
+		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil, false)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
 		}
@@ -232,10 +232,11 @@ func TestValidateEndpoints(t *testing.T) {
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
-	nodeLister := listers.NewNodeLister(testContext.NodeInformer.GetIndexer())
-	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, testPortName, negtypes.VmIpPortEndpointType, klog.TODO(), negtypes.PodLabelPropagationConfig{})
-	L4LocalEndpointCalculator := NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
-	L4ClusterEndpointCalculator := NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
+	nodeLister := testContext.NodeInformer.GetIndexer()
+	serviceLister := testContext.ServiceInformer.GetIndexer()
+	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, false, klog.TODO(), negtypes.PodLabelPropagationConfig{})
+	L4LocalEndpointCalculator := NewLocalL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, svcKey, klog.TODO())
+	L4ClusterEndpointCalculator := NewClusterL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, svcKey, klog.TODO())
 
 	testEndpointPodMap := map[negtypes.NetworkEndpoint]types.NamespacedName{
 		{
@@ -811,6 +812,128 @@ func TestValidateEndpoints(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			if got := tc.ec.ValidateEndpoints(tc.endpointsData, tc.endpointPodMap, tc.dupCount); !errors.Is(got, tc.expect) {
 				t.Errorf("ValidateEndpoints() = %t,  expected %t", got, tc.expect)
+			}
+		})
+	}
+}
+
+// TestEnableDegradedMode verifies if DegradedMode has been correctly enabled for L7 endpoint calculator
+func TestEnableDegradedMode(t *testing.T) {
+	t.Parallel()
+
+	testPortName := ""
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	testContext := negtypes.NewTestContext()
+	podLister := testContext.PodInformer.GetIndexer()
+	nodeLister := testContext.NodeInformer.GetIndexer()
+	serviceLister := testContext.ServiceInformer.GetIndexer()
+	addPodsToLister(podLister)
+
+	for i := 1; i <= 4; i++ {
+		nodeLister.Add(&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("instance%v", i),
+			},
+		})
+	}
+
+	validEndpointData := negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices())
+	invalidEndpointData := negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices())
+	invalidEndpointData[0].Addresses[0].NodeName = nil
+
+	endpointSets := map[string]negtypes.NetworkEndpointSet{
+		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
+			networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
+			networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"),
+			networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"),
+			networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80")),
+		negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+			networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
+	}
+	endpointMap := negtypes.EndpointPodMap{
+		networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+		networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+		networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+		networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+		networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
+		networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod6"},
+	}
+	testCases := []struct {
+		desc         string
+		ec           negtypes.NetworkEndpointsCalculator
+		endpointData []negtypes.EndpointsData
+		inErrorState bool
+		expectedSets map[string]negtypes.NetworkEndpointSet
+		expectedMap  negtypes.EndpointPodMap
+		expectErr    error
+	}{
+		{
+			desc:         "disable degraded mode, not in error state, using valid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, false, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: validEndpointData,
+			inErrorState: true,
+			expectedSets: endpointSets,
+			expectedMap:  endpointMap,
+			expectErr:    nil,
+		},
+		{
+			desc:         "disable degraded mode, not in error state, using invalid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, false, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: invalidEndpointData,
+			inErrorState: false,
+			expectedSets: nil,
+			expectedMap:  nil,
+			expectErr:    negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:         "disable degraded mode, in error state, using invalid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, false, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: invalidEndpointData,
+			inErrorState: true,
+			expectedSets: nil,
+			expectedMap:  nil,
+			expectErr:    negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:         "enable degraded mode, not in error state, using valid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, true, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: validEndpointData,
+			inErrorState: false,
+			expectedSets: endpointSets,
+			expectedMap:  endpointMap,
+			expectErr:    nil,
+		},
+		{
+			desc:         "enable degraded mode, not in error state, using invalid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, true, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: invalidEndpointData,
+			inErrorState: false,
+			expectedSets: nil,
+			expectedMap:  nil,
+			expectErr:    negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:         "enable degraded mode, in error state, using invalid endpoint",
+			ec:           NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, testPortName, negtypes.VmIpPortEndpointType, true, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+			endpointData: invalidEndpointData,
+			inErrorState: true,
+			expectedSets: endpointSets,
+			expectedMap:  endpointMap,
+			expectErr:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			retSet, retMap, _, err := tc.ec.CalculateEndpoints(tc.endpointData, nil, tc.inErrorState)
+			if !reflect.DeepEqual(retSet, tc.expectedSets) {
+				t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.expectedSets, retSet)
+			}
+			if !reflect.DeepEqual(retMap, tc.expectedMap) {
+				t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectedMap, retMap)
+			}
+			if !errors.Is(err, tc.expectErr) {
+				t.Errorf("For case %q, expect error %v, but got %v.", tc.desc, tc.expectErr, err)
 			}
 		})
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1390,7 +1390,7 @@ func TestUnknownNodes(t *testing.T) {
 
 func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, mode negtypes.EndpointsCalculatorMode) (negtypes.NegSyncer, *transactionSyncer) {
 	negsyncer, ts := newTestTransactionSyncer(fakeGCE, negtypes.VmIpEndpointType, false)
-	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.zoneGetter, ts.NegSyncerKey, mode, klog.TODO(), negtypes.PodLabelPropagationConfig{})
+	ts.endpointsCalculator = GetEndpointsCalculator(ts.nodeLister, ts.podLister, ts.serviceLister, ts.zoneGetter, ts.NegSyncerKey, mode, false, klog.TODO(), negtypes.PodLabelPropagationConfig{})
 	return negsyncer, ts
 }
 
@@ -1431,8 +1431,8 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 		testContext.NodeInformer.GetIndexer(),
 		testContext.SvcNegInformer.GetIndexer(),
 		reflector,
-		GetEndpointsCalculator(testContext.NodeInformer.GetIndexer(), testContext.PodInformer.GetIndexer(), fakeZoneGetter,
-			svcPort, mode, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
+		GetEndpointsCalculator(testContext.NodeInformer.GetIndexer(), testContext.PodInformer.GetIndexer(), testContext.SvcNegInformer.GetIndexer(),
+			fakeZoneGetter, svcPort, mode, false, klog.TODO(), negtypes.PodLabelPropagationConfig{}),
 		string(kubeSystemUID),
 		testContext.SvcNegClient,
 		metrics.FakeSyncerMetrics(),

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -218,7 +218,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 }
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
-func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, lpConfig negtypes.PodLabelPropagationConfig) (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, int, error) {
+func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, podLister cache.Indexer, zoneGetter negtypes.ZoneGetter, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, lpConfig negtypes.PodLabelPropagationConfig) (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, int, error) {
 	zoneNetworkEndpointMap := map[string]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	dupCount := 0
@@ -251,19 +251,31 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 			}
 			if endpointAddress.NodeName == nil || len(*endpointAddress.NodeName) == 0 {
 				klog.V(2).Infof("Detected unexpected error when checking missing nodeName. Endpoint %q in Endpoints %s/%s does not have an associated node. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
-				return nil, nil, dupCount, negtypes.ErrEPMissingNodeName
+				return nil, nil, dupCount, negtypes.ErrEPInvalidNodeName
 			}
 			if endpointAddress.TargetRef == nil {
 				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not have an associated pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
-				continue
+				return nil, nil, dupCount, negtypes.ErrEPInvalidPod
 			}
 			zone, err := zoneGetter.GetZoneForNode(*endpointAddress.NodeName)
 			if err != nil {
-				return nil, nil, dupCount, negtypes.ErrNodeNotFound
+				return nil, nil, dupCount, negtypes.ErrEPInvalidNodeName
 			}
 			if zone == "" {
-				klog.V(2).Info("Detected unexpected error when checking missing zone")
-				return nil, nil, dupCount, negtypes.ErrEPMissingZone
+				klog.V(2).Info("Detected unexpected error when checking zone")
+				return nil, nil, dupCount, negtypes.ErrEPInvalidZone
+			}
+
+			key := fmt.Sprintf("%s/%s", endpointAddress.TargetRef.Namespace, endpointAddress.TargetRef.Name)
+			obj, exists, err := podLister.GetByKey(key)
+			if err != nil || !exists {
+				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not correspond to an existing pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				return nil, nil, dupCount, negtypes.ErrEPInvalidPod
+			}
+			_, ok := obj.(*apiv1.Pod)
+			if !ok {
+				klog.V(2).Infof("Endpoint %q in Endpoints %s/%s does not correspond to an existing pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				return nil, nil, dupCount, negtypes.ErrEPInvalidPod
 			}
 			if zoneNetworkEndpointMap[zone] == nil {
 				zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1695,7 +1695,18 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 	fakeZoneGetter := negtypes.NewFakeZoneGetter()
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
-	addPodsToLister(podLister)
+	podLister.Add(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testServiceNamespace,
+			Name:      "pod1",
+		},
+		Spec: v1.PodSpec{
+			NodeName: testInstance1,
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	})
 
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	nodeLister.Add(&corev1.Node{

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package syncers
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -543,6 +544,363 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
 		}
 
+		if !reflect.DeepEqual(retMap, tc.expectMap) {
+			t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectMap, retMap)
+		}
+	}
+}
+
+// TestValidateEndpointFields validates if toZoneNetworkEndpointMap
+// returns correct type of error with invalid endpoint information
+func TestValidateEndpointFields(t *testing.T) {
+	t.Parallel()
+	zoneGetter := negtypes.NewFakeZoneGetter()
+	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
+	addPodsToLister(podLister)
+
+	instance1 := negtypes.TestInstance1
+	instance3 := negtypes.TestInstance3
+	instanceNotExist := "non-existent-node"
+	emptyZoneInstance := "empty-zone-instance"
+	zoneGetter.AddZone("", emptyZoneInstance)
+
+	emptyNamedPort := ""
+	emptyNodeName := ""
+	port80 := int32(80)
+	protocolTCP := v1.ProtocolTCP
+
+	testCases := []struct {
+		desc              string
+		portName          string
+		testEndpointSlice []*discovery.EndpointSlice
+		expectSets        map[string]negtypes.NetworkEndpointSet
+		expectMap         negtypes.EndpointPodMap
+		expectErr         error
+	}{
+		{
+			desc:     "endpoints no missing or invalid fields",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80")),
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
+			},
+			expectMap: negtypes.EndpointPodMap{
+				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+			},
+			expectErr: nil,
+		},
+		{
+			desc:     "include one endpoint that has missing nodeName",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  nil, // endpoint with missing nodeName
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:     "include one endpoint that has empty nodeName",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &emptyNodeName,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:     "include one endpoint that has missing pod",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: nil,
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidPod,
+		},
+		{
+			desc:     "include one endpoint that does correspond to an existing pod",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "foo", // this is a non-existing pod
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidPod,
+		},
+		{
+			desc:     "include one endpoint that does correspond to an existing node",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instanceNotExist,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidNodeName,
+		},
+		{
+			desc:     "include one endpoint that corresponds to an empty zone",
+			portName: "",
+			testEndpointSlice: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName + "-1",
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &emptyZoneInstance,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.3.1"},
+							NodeName:  &instance3,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod4",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectSets: nil,
+			expectMap:  nil,
+			expectErr:  negtypes.ErrEPInvalidZone,
+		},
+	}
+
+	// TODO(songrx1997): Add endpoint annotations for the test after calculation code is in
+	for _, tc := range testCases {
+		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlice), podLister, zoneGetter, tc.portName, negtypes.VmIpPortEndpointType, negtypes.PodLabelPropagationConfig{})
+		if !errors.Is(err, tc.expectErr) {
+			t.Errorf("For case %q, expect %v error, but got %v.", tc.desc, tc.expectErr, err)
+		}
+		if !reflect.DeepEqual(retSet, tc.expectSets) {
+			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.expectSets, retSet)
+		}
 		if !reflect.DeepEqual(retMap, tc.expectMap) {
 			t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectMap, retMap)
 		}
@@ -1844,7 +2202,7 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 					NodeName:  &instance3,
 					TargetRef: &v1.ObjectReference{
 						Namespace: namespace,
-						Name:      "pod10",
+						Name:      "pod13",
 					},
 				},
 				{
@@ -1852,7 +2210,7 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 					NodeName:  &instance4,
 					TargetRef: &v1.ObjectReference{
 						Namespace: namespace,
-						Name:      "pod11",
+						Name:      "pod14",
 					},
 				},
 				{
@@ -1860,7 +2218,7 @@ func getTestEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
 					NodeName:  &instance4,
 					TargetRef: &v1.ObjectReference{
 						Namespace: namespace,
-						Name:      "pod12",
+						Name:      "pod15",
 					},
 					Conditions: discovery.EndpointConditions{Ready: &notReady},
 				},

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -444,6 +444,9 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
 	zoneGetter := negtypes.NewFakeZoneGetter()
+	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
+	addPodsToLister(podLister)
+
 	testCases := []struct {
 		desc                string
 		portName            string
@@ -531,7 +534,7 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 
 	// TODO(songrx1997): Add endpoint annotations for the test after calculation code is in
 	for _, tc := range testCases {
-		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), zoneGetter, tc.portName, tc.networkEndpointType, negtypes.PodLabelPropagationConfig{})
+		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), podLister, zoneGetter, tc.portName, tc.networkEndpointType, negtypes.PodLabelPropagationConfig{})
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
 		}
@@ -1242,12 +1245,12 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
-				networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod2"},
-				networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod3"},
-				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod5"},
-				networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod6"},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+				networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+				networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
+				networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod6"},
 			},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1265,12 +1268,12 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod7"},
-				networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod8"},
-				networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod9"},
-				networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod10"},
-				networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod11"},
-				networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod12"},
+				networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod7"},
+				networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod8"},
+				networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod9"},
+				networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod10"},
+				networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod11"},
+				networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod12"},
 			},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1288,19 +1291,19 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.3.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
-				networkEndpointFromEncodedEndpoint("10.100.1.2||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod2"},
-				networkEndpointFromEncodedEndpoint("10.100.2.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod3"},
-				networkEndpointFromEncodedEndpoint("10.100.3.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod5"},
-				networkEndpointFromEncodedEndpoint("10.100.1.4||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod6"},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				networkEndpointFromEncodedEndpoint("10.100.1.2||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+				networkEndpointFromEncodedEndpoint("10.100.2.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+				networkEndpointFromEncodedEndpoint("10.100.3.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+				networkEndpointFromEncodedEndpoint("10.100.1.3||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
+				networkEndpointFromEncodedEndpoint("10.100.1.4||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod6"},
 			},
 			networkEndpointType: negtypes.NonGCPPrivateEndpointType,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			testEndpointSlices := getTestEndpointSlices(testService, testNamespace)
+			testEndpointSlices := getDefaultEndpointSlices()
 
 			targetMap, endpointPodMap, _, err := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(testEndpointSlices), fakeZoneGetter, podLister, nodeLister, tc.portName, tc.networkEndpointType)
 			if err != nil {
@@ -1328,7 +1331,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80")),
 	}
 	podMap := negtypes.EndpointPodMap{
-		networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+		networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
 	}
 
 	fakeZoneGetter := negtypes.NewFakeZoneGetter()
@@ -1356,7 +1359,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  &instance1,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1371,7 +1374,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  nil,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1386,7 +1389,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  &emptyNodeName,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1399,7 +1402,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 			desc: "Non-GCP network endpoint",
 			ep: negtypes.AddressData{
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				NodeName:  &emptyNodeName,
@@ -1413,7 +1416,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"}},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"}},
 		},
 	}
 	for _, tc := range testCases {
@@ -1453,7 +1456,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a valid pod with phase running",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Status: v1.PodStatus{
@@ -1469,7 +1472,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a terminal pod with phase failed",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod2",
 				},
 				Status: v1.PodStatus{
@@ -1485,7 +1488,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a terminal pod with phase succeeded",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod3",
 				},
 				Status: v1.PodStatus{
@@ -1501,7 +1504,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a pod from non-existent node",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod4",
 				},
 				Status: corev1.PodStatus{
@@ -1528,7 +1531,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	for i := 1; i <= 6; i++ {
 		podLister.Add(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testNamespace,
+				Namespace: testServiceNamespace,
 				Name:      fmt.Sprintf("pod%v", i),
 			},
 			Status: corev1.PodStatus{
@@ -1542,7 +1545,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	for i := 7; i <= 12; i++ {
 		podLister.Add(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testNamespace,
+				Namespace: testServiceNamespace,
 				Name:      fmt.Sprintf("pod%v", i),
 			},
 			Status: corev1.PodStatus{
@@ -1556,7 +1559,7 @@ func addPodsToLister(podLister cache.Indexer) {
 
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod3",
 		},
 		Status: corev1.PodStatus{
@@ -1568,7 +1571,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod4",
 		},
 		Status: corev1.PodStatus{
@@ -1580,7 +1583,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod7",
 		},
 		Status: corev1.PodStatus{
@@ -1592,7 +1595,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod10",
 		},
 		Status: corev1.PodStatus{

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -82,8 +82,9 @@ type NegSyncerManager interface {
 
 type NetworkEndpointsCalculator interface {
 	// CalculateEndpoints computes the NEG endpoints based on service endpoints and the current NEG state and returns a
-	// map of zone name to network endpoint set
-	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, int, error)
+	// map of zone name to network endpoint set. For L7 calculator, if inErrorState is true and degraded mode is enabled,
+	// do calculation using degraded mode procedures
+	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet, inErrorState bool) (map[string]NetworkEndpointSet, EndpointPodMap, int, error)
 	// Mode indicates the mode that the EndpointsCalculator is operating in.
 	Mode() EndpointsCalculatorMode
 	// ValidateEndpoints validates the NEG endpoint information is correct

--- a/pkg/neg/types/sync_results.go
+++ b/pkg/neg/types/sync_results.go
@@ -17,9 +17,9 @@ import "errors"
 
 const (
 	ResultEPCountsDiffer         = "EPCountsDiffer"
-	ResultEPMissingNodeName      = "EPMissingNodeName"
-	ResultNodeNotFound           = "NodeNotFound"
-	ResultEPMissingZone          = "EPMissingZone"
+	ResultEPInvalidNodeName      = "EPInvalidNodeName"
+	ResultEPInvalidPod           = "EPInvalidPod"
+	ResultEPInvalidZone          = "EPInvalidZone"
 	ResultEPSEndpointCountZero   = "EPSEndpointCountZero"
 	ResultEPCalculationCountZero = "EPCalculationCountZero"
 	ResultInvalidAPIResponse     = "InvalidAPIResponse"
@@ -37,9 +37,9 @@ const (
 
 var (
 	ErrEPCountsDiffer         = errors.New("endpoint counts from endpointData and endpointPodMap differ")
-	ErrEPMissingNodeName      = errors.New("endpoint has empty nodeName field")
-	ErrNodeNotFound           = errors.New("failed to retrieve associated zone of node")
-	ErrEPMissingZone          = errors.New("endpoint has empty zone field")
+	ErrEPInvalidNodeName      = errors.New("endpoint has invalid nodeName field")
+	ErrEPInvalidPod           = errors.New("endpoint has invalid pod field")
+	ErrEPInvalidZone          = errors.New("endpoint has invalid zone field")
 	ErrEPSEndpointCountZero   = errors.New("endpoint count from endpointData cannot be zero")
 	ErrEPCalculationCountZero = errors.New("endpoint count from endpointPodMap cannot be zero")
 	ErrInvalidAPIResponse     = errors.New("received response error doesn't match googleapi.Error type")
@@ -48,8 +48,9 @@ var (
 
 	// use this map for conversion between errors and sync results
 	ErrorStateResult = map[error]string{
-		ErrEPMissingNodeName:      ResultEPMissingNodeName,
-		ErrEPMissingZone:          ResultEPMissingZone,
+		ErrEPInvalidNodeName:      ResultEPInvalidNodeName,
+		ErrEPInvalidPod:           ResultEPInvalidPod,
+		ErrEPInvalidZone:          ResultEPInvalidZone,
 		ErrEPCalculationCountZero: ResultEPCalculationCountZero,
 		ErrEPSEndpointCountZero:   ResultEPSEndpointCountZero,
 		ErrEPCountsDiffer:         ResultEPCountsDiffer,


### PR DESCRIPTION
Add metrics that reports the number of endpoint differed between current endpoint calculation and degraded mode calculation. It is not emitted when current endpoint calculation returns any errors because they are errors defined in error states, and degraded mode will fix these errors and return nil, while current calculation will return error and empty endpoint maps.