### PR TITLE
Refactor syncInternalImpl and toZoneNetworkEndpointMap

### DIFF
--- a/pkg/neg/metrics/neg_metrics_collector.go
+++ b/pkg/neg/metrics/neg_metrics_collector.go
@@ -87,7 +87,7 @@ func (sm *SyncerMetrics) UpdateSyncer(key negtypes.NegSyncerKey, syncResult *neg
 		sm.syncerStatusMap = make(map[negtypes.NegSyncerKey]string)
 		sm.logger.V(3).Info("Syncer Metrics failed to initialize correctly, reinitializing syncerStatusMap: %v", sm.syncerStatusMap)
 	}
-	sm.syncerStatusMap[key] = syncResult.Result
+	sm.syncerStatusMap[key] = string(syncResult.Result)
 }
 
 // SetSyncerEPMetrics update the endpoint count based on the endpointStat

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -199,7 +199,8 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
-	return toZoneNetworkEndpointMap(eds, l.zoneGetter, l.servicePortName, l.networkEndpointType)
+	result, err := toZoneNetworkEndpointMap(eds, l.zoneGetter, l.podLister, l.servicePortName, l.networkEndpointType)
+	return result.NetworkEndpointSet, result.EndpointPodMap, result.DupCount, err
 }
 
 func nodeMapToString(nodeMap map[string][]*v1.Node) string {
@@ -235,7 +236,7 @@ func (l *L7EndpointsCalculator) ValidateEndpoints(endpointData []types.Endpoints
 	}
 
 	if countFromEndpointData != countFromPodMap {
-		l.logger.Info("Detected error when comparing endpoint counts", "endpointData", endpointData, "endpointPodMap", endpointPodMap, "dupCount", dupCount)
+		l.logger.Info("Detected error when comparing endpoint counts", "countFromEndpointData", countFromEndpointData, "countFromPodMap", countFromPodMap, "endpointData", endpointData, "endpointPodMap", endpointPodMap, "dupCount", dupCount)
 		return types.ErrEPCountsDiffer
 	}
 	return nil

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -232,10 +232,10 @@ func TestValidateEndpoints(t *testing.T) {
 	zoneGetter := negtypes.NewFakeZoneGetter()
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
-	nodeLister := listers.NewNodeLister(testContext.NodeInformer.GetIndexer())
-	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, testPortName, negtypes.VmIpPortEndpointType, klog.TODO(), testContext.EnableDualStackNEG)
-	L4LocalEndpointCalculator := NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
-	L4ClusterEndpointCalculator := NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, svcKey, klog.TODO())
+	nodeLister := testContext.NodeInformer.GetIndexer()
+	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, testPortName, negtypes.VmIpPortEndpointType, klog.TODO(), testContext.EnableDualStackNEG)
+	L4LocalEndpointCalculator := NewLocalL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, svcKey, klog.TODO())
+	L4ClusterEndpointCalculator := NewClusterL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, svcKey, klog.TODO())
 
 	testEndpointPodMap := map[negtypes.NetworkEndpoint]types.NamespacedName{
 		{

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -220,16 +220,15 @@ func (s *transactionSyncer) syncInternal() error {
 }
 
 func (s *transactionSyncer) syncInternalImpl() error {
+	if s.syncer.IsStopped() || s.syncer.IsShuttingDown() {
+		s.logger.V(3).Info("Skip syncing NEG", "negSyncerKey", s.NegSyncerKey.String())
+		return nil
+	}
 	if s.needInit || s.isZoneChange() {
 		if err := s.ensureNetworkEndpointGroups(); err != nil {
 			return err
 		}
 		s.needInit = false
-	}
-
-	if s.syncer.IsStopped() || s.syncer.IsShuttingDown() {
-		s.logger.V(3).Info("Skip syncing NEG", "negSyncerKey", s.NegSyncerKey.String())
-		return nil
 	}
 	s.logger.V(2).Info("Sync NEG", "negSyncerKey", s.NegSyncerKey.String(), "endpointsCalculatorMode", s.endpointsCalculator.Mode())
 

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -59,8 +59,6 @@ const (
 	testInstance4 = "instance4"
 	testInstance5 = "instance5"
 	testInstance6 = "instance6"
-	testNamespace = "ns"
-	testService   = "svc"
 )
 
 func TestTransactionSyncNetworkEndpoints(t *testing.T) {
@@ -900,8 +898,8 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negExists: true,
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
-				Namespace:   testNamespace,
-				ServiceName: testService,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
 				Port:        "80",
 			}.String(),
 			crStatusPopulated: true,
@@ -919,8 +917,8 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negExists: true,
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
-				Namespace:   testNamespace,
-				ServiceName: testService,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
 				Port:        "80",
 			}.String(),
 			crStatusPopulated: false,
@@ -931,8 +929,8 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negExists: true,
 			negDesc: utils.NegDescription{
 				ClusterUID:  "cluster-2",
-				Namespace:   testNamespace,
-				ServiceName: testService,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
 				Port:        "80",
 			}.String(),
 			crStatusPopulated: false,
@@ -944,7 +942,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   "namespace-2",
-				ServiceName: testService,
+				ServiceName: testServiceName,
 				Port:        "80",
 			}.String(),
 			crStatusPopulated: false,
@@ -955,7 +953,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negExists: true,
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
-				Namespace:   testNamespace,
+				Namespace:   testServiceNamespace,
 				ServiceName: "service-2",
 				Port:        "80",
 			}.String(),
@@ -967,8 +965,8 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			negExists: true,
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
-				Namespace:   testNamespace,
-				ServiceName: testService,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
 				Port:        "81",
 			}.String(),
 			crStatusPopulated: false,
@@ -980,8 +978,8 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			// Cause error by having a conflicting neg description
 			negDesc: utils.NegDescription{
 				ClusterUID:  kubeSystemUID,
-				Namespace:   testNamespace,
-				ServiceName: testService,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
 				Port:        "81",
 			}.String(),
 			crStatusPopulated: true,
@@ -1022,7 +1020,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			creationTS := v1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
 			//Create NEG CR for Syncer to update status on
 			origCR := createNegCR(testNegName, creationTS, tc.crStatusPopulated, tc.crStatusPopulated, refs)
-			neg, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testNamespace).Create(context2.Background(), origCR, v1.CreateOptions{})
+			neg, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context2.Background(), origCR, v1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Failed to create test NEG CR: %s", err)
 			}
@@ -1035,7 +1033,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 				t.Errorf("Expected error, but got none")
 			}
 
-			negCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testNamespace).Get(context2.Background(), testNegName, v1.GetOptions{})
+			negCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context2.Background(), testNegName, v1.GetOptions{})
 			if err != nil {
 				t.Errorf("Failed to get NEG from neg client: %s", err)
 			}
@@ -1080,7 +1078,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			}
 		})
 
-		negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testNamespace).Delete(context2.TODO(), testNegName, v1.DeleteOptions{})
+		negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Delete(context2.TODO(), testNegName, v1.DeleteOptions{})
 
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone1, syncer.NegSyncerKey.GetAPIVersion())
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, syncer.NegSyncerKey.GetAPIVersion())
@@ -1186,7 +1184,7 @@ func TestUpdateStatus(t *testing.T) {
 				// Since timestamp gets truncated to the second, there is a chance that the timestamps will be the same as LastTransitionTime or LastSyncTime so use creation TS from an earlier date
 				creationTS := v1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
 				origCR := createNegCR(testNegName, creationTS, tc.populateConditions[negv1beta1.Initialized], tc.populateConditions[negv1beta1.Synced], tc.negRefs)
-				origCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testNamespace).Create(context2.Background(), origCR, v1.CreateOptions{})
+				origCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context2.Background(), origCR, v1.CreateOptions{})
 				if err != nil {
 					t.Errorf("Failed to create test NEG CR: %s", err)
 				}
@@ -1194,7 +1192,7 @@ func TestUpdateStatus(t *testing.T) {
 
 				syncer.updateStatus(syncErr)
 
-				negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testNamespace).Get(context2.Background(), testNegName, v1.GetOptions{})
+				negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context2.Background(), testNegName, v1.GetOptions{})
 				if err != nil {
 					t.Errorf("Failed to create test NEG CR: %s", err)
 				}
@@ -1307,7 +1305,7 @@ func TestUnknownNodes(t *testing.T) {
 	testIP3 := "10.100.2.1"
 	testPort := int64(80)
 
-	testEndpointSlices := getTestEndpointSlices(testService, testNamespace)
+	testEndpointSlices := getDefaultEndpointSlices()
 	testEndpointSlices[0].Endpoints[0].NodeName = utilpointer.StringPtr("unknown-node")
 	testEndpointMap := map[string]*composite.NetworkEndpoint{
 		negtypes.TestZone1: &composite.NetworkEndpoint{
@@ -1344,7 +1342,7 @@ func TestUnknownNodes(t *testing.T) {
 	neg := &negv1beta1.ServiceNetworkEndpointGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testNegName,
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 		},
 		Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
 			NetworkEndpointGroups: objRefs,
@@ -1398,8 +1396,8 @@ func newL4ILBTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, m
 func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negType negtypes.NetworkEndpointType, customName bool) (negtypes.NegSyncer, *transactionSyncer) {
 	testContext := negtypes.NewTestContext()
 	svcPort := negtypes.NegSyncerKey{
-		Namespace: testNamespace,
-		Name:      testService,
+		Namespace: testServiceNamespace,
+		Name:      testServiceName,
 		NegType:   negType,
 		PortTuple: negtypes.SvcPortTuple{
 			Port:       80,
@@ -1481,7 +1479,7 @@ func generateEndpointSetAndMap(initialIp net.IP, num int, instance string, targe
 
 		endpoint := negtypes.NetworkEndpoint{IP: ip.String(), Node: instance, Port: targetPort}
 		retSet.Insert(endpoint)
-		retMap[endpoint] = types.NamespacedName{Namespace: testNamespace, Name: fmt.Sprintf("pod-%s-%d", instance, i)}
+		retMap[endpoint] = types.NamespacedName{Namespace: testServiceNamespace, Name: fmt.Sprintf("pod-%s-%d", instance, i)}
 	}
 	return retSet, retMap
 }
@@ -1656,7 +1654,7 @@ func createNegCR(testNegName string, creationTS metav1.Time, populateInitialized
 	neg := &negv1beta1.ServiceNetworkEndpointGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              testNegName,
-			Namespace:         testNamespace,
+			Namespace:         testServiceNamespace,
 			CreationTimestamp: creationTS,
 		},
 	}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -444,6 +444,8 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	t.Parallel()
 	zoneGetter := negtypes.NewFakeZoneGetter()
+	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
+	addPodsToLister(podLister)
 	testCases := []struct {
 		desc                string
 		portName            string
@@ -530,17 +532,17 @@ func TestToZoneNetworkEndpointMapUtil(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		retSet, retMap, _, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), zoneGetter, tc.portName, tc.networkEndpointType)
+		result, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), zoneGetter, podLister, tc.portName, tc.networkEndpointType)
 		if err != nil {
 			t.Errorf("For case %q, expect nil error, but got %v.", tc.desc, err)
 		}
 
-		if !reflect.DeepEqual(retSet, tc.endpointSets) {
-			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, retSet)
+		if !reflect.DeepEqual(result.NetworkEndpointSet, tc.endpointSets) {
+			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.endpointSets, result.NetworkEndpointSet)
 		}
 
-		if !reflect.DeepEqual(retMap, tc.expectMap) {
-			t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectMap, retMap)
+		if !reflect.DeepEqual(result.EndpointPodMap, tc.expectMap) {
+			t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectMap, result.EndpointPodMap)
 		}
 	}
 }

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1241,12 +1241,12 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
-				networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod2"},
-				networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod3"},
-				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod5"},
-				networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod6"},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+				networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+				networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
+				networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod6"},
 			},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1264,12 +1264,12 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod7"},
-				networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod8"},
-				networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81"):   types.NamespacedName{Namespace: testNamespace, Name: "pod9"},
-				networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod10"},
-				networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod11"},
-				networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081"): types.NamespacedName{Namespace: testNamespace, Name: "pod12"},
+				networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod7"},
+				networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod8"},
+				networkEndpointFromEncodedEndpoint("10.100.4.3||instance4||81"):   types.NamespacedName{Namespace: testServiceNamespace, Name: "pod9"},
+				networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod10"},
+				networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod11"},
+				networkEndpointFromEncodedEndpoint("10.100.4.4||instance4||8081"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod12"},
 			},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1287,19 +1287,19 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.3.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
-				networkEndpointFromEncodedEndpoint("10.100.1.2||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod2"},
-				networkEndpointFromEncodedEndpoint("10.100.2.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod3"},
-				networkEndpointFromEncodedEndpoint("10.100.3.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod4"},
-				networkEndpointFromEncodedEndpoint("10.100.1.3||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod5"},
-				networkEndpointFromEncodedEndpoint("10.100.1.4||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod6"},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				networkEndpointFromEncodedEndpoint("10.100.1.2||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+				networkEndpointFromEncodedEndpoint("10.100.2.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+				networkEndpointFromEncodedEndpoint("10.100.3.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
+				networkEndpointFromEncodedEndpoint("10.100.1.3||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod5"},
+				networkEndpointFromEncodedEndpoint("10.100.1.4||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod6"},
 			},
 			networkEndpointType: negtypes.NonGCPPrivateEndpointType,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			testEndpointSlices := getTestEndpointSlices(testService, testNamespace)
+			testEndpointSlices := getDefaultEndpointSlices()
 
 			targetMap, endpointPodMap, _, err := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(testEndpointSlices), fakeZoneGetter, podLister, nodeLister, tc.portName, tc.networkEndpointType)
 			if err != nil {
@@ -1327,7 +1327,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80")),
 	}
 	podMap := negtypes.EndpointPodMap{
-		networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+		networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
 	}
 
 	fakeZoneGetter := negtypes.NewFakeZoneGetter()
@@ -1355,7 +1355,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  &instance1,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1370,7 +1370,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  nil,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1385,7 +1385,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 				Addresses: []string{"10.100.1.1"},
 				NodeName:  &emptyNodeName,
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Ready: ready,
@@ -1398,7 +1398,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 			desc: "Non-GCP network endpoint",
 			ep: negtypes.AddressData{
 				TargetRef: &corev1.ObjectReference{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				NodeName:  &emptyNodeName,
@@ -1412,7 +1412,7 @@ func TestValidateAndAddEndpoints(t *testing.T) {
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testNamespace, Name: "pod1"}},
+				networkEndpointFromEncodedEndpoint("10.100.1.1||||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"}},
 		},
 	}
 	for _, tc := range testCases {
@@ -1452,7 +1452,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a valid pod with phase running",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod1",
 				},
 				Status: v1.PodStatus{
@@ -1468,7 +1468,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a terminal pod with phase failed",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod2",
 				},
 				Status: v1.PodStatus{
@@ -1484,7 +1484,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a terminal pod with phase succeeded",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod3",
 				},
 				Status: v1.PodStatus{
@@ -1500,7 +1500,7 @@ func TestValidatePod(t *testing.T) {
 			desc: "a pod from non-existent node",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testServiceNamespace,
 					Name:      "pod4",
 				},
 				Status: corev1.PodStatus{
@@ -1527,7 +1527,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	for i := 1; i <= 6; i++ {
 		podLister.Add(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testNamespace,
+				Namespace: testServiceNamespace,
 				Name:      fmt.Sprintf("pod%v", i),
 			},
 			Status: corev1.PodStatus{
@@ -1541,7 +1541,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	for i := 7; i <= 12; i++ {
 		podLister.Add(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testNamespace,
+				Namespace: testServiceNamespace,
 				Name:      fmt.Sprintf("pod%v", i),
 			},
 			Status: corev1.PodStatus{
@@ -1555,7 +1555,7 @@ func addPodsToLister(podLister cache.Indexer) {
 
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod3",
 		},
 		Status: corev1.PodStatus{
@@ -1567,7 +1567,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod4",
 		},
 		Status: corev1.PodStatus{
@@ -1579,7 +1579,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod7",
 		},
 		Status: corev1.PodStatus{
@@ -1591,7 +1591,7 @@ func addPodsToLister(podLister cache.Indexer) {
 	})
 	podLister.Update(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testServiceNamespace,
 			Name:      "pod10",
 		},
 		Status: corev1.PodStatus{

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -84,6 +84,8 @@ type NetworkEndpointsCalculator interface {
 	// CalculateEndpoints computes the NEG endpoints based on service endpoints and the current NEG state and returns a
 	// map of zone name to network endpoint set
 	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, int, error)
+	// CalculateEndpointsDegradedMode computes the NEG endpoints using degraded mode calculation
+	CalculateEndpointsDegradedMode(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, error)
 	// Mode indicates the mode that the EndpointsCalculator is operating in.
 	Mode() EndpointsCalculatorMode
 	// ValidateEndpoints validates the NEG endpoint information is correct

--- a/pkg/neg/types/sync_results.go
+++ b/pkg/neg/types/sync_results.go
@@ -15,56 +15,68 @@ package types
 
 import "errors"
 
+type Result string
+
 const (
-	ResultEPCountsDiffer         = "EPCountsDiffer"
-	ResultEPMissingNodeName      = "EPMissingNodeName"
-	ResultNodeNotFound           = "NodeNotFound"
-	ResultEPMissingZone          = "EPMissingZone"
-	ResultEPSEndpointCountZero   = "EPSEndpointCountZero"
-	ResultEPCalculationCountZero = "EPCalculationCountZero"
-	ResultInvalidAPIResponse     = "InvalidAPIResponse"
-	ResultInvalidEPAttach        = "InvalidEPAttach"
-	ResultInvalidEPDetach        = "InvalidEPDetach"
+	ResultEPCountsDiffer           = Result("EPCountsDiffer")
+	ResultEPNodeMissing            = Result("EPNodeMissing")
+	ResultEPNodeNotFound           = Result("EPNodeNotFound")
+	ResultEPPodMissing             = Result("EPPodMissing")
+	ResultEPPodNotFound            = Result("EPPodNotFound")
+	ResultEPPodTypeAssertionFailed = Result("EPPodTypeAssertionFailed")
+	ResultEPZoneMissing            = Result("EPZoneMissing")
+	ResultEPSEndpointCountZero     = Result("EPSEndpointCountZero")
+	ResultEPCalculationCountZero   = Result("EPCalculationCountZero")
+	ResultInvalidAPIResponse       = Result("InvalidAPIResponse")
+	ResultInvalidEPAttach          = Result("InvalidEPAttach")
+	ResultInvalidEPDetach          = Result("InvalidEPDetach")
 
 	// these results have their own errors
-	ResultNegNotFound       = "NegNotFound"
-	ResultCurrentEPNotFound = "CurrentEPNotFound"
-	ResultEPSNotFound       = "EPSNotFound"
-	ResultOtherError        = "OtherError"
-	ResultInProgress        = "InProgress"
-	ResultSuccess           = "Success"
+	ResultNegNotFound          = Result("NegNotFound")
+	ResultCurrentNegEPNotFound = Result("CurrentNegEPNotFound")
+	ResultEPSNotFound          = Result("EPSNotFound")
+	ResultOtherError           = Result("OtherError")
+	ResultInProgress           = Result("InProgress")
+	ResultSuccess              = Result("Success")
 )
 
 var (
-	ErrEPCountsDiffer         = errors.New("endpoint counts from endpointData and endpointPodMap differ")
-	ErrEPMissingNodeName      = errors.New("endpoint has empty nodeName field")
-	ErrNodeNotFound           = errors.New("failed to retrieve associated zone of node")
-	ErrEPMissingZone          = errors.New("endpoint has empty zone field")
-	ErrEPSEndpointCountZero   = errors.New("endpoint count from endpointData cannot be zero")
-	ErrEPCalculationCountZero = errors.New("endpoint count from endpointPodMap cannot be zero")
-	ErrInvalidAPIResponse     = errors.New("received response error doesn't match googleapi.Error type")
-	ErrInvalidEPAttach        = errors.New("endpoint information for attach operation is incorrect")
-	ErrInvalidEPDetach        = errors.New("endpoint information for detach operation is incorrect")
+	ErrEPCountsDiffer           = errors.New("endpoint counts from endpointData and endpointPodMap differ")
+	ErrEPNodeMissing            = errors.New("endpoint has missing nodeName field")
+	ErrEPNodeNotFound           = errors.New("endpoint corresponds to an non-existing node")
+	ErrEPPodMissing             = errors.New("endpoint has missing pod field")
+	ErrEPPodNotFound            = errors.New("endpoint corresponds to an non-existing pod")
+	ErrEPPodTypeAssertionFailed = errors.New("endpoint corresponds to an object that fails pod type assertion")
+	ErrEPZoneMissing            = errors.New("endpoint has missing zone field")
+	ErrEPSEndpointCountZero     = errors.New("endpoint count from endpointData cannot be zero")
+	ErrEPCalculationCountZero   = errors.New("endpoint count from endpointPodMap cannot be zero")
+	ErrInvalidAPIResponse       = errors.New("received response error doesn't match googleapi.Error type")
+	ErrInvalidEPAttach          = errors.New("endpoint information for attach operation is incorrect")
+	ErrInvalidEPDetach          = errors.New("endpoint information for detach operation is incorrect")
 
 	// use this map for conversion between errors and sync results
-	ErrorStateResult = map[error]string{
-		ErrEPMissingNodeName:      ResultEPMissingNodeName,
-		ErrEPMissingZone:          ResultEPMissingZone,
-		ErrEPCalculationCountZero: ResultEPCalculationCountZero,
-		ErrEPSEndpointCountZero:   ResultEPSEndpointCountZero,
-		ErrEPCountsDiffer:         ResultEPCountsDiffer,
-		ErrInvalidAPIResponse:     ResultInvalidAPIResponse,
-		ErrInvalidEPAttach:        ResultInvalidEPAttach,
-		ErrInvalidEPDetach:        ResultInvalidEPDetach,
+	ErrorStateResult = map[error]Result{
+		ErrEPNodeMissing:            ResultEPNodeMissing,
+		ErrEPNodeNotFound:           ResultEPNodeNotFound,
+		ErrEPPodMissing:             ResultEPPodMissing,
+		ErrEPPodNotFound:            ResultEPPodNotFound,
+		ErrEPPodTypeAssertionFailed: ResultEPPodTypeAssertionFailed,
+		ErrEPZoneMissing:            ResultEPZoneMissing,
+		ErrEPCalculationCountZero:   ResultEPCalculationCountZero,
+		ErrEPSEndpointCountZero:     ResultEPSEndpointCountZero,
+		ErrEPCountsDiffer:           ResultEPCountsDiffer,
+		ErrInvalidAPIResponse:       ResultInvalidAPIResponse,
+		ErrInvalidEPAttach:          ResultInvalidEPAttach,
+		ErrInvalidEPDetach:          ResultInvalidEPDetach,
 	}
 )
 
 type NegSyncResult struct {
 	Error  error
-	Result string
+	Result Result
 }
 
-func NewNegSyncResult(err error, result string) *NegSyncResult {
+func NewNegSyncResult(err error, result Result) *NegSyncResult {
 	return &NegSyncResult{
 		Error:  err,
 		Result: result,


### PR DESCRIPTION
Refactor syncInternalImpl, toZoneNetworkEndpointMap, and toZoneNetworkEndpointMapDegradedMode.
1. Refactor syncInternalImpl. 
- Create convertUntypedToEPS for converting endpointslice, and computeEPSStaleness for compute EPS staleness metrics.
- Create getEndpointsCalculation() to account for endpoint calculation for error state and enableDegradedMode.

2. Refactor toZoneNetworkEndpointMap. 

- Reduce the number of return values by wrapping them in a struct ZoneNetworkEndpointMapResult
- Create helper function getEndpointPod(), getEndpointZone() to simplify endpoint node, pod, and zone checking,
- Refactor endpoint node, pod, and zone checking

3. Refactor toZoneNetworkEndpointMapDegradedMode. 

- Reduce the number of return values by wrapping them in a struct ZoneNetworkEndpointMapResult
- Refactor endpoint node, pod, and zone checking
- Refactor and remove validateAndAddEndpoints since most of the code about validating(https://github.com/kubernetes/ingress-gce/blob/master/pkg/neg/syncers/utils.go#L337-L357) does not need to be in the for loop
- Update unit tests for validateAndAddEndpoints since this function no longer exists, move the checks to TestToZoneNetworkEndpointMapDegradedMode