### PR TITLE
Remove the flag EnableBackendConfigHealthCheck

### DIFF
--- a/docs/deploy/resources/glbc.yaml
+++ b/docs/deploy/resources/glbc.yaml
@@ -63,7 +63,6 @@ spec:
         - --gce-ratelimit=ga.BackendServices.Get,qps,1.8,1
         - --gce-ratelimit=ga.HealthChecks.Get,qps,1.8,1
         - --gce-ratelimit=alpha.HealthChecks.Get,qps,1.8,1
-        - --enable-backendconfig-healthcheck
         - --enable-frontend-config
         - --enable-endpoint-slices
       volumes:

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -219,7 +219,7 @@ func (t *Translator) setEnableTHC(sp *utils.ServicePort, svc *api_v1.Service) {
 		return
 	}
 
-	if flags.F.EnableBackendConfigHealthCheck && sp.BackendConfig != nil && sp.BackendConfig.Spec.HealthCheck != nil {
+	if sp.BackendConfig != nil && sp.BackendConfig.Spec.HealthCheck != nil {
 		return
 	}
 

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -1170,12 +1170,6 @@ func TestSetTrafficScaling(t *testing.T) {
 func TestSetEnableTHC(t *testing.T) {
 	// No t.Parallel()
 
-	oldFlag := flags.F.EnableBackendConfigHealthCheck
-	flags.F.EnableBackendConfigHealthCheck = true
-	defer func() {
-		flags.F.EnableBackendConfigHealthCheck = oldFlag
-	}()
-
 	newService := func(ann map[string]string) *apiv1.Service {
 		return &apiv1.Service{
 			ObjectMeta: metav1.ObjectMeta{Annotations: ann},

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -300,11 +300,9 @@ func (fwc *FirewallController) ilbFirewallSrcRange(gceIngresses []*v1.Ingress) (
 func (fwc *FirewallController) getCustomHealthCheckPorts(svcPorts []utils.ServicePort) []string {
 	var result []string
 
-	if flags.F.EnableBackendConfigHealthCheck {
-		for _, svcPort := range svcPorts {
-			if svcPort.BackendConfig != nil && svcPort.BackendConfig.Spec.HealthCheck != nil && svcPort.BackendConfig.Spec.HealthCheck.Port != nil {
-				result = append(result, strconv.FormatInt(*svcPort.BackendConfig.Spec.HealthCheck.Port, 10))
-			}
+	for _, svcPort := range svcPorts {
+		if svcPort.BackendConfig != nil && svcPort.BackendConfig.Spec.HealthCheck != nil && svcPort.BackendConfig.Spec.HealthCheck.Port != nil {
+			result = append(result, strconv.FormatInt(*svcPort.BackendConfig.Spec.HealthCheck.Port, 10))
 		}
 	}
 	if flags.F.EnableTransparentHealthChecks {

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -110,11 +110,8 @@ func TestFirewallCreateDelete(t *testing.T) {
 
 func TestGetCustomHealthCheckPorts(t *testing.T) {
 	// No t.Parallel().
-	oldBCHC := flags.F.EnableBackendConfigHealthCheck
 	oldTHC := flags.F.EnableTransparentHealthChecks
-	flags.F.EnableBackendConfigHealthCheck = true
 	defer func() {
-		flags.F.EnableBackendConfigHealthCheck = oldBCHC
 		flags.F.EnableTransparentHealthChecks = oldTHC
 	}()
 

--- a/pkg/healthchecks/healthchecks.go
+++ b/pkg/healthchecks/healthchecks.go
@@ -145,7 +145,7 @@ func (h *HealthChecks) SyncServicePort(sp *utils.ServicePort, probe *v1.Probe) (
 		translator.ApplyProbeSettingsToHC(probe, hc)
 	}
 	var bchcc *backendconfigv1.HealthCheckConfig
-	if flags.F.EnableBackendConfigHealthCheck && sp.BackendConfig != nil && sp.BackendConfig.Spec.HealthCheck != nil {
+	if sp.BackendConfig != nil && sp.BackendConfig.Spec.HealthCheck != nil {
 		bchcc = sp.BackendConfig.Spec.HealthCheck
 		klog.V(2).Infof("ServicePort (%v) has BackendConfig health check override (%+s)", sp.ID, formatBackendConfigHC(bchcc))
 	}

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -538,21 +538,17 @@ func getSingletonHealthcheck(t *testing.T, c *gce.Cloud) *compute.HealthCheck {
 // Test changing the value of the flag EnableUpdateCustomHealthCheckDescription from false to true.
 func TestRolloutUpdateCustomHCDescription(t *testing.T) {
 	// No parallel() because we modify the value of the flags:
-	// - EnableBackendConfigHealthCheck,
 	// - EnableUpdateCustomHealthCheckDescription,
 	// - GKEClusterName.
 
 	testClusterValues := gce.DefaultTestClusterValues()
 
-	oldEnableBC := flags.F.EnableBackendConfigHealthCheck
 	oldUpdateDescription := flags.F.EnableUpdateCustomHealthCheckDescription
 	oldGKEClusterName := flags.F.GKEClusterName
-	flags.F.EnableBackendConfigHealthCheck = true
 	// Start with EnableUpdateCustomHealthCheckDescription = false.
 	flags.F.EnableUpdateCustomHealthCheckDescription = false
 	flags.F.GKEClusterName = testClusterValues.ClusterName
 	defer func() {
-		flags.F.EnableBackendConfigHealthCheck = oldEnableBC
 		flags.F.EnableUpdateCustomHealthCheckDescription = oldUpdateDescription
 		flags.F.GKEClusterName = oldGKEClusterName
 	}()
@@ -1124,16 +1120,12 @@ func setupMockUpdate(mock *cloud.MockGCE) {
 
 func TestSyncServicePort(t *testing.T) {
 	// No parallel() because we modify the value of the flags:
-	// - EnableBackendConfigHealthCheck,
 	// - EnableUpdateCustomHealthCheckDescription,
-	// - GKEClusterName.	oldEnableBC := flags.F.EnableBackendConfigHealthCheck
-	oldEnableBC := flags.F.EnableBackendConfigHealthCheck
-	flags.F.EnableBackendConfigHealthCheck = true
+	// - GKEClusterName.
 	oldUpdateDescription := flags.F.EnableUpdateCustomHealthCheckDescription
 	oldGKEClusterName := flags.F.GKEClusterName
 	flags.F.GKEClusterName = gce.DefaultTestClusterValues().ClusterName
 	defer func() {
-		flags.F.EnableBackendConfigHealthCheck = oldEnableBC
 		flags.F.EnableUpdateCustomHealthCheckDescription = oldUpdateDescription
 		flags.F.GKEClusterName = oldGKEClusterName
 	}()


### PR DESCRIPTION
After this PR is merged, the next steps (with some soak time in between as appropriate) are:
 * remove the flag `--enable-backendconfig-healthcheck` from config files (internal),
 * remove the flag `--enable-backendconfig-healthcheck` from `pkg/flags/flags.go`.

~This is a child PR dependent on https://github.com/kubernetes/ingress-gce/pull/2088. Please review only the last commit `Remove the flag EnableBackendConfigHealthCheck`.~