### PR TITLE
bump timeout for building images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1800s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
It seems that 30 mins is just on the edge for building multi-arch images, since this is a postsubmit job we can afford to wait for 60 mins to be on the safe side

https://testgrid.k8s.io/sig-network-ingress-gce-e2e#post-ingress-gce-push-image