### PR TITLE
Delete RBS annotation explicitly in preventTargetPoolRaceWithRBSOnCreation

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -316,7 +316,7 @@ func (lc *L4NetLBController) preventTargetPoolRaceWithRBSOnCreation(service *v1.
 			"Failed to clean RBS resources for load balancer with target pool, err: %v", result.Error)
 		return result.Error
 	}
-	return nil
+	return lc.deleteRBSAnnotation(service)
 }
 
 func (lc *L4NetLBController) preventExistingTargetPoolToRBSMigration(service *v1.Service) error {


### PR DESCRIPTION
As we removed deleting RBS annotation in garbageCollectRBSNetLB we now need to remove annotation explicitly, otherwise service will not be handled by legacy controller

/assign @cezarygerard 