### PR TITLE
Add support for static DualStack IPs

### DIFF
--- a/pkg/annotations/l4_static_address.go
+++ b/pkg/annotations/l4_static_address.go
@@ -1,0 +1,75 @@
+package annotations
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+)
+
+// IPVersion represents compute.Address IpVersion field
+type IPVersion = string
+
+const (
+	// StaticL4AddressesAnnotationKey is new annotation key to specify static IPs (by name) for the services.
+	// Supports both IPv4 and IPv6
+	StaticL4AddressesAnnotationKey           = "networking.gke.io/load-balancer-ip-addresses"
+	maxAddressesNumber                       = 2
+	IPv4Version                    IPVersion = "IPV4"
+	IPv6Version                    IPVersion = "IPV6"
+)
+
+// IPv4AddressAnnotation return IPv4 address from networking.gke.io/load-balancer-ip-addresses annotation.
+// If no IPv4 address found, returns empty string.
+func (svc *Service) IPv4AddressAnnotation(cloud *gce.Cloud) (string, error) {
+	return ipAddressFromAnnotation(svc, cloud, IPv4Version)
+}
+
+// IPv6AddressAnnotation return IPv6 address from networking.gke.io/load-balancer-ip-addresses annotation.
+// If no IPv6 address found, returns empty string.
+func (svc *Service) IPv6AddressAnnotation(cloud *gce.Cloud) (string, error) {
+	return ipAddressFromAnnotation(svc, cloud, IPv6Version)
+}
+
+// ipAddressFromAnnotation checks annotation networking.gke.io/load-balancer-ip-addresses,
+// which should store comma separate names of IP Addresses reserved in google cloud,
+// and returns first address that matches required IpVersion (IPV4 or IPV6).
+func ipAddressFromAnnotation(svc *Service, cloud *gce.Cloud, ipVersion string) (string, error) {
+	annotationVal, ok := svc.v[StaticL4AddressesAnnotationKey]
+	if !ok {
+		return "", nil
+	}
+
+	addresses := strings.Split(annotationVal, ",")
+
+	// Truncated to 2 values (this is technically maximum, 1 IPv4 and 1 IPv6 address)
+	// to not make too many API calls.
+	if len(addresses) > maxAddressesNumber {
+		addresses = addresses[:maxAddressesNumber]
+	}
+
+	for _, address := range addresses {
+		trimmedAddress := strings.TrimSpace(address)
+		cloudAddress, err := cloud.GetRegionAddress(trimmedAddress, cloud.Region())
+		if err != nil {
+			if isNotFoundError(err) {
+				continue
+			}
+			return "", err
+		}
+		if cloudAddress.IpVersion == "" {
+			cloudAddress.IpVersion = IPv4Version
+		}
+
+		if cloudAddress.IpVersion == ipVersion {
+			return cloudAddress.Address, nil
+		}
+	}
+	return "", nil
+}
+
+func isNotFoundError(err error) bool {
+	var apiErr *googleapi.Error
+	return errors.As(err, &apiErr) && apiErr.Code == 404
+}

--- a/pkg/annotations/l4_static_address.go
+++ b/pkg/annotations/l4_static_address.go
@@ -15,7 +15,7 @@ const (
 	// StaticL4AddressesAnnotationKey is new annotation key to specify static IPs (by name) for the services.
 	// Supports both IPv4 and IPv6
 	StaticL4AddressesAnnotationKey           = "networking.gke.io/load-balancer-ip-addresses"
-	maxAddressesNumber                       = 2
+	maxNumberOfAddresses                     = 2
 	IPv4Version                    IPVersion = "IPV4"
 	IPv6Version                    IPVersion = "IPV6"
 )
@@ -41,17 +41,17 @@ func ipAddressFromAnnotation(svc *Service, cloud *gce.Cloud, ipVersion string) (
 		return "", nil
 	}
 
-	addresses := strings.Split(annotationVal, ",")
+	addressNames := strings.Split(annotationVal, ",")
 
 	// Truncated to 2 values (this is technically maximum, 1 IPv4 and 1 IPv6 address)
 	// to not make too many API calls.
-	if len(addresses) > maxAddressesNumber {
-		addresses = addresses[:maxAddressesNumber]
+	if len(addressNames) > maxNumberOfAddresses {
+		addressNames = addressNames[:maxNumberOfAddresses]
 	}
 
-	for _, address := range addresses {
-		trimmedAddress := strings.TrimSpace(address)
-		cloudAddress, err := cloud.GetRegionAddress(trimmedAddress, cloud.Region())
+	for _, addressName := range addressNames {
+		trimmedAddressName := strings.TrimSpace(addressName)
+		cloudAddress, err := cloud.GetRegionAddress(trimmedAddressName, cloud.Region())
 		if err != nil {
 			if isNotFoundError(err) {
 				continue

--- a/pkg/annotations/l4_static_address_test.go
+++ b/pkg/annotations/l4_static_address_test.go
@@ -1,0 +1,136 @@
+package annotations
+
+import (
+	"fmt"
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+)
+
+func TestAddressFromAnnotation(t *testing.T) {
+	vals := gce.DefaultTestClusterValues()
+
+	ipv4AddressString := "123.0.124.1"
+	ipv4AddressNoVersionString := "123.0.111.1"
+	ipv6AddressString := "0::1"
+
+	ipv4AddressName := "ipv4-address"
+	ipv4AddressNoVersionName := "ipv4-address-no-version"
+	ipv6AddressName := "ipv6-address"
+
+	ipv4Address := compute.Address{
+		Name:      ipv4AddressName,
+		Address:   ipv4AddressString,
+		IpVersion: IPv4Version,
+	}
+	ipv4AddressNoVersion := compute.Address{
+		Name:    ipv4AddressNoVersionName,
+		Address: ipv4AddressNoVersionString,
+	}
+	ipv6Address := compute.Address{
+		Name:      ipv6AddressName,
+		Address:   ipv6AddressString,
+		IpVersion: IPv6Version,
+	}
+	testCases := []struct {
+		desc              string
+		reservedAddresses []compute.Address
+		annotationVal     string
+		wantIPv4Address   string
+		wantIPv6Address   string
+	}{
+		{
+			desc: "Single existing IPv4 address",
+			reservedAddresses: []compute.Address{
+				ipv4Address,
+			},
+			annotationVal:   fmt.Sprintf("%s", ipv4Address.Name),
+			wantIPv4Address: ipv4Address.Address,
+		},
+		{
+			desc: "Single existing IPv6 address",
+			reservedAddresses: []compute.Address{
+				ipv6Address,
+			},
+			annotationVal:   fmt.Sprintf("%s", ipv6Address.Name),
+			wantIPv6Address: ipv6Address.Address,
+		},
+		{
+			desc: "Single existing IPv4 address with no IpVersion",
+			reservedAddresses: []compute.Address{
+				ipv4AddressNoVersion,
+			},
+			annotationVal:   fmt.Sprintf("%s", ipv4AddressNoVersion.Name),
+			wantIPv4Address: ipv4AddressNoVersion.Address,
+		},
+		{
+			desc:              "Many non-existing IPv4 and IPv6 addresses",
+			reservedAddresses: []compute.Address{},
+			annotationVal:     fmt.Sprintf("%s, %s,%s, %s", ipv4Address.Name, ipv4Address.Name, ipv6Address.Name, ipv4AddressNoVersion.Name),
+			wantIPv4Address:   "",
+			wantIPv6Address:   "",
+		},
+		{
+			desc: "Repeated existing IPv4 addresses",
+			reservedAddresses: []compute.Address{
+				ipv4Address,
+			},
+			annotationVal:   fmt.Sprintf("%s, %s", ipv4Address.Name, ipv4Address.Name),
+			wantIPv4Address: ipv4Address.Address,
+		},
+		{
+			desc: "IPv4 and IPv6 addresses",
+			reservedAddresses: []compute.Address{
+				ipv4Address,
+				ipv6Address,
+			},
+			annotationVal:   fmt.Sprintf("%s, %s", ipv4Address.Name, ipv6Address.Name),
+			wantIPv4Address: ipv4Address.Address,
+			wantIPv6Address: ipv6Address.Address,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						StaticL4AddressesAnnotationKey: tc.annotationVal,
+					},
+				},
+			}
+			fakeGCE := gce.NewFakeGCECloud(vals)
+			for i := range tc.reservedAddresses {
+				err := fakeGCE.ReserveRegionAddress(&tc.reservedAddresses[i], fakeGCE.Region())
+				if err != nil {
+					t.Fatalf("fakeGCE.ReserveRegionAddress(%v, %s) returned error %v", tc.reservedAddresses[i], fakeGCE.Region(), err)
+				}
+			}
+
+			ipv4Addr, err := FromService(svc).IPv4AddressAnnotation(fakeGCE)
+			if err != nil {
+				t.Fatalf("IPv4AddressAnnotation(..., %s) returned error %v", tc.annotationVal, err)
+			}
+			if ipv4Addr != tc.wantIPv4Address {
+				t.Errorf("IPv4AddressAnnotation(..., %s) returned %s, not equal to expected = %s", tc.annotationVal, ipv4Addr, tc.wantIPv4Address)
+			}
+
+			ipv6Addr, err := FromService(svc).IPv6AddressAnnotation(fakeGCE)
+			if err != nil {
+				t.Fatalf("IPv6AddressAnnotation(..., %s) returned error %v", tc.annotationVal, err)
+			}
+			if ipv6Addr != tc.wantIPv6Address {
+				t.Errorf("IPv6AddressAnnotation(..., %s) returned %s, not equal to expected = %s", tc.annotationVal, ipv6Addr, tc.wantIPv6Address)
+			}
+			if ipv6Addr != tc.wantIPv6Address {
+				t.Errorf("IPv6AddressAnnotation(..., %s) returned %s, not equal to expected = %s", tc.annotationVal, ipv6Addr, tc.wantIPv6Address)
+			}
+		})
+	}
+}

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
@@ -306,9 +307,9 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
 	// or specified in the Service spec, then requestedIP = "".
-	ipToUse, err := l4IPv4ToUse(l4netlb.cloud, l4netlb.Service, existingFwdRule, "")
+	ipToUse, err := ipv4AddrToUse(l4netlb.cloud, l4netlb.recorder, l4netlb.Service, existingFwdRule, "")
 	if err != nil {
-		klog.Errorf("l4IPv4ToUse for service %s/%s returned error %v", l4netlb.Service.Namespace, l4netlb.Service.Name, err)
+		klog.Errorf("ipv4AddrToUse for service %s/%s returned error %v", l4netlb.Service.Namespace, l4netlb.Service.Name, err)
 		return nil, IPAddrUndefined, err
 	}
 	klog.V(2).Infof("ensureIPv4ForwardingRule(%s): LoadBalancer IP %s", frName, ipToUse)
@@ -440,16 +441,23 @@ func equalResourcePaths(rp1, rp2 string) bool {
 	return rp1 == rp2 || utils.EqualResourceIDs(rp1, rp2)
 }
 
-// l4IPv4ToUse determines which IP address needs to be used in the ForwardingRule. If an IP has been
-// specified by the user, that is used. If there is an existing ForwardingRule, the ip address from
-// that is reused. In case a subnetwork change is requested, the existing ForwardingRule IP is ignored.
-func l4IPv4ToUse(cloud *gce.Cloud, svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSubnet string) (string, error) {
+// ipv4AddrToUse determines which IPv4 address needs to be used in the ForwardingRule,
+// address evaluated in the following order:
+//
+//  1. Use static addresses annotation "networking.gke.io/load-balancer-ip-addresses".
+//  2. Use .Spec.LoadBalancerIP (old field, was deprecated).
+//  3. Use existing forwarding rule IP. If subnetwork was changed (or no existing IP),
+//     reset the IP (by returning empty string).
+func ipv4AddrToUse(cloud *gce.Cloud, recorder record.EventRecorder, svc *v1.Service, fwdRule *composite.ForwardingRule, requestedSubnet string) (string, error) {
 	// Get value from new annotation which support both IPv4 and IPv6
 	ipv4FromAnnotation, err := annotations.FromService(svc).IPv4AddressAnnotation(cloud)
 	if err != nil {
 		return "", err
 	}
 	if ipv4FromAnnotation != "" {
+		if svc.Spec.LoadBalancerIP != "" {
+			recorder.Event(svc, v1.EventTypeNormal, "MixedStaticIP", "Found both .Spec.LoadBalancerIP and \"networking.gke.io/load-balancer-ip-addresses\" annotation. Consider using annotation only.")
+		}
 		return ipv4FromAnnotation, nil
 		// if no value from annotation (for example, annotation has only IPv6 addresses) -- continue
 	}

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -153,7 +153,11 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
 	// or specified in the Service spec, then requestedIP = "".
-	ipv6AddrToUse := ipv6AddressToUse(existingIPv6FwdRule, subnetworkURL)
+	ipv6AddrToUse, err := ipv6AddressToUse(l4netlb.cloud, l4netlb.Service, existingIPv6FwdRule, subnetworkURL)
+	if err != nil {
+		klog.Errorf("ipv6AddressToUse for service %s/%s returned error %v", l4netlb.Service.Namespace, l4netlb.Service.Name, err)
+		return nil, err
+	}
 	if !l4netlb.cloud.IsLegacyNetwork() {
 		nm := types.NamespacedName{Namespace: l4netlb.Service.Namespace, Name: l4netlb.Service.Name}.String()
 		addrMgr := newAddressManager(l4netlb.cloud, nm, l4netlb.cloud.Region(), subnetworkURL, expectedIPv6FrName, ipv6AddrToUse, cloud.SchemeExternal, cloud.NetworkTierPremium, IPv6Version)
@@ -266,16 +270,30 @@ func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) 
 		fr1.NetworkTier == fr2.NetworkTier, nil
 }
 
-func ipv6AddressToUse(ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) string {
+func ipv6AddressToUse(cloud *gce.Cloud, svc *corev1.Service, ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) (string, error) {
+	// Get value from new annotation which support both IPv4 and IPv6
+	ipv6AddressFromAnnotation, err := annotations.FromService(svc).IPv6AddressAnnotation(cloud)
+	if err != nil {
+		return "", err
+	}
+	if ipv6AddressFromAnnotation != "" {
+		// Google Cloud stores ipv6 addresses in CIDR form,
+		// but to create static address you need to specify address without range
+		return ipv6AddressWithoutRange(ipv6AddressFromAnnotation), nil
+	}
 	if ipv6FwdRule == nil {
-		return ""
+		return "", nil
 	}
 	if requestedSubnet != ipv6FwdRule.Subnetwork {
 		// reset ip address since subnet is being changed.
-		return ""
+		return "", nil
 	}
 
 	// Google Cloud creates ipv6 forwarding rules with IPAddress in CIDR form,
 	// but to create static address you need to specify address without range
-	return strings.Split(ipv6FwdRule.IPAddress, "/")[0]
+	return ipv6AddressWithoutRange(ipv6FwdRule.IPAddress), nil
+}
+
+func ipv6AddressWithoutRange(ipv6Address string) string {
+	return strings.Split(ipv6Address, "/")[0]
 }

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -270,6 +271,12 @@ func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) 
 		fr1.NetworkTier == fr2.NetworkTier, nil
 }
 
+// ipv6AddrToUse determines which IPv4 address needs to be used in the ForwardingRule,
+// address evaluated in the following order:
+//
+//  1. Use static addresses annotation "networking.gke.io/load-balancer-ip-addresses".
+//  2. Use existing forwarding rule IP. If subnetwork was changed (or no existing IP),
+//     reset the IP (by returning empty string).
 func ipv6AddressToUse(cloud *gce.Cloud, svc *corev1.Service, ipv6FwdRule *composite.ForwardingRule, requestedSubnet string) (string, error) {
 	// Get value from new annotation which support both IPv4 and IPv6
 	ipv6AddressFromAnnotation, err := annotations.FromService(svc).IPv6AddressAnnotation(cloud)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -347,9 +347,9 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	var ipv4AddressToUse string
 	if !l4.enableDualStack || utils.NeedsIPv4(l4.Service) {
 		existingIPv4FR, err = l4.getOldIPv4ForwardingRule(existingBS)
-		ipv4AddressToUse, err = l4IPv4ToUse(l4.cloud, l4.Service, existingIPv4FR, subnetworkURL)
+		ipv4AddressToUse, err = ipv4AddrToUse(l4.cloud, l4.recorder, l4.Service, existingIPv4FR, subnetworkURL)
 		if err != nil {
-			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: l4IPv4ToUse returned error: %w", err)
+			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: ipv4AddrToUse returned error: %w", err)
 			return result
 		}
 		expectedFRName := l4.GetFRName()

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -347,7 +347,11 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	var ipv4AddressToUse string
 	if !l4.enableDualStack || utils.NeedsIPv4(l4.Service) {
 		existingIPv4FR, err = l4.getOldIPv4ForwardingRule(existingBS)
-		ipv4AddressToUse = l4lbIPToUse(l4.Service, existingIPv4FR, subnetworkURL)
+		ipv4AddressToUse, err = l4IPv4ToUse(l4.cloud, l4.Service, existingIPv4FR, subnetworkURL)
+		if err != nil {
+			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: l4IPv4ToUse returned error: %w", err)
+			return result
+		}
 		expectedFRName := l4.GetFRName()
 		if !l4.cloud.IsLegacyNetwork() {
 			nm := types.NamespacedName{Namespace: l4.Service.Namespace, Name: l4.Service.Name}.String()
@@ -374,7 +378,11 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	var ipv6AddrToUse string
 	if l4.enableDualStack && utils.NeedsIPv6(l4.Service) {
 		existingIPv6FR, err = l4.getOldIPv6ForwardingRule(existingBS)
-		ipv6AddrToUse = ipv6AddressToUse(existingIPv6FR, subnetworkURL)
+		ipv6AddrToUse, err = ipv6AddressToUse(l4.cloud, l4.Service, existingIPv6FR, subnetworkURL)
+		if err != nil {
+			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: ipv6IPToUse returned error: %w", err)
+			return result
+		}
 		expectedIPv6FRName := l4.getIPv6FRName()
 		if !l4.cloud.IsLegacyNetwork() {
 			nm := types.NamespacedName{Namespace: l4.Service.Namespace, Name: l4.Service.Name}.String()

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -33,6 +32,7 @@ import (
 	"k8s.io/ingress-gce/pkg/healthchecksl4"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -1353,10 +1353,7 @@ func TestDualStackInternalLoadBalancerModifyProtocol(t *testing.T) {
 			t.Parallel()
 
 			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, v1.ServiceExternalTrafficPolicyTypeCluster)
-			l4, err := setupILBDualStackTestService(svc, nodeNames)
-			if err != nil {
-				t.Fatal(err)
-			}
+			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 			// This function simulates the error where backend service protocol cannot be changed
 			// before deleting the forwarding rule.
@@ -1466,10 +1463,7 @@ func TestDualStackInternalLoadBalancerModifyPorts(t *testing.T) {
 			t.Parallel()
 
 			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, v1.ServiceExternalTrafficPolicyTypeCluster)
-			l4, err := setupILBDualStackTestService(svc, nodeNames)
-			if err != nil {
-				t.Fatal(err)
-			}
+			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 			result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
 			if result.Error != nil {
@@ -1639,10 +1633,7 @@ func TestEnsureInternalDualStackLoadBalancer(t *testing.T) {
 			t.Parallel()
 
 			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, tc.trafficPolicy)
-			l4, err := setupILBDualStackTestService(svc, nodeNames)
-			if err != nil {
-				t.Fatal(err)
-			}
+			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 			result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
 			if result.Error != nil {
@@ -1824,10 +1815,7 @@ func TestDualStackILBTransitions(t *testing.T) {
 			nodeNames := []string{"test-node-1"}
 			svc := test.NewL4ILBDualStackService(8080, tc.initialProtocol, tc.initialIPFamily, tc.initialTrafficPolicy)
 
-			l4, err := setupILBDualStackTestService(svc, nodeNames)
-			if err != nil {
-				t.Fatal(err)
-			}
+			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 			result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
 			svc.Annotations = result.Annotations
@@ -1872,10 +1860,7 @@ func TestDualStackILBSyncIgnoresNoAnnotationIPv6Resources(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 
-	l4, err := setupILBDualStackTestService(svc, nodeNames)
-	if err != nil {
-		t.Fatal(err)
-	}
+	l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
 	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
@@ -1894,7 +1879,7 @@ func TestDualStackILBSyncIgnoresNoAnnotationIPv6Resources(t *testing.T) {
 	svc.Annotations = result.Annotations
 
 	ipv6FWName := l4.namer.L4IPv6Firewall(l4.Service.Namespace, l4.Service.Name)
-	err = verifyFirewallNotExists(l4.cloud, ipv6FWName)
+	err := verifyFirewallNotExists(l4.cloud, ipv6FWName)
 	if err == nil {
 		t.Errorf("firewall rule %s was deleted, expected not", ipv6FWName)
 	}
@@ -1916,10 +1901,7 @@ func TestDualStackILBSyncIgnoresNoAnnotationIPv4Resources(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 
-	l4, err := setupILBDualStackTestService(svc, nodeNames)
-	if err != nil {
-		t.Fatal(err)
-	}
+	l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}
 	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
@@ -1939,7 +1921,7 @@ func TestDualStackILBSyncIgnoresNoAnnotationIPv4Resources(t *testing.T) {
 
 	// Verify IPv6 Firewall was not deleted
 	backendServiceName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	err = verifyFirewallNotExists(l4.cloud, backendServiceName)
+	err := verifyFirewallNotExists(l4.cloud, backendServiceName)
 	if err == nil {
 		t.Errorf("firewall rule %s was deleted, expected not", backendServiceName)
 	}
@@ -1960,10 +1942,7 @@ func TestILBUserErrorOnExternalIPv6Subnet(t *testing.T) {
 	nodeNames := []string{"test-node-1"}
 	svc := test.NewL4ILBService(false, 8080)
 
-	l4, err := setupILBDualStackTestService(svc, nodeNames)
-	if err != nil {
-		t.Fatal(err)
-	}
+	l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}
 	// change to internal IPv6 subnet and expect error
@@ -1973,7 +1952,7 @@ func TestILBUserErrorOnExternalIPv6Subnet(t *testing.T) {
 		Ipv6AccessType: "EXTERNAL",
 		StackType:      "IPV4_IPV6",
 	}
-	err = l4.cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), externalSubnetKey, externalSubnetToCreate)
+	err := l4.cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), externalSubnetKey, externalSubnetToCreate)
 	if err != nil {
 		t.Fatalf("Failed to create subnet, error: %v", err)
 	}
@@ -2000,28 +1979,28 @@ func TestDualStackILBStaticIPAnnotation(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc                    string
-		staticAnnotationVal     string
-		addressesToReserve      []*compute.Address
-		expectedLoadBalancerIPs []string
+		desc                          string
+		staticAnnotationVal           string
+		addressesToReserve            []*compute.Address
+		expectedStaticLoadBalancerIPs []string
 	}{
 		{
-			desc:                    "2 Reserved addresses",
-			staticAnnotationVal:     "ipv4-address,ipv6-address",
-			addressesToReserve:      []*compute.Address{ipv4Address, ipv6Address},
-			expectedLoadBalancerIPs: []string{"111.111.111.111", "2::2"},
+			desc:                          "2 Reserved addresses",
+			staticAnnotationVal:           "ipv4-address,ipv6-address",
+			addressesToReserve:            []*compute.Address{ipv4Address, ipv6Address},
+			expectedStaticLoadBalancerIPs: []string{"111.111.111.111", "2::2"},
 		},
 		{
-			desc:                    "Addresses in annotation, but not reserved",
-			staticAnnotationVal:     "ipv4-address,ipv6-address",
-			addressesToReserve:      []*compute.Address{},
-			expectedLoadBalancerIPs: []string{"random", "random"},
+			desc:                          "Addresses in annotation, but not reserved",
+			staticAnnotationVal:           "ipv4-address,ipv6-address",
+			addressesToReserve:            []*compute.Address{},
+			expectedStaticLoadBalancerIPs: []string{},
 		},
 		{
-			desc:                    "1 Reserved address, 1 random",
-			staticAnnotationVal:     "ipv6-address",
-			addressesToReserve:      []*compute.Address{ipv6Address},
-			expectedLoadBalancerIPs: []string{"random", "2::2"},
+			desc:                          "1 Reserved address, 1 random",
+			staticAnnotationVal:           "ipv6-address",
+			addressesToReserve:            []*compute.Address{ipv6Address},
+			expectedStaticLoadBalancerIPs: []string{"2::2"},
 		},
 	}
 
@@ -2029,10 +2008,7 @@ func TestDualStackILBStaticIPAnnotation(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			svc := test.NewL4ILBService(false, 8080)
-			l4, err := setupILBDualStackTestService(svc, nodeNames)
-			if err != nil {
-				t.Fatal(err)
-			}
+			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
 
 			for _, addr := range tc.addressesToReserve {
 				err := l4.cloud.ReserveRegionAddress(addr, l4.cloud.Region())
@@ -2054,12 +2030,15 @@ func TestDualStackILBStaticIPAnnotation(t *testing.T) {
 			for _, ip := range result.Status.Ingress {
 				gotIPs = append(gotIPs, ip.IP)
 			}
-			sort.Strings(gotIPs)
-			for i, expectedIP := range tc.expectedLoadBalancerIPs {
-				if expectedIP != "random" && expectedIP != gotIPs[i] {
-					t.Errorf("Expected to get IP %s, got %s", expectedIP, gotIPs[i])
+			if len(gotIPs) != 2 {
+				t.Errorf("Expected to get 2 addresses for RequireDualStack Service, got %v", gotIPs)
+			}
+			for _, expectedAddr := range tc.expectedStaticLoadBalancerIPs {
+				if !slices.Contains(gotIPs, expectedAddr) {
+					t.Errorf("Expected to find static address %s in load balancer IPs, got %v", expectedAddr, gotIPs)
 				}
 			}
+
 			// Delete the loadbalancer
 			result = l4.EnsureInternalLoadBalancerDeleted(svc)
 			if result.Error != nil {
@@ -2078,7 +2057,7 @@ func TestDualStackILBStaticIPAnnotation(t *testing.T) {
 	}
 }
 
-func setupILBDualStackTestService(svc *v1.Service, nodeNames []string) (*L4, error) {
+func mustSetupILBTestHandler(t *testing.T, svc *v1.Service, nodeNames []string) *L4 {
 	vals := gce.DefaultTestClusterValues()
 
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
@@ -2095,7 +2074,7 @@ func setupILBDualStackTestService(svc *v1.Service, nodeNames []string) (*L4, err
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
-		return nil, fmt.Errorf("unexpected error when adding nodes %v", err)
+		t.Fatalf("Unexpected error when adding nodes %v", err)
 	}
 
 	// Create cluster subnet with Internal IPV6 range. Mock GCE uses subnet with empty string name.
@@ -2107,9 +2086,9 @@ func setupILBDualStackTestService(svc *v1.Service, nodeNames []string) (*L4, err
 	}
 	err := fakeGCE.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), key, subnetToCreate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create subnet, error: %w", err)
+		t.Fatalf("failed to create subnet %v, error: %v", subnetToCreate, err)
 	}
-	return l4, nil
+	return l4
 }
 
 func assertILBResources(t *testing.T, l4 *L4, nodeNames []string, resourceAnnotations map[string]string) {

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -41,6 +40,7 @@ import (
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/utils/strings/slices"
 )
 
 const (
@@ -361,7 +361,7 @@ func TestEnsureExternalDualStackLoadBalancer(t *testing.T) {
 			t.Parallel()
 
 			svc := test.NewL4NetLBRBSDualStackService(v1.ProtocolTCP, tc.ipFamilies, tc.trafficPolicy)
-			l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+			l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
 
 			result := l4NetLB.EnsureFrontend(nodeNames, svc)
 			if result.Error != nil {
@@ -439,7 +439,8 @@ func TestDualStackNetLBTransitions(t *testing.T) {
 			nodeNames := []string{"test-node-1"}
 
 			svc := test.NewL4NetLBRBSDualStackService(tc.initialProtocol, tc.initialIPFamily, tc.initialTrafficPolicy)
-			l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+			l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
 			l4NetLB.cloud.Compute().(*cloud.MockGCE).MockForwardingRules.DeleteHook = assertAddressOldReservedHook(t, l4NetLB.cloud)
 
 			result := l4NetLB.EnsureFrontend(nodeNames, svc)
@@ -487,7 +488,7 @@ func TestDualStackNetLBSyncIgnoresNoAnnotationIPv6Resources(t *testing.T) {
 
 	svc := test.NewL4NetLBRBSService(8080)
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
-	l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
 
 	result := l4NetLB.EnsureFrontend(nodeNames, svc)
 	svc.Annotations = result.Annotations
@@ -528,7 +529,7 @@ func TestDualStackNetLBSyncIgnoresNoAnnotationIPv4Resources(t *testing.T) {
 
 	svc := test.NewL4NetLBRBSService(8080)
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}
-	l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
 
 	result := l4NetLB.EnsureFrontend(nodeNames, svc)
 	svc.Annotations = result.Annotations
@@ -570,7 +571,7 @@ func TestEnsureIPv6ExternalLoadBalancerCustomSubnet(t *testing.T) {
 
 	svc := test.NewL4NetLBRBSService(8080)
 	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}
-	l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
 
 	result := l4NetLB.EnsureFrontend(nodeNames, l4NetLB.Service)
 	if result.Error != nil {
@@ -660,28 +661,28 @@ func TestDualStackNetLBStaticIPAnnotation(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc                    string
-		staticAnnotationVal     string
-		addressesToReserve      []*ga.Address
-		expectedLoadBalancerIPs []string
+		desc                          string
+		staticAnnotationVal           string
+		addressesToReserve            []*ga.Address
+		expectedStaticLoadBalancerIPs []string
 	}{
 		{
-			desc:                    "2 Reserved addresses",
-			staticAnnotationVal:     "ipv4-address,ipv6-address",
-			addressesToReserve:      []*ga.Address{ipv4Address, ipv6Address},
-			expectedLoadBalancerIPs: []string{"111.111.111.111", "2::2"},
+			desc:                          "2 Reserved addresses",
+			staticAnnotationVal:           "ipv4-address,ipv6-address",
+			addressesToReserve:            []*ga.Address{ipv4Address, ipv6Address},
+			expectedStaticLoadBalancerIPs: []string{"111.111.111.111", "2::2"},
 		},
 		{
-			desc:                    "Addresses in annotation, but not reserved",
-			staticAnnotationVal:     "ipv4-address,ipv6-address",
-			addressesToReserve:      []*ga.Address{},
-			expectedLoadBalancerIPs: []string{"random", "random"},
+			desc:                          "Addresses in annotation, but not reserved",
+			staticAnnotationVal:           "ipv4-address,ipv6-address",
+			addressesToReserve:            []*ga.Address{},
+			expectedStaticLoadBalancerIPs: []string{},
 		},
 		{
-			desc:                    "1 Reserved address, 1 random",
-			staticAnnotationVal:     "ipv6-address",
-			addressesToReserve:      []*ga.Address{ipv6Address},
-			expectedLoadBalancerIPs: []string{"random", "2::2"},
+			desc:                          "1 Reserved address, 1 random",
+			staticAnnotationVal:           "ipv6-address",
+			addressesToReserve:            []*ga.Address{ipv6Address},
+			expectedStaticLoadBalancerIPs: []string{"2::2"},
 		},
 	}
 
@@ -689,7 +690,7 @@ func TestDualStackNetLBStaticIPAnnotation(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			svc := test.NewL4NetLBRBSService(8080)
-			l4NetLB := mustSetupNetLBDualStackTestService(t, svc, nodeNames)
+			l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
 
 			for _, addr := range tc.addressesToReserve {
 				err := l4NetLB.cloud.ReserveRegionAddress(addr, l4NetLB.cloud.Region())
@@ -711,10 +712,12 @@ func TestDualStackNetLBStaticIPAnnotation(t *testing.T) {
 			for _, ip := range result.Status.Ingress {
 				gotIPs = append(gotIPs, ip.IP)
 			}
-			sort.Strings(gotIPs)
-			for i, expectedIP := range tc.expectedLoadBalancerIPs {
-				if expectedIP != "random" && expectedIP != gotIPs[i] {
-					t.Errorf("Expected to get IP %s, got %s", expectedIP, gotIPs[i])
+			if len(gotIPs) != 2 {
+				t.Errorf("Expected to get 2 addresses for RequireDualStack Service, got %v", gotIPs)
+			}
+			for _, expectedAddr := range tc.expectedStaticLoadBalancerIPs {
+				if !slices.Contains(gotIPs, expectedAddr) {
+					t.Errorf("Expected to find static address %s in load balancer IPs, got %v", expectedAddr, gotIPs)
 				}
 			}
 			// Delete the loadbalancer
@@ -735,7 +738,7 @@ func TestDualStackNetLBStaticIPAnnotation(t *testing.T) {
 	}
 }
 
-func mustSetupNetLBDualStackTestService(t *testing.T, svc *v1.Service, nodeNames []string) *L4NetLB {
+func mustSetupNetLBTestHandler(t *testing.T, svc *v1.Service, nodeNames []string) *L4NetLB {
 	t.Helper()
 
 	vals := gce.DefaultTestClusterValues()


### PR DESCRIPTION
- Introduce new annotation "networking.gke.io/load-balancer-ip-addresses", which
  will store comma-separated list of address names
- Add logic to identify address with matching IP family from new
  annotation