### PR TITLE
[Cherry-pick #2126] Change logic of deleting RBS service

### DIFF
--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -63,10 +63,10 @@ func mergeAnnotations(existing, lbAnnotations map[string]string, keysToRemove []
 	return existing
 }
 
-// updateL4ResourcesAnnotations this function checks if new annotations should be added to service and patch service metadata if needed.
+// updateL4ResourcesAnnotations checks if new annotations should be added to service and patch service metadata if needed.
 func updateL4ResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string) error {
 	klog.V(3).Infof("Updating annotations of service %s/%s", svc.Namespace, svc.Name)
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4LBResourceAnnotationKeys)
+	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4ResourceAnnotationKeys)
 	if newObjectMeta == nil {
 		klog.V(3).Infof("Service annotations not changed, skipping patch for service %s/%s", svc.Namespace, svc.Name)
 		return nil
@@ -75,33 +75,13 @@ func updateL4ResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Servic
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
-// updateL4DualStackResourcesAnnotations this function checks if new annotations should be added to dual-stack service and patch service metadata if needed.
+// updateL4DualStackResourcesAnnotations checks if new annotations should be added to dual-stack service and patch service metadata if needed.
 func updateL4DualStackResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string) error {
 	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4DualStackResourceAnnotationKeys)
 	if newObjectMeta == nil {
 		return nil
 	}
 	klog.V(3).Infof("Patching annotations of service %v/%v", svc.Namespace, svc.Name)
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
-// deleteL4RBSAnnotations deletes all annotations which could be added by L4 ELB RBS controller
-func deleteL4RBSAnnotations(ctx *context.ControllerContext, svc *v1.Service) error {
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, nil, loadbalancers.L4RBSAnnotations)
-	if newObjectMeta == nil {
-		return nil
-	}
-	klog.V(3).Infof("Deleting all annotations for L4 ELB RBS service %v/%v", svc.Namespace, svc.Name)
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
-// deleteL4RBSDualStackAnnotations deletes all annotations which could be added by L4 ELB RBS controller
-func deleteL4RBSDualStackAnnotations(ctx *context.ControllerContext, svc *v1.Service) error {
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, nil, loadbalancers.L4DualStackResourceRBSAnnotationKeys)
-	if newObjectMeta == nil {
-		return nil
-	}
-	klog.V(3).Infof("Deleting all DualStack annotations for L4 ELB RBS service %v/%v", svc.Namespace, svc.Name)
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 

--- a/pkg/loadbalancers/l4syncresult.go
+++ b/pkg/loadbalancers/l4syncresult.go
@@ -25,7 +25,7 @@ const (
 	SyncTypeDelete = "delete"
 )
 
-var L4LBResourceAnnotationKeys = []string{
+var L4ResourceAnnotationKeys = []string{
 	annotations.BackendServiceKey,
 	annotations.TCPForwardingRuleKey,
 	annotations.UDPForwardingRuleKey,
@@ -34,13 +34,10 @@ var L4LBResourceAnnotationKeys = []string{
 	annotations.FirewallRuleForHealthcheckKey,
 }
 
-var L4RBSAnnotations = append(L4LBResourceAnnotationKeys, annotations.RBSAnnotationKey)
-
-var l4IPv6AnnotationKeys = []string{
+var l4IPv6ResourceAnnotationKeys = []string{
 	annotations.FirewallRuleIPv6Key,
 	annotations.FirewallRuleForHealthcheckIPv6Key,
 	annotations.TCPForwardingRuleIPv6Key,
 	annotations.UDPForwardingRuleIPv6Key,
 }
-var L4DualStackResourceAnnotationKeys = append(L4LBResourceAnnotationKeys, l4IPv6AnnotationKeys...)
-var L4DualStackResourceRBSAnnotationKeys = append(L4DualStackResourceAnnotationKeys, annotations.RBSAnnotationKey)
+var L4DualStackResourceAnnotationKeys = append(L4ResourceAnnotationKeys, l4IPv6ResourceAnnotationKeys...)


### PR DESCRIPTION
- Delete only if service has finalizer or rbs forwarding rule, meaning it was provisioned by RBS controller at some point
- Don't delete RBS annotation on garbage collection

Merged in master https://github.com/kubernetes/ingress-gce/pull/2126