### PR TITLE
Use only one buildx command for e2e-test

### DIFF
--- a/Dockerfile.e2e-test
+++ b/Dockerfile.e2e-test
@@ -18,8 +18,8 @@
 # and has curl, gcloud, and ca-certificated preinstalled
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:debian_component_based
 
-#ARG_ARCH & ARG_BIN are replaces with sed in build/rules.mk
-ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+ARG TARGETARCH
+ADD bin/${TARGETARCH}/e2e-test /e2e-test
 COPY cmd/e2e-test/run.sh /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,7 +38,8 @@ steps:
     # This image is built separately because it has
     # additional dependencies (curl, gcloud-cli), and
     # requires `docker buildx` for multiarch building process
-    ./hack/push-multiarch.sh
+    gcloud auth configure-docker  \
+    && ./hack/push-multiarch.sh
 substitutions:
   _GIT_TAG: "12345"
   _PULL_BASE_REF: "main"


### PR DESCRIPTION
1) Docker buildx cmd can build a multiarch image
in one run. Use it instead of many commands
2) The hack/push-multiarch.sh script is used for e2e build
via docker buildx (/root/.docker/cli-plugins/docker-buildx).
It requires to specify HOME=/root so buildx works as expected.
See:
[github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
](https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#simple-build-example)