### PR TITLE
Read THC annotation and configure UHC accordingly

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -314,7 +314,7 @@ var (
 	ErrBackendConfigInvalidJSON       = errors.New("BackendConfig annotation is invalid json")
 	ErrBackendConfigAnnotationMissing = errors.New("BackendConfig annotation is missing")
 	ErrNEGAnnotationInvalid           = errors.New("NEG annotation is invalid.")
-	ErrTHCAnnotationInvalid           = errors.New("the annotation for Transparent Health Checker is invalid")
+	ErrTHCAnnotationInvalid           = errors.New("THC annotation is invalid")
 )
 
 // NEGAnnotation returns true if NEG annotation is found.

--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -65,6 +65,9 @@ const (
 	// The valid values are "Standard" and "Premium" (default, if unspecified).
 	NetworkTierAnnotationKey = "cloud.google.com/network-tier"
 
+	// THCAnnotationKey is the boolean annotation key to enable Transparent Health Checks.
+	THCAnnotationKey = "networking.gke.io/transparent-health-checker"
+
 	// ProtocolHTTP protocol for a service
 	ProtocolHTTP AppProtocol = "HTTP"
 	// ProtocolHTTPS protocol for a service
@@ -136,6 +139,12 @@ type NegAnnotation struct {
 	// ExposedPorts maps ServicePort to attributes of the NEG that should be
 	// associated with the ServicePort.
 	ExposedPorts map[int32]NegAttributes `json:"exposed_ports,omitempty"`
+}
+
+// THCAnnotation is the format of the annotation associated with the THCAnnotationKey key.
+type THCAnnotation struct {
+	// "enabled" indicates whether to enable the Transparent Health Checks feature.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // NegAttributes houses the attributes of the NEGs that are associated with the
@@ -305,6 +314,7 @@ var (
 	ErrBackendConfigInvalidJSON       = errors.New("BackendConfig annotation is invalid json")
 	ErrBackendConfigAnnotationMissing = errors.New("BackendConfig annotation is missing")
 	ErrNEGAnnotationInvalid           = errors.New("NEG annotation is invalid.")
+	ErrTHCAnnotationInvalid           = errors.New("the annotation for Transparent Health Checker is invalid")
 )
 
 // NEGAnnotation returns true if NEG annotation is found.
@@ -322,6 +332,21 @@ func (svc *Service) NEGAnnotation() (*NegAnnotation, bool, error) {
 	}
 
 	return &res, true, nil
+}
+
+// ShouldEnableTHC returns true if a THC annotation is found and its value is true.
+func (svc *Service) ShouldEnableTHC() (bool, error) {
+	var res THCAnnotation
+	annotation, ok := svc.v[THCAnnotationKey]
+	if !ok {
+		return false, nil
+	}
+
+	if err := json.Unmarshal([]byte(annotation), &res); err != nil {
+		return false, ErrTHCAnnotationInvalid
+	}
+
+	return res.Enabled, nil
 }
 
 func (svc *Service) NEGStatus() (*NegStatus, bool, error) {

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/healthchecks"
 	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/test"
@@ -42,7 +43,7 @@ type Jig struct {
 }
 
 func newTestJig(fakeGCE *gce.Cloud) *Jig {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter())
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter(), flags.F.EnableTransparentHealthChecks)
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -137,7 +137,7 @@ var (
 )
 
 func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
-	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter())
+	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter(), false)
 
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -210,6 +210,8 @@ func NewControllerContext(
 		context.PodInformer,
 		context.EndpointSliceInformer,
 		context.KubeClient,
+		flags.F.EnableTransparentHealthChecks,
+		context,
 	)
 	context.InstancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      context.Cloud,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -628,7 +628,7 @@ func (lbc *LoadBalancerController) sync(key string) error {
 	}
 
 	// Bootstrap state for GCP sync.
-	urlMap, errs := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPort.ID, lbc.ctx.ClusterNamer, lbc.ctx)
+	urlMap, errs := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPort.ID, lbc.ctx.ClusterNamer)
 
 	if errs != nil {
 		msg := fmt.Errorf("invalid ingress spec: %v", utils.JoinErrs(errs))
@@ -776,7 +776,7 @@ func updateAnnotations(client kubernetes.Interface, ing *v1.Ingress, newAnnotati
 func (lbc *LoadBalancerController) ToSvcPorts(ings []*v1.Ingress) []utils.ServicePort {
 	var knownPorts []utils.ServicePort
 	for _, ing := range ings {
-		urlMap, _ := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPort.ID, lbc.ctx.ClusterNamer, lbc.ctx)
+		urlMap, _ := lbc.Translator.TranslateIngress(ing, lbc.ctx.DefaultBackendSvcPort.ID, lbc.ctx.ClusterNamer)
 		knownPorts = append(knownPorts, urlMap.AllServicePorts()...)
 	}
 	return knownPorts

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -206,9 +206,9 @@ func (t *Translator) maybeEnableBackendConfig(sp *utils.ServicePort, svc *api_v1
 	return nil
 }
 
-// manageEnableTHC sets the THCEnabled for the service port as true or false depending on whether
+// setEnableTHC sets the THCEnabled for the service port as true or false depending on whether
 // Transparent Health Checks should be enabled.
-func (t *Translator) manageEnableTHC(sp *utils.ServicePort, svc *api_v1.Service) {
+func (t *Translator) setEnableTHC(sp *utils.ServicePort, svc *api_v1.Service) {
 	THCEnabled := false
 	defer func() {
 		klog.Infof("Is THC enabled for the sevice %v with service port (%v, %v)? %v", svc.Name, sp.Port, sp.PortName, THCEnabled)
@@ -282,7 +282,7 @@ func (t *Translator) getServicePort(id utils.ServicePortID, params *getServicePo
 		return svcPort, err
 	}
 
-	t.manageEnableTHC(svcPort, svc)
+	t.setEnableTHC(svcPort, svc)
 
 	return svcPort, nil
 }

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -229,6 +229,13 @@ func (t *Translator) manageEnableTHC(sp *utils.ServicePort, svc *api_v1.Service)
 		t.recorderGetter.Recorder(sp.ID.Service.Namespace).Event(svc, api_v1.EventTypeWarning, "THCAnnotationParsingFailed", message)
 		klog.Warning(message)
 	}
+
+	if THCEnabled && !sp.NEGEnabled {
+		message := "THC annotation present, but NEG is disabled. Will not enable Transparent Health Checks."
+		t.recorderGetter.Recorder(sp.ID.Service.Namespace).Event(svc, api_v1.EventTypeWarning, "THCAnnotationWithoutNEG", message)
+		klog.Warning(message)
+		THCEnabled = false
+	}
 }
 
 // getServicePort looks in the svc store for a matching service:port,

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -1167,7 +1167,7 @@ func TestSetTrafficScaling(t *testing.T) {
 	}
 }
 
-func TestManageEnableTHC(t *testing.T) {
+func TestSetEnableTHC(t *testing.T) {
 	// No t.Parallel()
 
 	oldFlag := flags.F.EnableBackendConfigHealthCheck
@@ -1193,7 +1193,7 @@ func TestManageEnableTHC(t *testing.T) {
 	}
 
 	const (
-		thcLabel = "networking.gke.io/transparent-health-checker"
+		thcLabel = annotations.THCAnnotationKey
 		thcValue = `{"enabled":true}`
 	)
 
@@ -1236,14 +1236,14 @@ func TestManageEnableTHC(t *testing.T) {
 			eventPrefix: "Warning THCAnnotationWithoutNEG THC annotation present, but NEG is disabled. Will not enable Transparent Health Checks.",
 		},
 		{
-			name:      "wrong annotation flag disabled",
+			name:      "invalid annotation flag disabled",
 			sp:        &utils.ServicePort{NEGEnabled: true, THCEnabled: true},
 			svc:       newService(map[string]string{thcLabel: "random text"}),
 			enableTHC: false,
 			want:      &utils.ServicePort{NEGEnabled: true, THCEnabled: false},
 		},
 		{
-			name:        "wrong annotation",
+			name:        "invalid annotation",
 			sp:          &utils.ServicePort{NEGEnabled: true, THCEnabled: true},
 			svc:         newService(map[string]string{thcLabel: "random text"}),
 			enableTHC:   true,
@@ -1281,9 +1281,9 @@ func TestManageEnableTHC(t *testing.T) {
 			translator.enableTHC = tc.enableTHC
 			sp := *tc.sp
 
-			translator.manageEnableTHC(&sp, tc.svc)
+			translator.setEnableTHC(&sp, tc.svc)
 			if !reflect.DeepEqual(&sp, tc.want) {
-				t.Errorf("manageEnableTHC, %s\ngot %s,\nwant %s", tc.name, pretty.Sprint(&sp), pretty.Sprint(tc.want))
+				t.Errorf("setEnableTHC, %s\ngot %s,\nwant %s", tc.name, pretty.Sprint(&sp), pretty.Sprint(tc.want))
 			}
 			if tc.wantEvent {
 				fakeRecorder := fakeSingletonRecorderGetter.FakeRecorder()

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -86,6 +86,8 @@ func configuredFakeTranslator() *Translator {
 		PodInformer,
 		EndpointSliceInformer,
 		client,
+		false,
+		healthchecks.NewFakeRecorderGetter(0),
 	)
 }
 
@@ -205,7 +207,7 @@ func TestTranslateIngress(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			gotGCEURLMap, gotErrs := translator.TranslateIngress(tc.ing, defaultBackend.ID, defaultNamer, healthchecks.NewFakeRecorderGetter(0))
+			gotGCEURLMap, gotErrs := translator.TranslateIngress(tc.ing, defaultBackend.ID, defaultNamer)
 			if len(gotErrs) != tc.wantErrCount {
 				t.Errorf("%s: TranslateIngress() = _, %+v, want %v errs", tc.desc, gotErrs, tc.wantErrCount)
 			}
@@ -350,7 +352,7 @@ func TestGetServicePort(t *testing.T) {
 			svcLister.Add(svc)
 			tc.id.Service = svcName
 
-			port, gotErr := translator.getServicePort(tc.id, &tc.params, defaultNamer, healthchecks.NewFakeRecorderGetter(0))
+			port, gotErr := translator.getServicePort(tc.id, &tc.params, defaultNamer)
 			if (gotErr != nil) != tc.wantErr {
 				t.Errorf("translator.getServicePort(%+v) = _, %v, want err? %v", tc.id, gotErr, tc.wantErr)
 			}
@@ -441,7 +443,7 @@ func TestGetServicePortWithBackendConfigEnabled(t *testing.T) {
 			svcLister.Add(svc)
 			backendConfigLister.Add(backendConfig)
 
-			port, gotErr := translator.getServicePort(tc.id, &tc.params, defaultNamer, healthchecks.NewFakeRecorderGetter(0))
+			port, gotErr := translator.getServicePort(tc.id, &tc.params, defaultNamer)
 			if (gotErr != nil) != tc.wantErr {
 				t.Errorf("%s: translator.getServicePort(%+v) = _, %v, want err? %v", tc.desc, tc.id, gotErr, tc.wantErr)
 			}
@@ -736,7 +738,7 @@ func TestPathValidation(t *testing.T) {
 		}
 		expectedGCEURLMap.HostRules = []utils.HostRule{{Hostname: hostname, Paths: expectedPathRules}}
 
-		gotGCEURLMap, gotErrs := translator.TranslateIngress(ing, defaultBackend.ID, defaultNamer, healthchecks.NewFakeRecorderGetter(0))
+		gotGCEURLMap, gotErrs := translator.TranslateIngress(ing, defaultBackend.ID, defaultNamer)
 		if tc.expectValid && len(gotErrs) > 0 {
 			t.Fatalf("%s: TranslateIngress() = _, %+v, want no errs", tc.desc, gotErrs)
 		} else if !tc.expectValid && len(gotErrs) == 0 {

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -190,7 +190,7 @@ func NewFirewallController(
 func (fwc *FirewallController) ToSvcPorts(ings []*v1.Ingress) []utils.ServicePort {
 	var knownPorts []utils.ServicePort
 	for _, ing := range ings {
-		urlMap, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer)
+		urlMap, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer, fwc.ctx)
 		knownPorts = append(knownPorts, urlMap.AllServicePorts()...)
 	}
 	return knownPorts

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -190,7 +190,7 @@ func NewFirewallController(
 func (fwc *FirewallController) ToSvcPorts(ings []*v1.Ingress) []utils.ServicePort {
 	var knownPorts []utils.ServicePort
 	for _, ing := range ings {
-		urlMap, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer, fwc.ctx)
+		urlMap, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer)
 		knownPorts = append(knownPorts, urlMap.AllServicePorts()...)
 	}
 	return knownPorts

--- a/pkg/healthchecks/healthcheck.go
+++ b/pkg/healthchecks/healthcheck.go
@@ -45,7 +45,7 @@ func (c *fieldDiffs) String() string { return strings.Join(c.f, ", ") }
 func (c *fieldDiffs) hasDiff() bool  { return len(c.f) > 0 }
 func (c *fieldDiffs) size() int64    { return int64(len(c.f)) }
 
-func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCheckConfig) *fieldDiffs {
+func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCheckConfig, thcEnabled bool) *fieldDiffs {
 	var changes fieldDiffs
 
 	if old.Protocol() != new.Protocol() {
@@ -57,28 +57,28 @@ func calculateDiff(old, new *translator.HealthCheck, c *backendconfigv1.HealthCh
 
 	// TODO(bowei): why don't we check Port, timeout etc.
 
-	if c == nil {
+	if c == nil && !thcEnabled {
 		return &changes
 	}
 
 	// This code assumes that the changes wrt to `c` has been applied to `new`.
-	if c.CheckIntervalSec != nil && old.CheckIntervalSec != new.CheckIntervalSec {
+	if (thcEnabled || c.CheckIntervalSec != nil) && old.CheckIntervalSec != new.CheckIntervalSec {
 		changes.add("CheckIntervalSec", strconv.FormatInt(old.CheckIntervalSec, 10), strconv.FormatInt(new.CheckIntervalSec, 10))
 	}
-	if c.TimeoutSec != nil && old.TimeoutSec != new.TimeoutSec {
+	if (thcEnabled || c.TimeoutSec != nil) && old.TimeoutSec != new.TimeoutSec {
 		changes.add("TimeoutSec", strconv.FormatInt(old.TimeoutSec, 10), strconv.FormatInt(new.TimeoutSec, 10))
 	}
-	if c.HealthyThreshold != nil && old.HealthyThreshold != new.HealthyThreshold {
+	if (thcEnabled || c.HealthyThreshold != nil) && old.HealthyThreshold != new.HealthyThreshold {
 		changes.add("HeathyThreshold", strconv.FormatInt(old.HealthyThreshold, 10), strconv.FormatInt(new.HealthyThreshold, 10))
 	}
-	if c.UnhealthyThreshold != nil && old.UnhealthyThreshold != new.UnhealthyThreshold {
+	if (thcEnabled || c.UnhealthyThreshold != nil) && old.UnhealthyThreshold != new.UnhealthyThreshold {
 		changes.add("UnhealthyThreshold", strconv.FormatInt(old.UnhealthyThreshold, 10), strconv.FormatInt(new.UnhealthyThreshold, 10))
 	}
 	// c.Type is handled by Protocol above.
-	if c.RequestPath != nil && old.RequestPath != new.RequestPath {
+	if (thcEnabled || c.RequestPath != nil) && old.RequestPath != new.RequestPath {
 		changes.add("RequestPath", old.RequestPath, new.RequestPath)
 	}
-	if c.Port != nil && old.Port != new.Port {
+	if (thcEnabled || c.Port != nil) && old.Port != new.Port {
 		changes.add("Port", strconv.FormatInt(old.Port, 10), strconv.FormatInt(new.Port, 10))
 	}
 	if old.Description != new.Description {

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -47,7 +47,7 @@ type HealthChecks struct {
 	recorderGetter    RecorderGetter
 	serviceGetter     ServiceGetter
 	clusterInfo       healthcheck.ClusterInfo
-	thcFlagEnabled    bool
+	thcEnabled        bool
 }
 
 // NewHealthChecker creates a new health checker.
@@ -129,8 +129,8 @@ func (h *HealthChecks) generateHealthcheckInfo(sp utils.ServicePort, iLB bool) h
 
 // SyncServicePort implements HealthChecker.
 func (h *HealthChecks) SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (string, error) {
-	klog.Infof("SyncServicePort: sp.ID=%v, sp.NodePort=%v, sp.Port=%v, sp.PortName=%v, sp.THCEnabled=%v, h.thcFlagEnabled=%v.", sp.ID, sp.NodePort, sp.Port, sp.PortName, sp.THCEnabled, h.thcFlagEnabled)
-	if !h.thcFlagEnabled && sp.THCEnabled {
+	klog.Infof("SyncServicePort: sp.ID=%v, sp.NodePort=%v, sp.Port=%v, sp.PortName=%v, sp.THCEnabled=%v, h.thcEnabled=%v.", sp.ID, sp.NodePort, sp.Port, sp.PortName, sp.THCEnabled, h.thcEnabled)
+	if !h.thcEnabled && sp.THCEnabled {
 		klog.Warningf("THC flag disabled for HealthChecks, but ServicePort %v has Transparent Health Checks enabled. Disabling.", sp.ID)
 		sp.THCEnabled = false
 	}

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -85,7 +85,7 @@ func (h *HealthChecks) new(sp utils.ServicePort) *translator.HealthCheck {
 	hc.Port = sp.NodePort
 	hc.RequestPath = h.pathFromSvcPort(sp)
 	if sp.THCEnabled {
-		hc = translator.THCHealthCheck()
+		translator.OverwriteWithTHC(hc)
 	}
 	hc.Name = sp.BackendName()
 	hc.Service = h.getService(sp)

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -64,7 +64,7 @@ func init() {
 	// flag.Lookup("v").Value.Set(logLevel)
 
 	// Generate many types of ServicePorts.
-	// Example: sps["HTTP-8000-neg-nil"] is a ServicePort for HTTP with NEG-enabled.
+	// Example: sps["HTTP-8000-neg-nil-nothc"] is a ServicePort for HTTP with NEG-enabled.
 	testSPs = map[string]*utils.ServicePort{}
 	for _, p := range []annotations.AppProtocol{
 		annotations.ProtocolHTTP,
@@ -88,25 +88,30 @@ func init() {
 						Port:               &num,
 					},
 				} {
-					sp := &utils.ServicePort{
-						NodePort:     np,
-						Protocol:     p,
-						BackendNamer: testNamer,
-					}
-					switch mode {
-					case "reg":
-					case "neg":
-						sp.NEGEnabled = true
-					case "ilb":
-						sp.NEGEnabled = true
-						sp.L7ILBEnabled = true
-					}
-					if bc != nil {
-						sp.BackendConfig = &backendconfigv1.BackendConfig{
-							Spec: backendconfigv1.BackendConfigSpec{HealthCheck: bc},
+					for thck, thc := range map[string]bool{"thc": true, "nothc": false} {
+						sp := &utils.ServicePort{
+							NodePort:     np,
+							Protocol:     p,
+							BackendNamer: testNamer,
 						}
+						switch mode {
+						case "reg":
+						case "neg":
+							sp.NEGEnabled = true
+						case "ilb":
+							sp.NEGEnabled = true
+							sp.L7ILBEnabled = true
+						}
+						if bc != nil {
+							sp.BackendConfig = &backendconfigv1.BackendConfig{
+								Spec: backendconfigv1.BackendConfigSpec{HealthCheck: bc},
+							}
+						}
+						if thc {
+							sp.THCEnabled = true
+						}
+						testSPs[fmt.Sprintf("%s-%s-%s-%s-%s", p, npk, mode, bck, thck)] = sp
 					}
-					testSPs[fmt.Sprintf("%s-%s-%s-%s", p, npk, mode, bck)] = sp
 				}
 			}
 		}
@@ -115,7 +120,7 @@ func init() {
 
 func TestHealthCheckAdd(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	sp := &utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: testNamer}
 	_, err := healthChecks.SyncServicePort(sp, nil)
@@ -149,11 +154,22 @@ func TestHealthCheckAdd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected the health check to exist, err: %v", err)
 	}
+
+	sp = &utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: testNamer, THCEnabled: true}
+	_, err = healthChecks.SyncServicePort(sp, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Verify the health check exists
+	_, err = fakeGCE.GetHealthCheck(testNamer.IGBackend(8080))
+	if err != nil {
+		t.Fatalf("expected the health check to exist, err: %v", err)
+	}
 }
 
 func TestHealthCheckAddExisting(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	// HTTP
 	// Manually insert a health check
@@ -168,6 +184,18 @@ func TestHealthCheckAddExisting(t *testing.T) {
 
 	sp := &utils.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: testNamer}
 	// Should not fail adding the same type of health check
+	_, err = healthChecks.SyncServicePort(sp, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Verify the health check exists
+	_, err = fakeGCE.GetHealthCheck(httpHC.Name)
+	if err != nil {
+		t.Fatalf("expected the health check to continue existing, err: %v", err)
+	}
+
+	// Enable Transparent Health Checks
+	sp = &utils.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP, NEGEnabled: false, BackendNamer: testNamer, THCEnabled: true}
 	_, err = healthChecks.SyncServicePort(sp, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -225,7 +253,7 @@ func TestHealthCheckAddExisting(t *testing.T) {
 
 func TestHealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	// Create HTTP HC for 1234
 	hc := translator.DefaultHealthCheck(1234, annotations.ProtocolHTTP)
@@ -255,7 +283,7 @@ func TestHealthCheckDelete(t *testing.T) {
 
 func TestHTTP2HealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	// Create HTTP2 HC for 1234
 	hc := translator.DefaultHealthCheck(1234, annotations.ProtocolHTTP2)
@@ -282,7 +310,7 @@ func TestHTTP2HealthCheckDelete(t *testing.T) {
 
 func TestRegionalHealthCheckDelete(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	hc := healthChecks.new(
 		utils.ServicePort{
@@ -301,7 +329,7 @@ func TestRegionalHealthCheckDelete(t *testing.T) {
 	)
 	hcName := testNamer.NEG("ns2", "svc2", 80)
 
-	if err := healthChecks.create(hc, nil); err != nil {
+	if err := healthChecks.create(hc, nil, false); err != nil {
 		t.Fatalf("healthchecks.Create(%q) = %v, want nil", hc.Name, err)
 	}
 
@@ -334,7 +362,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaHealthChecks.UpdateHook = mock.UpdateAlphaHealthCheckHook
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaHealthChecks.UpdateHook = mock.UpdateBetaHealthCheckHook
 
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
 
 	// HTTP
 	// Manually insert a health check
@@ -355,7 +383,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 
 	// Change to HTTPS
 	hc.Type = string(annotations.ProtocolHTTPS)
-	_, err = healthChecks.sync(hc, nil)
+	_, err = healthChecks.sync(hc, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
 	}
@@ -373,7 +401,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 
 	// Change to HTTP2
 	hc.Type = string(annotations.ProtocolHTTP2)
-	_, err = healthChecks.sync(hc, nil)
+	_, err = healthChecks.sync(hc, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
 	}
@@ -392,7 +420,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	// Change to NEG Health Check
 	hc.ForNEG = true
 	hc.PortSpecification = "USE_SERVING_PORT"
-	_, err = healthChecks.sync(hc, nil)
+	_, err = healthChecks.sync(hc, nil, false)
 
 	if err != nil {
 		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
@@ -413,7 +441,7 @@ func TestHealthCheckUpdate(t *testing.T) {
 	hc.Port = 3000
 	hc.PortSpecification = ""
 
-	_, err = healthChecks.sync(hc, nil)
+	_, err = healthChecks.sync(hc, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
 	}
@@ -430,6 +458,62 @@ func TestHealthCheckUpdate(t *testing.T) {
 
 	if hc.Port == 0 {
 		t.Fatalf("expected health check with PortSpecification to have Port")
+	}
+}
+
+func TestEnableTHC(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+
+	// Add Hooks
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockHealthChecks.UpdateHook = mock.UpdateHealthCheckHook
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaHealthChecks.UpdateHook = mock.UpdateAlphaHealthCheckHook
+	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaHealthChecks.UpdateHook = mock.UpdateBetaHealthCheckHook
+
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), false)
+
+	// HTTP
+	// Manually insert a health check
+	hc := translator.DefaultHealthCheck(3000, annotations.ProtocolHTTP)
+	hc.Name = testNamer.IGBackend(3000)
+	hc.RequestPath = "/my-probes-health"
+	v1hc, err := hc.ToComputeHealthCheck()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeGCE.CreateHealthCheck(v1hc)
+
+	// Verify the health check exists
+	initialObtainedHC, err := healthChecks.Get(hc.Name, meta.VersionGA, meta.Global)
+	if err != nil {
+		t.Fatalf("expected the health check to exist, err: %v", err)
+	}
+
+	wantHC := *initialObtainedHC // shallow copy
+	wantHC.CheckIntervalSec = 5
+	wantHC.TimeoutSec = 5
+	wantHC.UnhealthyThreshold = 10
+	wantHC.HealthyThreshold = 1
+	wantHC.Type = "HTTP"
+	wantHC.Description = "Kubernetes L7 transparent health check."
+	wantHC.RequestPath = "/api/podhealth"
+	wantHC.Port = 7877
+	wantHC.PortSpecification = "USE_FIXED_PORT"
+
+	// Enable Transparent Health Checks
+	_, err = healthChecks.sync(hc, nil, true)
+	if err != nil {
+		t.Fatalf("unexpected err while syncing healthcheck, err %v", err)
+	}
+
+	// Verify the health check exists
+	obtainedHC, err := healthChecks.Get(hc.Name, meta.VersionGA, meta.Global)
+	if err != nil {
+		t.Fatalf("expected the health check to exist, err: %v", err)
+	}
+
+	// Verify the parameters.
+	if !reflect.DeepEqual(obtainedHC, &wantHC) {
+		t.Fatalf("Translate healthcheck is:\n%s, want:\n%s", pretty.Sprint(obtainedHC), pretty.Sprint(wantHC))
 	}
 }
 
@@ -470,8 +554,8 @@ func TestRolloutUpdateCustomHCDescription(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(testClusterValues)
 
 	var (
-		defaultSP       *utils.ServicePort = testSPs["HTTP-80-reg-nil"]
-		backendConfigSP *utils.ServicePort = testSPs["HTTP-80-reg-bc"]
+		defaultSP       *utils.ServicePort = testSPs["HTTP-80-reg-nil-nothc"]
+		backendConfigSP *utils.ServicePort = testSPs["HTTP-80-reg-bc-nothc"]
 	)
 
 	// Add Hooks
@@ -480,7 +564,7 @@ func TestRolloutUpdateCustomHCDescription(t *testing.T) {
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockBetaHealthChecks.UpdateHook = mock.UpdateBetaHealthCheckHook
 
 	fakeSingletonRecorderGetter := NewFakeSingletonRecorderGetter(1)
-	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, fakeSingletonRecorderGetter, NewFakeServiceGetter())
+	healthChecks := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, fakeSingletonRecorderGetter, NewFakeServiceGetter(), false)
 
 	_, err := healthChecks.SyncServicePort(defaultSP, nil)
 	if err != nil {
@@ -879,7 +963,7 @@ func TestCalculateDiff(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			diffs := calculateDiff(tc.old, tc.new, tc.c)
+			diffs := calculateDiff(tc.old, tc.new, tc.c, false)
 			t.Logf("\nold=%+v\nnew=%+v\ndiffs = %s", tc.old, tc.new, diffs)
 			if diffs.hasDiff() != tc.hasDiff {
 				t.Errorf("calculateDiff(%+v, %+v, %+v) = %s; hasDiff = %t, want %t", tc.old, tc.new, tc.c, diffs, diffs.hasDiff(), tc.hasDiff)
@@ -916,12 +1000,32 @@ func (*syncSPFixture) hc() *compute.HealthCheck {
 	}
 }
 
+func (*syncSPFixture) thc() *compute.HealthCheck {
+	return &compute.HealthCheck{
+		Name:               "k8s-be-80--uid1",
+		CheckIntervalSec:   5,
+		HealthyThreshold:   1,
+		TimeoutSec:         5,
+		Type:               "HTTP",
+		UnhealthyThreshold: 10,
+		SelfLink:           regSelfLink,
+		HttpHealthCheck: &compute.HTTPHealthCheck{
+			PortSpecification: "USE_FIXED_PORT",
+			Port:              7877,
+			RequestPath:       "/api/podhealth",
+		},
+		Description: translator.DescriptionForTransparentHealthChecks,
+	}
+}
+
 func (f *syncSPFixture) hcs() *compute.HealthCheck  { return f.toS(f.hc()) }
 func (f *syncSPFixture) hc2() *compute.HealthCheck  { return f.to2(f.hc()) }
 func (f *syncSPFixture) negs() *compute.HealthCheck { return f.toS(f.neg()) }
 func (f *syncSPFixture) neg2() *compute.HealthCheck { return f.to2(f.neg()) }
 func (f *syncSPFixture) ilbs() *compute.HealthCheck { return f.toS(f.ilb()) }
 func (f *syncSPFixture) ilb2() *compute.HealthCheck { return f.to2(f.ilb()) }
+func (f *syncSPFixture) thcs() *compute.HealthCheck { panic("no such thing exists") }
+func (f *syncSPFixture) thc2() *compute.HealthCheck { panic("no such thing exists") }
 
 func (f *syncSPFixture) toS(h *compute.HealthCheck) *compute.HealthCheck {
 	h.Type = "HTTPS"
@@ -1034,16 +1138,17 @@ func TestSyncServicePort(t *testing.T) {
 		wantErr             bool
 		wantComputeHC       *compute.HealthCheck
 		updateHCDescription bool
+		enableTHC           bool
 	}
 	fixture := syncSPFixture{}
 
 	var cases []*tc
 
-	cases = append(cases, &tc{desc: "create http", sp: testSPs["HTTP-80-reg-nil"], wantComputeHC: fixture.hc()})
-	cases = append(cases, &tc{desc: "create https", sp: testSPs["HTTPS-80-reg-nil"], wantComputeHC: fixture.hcs()})
-	cases = append(cases, &tc{desc: "create http2", sp: testSPs["HTTP2-80-reg-nil"], wantComputeHC: fixture.hc2()})
-	cases = append(cases, &tc{desc: "create neg", sp: testSPs["HTTP-80-neg-nil"], wantComputeHC: fixture.neg()})
-	cases = append(cases, &tc{desc: "create ilb", sp: testSPs["HTTP-80-ilb-nil"], regional: true, wantComputeHC: fixture.ilb()})
+	cases = append(cases, &tc{desc: "create http", sp: testSPs["HTTP-80-reg-nil-nothc"], wantComputeHC: fixture.hc()})
+	cases = append(cases, &tc{desc: "create https", sp: testSPs["HTTPS-80-reg-nil-nothc"], wantComputeHC: fixture.hcs()})
+	cases = append(cases, &tc{desc: "create http2", sp: testSPs["HTTP2-80-reg-nil-nothc"], wantComputeHC: fixture.hc2()})
+	cases = append(cases, &tc{desc: "create neg", sp: testSPs["HTTP-80-neg-nil-nothc"], wantComputeHC: fixture.neg()})
+	cases = append(cases, &tc{desc: "create ilb", sp: testSPs["HTTP-80-ilb-nil-nothc"], regional: true, wantComputeHC: fixture.ilb()})
 
 	// Probe override
 	chc := fixture.hc()
@@ -1054,7 +1159,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromReadinessProbe
 	cases = append(cases, &tc{
 		desc: "create probe",
-		sp:   testSPs["HTTP-80-reg-nil"],
+		sp:   testSPs["HTTP-80-reg-nil-nothc"],
 		probe: &v1.Probe{
 			ProbeHandler: api_v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{Path: "/foo", Host: "foo.com"},
@@ -1062,6 +1167,15 @@ func TestSyncServicePort(t *testing.T) {
 			PeriodSeconds:  1,
 			TimeoutSeconds: 1234,
 		},
+		wantComputeHC: chc,
+	})
+
+	// Transparent Health Check
+	chc = fixture.thc()
+	cases = append(cases, &tc{
+		desc:          "create thc",
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		enableTHC:     true,
 		wantComputeHC: chc,
 	})
 
@@ -1074,7 +1188,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromReadinessProbe
 	cases = append(cases, &tc{
 		desc: "create probe neg",
-		sp:   testSPs["HTTP-80-neg-nil"],
+		sp:   testSPs["HTTP-80-neg-nil-nothc"],
 		probe: &v1.Probe{
 			ProbeHandler: api_v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{Path: "/foo", Host: "foo.com"},
@@ -1094,7 +1208,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromReadinessProbe
 	cases = append(cases, &tc{
 		desc:     "create probe ilb",
-		sp:       testSPs["HTTP-80-ilb-nil"],
+		sp:       testSPs["HTTP-80-ilb-nil-nothc"],
 		regional: true,
 		probe: &v1.Probe{
 			ProbeHandler: api_v1.ProbeHandler{
@@ -1110,7 +1224,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc = fixture.hc()
 	chc.HttpHealthCheck.RequestPath = "/foo"
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
-	cases = append(cases, &tc{desc: "create backendconfig", sp: testSPs["HTTP-80-reg-bc"], wantComputeHC: chc})
+	cases = append(cases, &tc{desc: "create backendconfig", sp: testSPs["HTTP-80-reg-bc-nothc"], wantComputeHC: chc})
 
 	// BackendConfig all
 	chc = fixture.hc()
@@ -1123,7 +1237,7 @@ func TestSyncServicePort(t *testing.T) {
 	// PortSpecification is set by the controller
 	chc.HttpHealthCheck.PortSpecification = "USE_FIXED_PORT"
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
-	cases = append(cases, &tc{desc: "create backendconfig all", sp: testSPs["HTTP-80-reg-bcall"], wantComputeHC: chc})
+	cases = append(cases, &tc{desc: "create backendconfig all", sp: testSPs["HTTP-80-reg-bcall-nothc"], wantComputeHC: chc})
 
 	i64 := func(i int64) *int64 { return &i }
 
@@ -1147,7 +1261,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
 	cases = append(cases, &tc{
 		desc:          "create backendconfig neg",
-		sp:            testSPs["HTTP-80-neg-bc"],
+		sp:            testSPs["HTTP-80-neg-bc-nothc"],
 		wantComputeHC: chc,
 	})
 
@@ -1157,7 +1271,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
 	cases = append(cases, &tc{
 		desc:          "create backendconfig ilb",
-		sp:            testSPs["HTTP-80-ilb-bc"],
+		sp:            testSPs["HTTP-80-ilb-bc-nothc"],
 		regional:      true,
 		wantComputeHC: chc,
 	})
@@ -1168,7 +1282,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
 	cases = append(cases, &tc{
 		desc:            "create backendconfig ilb regional cluster",
-		sp:              testSPs["HTTP-80-ilb-bc"],
+		sp:              testSPs["HTTP-80-ilb-bc-nothc"],
 		regional:        true,
 		regionalCluster: true,
 		wantComputeHC:   chc,
@@ -1183,7 +1297,7 @@ func TestSyncServicePort(t *testing.T) {
 	chc.Description = translator.DescriptionForHealthChecksFromBackendConfig
 	cases = append(cases, &tc{
 		desc: "create probe and backendconfig",
-		sp:   testSPs["HTTP-80-reg-bc"],
+		sp:   testSPs["HTTP-80-reg-bc-nothc"],
 		probe: &v1.Probe{
 			ProbeHandler: api_v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{Path: "/bar", Host: "foo.com"},
@@ -1198,31 +1312,31 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update http no change",
 		setup:         fixture.setupExistingHCFunc(fixture.hc()),
-		sp:            testSPs["HTTP-80-reg-nil"],
+		sp:            testSPs["HTTP-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hc(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update https no change",
 		setup:         fixture.setupExistingHCFunc(fixture.hcs()),
-		sp:            testSPs["HTTPS-80-reg-nil"],
+		sp:            testSPs["HTTPS-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hcs(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update http2 no change",
 		setup:         fixture.setupExistingHCFunc(fixture.hc2()),
-		sp:            testSPs["HTTP2-80-reg-nil"],
+		sp:            testSPs["HTTP2-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hc2(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update neg no change",
 		setup:         fixture.setupExistingHCFunc(fixture.neg()),
-		sp:            testSPs["HTTP-80-neg-nil"],
+		sp:            testSPs["HTTP-80-neg-nil-nothc"],
 		wantComputeHC: fixture.neg(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update ilb no change",
 		setup:         fixture.setupExistingHCFunc(fixture.ilb()),
-		sp:            testSPs["HTTP-80-ilb-nil"],
+		sp:            testSPs["HTTP-80-ilb-nil-nothc"],
 		regional:      true,
 		wantComputeHC: fixture.ilb(),
 	})
@@ -1231,39 +1345,72 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update http to https",
 		setup:         fixture.setupExistingHCFunc(fixture.hc()),
-		sp:            testSPs["HTTPS-80-reg-nil"],
+		sp:            testSPs["HTTPS-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hcs(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update http to http2",
 		setup:         fixture.setupExistingHCFunc(fixture.hc()),
-		sp:            testSPs["HTTP2-80-reg-nil"],
+		sp:            testSPs["HTTP2-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hc2(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update https to http",
 		setup:         fixture.setupExistingHCFunc(fixture.hcs()),
-		sp:            testSPs["HTTP-80-reg-nil"],
+		sp:            testSPs["HTTP-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hc(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update https to http2",
 		setup:         fixture.setupExistingHCFunc(fixture.hcs()),
-		sp:            testSPs["HTTP2-80-reg-nil"],
+		sp:            testSPs["HTTP2-80-reg-nil-nothc"],
 		wantComputeHC: fixture.hc2(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update neg protocol",
 		setup:         fixture.setupExistingHCFunc(fixture.neg()),
-		sp:            testSPs["HTTPS-80-neg-nil"],
+		sp:            testSPs["HTTPS-80-neg-nil-nothc"],
 		wantComputeHC: fixture.negs(),
 	})
 	cases = append(cases, &tc{
 		desc:          "update ilb protocol",
 		setup:         fixture.setupExistingRegionalHCFunc("us-central1", fixture.ilb()),
-		sp:            testSPs["HTTPS-80-ilb-nil"],
+		sp:            testSPs["HTTPS-80-ilb-nil-nothc"],
 		regional:      true,
 		wantComputeHC: fixture.ilbs(),
+	})
+	cases = append(cases, &tc{
+		desc:          "update http to thc",
+		setup:         fixture.setupExistingHCFunc(fixture.hc()),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		wantComputeHC: fixture.thc(),
+		enableTHC:     true,
+	})
+	cases = append(cases, &tc{
+		desc:          "update https to thc",
+		setup:         fixture.setupExistingHCFunc(fixture.hcs()),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		wantComputeHC: fixture.thc(),
+		enableTHC:     true,
+	})
+	cases = append(cases, &tc{
+		desc:          "update http2 to thc",
+		setup:         fixture.setupExistingHCFunc(fixture.hc2()),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		wantComputeHC: fixture.thc(),
+		enableTHC:     true,
+	})
+	cases = append(cases, &tc{
+		desc:          "update http to thc with flag disabled",
+		setup:         fixture.setupExistingHCFunc(fixture.hc()),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		wantComputeHC: fixture.hc(),
+	})
+	cases = append(cases, &tc{
+		desc:          "update http to https thc with flag disabled",
+		setup:         fixture.setupExistingHCFunc(fixture.hc()),
+		sp:            testSPs["HTTPS-80-reg-nil-thc"],
+		wantComputeHC: fixture.hcs(),
 	})
 
 	// Preserve user settings.
@@ -1273,7 +1420,18 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update preserve",
 		setup:         fixture.setupExistingHCFunc(chc),
-		sp:            testSPs["HTTP-80-reg-nil"],
+		sp:            testSPs["HTTP-80-reg-nil-nothc"],
+		wantComputeHC: chc,
+	})
+
+	// Preserve user settings despite thc annotation when flag disabled.
+	chc = fixture.hc()
+	chc.HttpHealthCheck.RequestPath = "/user-path"
+	chc.CheckIntervalSec = 1234
+	cases = append(cases, &tc{
+		desc:          "update preserve",
+		setup:         fixture.setupExistingHCFunc(chc),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
 		wantComputeHC: chc,
 	})
 
@@ -1287,7 +1445,7 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update preserve across protocol change",
 		setup:         fixture.setupExistingHCFunc(chc),
-		sp:            testSPs["HTTPS-80-reg-nil"],
+		sp:            testSPs["HTTPS-80-reg-nil-nothc"],
 		wantComputeHC: wantCHC,
 	})
 
@@ -1301,7 +1459,7 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update preserve across protocol change neg",
 		setup:         fixture.setupExistingHCFunc(chc),
-		sp:            testSPs["HTTPS-80-neg-nil"],
+		sp:            testSPs["HTTPS-80-neg-nil-nothc"],
 		wantComputeHC: wantCHC,
 	})
 
@@ -1315,7 +1473,7 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update preserve across protocol change ilb",
 		setup:         fixture.setupExistingRegionalHCFunc("us-central1", chc),
-		sp:            testSPs["HTTPS-80-ilb-nil"],
+		sp:            testSPs["HTTPS-80-ilb-nil-nothc"],
 		regional:      true,
 		wantComputeHC: wantCHC,
 	})
@@ -1330,7 +1488,7 @@ func TestSyncServicePort(t *testing.T) {
 	wantCHC.Description = translator.DescriptionForHealthChecksFromBackendConfig
 	cases = append(cases, &tc{
 		desc:          "update preserve and backendconfig (path)",
-		sp:            testSPs["HTTP-80-reg-bc"],
+		sp:            testSPs["HTTP-80-reg-bc-nothc"],
 		setup:         fixture.setupExistingHCFunc(chc),
 		wantComputeHC: wantCHC,
 	})
@@ -1351,8 +1509,26 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:          "update preserve backendconfig all",
 		setup:         fixture.setupExistingHCFunc(chc),
-		sp:            testSPs["HTTP-80-reg-bcall"],
+		sp:            testSPs["HTTP-80-reg-bcall-nothc"],
 		wantComputeHC: wantCHC,
+	})
+
+	// Override all settings from thc.
+	chc = fixture.hc()
+	chc.HttpHealthCheck.RequestPath = "/user-path"
+	chc.CheckIntervalSec = 5678
+	chc.CheckIntervalSec = 5678
+	chc.HealthyThreshold = 5678
+	chc.UnhealthyThreshold = 5678
+	chc.TimeoutSec = 5678
+	chc.HttpHealthCheck.Port = 5678
+	chc.HttpHealthCheck.PortSpecification = "USE_FIXED_PORT"
+	cases = append(cases, &tc{
+		desc:          "update preserve thc",
+		setup:         fixture.setupExistingHCFunc(chc),
+		sp:            testSPs["HTTP-80-reg-nil-thc"],
+		wantComputeHC: fixture.thc(),
+		enableTHC:     true,
 	})
 
 	// BUG: changing probe settings has not effect on the healthcheck
@@ -1363,7 +1539,7 @@ func TestSyncServicePort(t *testing.T) {
 	cases = append(cases, &tc{
 		desc:  "update probe has no effect (bug)",
 		setup: fixture.setupExistingHCFunc(chc),
-		sp:    testSPs["HTTP-80-reg-nil"],
+		sp:    testSPs["HTTP-80-reg-nil-nothc"],
 		probe: &v1.Probe{
 			ProbeHandler: api_v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{Path: "/foo", Host: "foo.com"},
@@ -1421,7 +1597,7 @@ func TestSyncServicePort(t *testing.T) {
 				tc.setup(mock)
 			}
 
-			hcs := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter())
+			hcs := NewHealthChecker(fakeGCE, "/", defaultBackendSvc, NewFakeRecorderGetter(0), NewFakeServiceGetter(), tc.enableTHC)
 
 			gotSelfLink, err := hcs.SyncServicePort(tc.sp, tc.probe)
 			if gotErr := err != nil; gotErr != tc.wantErr {

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -60,6 +60,16 @@ const (
 	// defaultNEGTimeout defines the timeout of each probe for NEG
 	defaultNEGTimeout = 15 * time.Second
 
+	// Similar defaults as above, but for Transparent Health Checks.
+	defaultTHCCheckInterval      = 5 * time.Second
+	defaultTHCTimeout            = 5 * time.Second
+	defaultTHCUnhealthyThreshold = defaultUnhealthyThreshold
+	defaultTHCHealthyThreshold   = 1
+	defaultTHCType               = string(annotations.ProtocolHTTP)
+	defaultTHCPortSpecification  = "USE_FIXED_PORT"
+	defaultTHCPort               = 7877
+	defaultTHCRequestPath        = "/api/podhealth"
+
 	// useServingPortSpecification is a constant for GCE API.
 	// USE_SERVING_PORT: For NetworkEndpointGroup, the port specified for
 	// each network endpoint is used for health checking. For other
@@ -72,6 +82,7 @@ const (
 	DescriptionForDefaultILBHealthChecks         = "Default kubernetes L7 Loadbalancing health check for ILB."
 	DescriptionForHealthChecksFromReadinessProbe = "Kubernetes L7 health check generated with readiness probe settings."
 	DescriptionForHealthChecksFromBackendConfig  = "Kubernetes L7 health check generated with BackendConfig CRD."
+	DescriptionForTransparentHealthChecks        = "Kubernetes L7 transparent health check."
 
 	// TODO: revendor the GCE API go client so that this error will not be hit.
 	newHealthCheckErrorMessageTemplate = "the %v health check configuration on the existing health check %v is nil. " +
@@ -213,6 +224,18 @@ func (hc *HealthCheck) Version() meta.Version {
 		return meta.VersionBeta
 	}
 	return meta.VersionGA
+}
+
+func (hc *HealthCheck) ApplyTHCSettings() {
+	hc.CheckIntervalSec = int64(defaultTHCCheckInterval.Seconds())
+	hc.TimeoutSec = int64(defaultTHCTimeout.Seconds())
+	hc.UnhealthyThreshold = defaultTHCUnhealthyThreshold
+	hc.HealthyThreshold = defaultTHCHealthyThreshold
+	hc.Type = defaultTHCType
+	hc.Description = DescriptionForTransparentHealthChecks
+	hc.PortSpecification = defaultTHCPortSpecification
+	hc.Port = defaultTHCPort
+	hc.RequestPath = defaultTHCRequestPath
 }
 
 func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckConfig) {

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -61,14 +61,13 @@ const (
 	defaultNEGTimeout = 15 * time.Second
 
 	// Similar defaults as above, but for Transparent Health Checks.
-	defaultTHCCheckInterval      = 5 * time.Second
-	defaultTHCTimeout            = 5 * time.Second
-	defaultTHCUnhealthyThreshold = defaultUnhealthyThreshold
-	defaultTHCHealthyThreshold   = 1
-	defaultTHCType               = string(annotations.ProtocolHTTP)
-	defaultTHCPortSpecification  = "USE_FIXED_PORT"
-	defaultTHCPort               = 7877
-	defaultTHCRequestPath        = "/api/podhealth"
+	thcCheckInterval     = 5 * time.Second
+	thcTimeout           = 5 * time.Second
+	thcHealthyThreshold  = 1
+	thcType              = string(annotations.ProtocolHTTP)
+	thcPortSpecification = "USE_FIXED_PORT"
+	THCPort              = 7877
+	thcRequestPath       = "/api/podhealth"
 
 	// useServingPortSpecification is a constant for GCE API.
 	// USE_SERVING_PORT: For NetworkEndpointGroup, the port specified for
@@ -226,16 +225,19 @@ func (hc *HealthCheck) Version() meta.Version {
 	return meta.VersionGA
 }
 
-func (hc *HealthCheck) ApplyTHCSettings() {
-	hc.CheckIntervalSec = int64(defaultTHCCheckInterval.Seconds())
-	hc.TimeoutSec = int64(defaultTHCTimeout.Seconds())
-	hc.UnhealthyThreshold = defaultTHCUnhealthyThreshold
-	hc.HealthyThreshold = defaultTHCHealthyThreshold
-	hc.Type = defaultTHCType
-	hc.Description = DescriptionForTransparentHealthChecks
-	hc.PortSpecification = defaultTHCPortSpecification
-	hc.Port = defaultTHCPort
-	hc.RequestPath = defaultTHCRequestPath
+// THCHealthCheck returns the transparent health check.
+func THCHealthCheck() *HealthCheck {
+	hc := HealthCheck{}
+	hc.CheckIntervalSec = int64(thcCheckInterval.Seconds())
+	hc.TimeoutSec = int64(thcTimeout.Seconds())
+	hc.UnhealthyThreshold = defaultUnhealthyThreshold
+	hc.HealthyThreshold = thcHealthyThreshold
+	hc.Type = thcType
+	hc.Description = DescriptionForTransparentHealthChecks //TODO(DamianSawicki): JSONify.
+	hc.PortSpecification = thcPortSpecification
+	hc.Port = THCPort
+	hc.RequestPath = thcRequestPath
+	return &hc
 }
 
 func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckConfig) {

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -225,9 +225,8 @@ func (hc *HealthCheck) Version() meta.Version {
 	return meta.VersionGA
 }
 
-// THCHealthCheck returns the transparent health check.
-func THCHealthCheck() *HealthCheck {
-	hc := HealthCheck{}
+// OverwriteWithTHC applies the standard values for Transparent Health Checks.
+func OverwriteWithTHC(hc *HealthCheck) {
 	hc.CheckIntervalSec = int64(thcCheckInterval.Seconds())
 	hc.TimeoutSec = int64(thcTimeout.Seconds())
 	hc.UnhealthyThreshold = defaultUnhealthyThreshold
@@ -237,7 +236,6 @@ func THCHealthCheck() *HealthCheck {
 	hc.PortSpecification = thcPortSpecification
 	hc.Port = THCPort
 	hc.RequestPath = thcRequestPath
-	return &hc
 }
 
 func (hc *HealthCheck) UpdateFromBackendConfig(c *backendconfigv1.HealthCheckConfig) {

--- a/pkg/translator/healthchecks_test.go
+++ b/pkg/translator/healthchecks_test.go
@@ -87,7 +87,7 @@ func TestMerge(t *testing.T) {
 	}
 }
 
-func TestTHCHealthCheck(t *testing.T) {
+func TestOverwriteWithTHC(t *testing.T) {
 	wantHC := &HealthCheck{
 		HealthCheck: computealpha.HealthCheck{
 			CheckIntervalSec:   5,
@@ -104,7 +104,8 @@ func TestTHCHealthCheck(t *testing.T) {
 		},
 	}
 
-	hc := THCHealthCheck()
+	hc := &HealthCheck{}
+	OverwriteWithTHC(hc)
 	if !reflect.DeepEqual(hc, wantHC) {
 		t.Fatalf("Translate healthcheck is:\n%s, want:\n%s", pretty.Sprint(hc), pretty.Sprint(wantHC))
 	}

--- a/pkg/translator/healthchecks_test.go
+++ b/pkg/translator/healthchecks_test.go
@@ -87,8 +87,7 @@ func TestMerge(t *testing.T) {
 	}
 }
 
-func TestApplyTHCSettings(t *testing.T) {
-	hc := &HealthCheck{HealthCheck: computealpha.HealthCheck{Type: "HTTP"}}
+func TestTHCHealthCheck(t *testing.T) {
 	wantHC := &HealthCheck{
 		HealthCheck: computealpha.HealthCheck{
 			CheckIntervalSec:   5,
@@ -105,7 +104,7 @@ func TestApplyTHCSettings(t *testing.T) {
 		},
 	}
 
-	hc.ApplyTHCSettings()
+	hc := THCHealthCheck()
 	if !reflect.DeepEqual(hc, wantHC) {
 		t.Fatalf("Translate healthcheck is:\n%s, want:\n%s", pretty.Sprint(hc), pretty.Sprint(wantHC))
 	}

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -53,6 +53,7 @@ type ServicePort struct {
 	VMIPNEGEnabled bool
 	L4RBSEnabled   bool
 	L7ILBEnabled   bool
+	THCEnabled     bool
 	BackendConfig  *backendconfigv1.BackendConfig
 	BackendNamer   namer.BackendNamer
 	// Traffic policy fields that apply if non-nil.


### PR DESCRIPTION
Configure UHC with THC defaults when the THC annotation is present for the service. Flag-gated with `flags.F.EnableTransparentHealthChecks`.