### PR TITLE
update k8s/gce server request metrics to count server error

### DIFF
--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -383,14 +383,14 @@ func getResult(err error) string {
 }
 
 func getErrorLabel(err error, isIgnored bool) string {
-	if isIgnored {
-		return ignoredError
-	}
 	if utils.IsGCEServerError(err) {
 		return gceServerError
 	}
 	if utils.IsK8sServerError(err) {
 		return k8sServerError
+	}
+	if isIgnored {
+		return ignoredError
 	}
 	return otherError
 }

--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -345,14 +345,32 @@ func PublishAnnotationMetrics(annotationSize int, labelNumber int) {
 
 // PublishGCERequestCountMetrics publishes collected metrics for GCE Request Counts
 func PublishGCERequestCountMetrics(start time.Time, requestType string, err error) {
-	result := getResult(err)
+	var result string
+	if err == nil {
+		result = resultSuccess
+	} else {
+		if utils.IsGCEServerError(err) {
+			result = gceServerError
+		} else {
+			result = otherError
+		}
+	}
 	GCERequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
 	GCERequestCount.WithLabelValues(requestType, result).Inc()
 }
 
 // PublishK8sRequestCountMetrics publishes collected metrics for K8s Request Counts
 func PublishK8sRequestCountMetrics(start time.Time, requestType string, err error) {
-	result := getResult(err)
+	var result string
+	if err == nil {
+		result = resultSuccess
+	} else {
+		if utils.IsK8sServerError(err) {
+			result = k8sServerError
+		} else {
+			result = otherError
+		}
+	}
 	K8sRequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
 	K8sRequestCount.WithLabelValues(requestType, result).Inc()
 }


### PR DESCRIPTION
- Update k8s/gce server request metrics to count server error
- For NEG controller error count metrics, count server error with ignore=True as server error instead of ignored error. Ignore=True means we are okay with these errors, but we do care if the failure is due to server error.