### PR TITLE
Trim the path after status code

### DIFF
--- a/cmd/404-server-with-metrics/server-with-metrics.go
+++ b/cmd/404-server-with-metrics/server-with-metrics.go
@@ -254,8 +254,14 @@ func (s *server) notFoundHandler() http.HandlerFunc {
 // If URL path does not contain a valid status code, returns 404 (NotFound).
 func (s *server) statusCodeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// path: "/statuscode/500" -> p: "500"
+		// path: "/statuscode/500/foo/" -> p: "500/foo/" -> p: "500"
 		p := strings.TrimPrefix(r.URL.Path, statusCodePrefix)
 		code, err := strconv.Atoi(p)
+		slashIndex := strings.Index(p, "/")
+		if slashIndex != -1 {
+			p = p[:slashIndex]
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, "response 404, service rules for [ %s ] non-existent, [ %s ] cannot be converted into status code \n", r.URL.Path, p)


### PR DESCRIPTION
Currently GKE Gateway controller gxlb use urlRewrite to rewrite pathPrefix to "/statuscode/500" and set backend service to this 404 server.

For example, an HTTPRoute specifies path prefix match of "/" with an invalid backend reference. A request to path "/foo" would get rewritten to "/statuscode/500/foo".

However, Ingress 404 server currently uses exact match in statusCodeHandler() to generate the status code to be returned. When request URL path is "/statuscode/500", 500 is returned. But with path being "/statuscode/500/foo", an error occurs and 404 is returned instead.

We need to update 404 server to treat "/statuscode/500" as a prefix.