### PR TITLE
Reserve Static IPv6 address before syncing L4 ILB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module k8s.io/ingress-gce
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.23.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.24.0
 	github.com/google/go-cmp v0.5.9
-	github.com/kr/pretty v0.2.0
+	github.com/kr/pretty v0.3.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/spf13/cobra v1.6.0
@@ -64,6 +64,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.23.0 h1:t7VxYo6K75axT6J43S/QAOhnFChl5ul5umel4FWFW+M=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.23.0/go.mod h1:cBEoHknnCbHPtbZIkqPCCTlKeo/7ehAJcwOMQOlV1kk=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.24.0 h1:a/2jEb6YZq88x+36TcyUu9widTOcGlndZc4L54r+Jys=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.24.0/go.mod h1:SZTgFVlGGwQ/X9NQsExTrYerE+frOeQvIuHCTuAGODI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -210,8 +210,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -272,6 +273,9 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pkg/loadbalancers/address_manager_test.go
+++ b/pkg/loadbalancers/address_manager_test.go
@@ -238,17 +238,6 @@ func TestAddressManagerIPv6(t *testing.T) {
 	}
 }
 
-// TestAddressManagerEmptyIPv6 tests the typical case of reserving and releasing an IPv6 address.
-func TestAddressManagerEmptyIPv6(t *testing.T) {
-	svc, err := fakeGCECloud(vals)
-	require.NoError(t, err)
-	targetIP := ""
-
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv6Version)
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
-	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
-}
-
 func testHoldAddress(t *testing.T, mgr *addressManager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)

--- a/pkg/loadbalancers/address_manager_test.go
+++ b/pkg/loadbalancers/address_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"net"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
@@ -42,7 +43,7 @@ func TestAddressManagerNoRequestedIP(t *testing.T) {
 	require.NoError(t, err)
 	targetIP := ""
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -53,7 +54,7 @@ func TestAddressManagerBasic(t *testing.T) {
 	require.NoError(t, err)
 	targetIP := "1.1.1.1"
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -69,7 +70,7 @@ func TestAddressManagerOrphaned(t *testing.T) {
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 	require.NoError(t, err)
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -81,7 +82,7 @@ func TestAddressManagerStandardNetworkTier(t *testing.T) {
 	require.NoError(t, err)
 	targetIP := "1.1.1.1"
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierStandard)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierStandard, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierStandard.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -92,7 +93,7 @@ func TestAddressManagerStandardNetworkTierNotAvailableForInternalAddress(t *test
 	require.NoError(t, err)
 	targetIP := "1.1.1.1"
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierStandard)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierStandard, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierPremium.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -109,7 +110,7 @@ func TestAddressManagerOutdatedOrphan(t *testing.T) {
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 	require.NoError(t, err)
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv4Version)
 	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
@@ -125,7 +126,7 @@ func TestAddressManagerExternallyOwned(t *testing.T) {
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 	require.NoError(t, err)
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium, IPv4Version)
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)
 	assert.NotEmpty(t, ipToUse)
@@ -145,7 +146,7 @@ func TestAddressManagerNonExisting(t *testing.T) {
 	require.NoError(t, err)
 	targetIP := "1.1.1.1"
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium, IPv4Version)
 
 	svc.Compute().(*cloud.MockGCE).MockAddresses.InsertHook = test.InsertAddressNotAllocatedToProjectErrorHook
 	_, _, err = mgr.HoldAddress()
@@ -162,7 +163,7 @@ func TestAddressManagerWrongTypeReserved(t *testing.T) {
 	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(cloud.SchemeInternal)}
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium, IPv4Version)
 
 	_, _, err = mgr.HoldAddress()
 	require.Error(t, err)
@@ -179,7 +180,7 @@ func TestAddressManagerExternallyOwnedWrongNetworkTier(t *testing.T) {
 	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(cloud.SchemeInternal), NetworkTier: string(cloud.NetworkTierStandard)}
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 	require.NoError(t, err, "")
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium, IPv4Version)
 	svc.Compute().(*cloud.MockGCE).MockAddresses.InsertHook = test.InsertAddressNetworkErrorHook
 	_, _, err = mgr.HoldAddress()
 	if err == nil || !utils.IsNetworkTierError(err) {
@@ -198,10 +199,54 @@ func TestAddressManagerBadExternallyOwned(t *testing.T) {
 	err = svc.ReserveRegionAddress(addr, vals.Region)
 	require.NoError(t, err)
 
-	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium)
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium, IPv4Version)
 	ad, _, err := mgr.HoldAddress()
 	assert.NotNil(t, err) // FIXME
 	require.Equal(t, ad, "")
+}
+
+// TestAddressManagerIPv6 tests the typical case of reserving and releasing an IPv6 address.
+func TestAddressManagerIPv6(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		targetIP string
+	}{
+		{
+			desc:     "Defined IPv6 address",
+			targetIP: "1111:2222:3333:4444:5555:0:0:0",
+		},
+		{
+			desc:     "Empty IPv6 address",
+			targetIP: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc, err := fakeGCECloud(vals)
+			if err != nil {
+				t.Fatalf("fakeGCECloud(%v) returned error %v", vals, err)
+			}
+
+			mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, tc.targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv6Version)
+			testHoldAddress(t, mgr, svc, testLBName, vals.Region, tc.targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+			testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
+		})
+	}
+}
+
+// TestAddressManagerEmptyIPv6 tests the typical case of reserving and releasing an IPv6 address.
+func TestAddressManagerEmptyIPv6(t *testing.T) {
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	targetIP := ""
+
+	mgr := newAddressManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, IPv6Version)
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
 func testHoldAddress(t *testing.T, mgr *addressManager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
@@ -213,7 +258,8 @@ func testHoldAddress(t *testing.T, mgr *addressManager, svc gce.CloudAddressServ
 	addr, err := svc.GetRegionAddress(name, region)
 	require.NoError(t, err)
 	if targetIP != "" {
-		assert.EqualValues(t, targetIP, addr.Address)
+		expectedTargetIP := net.ParseIP(targetIP).String()
+		assert.EqualValues(t, expectedTargetIP, addr.Address)
 	}
 	assert.EqualValues(t, scheme, addr.AddressType)
 	assert.EqualValues(t, addr.NetworkTier, netTier)

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -314,10 +314,10 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 	// If the network is not a legacy network, use the address manager
 	if !l4netlb.cloud.IsLegacyNetwork() {
 		nm := types.NamespacedName{Namespace: l4netlb.Service.Namespace, Name: l4netlb.Service.Name}.String()
-		addrMgr := newAddressManager(l4netlb.cloud, nm, l4netlb.cloud.Region() /*subnetURL = */, "", frName, ipToUse, cloud.SchemeExternal, netTier)
+		addrMgr := newAddressManager(l4netlb.cloud, nm, l4netlb.cloud.Region() /*subnetURL = */, "", frName, ipToUse, cloud.SchemeExternal, netTier, IPv4Version)
 
 		// If network tier annotation in Service Spec is present
-		// check if it match network tiers from forwarding rule and external ip Address.
+		// check if it matches network tiers from forwarding rule and external ip Address.
 		// If they do not match, tear down the existing resources with the wrong tier.
 		if isFromAnnotation {
 			if err := l4netlb.tearDownResourcesWithWrongNetworkTier(existingFwdRule, netTier, addrMgr); err != nil {

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -38,12 +38,12 @@ const (
 	IPVersionIPv6 = "IPV6"
 )
 
-func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions, existingIPv6FwdRule *composite.ForwardingRule, ipv6ToUse string) (*composite.ForwardingRule, error) {
+func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions, existingIPv6FwdRule *composite.ForwardingRule, ipv6AddressToUse string) (*composite.ForwardingRule, error) {
 	start := time.Now()
 
-	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options, ipv6ToUse)
+	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options, ipv6AddressToUse)
 	if err != nil {
-		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v, %s) returned error %w, want nil", bsLink, options, ipv6ToUse, err)
+		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v, %s) returned error %w, want nil", bsLink, options, ipv6AddressToUse, err)
 	}
 
 	klog.V(2).Infof("Ensuring internal ipv6 forwarding rule %s for L4 ILB Service %s/%s, backend service link: %s", expectedIPv6FwdRule.Name, l4.Service.Namespace, l4.Service.Name, bsLink)
@@ -76,7 +76,7 @@ func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions, ex
 	return createdFr, err
 }
 
-func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOptions, ipv6ToUse string) (*composite.ForwardingRule, error) {
+func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOptions, ipv6AddressToUse string) (*composite.ForwardingRule, error) {
 	frName := l4.getIPv6FRName()
 
 	frDesc, err := utils.MakeL4IPv6ForwardingRuleDescription(l4.Service)
@@ -100,7 +100,7 @@ func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOpti
 	fr := &composite.ForwardingRule{
 		Name:                frName,
 		Description:         frDesc,
-		IPAddress:           ipv6ToUse,
+		IPAddress:           ipv6AddressToUse,
 		IPProtocol:          string(protocol),
 		Ports:               ports,
 		LoadBalancingScheme: string(cloud.SchemeInternal),
@@ -246,7 +246,7 @@ func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) 
 		fr1.NetworkTier == fr2.NetworkTier, nil
 }
 
-func ipv6IPToUse(ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) string {
+func ipv6AddressToUse(ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) string {
 	if ipv6FwdRule == nil {
 		return ""
 	}

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -18,6 +18,7 @@ package loadbalancers
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -37,23 +38,18 @@ const (
 	IPVersionIPv6 = "IPV6"
 )
 
-func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions, existingIPv6FwdRule *composite.ForwardingRule, ipv6ToUse string) (*composite.ForwardingRule, error) {
 	start := time.Now()
 
-	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options)
+	expectedIPv6FwdRule, err := l4.buildExpectedIPv6ForwardingRule(bsLink, options, ipv6ToUse)
 	if err != nil {
-		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v) returned error %w, want nil", bsLink, options, err)
+		return nil, fmt.Errorf("l4.buildExpectedIPv6ForwardingRule(%s, %v, %s) returned error %w, want nil", bsLink, options, ipv6ToUse, err)
 	}
 
 	klog.V(2).Infof("Ensuring internal ipv6 forwarding rule %s for L4 ILB Service %s/%s, backend service link: %s", expectedIPv6FwdRule.Name, l4.Service.Namespace, l4.Service.Name, bsLink)
 	defer func() {
 		klog.V(2).Infof("Finished ensuring internal ipv6 forwarding rule %s for L4 ILB Service %s/%s, time taken: %v", expectedIPv6FwdRule.Name, l4.Service.Namespace, l4.Service.Name, time.Since(start))
 	}()
-
-	existingIPv6FwdRule, err := l4.forwardingRules.Get(expectedIPv6FwdRule.Name)
-	if err != nil {
-		return nil, fmt.Errorf("l4.forwardingRules.GetForwardingRule(%s) returned error %w, want nil", expectedIPv6FwdRule.Name, err)
-	}
 
 	if existingIPv6FwdRule != nil {
 		equal, err := EqualIPv6ForwardingRules(existingIPv6FwdRule, expectedIPv6FwdRule)
@@ -80,7 +76,7 @@ func (l4 *L4) ensureIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*
 	return createdFr, err
 }
 
-func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOptions) (*composite.ForwardingRule, error) {
+func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOptions, ipv6ToUse string) (*composite.ForwardingRule, error) {
 	frName := l4.getIPv6FRName()
 
 	frDesc, err := utils.MakeL4IPv6ForwardingRuleDescription(l4.Service)
@@ -104,6 +100,7 @@ func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOpti
 	fr := &composite.ForwardingRule{
 		Name:                frName,
 		Description:         frDesc,
+		IPAddress:           ipv6ToUse,
 		IPProtocol:          string(protocol),
 		Ports:               ports,
 		LoadBalancingScheme: string(cloud.SchemeInternal),
@@ -247,4 +244,18 @@ func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) 
 		fr1.AllPorts == fr2.AllPorts &&
 		fr1.Subnetwork == fr2.Subnetwork &&
 		fr1.NetworkTier == fr2.NetworkTier, nil
+}
+
+func ipv6IPToUse(ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) string {
+	if ipv6FwdRule == nil {
+		return ""
+	}
+	if requestedSubnet != ipv6FwdRule.Subnetwork {
+		// reset ip address since subnet is being changed.
+		return ""
+	}
+
+	// Google Cloud creates ipv6 forwarding rules with IPAddress in CIDR form,
+	// but to create static address you need to specify address without range
+	return strings.Split(ipv6FwdRule.IPAddress, "/")[0]
 }

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
@@ -1399,12 +1400,9 @@ func TestDualStackInternalLoadBalancerModifyProtocol(t *testing.T) {
 				if err != nil {
 					return false, err
 				}
-				// we don't reserve addresses for IPv6 forwarding rules
-				if fr.IpVersion == IPVersionIPv6 {
-					return false, nil
-				}
 
-				addr, err := l4.cloud.GetRegionAddressByIP(fr.Region, fr.IPAddress)
+				ipv6Address := net.ParseIP(fr.IPAddress).String()
+				addr, err := l4.cloud.GetRegionAddressByIP(fr.Region, ipv6Address)
 				if utils.IgnoreHTTPNotFound(err) != nil {
 					return true, err
 				}

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -32,8 +33,8 @@ import (
 // - IPv6 Forwarding Rule
 // - IPv6 Firewall
 // it also adds IPv6 address to LB status
-func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string) {
-	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options)
+func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string, existingIPv6FwdRule *composite.ForwardingRule, ipv6ToUse string) {
+	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options, existingIPv6FwdRule, ipv6ToUse)
 	if err != nil {
 		klog.Errorf("ensureIPv6Resources: Failed to ensure ipv6 forwarding rule - %v", err)
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
@@ -180,4 +181,16 @@ func (l4 *L4) deleteIPv6NodesFirewall() error {
 	}()
 
 	return l4.deleteFirewall(ipv6FirewallName)
+}
+
+func (l4 *L4) getOldIPv6ForwardingRule(existingBS *composite.BackendService) (*composite.ForwardingRule, error) {
+	servicePorts := l4.Service.Spec.Ports
+	protocol := utils.GetProtocol(servicePorts)
+
+	oldIPv6FRName := l4.getIPv6FRName()
+	if existingBS != nil && existingBS.Protocol != string(protocol) {
+		oldIPv6FRName = l4.getIPv6FRNameWithProtocol(existingBS.Protocol)
+	}
+
+	return l4.forwardingRules.Get(oldIPv6FRName)
 }

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -33,8 +33,8 @@ import (
 // - IPv6 Forwarding Rule
 // - IPv6 Firewall
 // it also adds IPv6 address to LB status
-func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string, existingIPv6FwdRule *composite.ForwardingRule, ipv6ToUse string) {
-	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options, existingIPv6FwdRule, ipv6ToUse)
+func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string, existingIPv6FwdRule *composite.ForwardingRule, ipv6AddressToUse string) {
+	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options, existingIPv6FwdRule, ipv6AddressToUse)
 	if err != nil {
 		klog.Errorf("ensureIPv6Resources: Failed to ensure ipv6 forwarding rule - %v", err)
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
@@ -183,6 +183,9 @@ func (l4 *L4) deleteIPv6NodesFirewall() error {
 	return l4.deleteFirewall(ipv6FirewallName)
 }
 
+// getOldIPv6ForwardingRule returns old IPv6 forwarding rule, with checking backend service protocol, if it exists.
+// This is useful when switching protocols of the service,
+// because forwarding rule name depends on the protocol, and we need to get forwarding rule from the old protocol name.
 func (l4 *L4) getOldIPv6ForwardingRule(existingBS *composite.BackendService) (*composite.ForwardingRule, error) {
 	servicePorts := l4.Service.Spec.Ports
 	protocol := utils.GetProtocol(servicePorts)

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock/mock.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock/mock.go
@@ -18,7 +18,8 @@ limitations under the License.
 // These methods are used to override the mock objects' methods in order to
 // intercept the standard processing and to add custom logic for test purposes.
 //
-//  // Example usage:
+//	// Example usage:
+//
 // cloud := cloud.NewMockGCE()
 // cloud.MockTargetPools.AddInstanceHook = mock.AddInstanceHook
 package mock
@@ -245,7 +246,12 @@ func convertAndInsertAlphaAddress(key *meta.Key, obj gceObject, mAddrs map[meta.
 	}
 
 	if addr.Address == "" {
-		addr.Address = fmt.Sprintf("1.2.3.%d", addressAttrs.IPCounter)
+		if addr.IpVersion == "IPV6" {
+			addr.Address = fmt.Sprintf("1111:2222:3333:4444:5555:%d:0:0", addressAttrs.IPCounter)
+			addr.PrefixLength = 96
+		} else {
+			addr.Address = fmt.Sprintf("1.2.3.%d", addressAttrs.IPCounter)
+		}
 		addressAttrs.IPCounter++
 	}
 
@@ -1037,7 +1043,6 @@ func SetSslPolicyBetaTargetHTTPSProxyHook(ctx context.Context, key *meta.Key, re
 	tp.SslPolicy = ref.SslPolicy
 	return nil
 }
-
 
 // InsertFirewallsUnauthorizedErrHook mocks firewall insertion. A forbidden error will be thrown as return.
 func InsertFirewallsUnauthorizedErrHook(ctx context.Context, key *meta.Key, obj *ga.Firewall, m *cloud.MockFirewalls) (bool, error) {

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/observe.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/observe.go
@@ -32,7 +32,9 @@ type CallObserver interface {
 	End(ctx context.Context, key *RateLimitKey, err error)
 }
 
-var callObserverContextKey = &struct{}{}
+type contextKey string
+
+var callObserverContextKey = contextKey("call observer")
 
 // WithCallObserver adds a CallObserver that will be called on the
 // operation being called.
@@ -54,7 +56,7 @@ func callObserverStart(ctx context.Context, key *CallContextKey) {
 	}
 	co, ok := obj.(CallObserver)
 	if !ok {
-		panic(fmt.Sprintf("expected CallObserver, got %T", co))
+		panic(fmt.Sprintf("expected CallObserver, got %T", obj))
 	}
 	co.Start(ctx, key)
 }
@@ -66,7 +68,7 @@ func callObserverEnd(ctx context.Context, key *CallContextKey, err error) {
 	}
 	co, ok := obj.(CallObserver)
 	if !ok {
-		panic(fmt.Sprintf("expected CallObserver, got %T", co))
+		panic(fmt.Sprintf("expected CallObserver, got %T", obj))
 	}
 	co.End(ctx, key, err)
 }

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/utils.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/utils.go
@@ -49,17 +49,45 @@ type ResourceID struct {
 func (r *ResourceID) Equal(other *ResourceID) bool {
 	switch {
 	case r == nil && other == nil:
-	  return true
+		return true
 	case r == nil || other == nil:
-	  return false
+		return false
 	case r.ProjectID != other.ProjectID || r.Resource != other.Resource:
-	  return false
+		return false
 	case r.Key != nil && other.Key != nil:
-	  return *r.Key == *other.Key
+		return *r.Key == *other.Key
 	case r.Key == nil && other.Key == nil:
-	  return true
+		return true
 	default:
-	  return false
+		return false
+	}
+}
+
+// ResourceMapKey is a flat ResourceID that can be used as a key in maps.
+type ResourceMapKey struct {
+	ProjectID string
+	Resource  string
+	Name      string
+	Zone      string
+	Region    string
+}
+
+func (rk ResourceMapKey) ToID() *ResourceID {
+	return &ResourceID{
+		ProjectID: rk.ProjectID,
+		Resource:  rk.Resource,
+		Key:       &meta.Key{Name: rk.Name, Zone: rk.Zone, Region: rk.Region},
+	}
+}
+
+// MapKey returns a flat key that can be used for referencing in maps.
+func (r *ResourceID) MapKey() ResourceMapKey {
+	return ResourceMapKey{
+		ProjectID: r.ProjectID,
+		Resource:  r.Resource,
+		Name:      r.Key.Name,
+		Zone:      r.Key.Zone,
+		Region:    r.Key.Region,
 	}
 }
 
@@ -78,18 +106,28 @@ func (r *ResourceID) SelfLink(ver meta.Version) string {
 	return SelfLink(ver, r.ProjectID, r.Resource, r.Key)
 }
 
+func (r *ResourceID) String() string {
+	switch r.Key.Type() {
+	case meta.Zonal:
+		return fmt.Sprintf("%s:%s/%s/%s", r.Resource, r.ProjectID, r.Key.Zone, r.Key.Name)
+	case meta.Regional:
+		return fmt.Sprintf("%s:%s/%s/%s", r.Resource, r.ProjectID, r.Key.Region, r.Key.Name)
+	}
+	return fmt.Sprintf("%s:%s/%s", r.Resource, r.ProjectID, r.Key.Name)
+}
+
 // ParseResourceURL parses resource URLs of the following formats:
 //
-//   global/<res>/<name>
-//   regions/<region>/<res>/<name>
-//   zones/<zone>/<res>/<name>
-//   projects/<proj>
-//   projects/<proj>/global/<res>/<name>
-//   projects/<proj>/regions/<region>/<res>/<name>
-//   projects/<proj>/zones/<zone>/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/global/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/regions/<region>/<res>/<name>
-//   [https://www.googleapis.com/compute/<ver>]/projects/<proj>/zones/<zone>/<res>/<name>
+//	global/<res>/<name>
+//	regions/<region>/<res>/<name>
+//	zones/<zone>/<res>/<name>
+//	projects/<proj>
+//	projects/<proj>/global/<res>/<name>
+//	projects/<proj>/regions/<region>/<res>/<name>
+//	projects/<proj>/zones/<zone>/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/global/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/regions/<region>/<res>/<name>
+//	[https://www.googleapis.com/compute/<ver>]/projects/<proj>/zones/<zone>/<res>/<name>
 func ParseResourceURL(url string) (*ResourceID, error) {
 	errNotValid := fmt.Errorf("%q is not a valid resource URL", url)
 

--- a/vendor/github.com/kr/pretty/formatter.go
+++ b/vendor/github.com/kr/pretty/formatter.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/kr/text"
+	"github.com/rogpeppe/go-internal/fmtsort"
 )
 
 type formatter struct {
@@ -37,7 +38,7 @@ func (fo formatter) passThrough(f fmt.State, c rune) {
 	s := "%"
 	for i := 0; i < 128; i++ {
 		if f.Flag(i) {
-			s += string(i)
+			s += string(rune(i))
 		}
 	}
 	if w, ok := f.Width(); ok {
@@ -97,6 +98,14 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		return
 	}
 
+	if v.IsValid() && v.CanInterface() {
+		i := v.Interface()
+		if goStringer, ok := i.(fmt.GoStringer); ok {
+			io.WriteString(p, goStringer.GoString())
+			return
+		}
+	}
+
 	switch v.Kind() {
 	case reflect.Bool:
 		p.printInline(v, v.Bool(), showType)
@@ -123,10 +132,10 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 				writeByte(p, '\n')
 				pp = p.indent()
 			}
-			keys := v.MapKeys()
+			sm := fmtsort.Sort(v)
 			for i := 0; i < v.Len(); i++ {
-				k := keys[i]
-				mv := v.MapIndex(k)
+				k := sm.Key[i]
+				mv := sm.Value[i]
 				pp.printValue(k, false, true)
 				writeByte(pp, ':')
 				if expand {

--- a/vendor/github.com/rogpeppe/go-internal/LICENSE
+++ b/vendor/github.com/rogpeppe/go-internal/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2018 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/rogpeppe/go-internal/fmtsort/mapelem.go
+++ b/vendor/github.com/rogpeppe/go-internal/fmtsort/mapelem.go
@@ -1,0 +1,23 @@
+//go:build go1.12
+// +build go1.12
+
+package fmtsort
+
+import "reflect"
+
+const brokenNaNs = false
+
+func mapElems(mapValue reflect.Value) ([]reflect.Value, []reflect.Value) {
+	// Note: this code is arranged to not panic even in the presence
+	// of a concurrent map update. The runtime is responsible for
+	// yelling loudly if that happens. See issue 33275.
+	n := mapValue.Len()
+	key := make([]reflect.Value, 0, n)
+	value := make([]reflect.Value, 0, n)
+	iter := mapValue.MapRange()
+	for iter.Next() {
+		key = append(key, iter.Key())
+		value = append(value, iter.Value())
+	}
+	return key, value
+}

--- a/vendor/github.com/rogpeppe/go-internal/fmtsort/mapelem_1.11.go
+++ b/vendor/github.com/rogpeppe/go-internal/fmtsort/mapelem_1.11.go
@@ -1,0 +1,24 @@
+//go:build !go1.12
+// +build !go1.12
+
+package fmtsort
+
+import "reflect"
+
+const brokenNaNs = true
+
+func mapElems(mapValue reflect.Value) ([]reflect.Value, []reflect.Value) {
+	key := mapValue.MapKeys()
+	value := make([]reflect.Value, 0, len(key))
+	for _, k := range key {
+		v := mapValue.MapIndex(k)
+		if !v.IsValid() {
+			// Note: we can't retrieve the value, probably because
+			// the key is NaN, so just do the best we can and
+			// add a zero value of the correct type in that case.
+			v = reflect.Zero(mapValue.Type().Elem())
+		}
+		value = append(value, v)
+	}
+	return key, value
+}

--- a/vendor/github.com/rogpeppe/go-internal/fmtsort/sort.go
+++ b/vendor/github.com/rogpeppe/go-internal/fmtsort/sort.go
@@ -1,0 +1,210 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package fmtsort provides a general stable ordering mechanism
+// for maps, on behalf of the fmt and text/template packages.
+// It is not guaranteed to be efficient and works only for types
+// that are valid map keys.
+package fmtsort
+
+import (
+	"reflect"
+	"sort"
+)
+
+// Note: Throughout this package we avoid calling reflect.Value.Interface as
+// it is not always legal to do so and it's easier to avoid the issue than to face it.
+
+// SortedMap represents a map's keys and values. The keys and values are
+// aligned in index order: Value[i] is the value in the map corresponding to Key[i].
+type SortedMap struct {
+	Key   []reflect.Value
+	Value []reflect.Value
+}
+
+func (o *SortedMap) Len() int           { return len(o.Key) }
+func (o *SortedMap) Less(i, j int) bool { return compare(o.Key[i], o.Key[j]) < 0 }
+func (o *SortedMap) Swap(i, j int) {
+	o.Key[i], o.Key[j] = o.Key[j], o.Key[i]
+	o.Value[i], o.Value[j] = o.Value[j], o.Value[i]
+}
+
+// Sort accepts a map and returns a SortedMap that has the same keys and
+// values but in a stable sorted order according to the keys, modulo issues
+// raised by unorderable key values such as NaNs.
+//
+// The ordering rules are more general than with Go's < operator:
+//
+//  - when applicable, nil compares low
+//  - ints, floats, and strings order by <
+//  - NaN compares less than non-NaN floats
+//  - bool compares false before true
+//  - complex compares real, then imag
+//  - pointers compare by machine address
+//  - channel values compare by machine address
+//  - structs compare each field in turn
+//  - arrays compare each element in turn.
+//    Otherwise identical arrays compare by length.
+//  - interface values compare first by reflect.Type describing the concrete type
+//    and then by concrete value as described in the previous rules.
+//
+func Sort(mapValue reflect.Value) *SortedMap {
+	if mapValue.Type().Kind() != reflect.Map {
+		return nil
+	}
+	key, value := mapElems(mapValue)
+	sorted := &SortedMap{
+		Key:   key,
+		Value: value,
+	}
+	sort.Stable(sorted)
+	return sorted
+}
+
+// compare compares two values of the same type. It returns -1, 0, 1
+// according to whether a > b (1), a == b (0), or a < b (-1).
+// If the types differ, it returns -1.
+// See the comment on Sort for the comparison rules.
+func compare(aVal, bVal reflect.Value) int {
+	aType, bType := aVal.Type(), bVal.Type()
+	if aType != bType {
+		return -1 // No good answer possible, but don't return 0: they're not equal.
+	}
+	switch aVal.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a, b := aVal.Int(), bVal.Int()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		a, b := aVal.Uint(), bVal.Uint()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.String:
+		a, b := aVal.String(), bVal.String()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Float32, reflect.Float64:
+		return floatCompare(aVal.Float(), bVal.Float())
+	case reflect.Complex64, reflect.Complex128:
+		a, b := aVal.Complex(), bVal.Complex()
+		if c := floatCompare(real(a), real(b)); c != 0 {
+			return c
+		}
+		return floatCompare(imag(a), imag(b))
+	case reflect.Bool:
+		a, b := aVal.Bool(), bVal.Bool()
+		switch {
+		case a == b:
+			return 0
+		case a:
+			return 1
+		default:
+			return -1
+		}
+	case reflect.Ptr:
+		a, b := aVal.Pointer(), bVal.Pointer()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Chan:
+		if c, ok := nilCompare(aVal, bVal); ok {
+			return c
+		}
+		ap, bp := aVal.Pointer(), bVal.Pointer()
+		switch {
+		case ap < bp:
+			return -1
+		case ap > bp:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Struct:
+		for i := 0; i < aVal.NumField(); i++ {
+			if c := compare(aVal.Field(i), bVal.Field(i)); c != 0 {
+				return c
+			}
+		}
+		return 0
+	case reflect.Array:
+		for i := 0; i < aVal.Len(); i++ {
+			if c := compare(aVal.Index(i), bVal.Index(i)); c != 0 {
+				return c
+			}
+		}
+		return 0
+	case reflect.Interface:
+		if c, ok := nilCompare(aVal, bVal); ok {
+			return c
+		}
+		c := compare(reflect.ValueOf(aVal.Elem().Type()), reflect.ValueOf(bVal.Elem().Type()))
+		if c != 0 {
+			return c
+		}
+		return compare(aVal.Elem(), bVal.Elem())
+	default:
+		// Certain types cannot appear as keys (maps, funcs, slices), but be explicit.
+		panic("bad type in compare: " + aType.String())
+	}
+}
+
+// nilCompare checks whether either value is nil. If not, the boolean is false.
+// If either value is nil, the boolean is true and the integer is the comparison
+// value. The comparison is defined to be 0 if both are nil, otherwise the one
+// nil value compares low. Both arguments must represent a chan, func,
+// interface, map, pointer, or slice.
+func nilCompare(aVal, bVal reflect.Value) (int, bool) {
+	if aVal.IsNil() {
+		if bVal.IsNil() {
+			return 0, true
+		}
+		return -1, true
+	}
+	if bVal.IsNil() {
+		return 1, true
+	}
+	return 0, false
+}
+
+// floatCompare compares two floating-point values. NaNs compare low.
+func floatCompare(a, b float64) int {
+	switch {
+	case isNaN(a):
+		return -1 // No good answer if b is a NaN so don't bother checking.
+	case isNaN(b):
+		return 1
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	}
+	return 0
+}
+
+func isNaN(a float64) bool {
+	return a != a
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ cloud.google.com/go/compute/internal
 # cloud.google.com/go/compute/metadata v0.2.3
 ## explicit; go 1.19
 cloud.google.com/go/compute/metadata
-# github.com/GoogleCloudPlatform/k8s-cloud-provider v1.23.0
+# github.com/GoogleCloudPlatform/k8s-cloud-provider v1.24.0
 ## explicit; go 1.20
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter
@@ -124,7 +124,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/kr/pretty v0.2.0
+# github.com/kr/pretty v0.3.0
 ## explicit; go 1.12
 github.com/kr/pretty
 # github.com/kr/text v0.2.0
@@ -172,6 +172,9 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rogpeppe/go-internal v1.9.0
+## explicit; go 1.17
+github.com/rogpeppe/go-internal/fmtsort
 # github.com/spf13/cobra v1.6.0
 ## explicit; go 1.15
 github.com/spf13/cobra


### PR DESCRIPTION
This will prevent losing address while recreating forwarding rule

Tested running locally with real cluster