### PR TITLE
JSONify healthcheck Description for BackendConfig

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -328,12 +328,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 	// In NonGCP mode, use the zone specified in gce.conf directly.
 	// This overrides the zone/fault-domain label on nodes for NEG controller.
 	if flags.F.EnableNonGCPMode {
-		zone, err := ctx.Cloud.GetZone(context.Background())
-		if err != nil {
-			klog.Errorf("Failed to retrieve zone information from Cloud provider: %v; Please check if local-zone is specified in gce.conf.", err)
-		} else {
-			zoneGetter = negtypes.NewSimpleZoneGetter(zone.FailureDomain)
-		}
+		zoneGetter = negtypes.NewSimpleZoneGetter(ctx.Cloud.LocalZone())
 	}
 
 	enableAsm := false

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/apimachinery v0.26.2
 	k8s.io/client-go v0.26.2
 	k8s.io/cloud-provider v0.26.2
-	k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230322202223-f7280f55e36f
+	k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230414153241-658d4df496a9
 	k8s.io/component-base v0.26.2
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ k8s.io/cloud-provider-gcp/crd v0.0.0-20230227183622-3f1543249ff5 h1:xMNJz+8qU0Kk
 k8s.io/cloud-provider-gcp/crd v0.0.0-20230227183622-3f1543249ff5/go.mod h1:YDxdayH9Du6f2XUhZiRfM2B0vsJ9b7qbrmI2J2dd89Y=
 k8s.io/cloud-provider-gcp/crd v0.0.0-20230411231432-6ab330834e4e h1:MtQR9NbmkvuotfNK3MbZRjF13quIXWZ4624yYvy4biw=
 k8s.io/cloud-provider-gcp/crd v0.0.0-20230411231432-6ab330834e4e/go.mod h1:A//VRRwQBcvAI20bbCc5jmxMSegf/DqxDI7XVK9oyYo=
-k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230322202223-f7280f55e36f h1:XPbo07vZ+h1xiGFIAN+gmlGm6G8zrZyhf/Xb6jNerTk=
-k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230322202223-f7280f55e36f/go.mod h1:dDBqOcDqYsqo7ZM7yuX+6Xg9WiyEPYk1Q9m2oHrnePo=
+k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230414153241-658d4df496a9 h1:u6Vv7TkVd34+nO6kB79CLWa0OW/QgBdWEI38og04S/k=
+k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230414153241-658d4df496a9/go.mod h1:dDBqOcDqYsqo7ZM7yuX+6Xg9WiyEPYk1Q9m2oHrnePo=
 k8s.io/component-base v0.26.2 h1:IfWgCGUDzrD6wLLgXEstJKYZKAFS2kO+rBRi0p3LqcI=
 k8s.io/component-base v0.26.2/go.mod h1:DxbuIe9M3IZPRxPIzhch2m1eT7uFrSBJUBuVCQEBivs=
 k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=

--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -128,11 +128,7 @@ func NewController(ctx *context.ControllerContext) *Controller {
 	if controller.regionalCluster {
 		controller.clusterLoc = controller.cloud.Region()
 	} else {
-		zone, err := controller.cloud.GetZone(context2.Background())
-		if err != nil {
-			klog.Errorf("Failed to retrieve zone information from cloud provider: %q", err)
-		}
-		controller.clusterLoc = zone.FailureDomain
+		controller.clusterLoc = controller.cloud.LocalZone()
 	}
 
 	ctx.SAInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/psc/controller_test.go
+++ b/pkg/psc/controller_test.go
@@ -301,11 +301,8 @@ func TestServiceAttachmentCreation(t *testing.T) {
 					t.Errorf("%s", err)
 				}
 
-				zone, err := fakeCloud.GetZone(context2.TODO())
-				if err != nil {
-					t.Errorf("failed to get zone %q", err)
-				}
-				desc := sautils.NewServiceAttachmentDesc(testNamespace, saName, ClusterName, zone.FailureDomain, false)
+				zone := fakeCloud.LocalZone()
+				desc := sautils.NewServiceAttachmentDesc(testNamespace, saName, ClusterName, zone, false)
 
 				expectedSA := &ga.ServiceAttachment{
 					ConnectionPreference: tc.connectionPreference,

--- a/pkg/utils/healthcheck/healthcheckdesc.go
+++ b/pkg/utils/healthcheck/healthcheckdesc.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/ingress-gce/pkg/utils/descutils"
+	"k8s.io/klog/v2"
+)
+
+type ClusterInfo struct {
+	Name     string
+	Location string
+	Regional bool
+}
+
+type ServiceInfo types.NamespacedName
+
+type HealthcheckConfig string
+
+const (
+	DefaultHC        HealthcheckConfig = "Default"
+	ReadinessProbeHC HealthcheckConfig = "ReadinessProbe"
+	BackendConfigHC  HealthcheckConfig = "BackendConfig"
+)
+
+type HealthcheckInfo struct {
+	ClusterInfo
+	ServiceInfo
+	HealthcheckConfig
+}
+
+type HealthcheckDesc struct {
+	K8sCluster  string            `json:"k8sCluster,omitempty"`
+	K8sResource string            `json:"k8sResource,omitempty"`
+	Config      HealthcheckConfig `json:"config,omitempty"`
+}
+
+func (i *ClusterInfo) generateClusterDescription() string {
+	// locType here differs from locType in descutils.GenerateClusterLink().
+	locType := "locations"
+	return fmt.Sprintf("/%s/%s/clusters/%s", locType, i.Location, i.Name)
+}
+
+func NewServiceInfo(namespace, resourceName string) ServiceInfo {
+	return ServiceInfo{namespace, resourceName}
+}
+
+func (i *ServiceInfo) generateK8sResourceDescription() string {
+	return descutils.GenerateK8sResourceLink(i.Namespace, "services", i.Name)
+}
+
+func (i *HealthcheckInfo) GenerateHealthcheckDescription() string {
+	desc := HealthcheckDesc{}
+	desc.K8sCluster = i.ClusterInfo.generateClusterDescription()
+	desc.K8sResource = i.ServiceInfo.generateK8sResourceDescription()
+	desc.Config = i.HealthcheckConfig
+	json, err := json.MarshalIndent(desc, "", "    ")
+	if err != nil {
+		klog.Error("Failed to marshall HealthcheckDesc %s: %v", desc, err)
+	}
+	return string(json)
+}

--- a/pkg/utils/healthcheck/healthcheckdesc_test.go
+++ b/pkg/utils/healthcheck/healthcheckdesc_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"testing"
+)
+
+func TestGenerateClusterDescription(t *testing.T) {
+	testName := "cluster-name"
+	testRegion := "pl-central7"
+	clusterInfo := ClusterInfo{testName, testRegion, true}
+	expectedDescription := "/locations/pl-central7/clusters/cluster-name"
+
+	generatedDescription := clusterInfo.generateClusterDescription()
+	if generatedDescription != expectedDescription {
+		t.Errorf("unexpected cluster description: wanted %s, but got %s", expectedDescription, generatedDescription)
+	}
+
+	testZone := "pl-central7-g"
+	clusterInfo = ClusterInfo{testName, testZone, false}
+	expectedDescription = "/locations/pl-central7-g/clusters/cluster-name"
+
+	generatedDescription = clusterInfo.generateClusterDescription()
+	if generatedDescription != expectedDescription {
+		t.Errorf("unexpected cluster description: wanted %s, but got %s", expectedDescription, generatedDescription)
+	}
+}
+
+func TestGenerateK8sResourceDescription(t *testing.T) {
+	testName := "service-name"
+	testNamespace := "testNamespace"
+	serviceInfo := NewServiceInfo(testNamespace, testName)
+	expectedDescription := "/namespaces/testNamespace/services/service-name"
+
+	generatedDescription := serviceInfo.generateK8sResourceDescription()
+	if generatedDescription != expectedDescription {
+		t.Errorf("unexpected service description: wanted %v, but got %v", expectedDescription, generatedDescription)
+	}
+}
+
+func TestGenerateHealthcheckDescription(t *testing.T) {
+	testCluster := "cluster-name"
+	testRegion := "pl-central7"
+	clusterInfo := ClusterInfo{testCluster, testRegion, true}
+	testService := "service-name"
+	testNamespace := "testNamespace"
+	serviceInfo := NewServiceInfo(testNamespace, testService)
+	hcConfig := DefaultHC
+	i := HealthcheckInfo{
+		ClusterInfo:       clusterInfo,
+		ServiceInfo:       serviceInfo,
+		HealthcheckConfig: hcConfig,
+	}
+	expectedDescription := "" +
+		"{\n" +
+		"    \"k8sCluster\": \"/locations/pl-central7/clusters/cluster-name\",\n" +
+		"    \"k8sResource\": \"/namespaces/testNamespace/services/service-name\",\n" +
+		"    \"config\": \"Default\"\n" +
+		"}"
+
+	generatedDescription := i.GenerateHealthcheckDescription()
+	if generatedDescription != expectedDescription {
+		t.Errorf("unexpected healthcheck description: wanted %v, but got %v", expectedDescription, generatedDescription)
+	}
+}

--- a/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce.go
+++ b/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce.go
@@ -726,6 +726,16 @@ func (g *Cloud) Region() string {
 	return g.region
 }
 
+// Regional returns true if the cluster is regional.
+func (g *Cloud) Regional() bool {
+	return g.regional
+}
+
+// LocalZone returns the localZone.
+func (g *Cloud) LocalZone() string {
+	return g.localZone
+}
+
 // OnXPN returns true if the cluster is running on a cross project network (XPN)
 func (g *Cloud) OnXPN() bool {
 	return g.onXPN

--- a/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_fake.go
+++ b/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_fake.go
@@ -37,6 +37,7 @@ type TestClusterValues struct {
 	ClusterID         string
 	ClusterName       string
 	OnXPN             bool
+	Regional          bool
 }
 
 // DefaultTestClusterValues Creates a reasonable set of default cluster values
@@ -48,7 +49,7 @@ func DefaultTestClusterValues() TestClusterValues {
 		ZoneName:          "us-central1-b",
 		SecondaryZoneName: "us-central1-c",
 		ClusterID:         "test-cluster-id",
-		ClusterName:       "Test Cluster Name",
+		ClusterName:       "Test-Cluster-Name",
 	}
 }
 
@@ -73,12 +74,14 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		region:           vals.Region,
 		service:          service,
 		managedZones:     []string{vals.ZoneName},
+		localZone:        vals.ZoneName,
 		projectID:        vals.ProjectID,
 		networkProjectID: vals.ProjectID,
 		ClusterID:        fakeClusterID(vals.ClusterID),
 		onXPN:            vals.OnXPN,
 		metricsCollector: newLoadBalancerMetrics(),
 		projectsBasePath: getProjectsBasePath(service.BasePath),
+		regional:         vals.Regional,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -816,7 +816,7 @@ k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/
 k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/v1alpha1
 k8s.io/cloud-provider-gcp/crd/client/network/listers/network/v1
 k8s.io/cloud-provider-gcp/crd/client/network/listers/network/v1alpha1
-# k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230322202223-f7280f55e36f
+# k8s.io/cloud-provider-gcp/providers v0.26.3-0.20230414153241-658d4df496a9
 ## explicit; go 1.19
 k8s.io/cloud-provider-gcp/providers/gce
 # k8s.io/component-base v0.26.2


### PR DESCRIPTION
Replace a plain string with a JSON string as the health check Description when the health check is configured with a BackendConfig CRD. The longer plan is to similarly JSONify all health check Descriptions, irrespective of the health check configuration.