### PR TITLE
Fix a case when regional instance group linker has to add a backend t…

### DIFF
--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -60,16 +60,14 @@ func (linker *RegionalInstanceGroupLinker) Link(sp utils.ServicePort, projectID 
 		return nil
 	}
 
-	var newBackends []*composite.Backend
 	for _, igLink := range addIGs {
 		b := &composite.Backend{
 			Group: igLink,
 		}
-		newBackends = append(newBackends, b)
+		bs.Backends = append(bs.Backends, b)
 	}
 
-	bs.Backends = newBackends
-	klog.V(3).Infof("Update Backend %s, with %d backends.", sp.BackendName(), len(addIGs))
+	klog.V(3).Infof("Update Backend %s, with %d added backends (total %d).", sp.BackendName(), len(addIGs), len(bs.Backends))
 	if err := linker.backendPool.Update(bs); err != nil {
 		return fmt.Errorf("updating backend service %s for IG failed, err:%w", sp.BackendName(), err)
 	}


### PR DESCRIPTION
…o the list of already linked backends.

The previous code would set the backends to only the new instance groups and later cause the controller to flip new/old backends on each refresh.