### PR TITLE
Create run-make-cmd.sh

### DIFF
--- a/hack/run-make-cmd.sh
+++ b/hack/run-make-cmd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Run make commands that build and push images
+# (see Dockerfiles in the root directory)
+
+# ENV variables: 
+# * BINARY (example: "e2e-test")
+# * ALL_ARCH (example: "amd64 arm64")
+# * REGISTRY (container registry)
+# * VERBOSE (example: -3)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd ${REPO_ROOT}
+
+BINARY=${BINARY:-e2e-test}
+ARCH=${ARCH:-"amd64"}
+ALL_ARCH=${ALL_ARCH:-"amd64 arm64"}
+REGISTRY=${REGISTRY:-gcr.io/example}
+VERBOSE=${VERBOSE:1}
+
+# This command builds an image of $BINARY and
+# pushes it to the $REGISTRY
+make push VERBOSE="${VERBOSE}" CONTAINER_BINARIES="${BINARY}" \
+          REGISTRY="${REGISTRY}" ARCH="${ARCH}"
+# Based on the image from the previous step,
+# all-push command will try to create a multiarch image 
+# (there is no $ARCH parameter)
+make all-push VERBOSE="${VERBOSE}" CONTAINER_BINARIES="${BINARY}" \
+              REGISTRY="${REGISTRY}" ALL_ARCH="${ALL_ARCH}"


### PR DESCRIPTION
It is hard to run an image with multiple commands inside a python script (example: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml) because it will be presented not like: 

```
scrupt.py $(cmd1 && cmd2 && cmd3)
```

but: 

```
script.py cmd1 && cmd2 && cmd3
```