### PR TITLE
Update set error state for CalculateEndpoints()

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -193,6 +193,7 @@ func (s *transactionSyncer) syncInternal() error {
 	start := time.Now()
 	err := s.syncInternalImpl()
 	if err != nil {
+		s.logger.V(3).Info("Updating error state", "error state", s.getErrorStateReason(err))
 		s.setErrorState(s.getErrorStateReason(err))
 	}
 	s.updateStatus(err)
@@ -261,8 +262,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	endpointsData := negtypes.EndpointsDataFromEndpointSlices(endpointSlices)
 	targetMap, endpointPodMap, dupCount, err = s.endpointsCalculator.CalculateEndpoints(endpointsData, currentMap)
 	if err != nil {
-		s.setErrorState(s.getErrorStateReason(err))
-		return fmt.Errorf("endpoints calculation error in mode %q, err: %w", s.endpointsCalculator.Mode(), err)
+		return err
 	}
 	err = s.endpointsCalculator.ValidateEndpoints(endpointsData, endpointPodMap, dupCount)
 	if err != nil {


### PR DESCRIPTION
Remove set error state from calculateEndpoints and instead set it during syncInternal, otherwise, the error state will be overwritten and error state won't be found.