### PR TITLE
Track GCE/K8s server error

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -149,10 +149,12 @@ func NewController(
 	err := scheme.AddToScheme(negScheme)
 	if err != nil {
 		logger.Error(err, "Errored adding default scheme to event recorder")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 	err = svcnegv1beta1.AddToScheme(negScheme)
 	if err != nil {
 		logger.Error(err, "Errored adding NEG CRD scheme to event recorder")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 	recorder := eventBroadcaster.NewRecorder(negScheme,
 		apiv1.EventSource{Component: "neg-controller"})
@@ -401,6 +403,7 @@ func (c *Controller) processEndpoint(key string) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		c.logger.Error(err, "Failed to split endpoint namespaced key", "key", key)
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return
 	}
 	c.manager.Sync(namespace, name)
@@ -416,6 +419,7 @@ func (c *Controller) serviceWorker() {
 			defer c.serviceQueue.Done(key)
 			err := c.processService(key.(string))
 			c.handleErr(err, key)
+			metrics.PublishNegControllerErrorCountMetrics(err, false)
 		}()
 	}
 }
@@ -713,6 +717,7 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	c.logger.Error(nil, msg)
 	if service, exists, err := c.serviceLister.GetByKey(key.(string)); err != nil {
 		c.logger.Error(err, "Failed to retrieve service from store", "service", key.(string))
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	} else if exists {
 		c.recorder.Eventf(service.(*apiv1.Service), apiv1.EventTypeWarning, "ProcessServiceFailed", msg)
 	}
@@ -735,6 +740,7 @@ func (c *Controller) enqueueEndpointSlice(obj interface{}) {
 	key, err := endpointslices.EndpointSlicesServiceKey(endpointSlice)
 	if err != nil {
 		c.logger.Error(err, "Failed to find a service label inside endpoint slice", "endpointSlice", klog.KObj(endpointSlice))
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return
 	}
 	c.logger.V(3).Info("Adding EndpointSlice to endpointQueue for processing", "endpointSlice", key)
@@ -745,6 +751,7 @@ func (c *Controller) enqueueNode(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		c.logger.Error(err, "Failed to generate node key")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return
 	}
 	c.logger.V(3).Info("Adding Node to nodeQueue for processing", "node", key)
@@ -755,6 +762,7 @@ func (c *Controller) enqueueService(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		c.logger.Error(err, "Failed to generate service key")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return
 	}
 	c.logger.V(3).Info("Adding Service to serviceQueue for processing", "service", key)
@@ -777,6 +785,7 @@ func (c *Controller) enqueueIngressServices(ing *v1.Ingress) {
 func (c *Controller) gc() {
 	if err := c.manager.GC(); err != nil {
 		c.logger.Error(err, "NEG controller garbage collection failed")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 }
 

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -349,6 +349,7 @@ func updateZoneMap(existingZoneMap *map[string]struct{}, candidateNodePredicate 
 	zones, err := zoneGetter.ListZones(candidateNodePredicate)
 	if err != nil {
 		logger.Error(err, "Unable to list zones")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return false
 	}
 
@@ -407,6 +408,7 @@ func (manager *syncerManager) ReadinessGateEnabledNegs(namespace string, podLabe
 		obj, exists, err := manager.serviceLister.GetByKey(svcKey.Key())
 		if err != nil {
 			manager.logger.Error(err, "Failed to retrieve service from store", "service", svcKey.Key())
+			metrics.PublishNegControllerErrorCountMetrics(err, true)
 			continue
 		}
 
@@ -682,6 +684,7 @@ func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string
 	if err != nil {
 		if utils.IsNotFoundError(err) || utils.IsHTTPErrorCode(err, http.StatusBadRequest) {
 			manager.logger.V(2).Info("Ignoring error when querying for neg during GC", "negName", name, "zone", zone, "err", err)
+			metrics.PublishNegControllerErrorCountMetrics(err, true)
 			return nil
 		}
 		return err

--- a/pkg/neg/readiness/reflector.go
+++ b/pkg/neg/readiness/reflector.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/klog/v2"
@@ -225,6 +226,7 @@ func (r *readinessReflector) SyncPod(pod *v1.Pod) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pod)
 	if err != nil {
 		r.logger.Error(err, "Failed to generate pod key")
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 		return
 	}
 
@@ -260,6 +262,7 @@ func (r *readinessReflector) pollNeg(key negMeta) {
 	retry, err := r.poller.Poll(key)
 	if err != nil {
 		r.logger.Error(err, "Failed to poll neg", "neg", key)
+		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 	if retry {
 		r.poll()

--- a/pkg/neg/readiness/utils.go
+++ b/pkg/neg/readiness/utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/utils/patch"
@@ -136,6 +137,7 @@ func removeIrrelevantEndpoints(endpointMap negtypes.EndpointPodMap, podLister ca
 		pod, exists, err := getPodFromStore(podLister, namespacedName.Namespace, namespacedName.Name)
 		if err != nil {
 			klog.Warningf("Failed to retrieve pod %q from store: %v", namespacedName.String(), err)
+			metrics.PublishNegControllerErrorCountMetrics(err, true)
 		}
 		if err == nil && exists && needToProcess(pod) {
 			continue

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -87,6 +87,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 			node, err := l.nodeLister.Get(*addr.NodeName)
 			if err != nil {
 				l.logger.Error(err, "failed to retrieve node object", "nodeName", *addr.NodeName)
+				metrics.PublishNegControllerErrorCountMetrics(err, true)
 				continue
 			}
 			if ok := candidateNodeCheck(node); !ok {
@@ -96,6 +97,7 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 			zone, err := l.zoneGetter.GetZoneForNode(node.Name)
 			if err != nil {
 				l.logger.Error(err, "Unable to find zone for node, skipping", "nodeName", node.Name)
+				metrics.PublishNegControllerErrorCountMetrics(err, true)
 				continue
 			}
 			zoneNodeMap[zone] = append(zoneNodeMap[zone], node)
@@ -164,6 +166,7 @@ func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.Endpoints
 		zone, err := l.zoneGetter.GetZoneForNode(node.Name)
 		if err != nil {
 			l.logger.Error(err, "Unable to find zone for node skipping", "nodeName", node.Name)
+			metrics.PublishNegControllerErrorCountMetrics(err, true)
 			continue
 		}
 		zoneNodeMap[zone] = append(zoneNodeMap[zone], node)

--- a/pkg/neg/syncers/syncer.go
+++ b/pkg/neg/syncers/syncer.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -89,6 +90,7 @@ func (s *syncer) Start() error {
 			retryCh := make(<-chan time.Time)
 			err := s.core.sync()
 			if err != nil {
+				metrics.PublishNegControllerErrorCountMetrics(err, false)
 				delay, retryErr := s.backoff.NextRetryDelay()
 				retryMsg := ""
 				if retryErr == ErrRetriesExceeded {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -268,6 +268,40 @@ func GetErrorType(err error) string {
 	return ""
 }
 
+// IsGCEServerError returns true if the error is GCE server error
+func IsGCEServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	for {
+		if apiErr, ok := err.(*googleapi.Error); ok {
+			return apiErr.Code >= http.StatusInternalServerError
+		}
+		err = errors.Unwrap(err)
+	}
+}
+
+// IsK8sServerError returns true if the error is K8s server error
+func IsK8sServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var k8serr *k8serrors.StatusError
+	if !errors.As(err, &k8serr) {
+		return false
+	}
+	for {
+		if apiErr, ok := err.(*k8serrors.StatusError); ok {
+			return apiErr.ErrStatus.Code >= http.StatusInternalServerError
+		}
+		err = errors.Unwrap(err)
+	}
+}
+
 // PrettyJson marshals an object in a human-friendly format.
 func PrettyJson(data interface{}) (string, error) {
 	buffer := new(bytes.Buffer)


### PR DESCRIPTION
Define `NegControllerErrorCount` that tracks both internal sync error and API server errors(GCE/K8s).