### PR TITLE
don't log all nodenames

### DIFF
--- a/pkg/firewalls/firewalls.go
+++ b/pkg/firewalls/firewalls.go
@@ -64,7 +64,7 @@ func NewFirewallPool(cloud Firewall, namer *namer_util.Namer, l7SrcRanges []stri
 
 // Sync firewall rules with the cloud.
 func (fr *FirewallRules) Sync(nodeNames, additionalPorts, additionalRanges []string, allowNodePort bool) error {
-	klog.V(4).Infof("Sync(%v)", nodeNames)
+	klog.V(4).Infof("Sync %d nodes", len(nodeNames))
 	name := fr.namer.FirewallRule()
 	existingFirewall, _ := fr.cloud.GetFirewall(name)
 

--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -282,7 +282,7 @@ func (m *manager) add(groupName string, names []string) error {
 	events.GlobalEventf(m.recorder, core.EventTypeNormal, events.AddNodes, "Adding %s to InstanceGroup %q", events.TruncatedStringList(names), groupName)
 	var errs []error
 	for zone, nodeNames := range m.splitNodesByZone(names) {
-		klog.V(1).Infof("Adding nodes %v to %v in zone %v", nodeNames, groupName, zone)
+		klog.V(1).Infof("Adding %d nodes to %v in zone %v", len(nodeNames), groupName, zone)
 		if err := m.cloud.AddInstancesToInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames)); err != nil {
 			errs = append(errs, err)
 		}
@@ -301,7 +301,7 @@ func (m *manager) remove(groupName string, names []string) error {
 	events.GlobalEventf(m.recorder, core.EventTypeNormal, events.RemoveNodes, "Removing %s from InstanceGroup %q", events.TruncatedStringList(names), groupName)
 	var errs []error
 	for zone, nodeNames := range m.splitNodesByZone(names) {
-		klog.V(1).Infof("Removing nodes %v from %v in zone %v", nodeNames, groupName, zone)
+		klog.V(1).Infof("Removing %d nodes from %v in zone %v", len(nodeNames), groupName, zone)
 		if err := m.cloud.RemoveInstancesFromInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames)); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
This is a problem at large scale, it also make the browser to crash when accessing the log entries