### PR TITLE
Emit event on Description-only healthcheck update

### DIFF
--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -42,7 +42,7 @@ type Jig struct {
 }
 
 func newTestJig(fakeGCE *gce.Cloud) *Jig {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter())
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -137,7 +137,7 @@ var (
 )
 
 func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc)
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter())
 
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,7 +114,7 @@ func NewLoadBalancerController(
 		Interface: ctx.KubeClient.CoreV1().Events(""),
 	})
 
-	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service)
+	healthChecker := healthchecks.NewHealthChecker(ctx.Cloud, ctx.HealthCheckPath, ctx.DefaultBackendSvcPort.ID.Service, ctx, ctx.Translator)
 	backendPool := backends.NewPool(ctx.Cloud, ctx.ClusterNamer)
 
 	lbc := LoadBalancerController{

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
@@ -107,6 +108,12 @@ func (t *Translator) getCachedService(id utils.ServicePortID) (*api_v1.Service, 
 		return nil, fmt.Errorf("cannot convert to Service (%T)", svc)
 	}
 	return svc, nil
+}
+
+// GetService Implements ServiceGetter interface.
+func (t *Translator) GetService(namespace, name string) (*api_v1.Service, error) {
+	dummyServicePort := utils.ServicePortID{Service: types.NamespacedName{Namespace: namespace, Name: name}}
+	return t.getCachedService(dummyServicePort)
 }
 
 // maybeEnableNEG enables NEG on the service port if necessary

--- a/pkg/healthchecks/fakes.go
+++ b/pkg/healthchecks/fakes.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthchecks
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func NewFakeServiceGetter() ServiceGetter {
+	return &fakeServiceGetter{}
+}
+
+type fakeServiceGetter struct{}
+
+func (fsg *fakeServiceGetter) GetService(namespace, name string) (*v1.Service, error) {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}, nil
+}
+
+func NewFakeRecorderGetter(bufferSize int) RecorderGetter {
+	return &fakeRecorderGetter{bufferSize}
+}
+
+type fakeRecorderGetter struct {
+	bufferSize int
+}
+
+// Returns a different record.EventRecorder for every call.
+func (frg *fakeRecorderGetter) Recorder(namespace string) record.EventRecorder {
+	return record.NewFakeRecorder(frg.bufferSize)
+}
+
+type singletonFakeRecorderGetter struct {
+	recorder *record.FakeRecorder
+}
+
+// Returns the same record.EventRecorder irrespective of the namespace.
+func (sfrg *singletonFakeRecorderGetter) Recorder(namespace string) record.EventRecorder {
+	return sfrg.FakeRecorder()
+}
+
+func (sfrg *singletonFakeRecorderGetter) FakeRecorder() *record.FakeRecorder {
+	if sfrg.recorder == nil {
+		panic("singletonFakeRecorderGetter not initialised: recorder is nil.")
+	}
+	return sfrg.recorder
+}
+
+func NewFakeSingletonRecorderGetter(bufferSize int) *singletonFakeRecorderGetter {
+	return &singletonFakeRecorderGetter{recorder: record.NewFakeRecorder(bufferSize)}
+}

--- a/pkg/healthchecks/healthcheck.go
+++ b/pkg/healthchecks/healthcheck.go
@@ -33,6 +33,14 @@ type fieldDiffs struct {
 func (c *fieldDiffs) add(field, oldv, newv string) {
 	c.f = append(c.f, fmt.Sprintf("%s:%s -> %s", field, oldv, newv))
 }
+func (c *fieldDiffs) has(field string) bool {
+	for _, s := range c.f {
+		if strings.HasPrefix(s, field+":") {
+			return true
+		}
+	}
+	return false
+}
 func (c *fieldDiffs) String() string { return strings.Join(c.f, ", ") }
 func (c *fieldDiffs) hasDiff() bool  { return len(c.f) > 0 }
 func (c *fieldDiffs) size() int64    { return int64(len(c.f)) }
@@ -74,7 +82,6 @@ func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCh
 		changes.add("Port", strconv.FormatInt(old.Port, 10), strconv.FormatInt(new.Port, 10))
 	}
 	if old.Description != new.Description {
-		// TODO(DamianSawicki): Emit an event.
 		changes.add("Description", old.Description, new.Description)
 	}
 

--- a/pkg/healthchecks/interfaces.go
+++ b/pkg/healthchecks/interfaces.go
@@ -22,6 +22,7 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -55,4 +56,13 @@ type HealthChecker interface {
 	SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (string, error)
 	Delete(name string, scope meta.KeyType) error
 	Get(name string, version meta.Version, scope meta.KeyType) (*translator.HealthCheck, error)
+}
+
+// ServiceGetter is an interface to retrieve Kubernetes Services.
+type ServiceGetter interface {
+	GetService(namespace, name string) (*v1.Service, error)
+}
+
+type RecorderGetter interface {
+	Recorder(ns string) record.EventRecorder
 }

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -90,6 +90,8 @@ type HealthCheck struct {
 	// compute struct back.
 	computealpha.HTTPHealthCheck
 	computealpha.HealthCheck
+
+	Service *v1.Service
 }
 
 // NewHealthCheck creates a HealthCheck which abstracts nested structs away


### PR DESCRIPTION
Since https://github.com/kubernetes/ingress-gce/pull/2008, the health check description is modified if the service health check is configured with a BackendConfig CRD. The purpose of the present PR is to emit an event on the service on this occasion.

The changes are guarded with the flag `flags.F.EnableUpdateCustomHealthCheckDescription` from https://github.com/kubernetes/ingress-gce/pull/2018/.