### PR TITLE
use cloudbuild to build container images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1800s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: E2_HIGHCPU_8
+steps:
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230206-8160eea68e
+  entrypoint: make
+  env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - REGISTRY="gcr.io/k8s-ingress-image-push"
+    - VERSION=$_PULL_BASE_REF
+    - VERBOSE=1
+    - HOME=/root
+    - USER=root
+  args: ['all-push','ALL_ARCH=amd64 arm64']
+substitutions:
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "main"


### PR DESCRIPTION
This is the canonical and supported way to build images in kubernetes

https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#image-pushing-jobs