### PR TITLE
Add Observe() func to internal GCERateLimiter

### DIFF
--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -110,6 +110,9 @@ func (grl *GCERateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) 
 	return err
 }
 
+// Observe is a no-op func to satisfy cloud.RateLimiter
+func (grl *GCERateLimiter) Observe(context.Context, error, *cloud.RateLimitKey) {}
+
 // rateLimitImpl returns the flowcontrol.RateLimiter implementation
 // associated with the passed in key.
 func (grl *GCERateLimiter) rateLimitImpl(key *cloud.RateLimitKey) flowcontrol.RateLimiter {


### PR DESCRIPTION
It appears that there's yet another rate limiter that has to be updated due to https://github.com/GoogleCloudPlatform/k8s-cloud-provider/pull/77

In my testing, this is the last patch needed to build ingress with the newest k8s-cloud-provider

/assign @aojea 