### PR TITLE
Change e2e-test dockerfile run cmds

### DIFF
--- a/Dockerfile.e2e-test
+++ b/Dockerfile.e2e-test
@@ -16,22 +16,28 @@
 # and replace with a new one if needed
 FROM debian:11
 
+#ARG_ARCH & ARG_BIN are replaces with sed in build/rules.mk
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
-ARG CLOUD_SDK_VERSION="416.0.0-0"
+
+ARG CLOUD_SDK_VERSION="416.0.0"
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
+ENV PATH /google-cloud-sdk/bin:$PATH
 
 COPY cmd/e2e-test/run.sh /run.sh
+
+# Get architecture for gcloud cli installation
+RUN if [ "ARG_ARCH" = "amd64" ]; \
+  then echo -n "x86_64" > /tmp/arch; \
+  else echo -n "arm" > /tmp/arch; fi;
 
 # Download Google Cloud GPG and install google-cloud-cli
 # See recommended instructions:
 # cloud.google.com/sdk/docs/install#installation_instructions
-RUN apt-get update && \
+RUN ARCH=`cat /tmp/arch` && \
+  apt-get update && \
   apt-get install -y curl python apt-transport-https ca-certificates gnupg && \
-  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
-  http://packages.cloud.google.com/apt cloud-sdk main" | \
-  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-  apt-get update -y && apt-get install google-cloud-cli=$CLOUD_SDK_VERSION -y
+  curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+  tar xvf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+  rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz 
 
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
Install gcloud cli in e2e-test image
based on architecture to support multiarch.

Signed-off-by: Elina Akhmanova <elinka@google.com>