### PR TITLE
Emit Events on THC (mis)configuration

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -334,8 +334,8 @@ func (svc *Service) NEGAnnotation() (*NegAnnotation, bool, error) {
 	return &res, true, nil
 }
 
-// ShouldEnableTHC returns true if a THC annotation is found and its value is true.
-func (svc *Service) ShouldEnableTHC() (bool, error) {
+// IsThcAnnotated returns true if a THC annotation is found and its value is true.
+func (svc *Service) IsThcAnnotated() (bool, error) {
 	var res THCAnnotation
 	annotation, ok := svc.v[THCAnnotationKey]
 	if !ok {

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -191,7 +191,7 @@ func NewFirewallController(
 func (fwc *FirewallController) ToSvcPorts(ings []*v1.Ingress) []utils.ServicePort {
 	var knownPorts []utils.ServicePort
 	for _, ing := range ings {
-		urlMap, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer)
+		urlMap, _, _ := fwc.translator.TranslateIngress(ing, fwc.ctx.DefaultBackendSvcPort.ID, fwc.ctx.ClusterNamer)
 		knownPorts = append(knownPorts, urlMap.AllServicePorts()...)
 	}
 	return knownPorts

--- a/pkg/translator/healthchecks.go
+++ b/pkg/translator/healthchecks.go
@@ -235,7 +235,7 @@ func OverwriteWithTHC(hc *HealthCheck) {
 	hc.UnhealthyThreshold = defaultUnhealthyThreshold
 	hc.HealthyThreshold = thcHealthyThreshold
 	hc.Type = thcType
-	hc.Description = DescriptionForTransparentHealthChecks //TODO(DamianSawicki): JSONify.
+	hc.Description = DescriptionForTransparentHealthChecks
 	hc.PortSpecification = thcPortSpecification
 	hc.Port = THCPort
 	hc.RequestPath = thcRequestPath

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -37,6 +37,19 @@ func (id ServicePortID) String() string {
 	return fmt.Sprintf("%v/%v", id.Service.String(), id.Port.String())
 }
 
+// THCEvents stores information relevant for emitting Events when THC is configured or misconfigured.
+type THCEvents struct {
+	THCConfigured             bool
+	BackendConfigOverridesTHC bool
+	THCAnnotationWithoutFlag  bool
+	THCAnnotationWithoutNEG   bool
+}
+
+type THCConfiguration struct {
+	THCOptInOnSvc bool
+	THCEvents     THCEvents
+}
+
 // ServicePort maintains configuration for a single backend.
 type ServicePort struct {
 	// Ingress backend-specified service name and port
@@ -46,16 +59,16 @@ type ServicePort struct {
 	// Numerical port of the Service, retrieved from the Service
 	Port int32
 	// Name of the port of the Service, retrieved from the Service
-	PortName       string
-	Protocol       annotations.AppProtocol
-	TargetPort     intstr.IntOrString
-	NEGEnabled     bool
-	VMIPNEGEnabled bool
-	L4RBSEnabled   bool
-	L7ILBEnabled   bool
-	THCEnabled     bool
-	BackendConfig  *backendconfigv1.BackendConfig
-	BackendNamer   namer.BackendNamer
+	PortName         string
+	Protocol         annotations.AppProtocol
+	TargetPort       intstr.IntOrString
+	NEGEnabled       bool
+	VMIPNEGEnabled   bool
+	L4RBSEnabled     bool
+	L7ILBEnabled     bool
+	THCConfiguration THCConfiguration
+	BackendConfig    *backendconfigv1.BackendConfig
+	BackendNamer     namer.BackendNamer
 	// Traffic policy fields that apply if non-nil.
 	MaxRatePerEndpoint *float64
 	CapacityScaler     *float64


### PR DESCRIPTION
The purpose of the PR is to emit Events on Service/Ingress objects when the UHC health check for the Service has been successfully configured with the Transparent Health Checks (THC) feature or such a configuration has been attempted.