### PR TITLE
Consume IPv6 Health status for NEG pod readiness

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -184,6 +184,7 @@ func NewController(
 			podInformer.GetIndexer(),
 			cloud,
 			manager,
+			enableDualStackNEG,
 			logger,
 		)
 	} else {

--- a/pkg/neg/readiness/reflector.go
+++ b/pkg/neg/readiness/reflector.go
@@ -76,7 +76,7 @@ type readinessReflector struct {
 	logger klog.Logger
 }
 
-func NewReadinessReflector(kubeClient kubernetes.Interface, podLister cache.Indexer, negCloud negtypes.NetworkEndpointGroupCloud, lookup NegLookup, logger klog.Logger) Reflector {
+func NewReadinessReflector(kubeClient kubernetes.Interface, podLister cache.Indexer, negCloud negtypes.NetworkEndpointGroupCloud, lookup NegLookup, enableDualStackNEG bool, logger klog.Logger) Reflector {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{
@@ -94,7 +94,7 @@ func NewReadinessReflector(kubeClient kubernetes.Interface, podLister cache.Inde
 		queue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		logger:           logger,
 	}
-	poller := NewPoller(podLister, lookup, reflector, negCloud, logger)
+	poller := NewPoller(podLister, lookup, reflector, negCloud, enableDualStackNEG, logger)
 	reflector.poller = poller
 	return reflector
 }

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -48,7 +48,7 @@ func (f *fakeLookUp) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool 
 }
 
 func newTestReadinessReflector(testContext *negtypes.TestContext) *readinessReflector {
-	reflector := NewReadinessReflector(testContext.KubeClient, testContext.PodInformer.GetIndexer(), negtypes.NewAdapter(testContext.Cloud), &fakeLookUp{}, klog.TODO())
+	reflector := NewReadinessReflector(testContext.KubeClient, testContext.PodInformer.GetIndexer(), negtypes.NewAdapter(testContext.Cloud), &fakeLookUp{}, false, klog.TODO())
 	ret := reflector.(*readinessReflector)
 	return ret
 }


### PR DESCRIPTION
Before: Only IPv4 Health status was used to decide if NEG endpoint is ready
Now: Both IPv4 and IPv6 health statuses will be used to decide if NEG endpoint is ready.

/assign @swetharepakula 