### PR TITLE
Pin golang patch version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ARCH ?= amd64
 ALL_ARCH := amd64
 
 # Image to use for building.
-BUILD_IMAGE ?= golang:1.20
+BUILD_IMAGE ?= golang:1.20.4
 # Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION).
 CONTAINER_PREFIX ?= ingress-gce
 


### PR DESCRIPTION
Patches of golang could differ and
make the debugging process harder.
To demolish that problem we should
pin not only major.minor versions
but also patch one.

@cezarygerard I decided to proceed with patch, not sha because it's more readable and can be used in any basic image.  
![image](https://github.com/kubernetes/ingress-gce/assets/113995564/fafb9258-9bba-4859-9971-885deaf8b9a9)
see: https://hub.docker.com/_/golang