### PR TITLE
Strong Session Affinity for L4NetLB

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -209,19 +209,20 @@ func main() {
 	cloud := app.NewGCEClient()
 	defaultBackendServicePort := app.DefaultBackendServicePort(kubeClient)
 	ctxConfig := ingctx.ControllerContextConfig{
-		Namespace:              flags.F.WatchNamespace,
-		ResyncPeriod:           flags.F.ResyncPeriod,
-		NumL4Workers:           flags.F.NumL4Workers,
-		NumL4NetLBWorkers:      flags.F.NumL4NetLBWorkers,
-		DefaultBackendSvcPort:  defaultBackendServicePort,
-		HealthCheckPath:        flags.F.HealthCheckPath,
-		FrontendConfigEnabled:  flags.F.EnableFrontendConfig,
-		EnableASMConfigMap:     flags.F.EnableASMConfigMapBasedConfig,
-		ASMConfigMapNamespace:  flags.F.ASMConfigMapBasedConfigNamespace,
-		ASMConfigMapName:       flags.F.ASMConfigMapBasedConfigCMName,
-		MaxIGSize:              flags.F.MaxIGSize,
-		EnableL4ILBDualStack:   flags.F.EnableL4ILBDualStack,
-		EnableL4NetLBDualStack: flags.F.EnableL4NetLBDualStack,
+		Namespace:                     flags.F.WatchNamespace,
+		ResyncPeriod:                  flags.F.ResyncPeriod,
+		NumL4Workers:                  flags.F.NumL4Workers,
+		NumL4NetLBWorkers:             flags.F.NumL4NetLBWorkers,
+		DefaultBackendSvcPort:         defaultBackendServicePort,
+		HealthCheckPath:               flags.F.HealthCheckPath,
+		FrontendConfigEnabled:         flags.F.EnableFrontendConfig,
+		EnableASMConfigMap:            flags.F.EnableASMConfigMapBasedConfig,
+		ASMConfigMapNamespace:         flags.F.ASMConfigMapBasedConfigNamespace,
+		ASMConfigMapName:              flags.F.ASMConfigMapBasedConfigCMName,
+		MaxIGSize:                     flags.F.MaxIGSize,
+		EnableL4ILBDualStack:          flags.F.EnableL4ILBDualStack,
+		EnableL4NetLBDualStack:        flags.F.EnableL4NetLBDualStack,
+		EnableL4StrongSessionAffinity: flags.F.EnableL4StrongSessionAffinity,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, ingParamsClient, svcAttachmentClient, networkClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)

--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -120,8 +120,10 @@ const (
 	FirewallForHealthcheckIPv6Resource = FirewallRuleForHealthcheckKey + IPv6Suffix
 	AddressResource                    = "address"
 	// TODO(slavik): import this from gce_annotations when it will be merged in k8s
-	RBSAnnotationKey = "cloud.google.com/l4-rbs"
-	RBSEnabled       = "enabled"
+	RBSAnnotationKey                   = "cloud.google.com/l4-rbs"
+	RBSEnabled                         = "enabled"
+	StrongSessionAffinityAnnotationKey = "networking.gke.io/l4-strong-session-affinity"
+	StrongSessionAffinityEnabled       = "enabled"
 	// CustomSubnetAnnotationKey is the new way to specify custom subnet both for ILB and NetLB (only for IPv6)
 	// Replaces networking.gke.io/internal-load-balancer-subnet with backward compatibility.
 	CustomSubnetAnnotationKey = "networking.gke.io/load-balancer-subnet"
@@ -266,6 +268,18 @@ func HasRBSAnnotation(service *v1.Service) bool {
 	}
 
 	if val, ok := service.Annotations[RBSAnnotationKey]; ok && val == RBSEnabled {
+		return true
+	}
+	return false
+}
+
+// HasStrongSessionAffinityAnnotation checks if the given service has the strong session affinity annotation.
+func HasStrongSessionAffinityAnnotation(service *v1.Service) bool {
+	if service == nil {
+		return false
+	}
+
+	if val, ok := service.Annotations[StrongSessionAffinityAnnotationKey]; ok && val == StrongSessionAffinityEnabled {
 		return true
 	}
 	return false

--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -668,6 +668,49 @@ func TestRBSAnnotation(t *testing.T) {
 			got := HasRBSAnnotation(tc.svc)
 			if tc.want != got {
 				t.Errorf("output of HasRBSAnnotaiton differed, want=%v, got=%v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHasStrongSessionAffinityAnnotation(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		svc  *v1.Service
+		want bool
+	}{
+		{
+			desc: "Strong Session Affinity annotation was not specified",
+			svc:  &v1.Service{},
+			want: false,
+		},
+		{
+			desc: "Strong Session Affinity annotation was correctly specified",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						StrongSessionAffinityAnnotationKey: StrongSessionAffinityEnabled,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "Strong Session Affinity annotation has wrong value",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						StrongSessionAffinityAnnotationKey: "otherValue",
+					},
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := HasStrongSessionAffinityAnnotation(tc.svc)
+			if tc.want != got {
+				t.Errorf("output of HasStrongSessionAffinityAnnotation differed, want=%v, got=%v", tc.want, got)
 			}
 		})
 	}

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -6,56 +6,105 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
-	namer "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
 const (
-	kubeSystemUID = "ksuid123"
+	kubeSystemUID        = "ksuid123"
+	defaultIdleTimeout   = int64(10 * 60)     // 10 minutes
+	prolongedIdleTimeout = int64(2 * 60 * 60) // 2 hours
 )
 
 func TestEnsureL4BackendService(t *testing.T) {
-	serviceName := types.NamespacedName{Name: "test-service", Namespace: "test-ns"}
-	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
-	l4namer := namer.NewL4Namer(kubeSystemUID, nil)
-	backendPool := NewPool(fakeGCE, l4namer)
+	for _, tc := range []struct {
+		desc                        string
+		serviceName                 string
+		serviceNamespace            string
+		protocol                    string
+		affinityType                string
+		schemeType                  string
+		enableStrongSessionAffinity bool
+		idleTimeout                 int64
+		trackingMode                string
+	}{
+		{
+			desc:                        "Test basic Backend Service with Internal scheme type",
+			serviceName:                 "test-service",
+			serviceNamespace:            "test-ns",
+			protocol:                    "TCP",
+			affinityType:                string(v1.ServiceAffinityNone),
+			schemeType:                  string(cloud.SchemeInternal),
+			enableStrongSessionAffinity: false,
+			idleTimeout:                 defaultIdleTimeout,
+			trackingMode:                DefaultTrackingMode,
+		},
+		{
+			desc:                        "Test Backend Service with Strong Session Affinity configuration",
+			serviceName:                 "test-service",
+			serviceNamespace:            "test-ns",
+			protocol:                    "TCP",
+			affinityType:                string(v1.ServiceAffinityClientIP),
+			schemeType:                  string(cloud.SchemeExternal),
+			enableStrongSessionAffinity: true,
+			idleTimeout:                 prolongedIdleTimeout,
+			trackingMode:                PerSessionTrackingMode,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			namespacedName := types.NamespacedName{Name: tc.serviceName, Namespace: tc.serviceNamespace}
+			connectionTrackingPolicy := &composite.BackendServiceConnectionTrackingPolicy{
+				EnableStrongAffinity: tc.enableStrongSessionAffinity,
+				IdleTimeoutSec:       tc.idleTimeout,
+				TrackingMode:         tc.trackingMode,
+			}
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			l4namer := namer.NewL4Namer(kubeSystemUID, nil)
+			backendPool := NewPool(fakeGCE, l4namer)
 
-	hcLink := l4namer.L4HealthCheck(serviceName.Namespace, serviceName.Name, false)
-	bsName := l4namer.L4Backend(serviceName.Namespace, serviceName.Name)
-	network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
-	bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), serviceName, network)
-	if err != nil {
-		t.Errorf("EnsureL4BackendService failed")
+			hcLink := l4namer.L4HealthCheck(tc.serviceNamespace, tc.serviceName, false)
+			bsName := l4namer.L4Backend(tc.serviceNamespace, tc.serviceName)
+			network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
+			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, connectionTrackingPolicy)
+			if err != nil {
+				t.Errorf("EnsureL4BackendService failed")
+			}
+			// backend service changes the session affinity from ClientIP to CLIENT_IP etc
+			gotSessionAffinity := strings.Replace(bs.SessionAffinity, "_", "", -1)
+			if gotSessionAffinity != strings.ToUpper(tc.affinityType) {
+				t.Errorf("BackendService.SessionAffinity was not populated correctly want=%q, got=%q", strings.ToUpper(tc.affinityType), gotSessionAffinity)
+			}
+			if bs.Network != network.NetworkURL {
+				t.Errorf("BackendService.Network was not populated correctly, want=%q, got=%q", network.NetworkURL, bs.Network)
+			}
+			if len(bs.HealthChecks) != 1 || bs.HealthChecks[0] != hcLink {
+				t.Errorf("BackendService.HealthChecks was not populated correctly, want=%q, got=%q", hcLink, bs.HealthChecks)
+			}
+			description, err := utils.MakeL4LBServiceDescription(namespacedName.String(), "", meta.VersionGA, false, utils.ILB)
+			if err != nil {
+				t.Errorf("utils.MakeL4LBServiceDescription() failed %v", err)
+			}
+			if bs.Description != description {
+				t.Errorf("BackendService.Description was not populated correctly, want=%q, got=%q", description, bs.Description)
+			}
+			if bs.Protocol != tc.protocol {
+				t.Errorf("BackendService.Protocol was not populated correctly, want=%q, got=%q", "TCP", bs.Protocol)
+			}
+			if bs.LoadBalancingScheme != tc.schemeType {
+				t.Errorf("BackendService.LoadBalancingScheme was not populated correctly, want=%q, got=%q", tc.schemeType, bs.LoadBalancingScheme)
+			}
+			if bs.ConnectionDraining == nil || bs.ConnectionDraining.DrainingTimeoutSec != DefaultConnectionDrainingTimeoutSeconds {
+				t.Errorf("BackendService.ConnectionDraining was not populated correctly, want=connection draining with %q, got=%q", DefaultConnectionDrainingTimeoutSeconds, bs.ConnectionDraining)
+			}
+			if diff := cmp.Diff(bs.ConnectionTrackingPolicy, connectionTrackingPolicy); diff != "" {
+				t.Errorf("BackendService.ConnectionTrackingPolicy was not populated correctly, expected to be different: %s", diff)
+			}
+		})
 	}
-
-	if bs.SessionAffinity != strings.ToUpper(string(v1.ServiceAffinityNone)) {
-		t.Errorf("BackendService.SessionAffinity was not populated correctly want=%q, got=%q", strings.ToUpper(string(v1.ServiceAffinityNone)), bs.SessionAffinity)
-	}
-	if bs.Network != network.NetworkURL {
-		t.Errorf("BackendService.Network was not populated correctly, want=%q, got=%q", network.NetworkURL, bs.Network)
-	}
-	if len(bs.HealthChecks) != 1 || bs.HealthChecks[0] != hcLink {
-		t.Errorf("BackendService.HealthChecks was not populated correctly, want=%q, got=%q", hcLink, bs.HealthChecks)
-	}
-	description, err := utils.MakeL4LBServiceDescription(serviceName.String(), "", meta.VersionGA, false, utils.ILB)
-	if err != nil {
-		t.Errorf("utils.MakeL4LBServiceDescription() failed %v", err)
-	}
-	if bs.Description != description {
-		t.Errorf("BackendService.Description was not populated correctly, want=%q, got=%q", description, bs.Description)
-	}
-	if bs.Protocol != "TCP" {
-		t.Errorf("BackendService.Protocol was not populated correctly, want=%q, got=%q", "TCP", bs.Protocol)
-	}
-	if bs.LoadBalancingScheme != string(cloud.SchemeInternal) {
-		t.Errorf("BackendService.LoadBalancingScheme was not populated correctly, want=%q, got=%q", string(cloud.SchemeInternal), bs.LoadBalancingScheme)
-	}
-	if bs.ConnectionDraining == nil || bs.ConnectionDraining.DrainingTimeoutSec != DefaultConnectionDrainingTimeoutSeconds {
-		t.Errorf("BackendService.ConnectionDraining was not populated correctly, want=connection draining with %q, got=%q", DefaultConnectionDrainingTimeoutSeconds, bs.ConnectionDraining)
-	}
-
 }

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/test"
@@ -233,7 +234,7 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 	serviceAffinityNone := string(apiv1.ServiceAffinityNone)
 	schemeExternal := string(cloud.SchemeExternal)
 	defaultNetworkInfo := network.NetworkInfo{IsDefault: true}
-	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo); err != nil {
+	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -127,15 +127,16 @@ type ControllerContextConfig struct {
 	NumL4Workers      int
 	NumL4NetLBWorkers int
 	// DefaultBackendSvcPortID is the ServicePort for the system default backend.
-	DefaultBackendSvcPort  utils.ServicePort
-	HealthCheckPath        string
-	FrontendConfigEnabled  bool
-	EnableASMConfigMap     bool
-	ASMConfigMapNamespace  string
-	ASMConfigMapName       string
-	MaxIGSize              int
-	EnableL4ILBDualStack   bool
-	EnableL4NetLBDualStack bool
+	DefaultBackendSvcPort         utils.ServicePort
+	HealthCheckPath               string
+	FrontendConfigEnabled         bool
+	EnableASMConfigMap            bool
+	ASMConfigMapNamespace         string
+	ASMConfigMapName              string
+	MaxIGSize                     int
+	EnableL4ILBDualStack          bool
+	EnableL4NetLBDualStack        bool
+	EnableL4StrongSessionAffinity bool // flag that enables strong session affinity feature
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -119,6 +119,7 @@ var (
 		EnableL4NetLBDualStack                   bool
 		EnableMultipleIGs                        bool
 		EnableServiceMetrics                     bool
+		EnableL4StrongSessionAffinity            bool
 		EnableNEGLabelPropagation                bool
 		EnableMultiNetworking                    bool
 		MaxIGSize                                int
@@ -288,6 +289,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnablePinhole, "enable-pinhole", false, "Enable Pinhole firewall feature")
 	flag.BoolVar(&F.EnableL4ILBDualStack, "enable-l4ilb-dual-stack", false, "Enable Dual-Stack handling for L4 Internal Load Balancers")
 	flag.BoolVar(&F.EnableL4NetLBDualStack, "enable-l4netlb-dual-stack", false, "Enable Dual-Stack handling for L4 External Load Balancers")
+	flag.BoolVar(&F.EnableL4StrongSessionAffinity, "enable-l4lb-strong-sa", false, "Enable Strong Session Affinity for L4 External Load Balancers")
 	flag.BoolVar(&F.EnableMultipleIGs, "enable-multiple-igs", false, "Enable using multiple unmanaged instance groups")
 	flag.BoolVar(&F.EnableMultiNetworking, "enable-multi-networking", false, "Enable support for multi-networking L4 load balancers.")
 	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -429,7 +429,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network)
+	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -81,13 +81,13 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE))
+	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE))
+	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -108,7 +108,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE))
+	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -255,7 +255,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE))
+	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -937,3 +937,20 @@ func SubnetHasIPv6Range(cloud *gce.Cloud, subnetName, ipv6AccessType string) (bo
 	}
 	return subnet.StackType == DualStackSubnetStackType && subnet.Ipv6AccessType == ipv6AccessType, nil
 }
+
+// IsUnsupportedFeatureError returns true if the error has 400 number,
+// and has information that `featureName` isn't supported
+//
+//	ex: ```Error 400: Invalid value for field
+//	resource.connectionTrackingPolicy.enableStrongAffinity': 'true'.
+//	EnableStrongAffinity is not supported., invalid```
+func IsUnsupportedFeatureError(err error, featureName string) bool {
+	if err == nil {
+		return false
+	}
+	isUnsupported := strings.Contains(err.Error(), "is not supported") && IsHTTPErrorCode(err, http.StatusBadRequest)
+	if strings.Contains(err.Error(), featureName) && isUnsupported {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1574,3 +1574,63 @@ func TestAddIPToLBStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUnsupportedFeatureError(t *testing.T) {
+	testCases := []struct {
+		desc                string
+		featureName         string
+		errorMessage        string
+		errorCode           int
+		expectedReturnValue bool
+	}{
+		{
+			desc:                "empty error",
+			featureName:         "randomFeature",
+			errorMessage:        "",
+			errorCode:           200,
+			expectedReturnValue: false,
+		},
+		{
+			desc:                "wrong error code",
+			featureName:         "randomFeature",
+			errorMessage:        "randomFeature is not supported",
+			errorCode:           200,
+			expectedReturnValue: false,
+		},
+		{
+			desc:                "wrong error message",
+			featureName:         "randomFeature",
+			errorMessage:        "randomFeature abc",
+			errorCode:           400,
+			expectedReturnValue: false,
+		},
+		{
+			desc:                "wrong feature name",
+			featureName:         "newFeature",
+			errorMessage:        "randomFeature is not supported",
+			errorCode:           400,
+			expectedReturnValue: false,
+		},
+		{
+			desc:                "feature is not supported",
+			featureName:         "enableStrongAffinity",
+			errorMessage:        "Invalid value for field 'resource.connectionTrackingPolicy.enableStrongAffinity': 'true'. EnableStrongAffinity is not supported., invalid",
+			errorCode:           400,
+			expectedReturnValue: true,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := googleapi.Error{
+				Message: tc.errorMessage,
+				Code:    tc.errorCode,
+			}
+			if IsUnsupportedFeatureError(&err, tc.featureName) != tc.expectedReturnValue {
+				t.Errorf("IsUnsupportedFeatureError returned unexpected result: %v, expectations: %v for error: %v", IsUnsupportedFeatureError(&err, tc.featureName), tc.expectedReturnValue, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The change allows users to create a NetLB service with strong session affinity. 
What was added: 
* flag to enable strong session affinity feature
* annotation for the strong session affinity in the service specs
* functions to check all requirements and configurations for strong session affinity, session affinity type, and session affinity config
* unit tests

Commits are only for reviewing purposes, it will be squashed into one big commit before the merge. Or maybe two commits: changes & unit tests