### PR TITLE
Build binaries for docker images in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,15 +5,35 @@ options:
   machineType: E2_HIGHCPU_8
 steps:
 - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230206-8160eea68e
-  entrypoint: make
+  id: build-binaries
+  entrypoint: bash
   env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - REGISTRY="gcr.io/k8s-ingress-image-push"
-    - VERSION=$_PULL_BASE_REF
-    - VERBOSE=1
-    - HOME=/root
-    - USER=root
-  args: ['all-push','ALL_ARCH=amd64 arm64']
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - VERSION=$_PULL_BASE_REF
+  - ALL_ARCH="amd64 arm64"
+  - VERBOSE=1
+  - HOME=/root
+  - USER=root
+  args: 
+  - -c
+  - |
+    VERBOSE="${VERBOSE}" make all-build
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230206-8160eea68e
+  id: push-images
+  waitFor: ["build-binaries"]
+  entrypoint: bash
+  env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - REGISTRY="gcr.io/k8s-ingress-image-push"
+  - VERSION=$_PULL_BASE_REF
+  - ALL_ARCH="amd64 arm64"
+  - VERBOSE=1
+  - HOME=/root
+  - USER=root
+  args:
+  - -c
+  - |
+    make all-push ALL_ARCH="${ALL_ARCH}"
 substitutions:
   _GIT_TAG: "12345"
   _PULL_BASE_REF: "main"


### PR DESCRIPTION
If I run an image: gcr.io/k8s-ingress-image-push/ingress-gce-e2e-test
I see an error: 

```
==============================================================================
E2E TEST

./run.sh: line 113: /e2e-test: No such file or directory
```

It means it doesn't have binaries that were supposed to be copied. 
This change adds a line that builds those binaries (make all-build). 
