### PR TITLE
Update endpoint checking return

### DIFF
--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package syncers
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -2003,9 +2004,9 @@ func TestValidatePod(t *testing.T) {
 		},
 	})
 	testCases := []struct {
-		desc   string
-		pod    *v1.Pod
-		expect bool
+		desc      string
+		pod       *v1.Pod
+		expectErr error
 	}{
 		{
 			desc: "a valid pod with phase running",
@@ -2021,7 +2022,7 @@ func TestValidatePod(t *testing.T) {
 					NodeName: instance1,
 				},
 			},
-			expect: true,
+			expectErr: nil,
 		},
 		{
 			desc: "a terminal pod with phase failed",
@@ -2037,7 +2038,7 @@ func TestValidatePod(t *testing.T) {
 					NodeName: instance1,
 				},
 			},
-			expect: false,
+			expectErr: negtypes.ErrEPPodTerminal,
 		},
 		{
 			desc: "a terminal pod with phase succeeded",
@@ -2053,7 +2054,7 @@ func TestValidatePod(t *testing.T) {
 					NodeName: instance1,
 				},
 			},
-			expect: false,
+			expectErr: negtypes.ErrEPPodTerminal,
 		},
 		{
 			desc: "a pod from non-existent node",
@@ -2069,13 +2070,13 @@ func TestValidatePod(t *testing.T) {
 					NodeName: testNodeNonExistent,
 				},
 			},
-			expect: false,
+			expectErr: negtypes.ErrEPNodeNotFound,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := validatePod(tc.pod, nodeLister); got != tc.expect {
-				t.Errorf("validatePod() = %t, expected %t\n", got, tc.expect)
+			if got := validatePod(tc.pod, nodeLister); !errors.Is(got, tc.expectErr) {
+				t.Errorf("validatePod() = %t, expected %t\n", got, tc.expectErr)
 			}
 		})
 	}

--- a/pkg/neg/types/sync_errors.go
+++ b/pkg/neg/types/sync_errors.go
@@ -18,18 +18,20 @@ import "errors"
 type Reason string
 
 const (
-	ReasonEPCountsDiffer           = Reason("EPCountsDiffer")
-	ReasonEPNodeMissing            = Reason("EPNodeMissing")
-	ReasonEPNodeNotFound           = Reason("EPNodeNotFound")
-	ReasonEPPodMissing             = Reason("EPPodMissing")
-	ReasonEPPodNotFound            = Reason("EPPodNotFound")
-	ReasonEPPodTypeAssertionFailed = Reason("EPPodTypeAssertionFailed")
-	ReasonEPZoneMissing            = Reason("EPZoneMissing")
-	ReasonEPSEndpointCountZero     = Reason("EPSEndpointCountZero")
-	ReasonEPCalculationCountZero   = Reason("EPCalculationCountZero")
-	ReasonInvalidAPIResponse       = Reason("InvalidAPIResponse")
-	ReasonInvalidEPAttach          = Reason("InvalidEPAttach")
-	ReasonInvalidEPDetach          = Reason("InvalidEPDetach")
+	ReasonEPCountsDiffer            = Reason("EPCountsDiffer")
+	ReasonEPNodeMissing             = Reason("EPNodeMissing")
+	ReasonEPNodeNotFound            = Reason("EPNodeNotFound")
+	ReasonEPNodeTypeAssertionFailed = Reason("EPNodeTypeAssertionFailed")
+	ReasonEPPodMissing              = Reason("EPPodMissing")
+	ReasonEPPodNotFound             = Reason("EPPodNotFound")
+	ReasonEPPodTypeAssertionFailed  = Reason("EPPodTypeAssertionFailed")
+	ReasonEPPodTerminal             = Reason("EPPodTerminal")
+	ReasonEPZoneMissing             = Reason("EPZoneMissing")
+	ReasonEPSEndpointCountZero      = Reason("EPSEndpointCountZero")
+	ReasonEPCalculationCountZero    = Reason("EPCalculationCountZero")
+	ReasonInvalidAPIResponse        = Reason("InvalidAPIResponse")
+	ReasonInvalidEPAttach           = Reason("InvalidEPAttach")
+	ReasonInvalidEPDetach           = Reason("InvalidEPDetach")
 
 	// these are for non error-state error
 	ReasonNegNotFound          = Reason("NegNotFound")
@@ -55,6 +57,11 @@ var (
 		Reason:       ReasonEPNodeNotFound,
 		IsErrorState: true,
 	}
+	ErrEPNodeTypeAssertionFailed = NegSyncError{
+		Err:          errors.New("endpoint corresponds to an object that fails node type assertion"),
+		Reason:       ReasonEPNodeTypeAssertionFailed,
+		IsErrorState: true,
+	}
 	ErrEPPodMissing = NegSyncError{
 		Err:          errors.New("endpoint has missing pod field"),
 		Reason:       ReasonEPPodMissing,
@@ -68,6 +75,11 @@ var (
 	ErrEPPodTypeAssertionFailed = NegSyncError{
 		Err:          errors.New("endpoint corresponds to an object that fails pod type assertion"),
 		Reason:       ReasonEPPodTypeAssertionFailed,
+		IsErrorState: true,
+	}
+	ErrEPPodTerminal = NegSyncError{
+		Err:          errors.New("endpoint corresponds to a terminal pod"),
+		Reason:       ReasonEPPodTerminal,
 		IsErrorState: true,
 	}
 	ErrEPZoneMissing = NegSyncError{


### PR DESCRIPTION
Update validatePod to return error so we can get more context on the failing reason.
Change errors from get zone to ErrEPZoneMissing, and raise NodeNotFound error when we validate endpoint's node resource.
Addressing comment https://github.com/kubernetes/ingress-gce/pull/2044#discussion_r1158984260.