### PR TITLE
Update syncer count metrics emit

### DIFF
--- a/pkg/neg/metrics/metricscollector/metrics.go
+++ b/pkg/neg/metrics/metricscollector/metrics.go
@@ -146,6 +146,21 @@ type syncerState struct {
 	inErrorState   bool
 }
 
+// listAllSyncerStates lists all possible states for syncers.
+func listAllSyncerStates() []syncerState {
+	var syncerStates []syncerState
+	// For error state errors, we should expect the syncer also in error state.
+	for _, state := range negtypes.ListErrorStates() {
+		syncerStates = append(syncerStates, syncerState{lastSyncResult: state, inErrorState: true})
+	}
+
+	for _, state := range negtypes.ListNonErrorStates() {
+		syncerStates = append(syncerStates, syncerState{lastSyncResult: state, inErrorState: true})
+		syncerStates = append(syncerStates, syncerState{lastSyncResult: state, inErrorState: false})
+	}
+	return syncerStates
+}
+
 type syncerStateCount map[syncerState]int
 
 // LabelPropagationStat contains stats related to label propagation.

--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -385,7 +385,10 @@ func (sm *SyncerMetrics) computeDualStackMigrationCounts() (map[string]int, int,
 }
 
 func PublishSyncerStateMetrics(stateCount syncerStateCount) {
-	for state, count := range stateCount {
-		SyncerCountBySyncResult.WithLabelValues(string(state.lastSyncResult), strconv.FormatBool(state.inErrorState)).Set(float64(count))
+	// Iterate to initialize all possible syncer state values.
+	for _, syncerState := range listAllSyncerStates() {
+		SyncerCountBySyncResult.WithLabelValues(
+			string(syncerState.lastSyncResult), strconv.FormatBool(syncerState.inErrorState)).
+			Set(float64(stateCount[syncerState]))
 	}
 }

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -519,7 +519,6 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, zone stri
 		s.recordEvent(apiv1.EventTypeWarning, operation.String()+"Failed", fmt.Sprintf("Failed to %s %d network endpoint(s) (NEG %q in zone %q): %v", operation.String(), len(networkEndpointMap), s.NegSyncerKey.NegName, zone, err))
 		err := checkEndpointBatchErr(err, operation)
 		syncErr := negtypes.ClassifyError(err)
-		s.syncMetricsCollector.UpdateSyncerStatusInMetrics(s.NegSyncerKey, syncErr, s.inErrorState())
 		// If the API call fails for invalid endpoint update request in any goroutine,
 		// we would set error state and retry. For successful calls, we won't update
 		// error state, so its value won't be overwritten within API call go routines.
@@ -529,6 +528,7 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, zone stri
 			s.setErrorState()
 			s.syncLock.Unlock()
 		}
+		s.syncMetricsCollector.UpdateSyncerStatusInMetrics(s.NegSyncerKey, syncErr, s.inErrorState())
 	}
 
 	metrics.PublishNegOperationMetrics(operation.String(), string(s.NegSyncerKey.NegType), string(s.NegSyncerKey.GetAPIVersion()), err, len(networkEndpointMap), start)

--- a/pkg/neg/types/sync_errors.go
+++ b/pkg/neg/types/sync_errors.go
@@ -194,3 +194,19 @@ func ClassifyError(err error) NegSyncError {
 		err = errors.Unwrap(err)
 	}
 }
+
+// ListErrorStates lists all error-state reasons.
+func ListErrorStates() []Reason {
+	return []Reason{ReasonEPCountsDiffer, ReasonEPNodeMissing, ReasonEPNodeNotFound,
+		ReasonEPNodeTypeAssertionFailed, ReasonEPPodMissing, ReasonEPPodNotFound,
+		ReasonEPPodTypeAssertionFailed, ReasonEPPodTerminal, ReasonEPZoneMissing,
+		ReasonEPSEndpointCountZero, ReasonEPCalculationCountZero, ReasonInvalidAPIResponse,
+		ReasonInvalidEPAttach, ReasonInvalidEPDetach, ReasonEPIPInvalid, ReasonEPIPNotFromPod,
+		ReasonEPIPOutOfPodCIDR, ReasonEPServiceNotFound, ReasonEPPodLabelMismatch}
+}
+
+// ListErrorStates lists all non error-state reasons.
+func ListNonErrorStates() []Reason {
+	return []Reason{ReasonNegNotFound, ReasonCurrentNegEPNotFound,
+		ReasonEPSNotFound, ReasonOtherError, ReasonSuccess}
+}


### PR DESCRIPTION
1. We should update state of syncers after we check for error state. In syncInternal(), we update after checking, but in operationInternal(), we update before checking. On the other hand, it doesn't make sense to have a syncer not in error state while it triggers an error state error.
![image](https://github.com/kubernetes/ingress-gce/assets/46586072/1b30f456-3e02-42cb-bc14-2c8d29581595)

2. When publishing metrics, export all possible states otherwise we might have states that currently don't exist but are not updated during metrics collection. For example, we have a syncer in error state before, so we set errorCount=1 in metrics. When it now succeeds, we set successCount=1, but we haven't reset the errorCount, so we end up with sucessCount=1 and errorCount=1.