### PR TITLE
Reset gauges when collecting service metrics

### DIFF
--- a/pkg/servicemetrics/servicemetrics.go
+++ b/pkg/servicemetrics/servicemetrics.go
@@ -195,6 +195,10 @@ func calculateMetrics(services []*v1.Service) (map[serviceL4ProtocolMetricState]
 }
 
 func updatePrometheusMetrics(l4ProtocolState map[serviceL4ProtocolMetricState]int64, ipStackState map[serviceIPStackMetricState]int64, gcpFeaturesState map[serviceGCPFeaturesMetricState]int64) {
+	serviceL4ProtocolStatsCount.Reset()
+	serviceIPStackStatsCount.Reset()
+	serviceGCPFeaturesStatsCount.Reset()
+
 	for serviceStat, count := range l4ProtocolState {
 		serviceL4ProtocolStatsCount.With(prometheus.Labels{
 			labelType:                  serviceStat.Type,


### PR DESCRIPTION
otherwise deleted services will appear in metrics forever it their label combination was unique