### PR TITLE
Add unit tests to validate error states are detected

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -224,7 +224,7 @@ func (s *transactionSyncer) syncInternal() error {
 	err := s.syncInternalImpl()
 	if err != nil {
 		if syncErr := negtypes.ClassifyError(err); syncErr.IsErrorState {
-			s.logger.V(3).Info("Updating error state", "error state", syncErr.Reason)
+			s.logger.Info("Updating error state", "error state", syncErr.Reason)
 			s.setErrorState()
 		}
 	}
@@ -523,9 +523,9 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, zone stri
 		// we would set error state and retry. For successful calls, we won't update
 		// error state, so its value won't be overwritten within API call go routines.
 		if syncErr.IsErrorState {
-			s.logger.Info("Detected unexpected error when checking endpoint update response", "operation", operation, "error", err)
+			s.logger.Error(err, "Detected unexpected error when checking endpoint update response", "operation", operation)
 			s.syncLock.Lock()
-			s.logger.V(3).Info("Updating error state", "error state", syncErr.Reason)
+			s.logger.Info("Updating error state", "error state", syncErr.Reason)
 			s.setErrorState()
 			s.syncLock.Unlock()
 		}

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -523,8 +523,9 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, zone stri
 		// we would set error state and retry. For successful calls, we won't update
 		// error state, so its value won't be overwritten within API call go routines.
 		if syncErr.IsErrorState {
-			s.logger.V(3).Info("Updating error state", "error state", syncErr.Reason)
+			s.logger.Info("Detected unexpected error when checking endpoint update response", "operation", operation, "error", err)
 			s.syncLock.Lock()
+			s.logger.V(3).Info("Updating error state", "error state", syncErr.Reason)
 			s.setErrorState()
 			s.syncLock.Unlock()
 		}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -436,7 +436,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			}
 			zone, getZoneErr := zoneGetter.GetZoneForNode(nodeName)
 			if getZoneErr != nil {
-				klog.Errorf("For endpoint %q in pod %q, its corresponding node %q does not have valid zone information: %w, skipping", endpointAddress.Addresses, pod.ObjectMeta.Name, nodeName, getZoneErr)
+				klog.Errorf("For endpoint %q in pod %q, its corresponding node %q does not have valid zone information: %v, skipping", endpointAddress.Addresses, pod.ObjectMeta.Name, nodeName, getZoneErr)
 				metrics.PublishNegControllerErrorCountMetrics(getZoneErr, true)
 				localEPCount[negtypes.ZoneMissing]++
 				continue
@@ -461,7 +461,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			// endpoint address should match to the IP of its pod
 			checkIPErr := podContainsEndpointAddress(networkEndpoint, pod)
 			if checkIPErr != nil {
-				klog.Errorf("Endpoint %q in Endpoints %s/%s has IP(s) not match to its pod %s: %w, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, pod.Name, checkIPErr)
+				klog.Errorf("Endpoint %q in Endpoints %s/%s has IP(s) not match to its pod %s: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, pod.Name, checkIPErr)
 				metrics.PublishNegControllerErrorCountMetrics(checkIPErr, true)
 				localEPCount[negtypes.IPNotFromPod] += 1
 				continue

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -359,8 +359,8 @@ func getEndpointZone(endpointAddress negtypes.AddressData, zoneGetter negtypes.Z
 	}
 	zone, err := zoneGetter.GetZoneForNode(*endpointAddress.NodeName)
 	if err != nil {
-		count[negtypes.ZoneMissing]++
-		return zone, count, fmt.Errorf("%w: %v", negtypes.ErrEPZoneMissing, err)
+		count[negtypes.NodeNotFound]++
+		return zone, count, fmt.Errorf("%w: %v", negtypes.ErrEPNodeNotFound, err)
 	}
 	if zone == "" {
 		count[negtypes.ZoneMissing]++
@@ -438,7 +438,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			if getZoneErr != nil {
 				klog.Errorf("For endpoint %q in pod %q, its corresponding node %q does not have valid zone information: %v, skipping", endpointAddress.Addresses, pod.ObjectMeta.Name, nodeName, getZoneErr)
 				metrics.PublishNegControllerErrorCountMetrics(getZoneErr, true)
-				localEPCount[negtypes.ZoneMissing]++
+				localEPCount[negtypes.NodeNotFound]++
 				continue
 			}
 			if zoneNetworkEndpointMap[zone] == nil {

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1035,7 +1035,7 @@ func TestValidateEndpointFields(t *testing.T) {
 			},
 			expectSets: nil,
 			expectMap:  nil,
-			expectErr:  negtypes.ErrEPNodeMissing,
+			expectErr:  negtypes.ErrEPNodeNotFound,
 		},
 		{
 			desc: "include one endpoint that corresponds to an empty zone",


### PR DESCRIPTION
Add TestParseEndpointBatchErr to verify invalid endpoint batch error state. Add TestValidateEndpointFields to verify invalid endpoint information error state.