### PR TITLE
Add explicit verification for External/Internal IPv6 subnet

### DIFF
--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/metrics"
@@ -570,17 +569,7 @@ func TestCreateDeleteDualStackService(t *testing.T) {
 			}
 			newSvc := test.NewL4ILBDualStackService(8080, api_v1.ProtocolTCP, tc.ipFamilies, api_v1.ServiceExternalTrafficPolicyTypeCluster)
 
-			// Create cluster subnet with Internal IPV6 range. Mock GCE uses subnet with empty string name.
-			clusterSubnetName := ""
-			subnetKey := meta.RegionalKey(clusterSubnetName, l4c.ctx.Cloud.Region())
-			subnetToCreate := &compute.Subnetwork{
-				Ipv6AccessType: "INTERNAL",
-				StackType:      "IPV4_IPV6",
-			}
-			err = l4c.ctx.Cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), subnetKey, subnetToCreate)
-			if err != nil {
-				t.Fatal(err)
-			}
+			test.MustCreateDualStackClusterSubnet(t, l4c.ctx.Cloud, "INTERNAL")
 			addILBService(l4c, newSvc)
 			addNEG(l4c, newSvc)
 			err = l4c.sync(getKeyForSvc(newSvc, t))
@@ -633,17 +622,8 @@ func TestProcessDualStackServiceOnUserError(t *testing.T) {
 	l4c := newServiceController(t, newFakeGCE())
 	l4c.enableDualStack = true
 
-	// Create cluster subnet with External IPV6 range. Mock GCE uses subnet with empty string name.
-	clusterSubnetName := ""
-	subnetKey := meta.RegionalKey(clusterSubnetName, l4c.ctx.Cloud.Region())
-	subnetToCreate := &compute.Subnetwork{
-		Ipv6AccessType: "EXTERNAL",
-		StackType:      "IPV4_IPV6",
-	}
-	err := l4c.ctx.Cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), subnetKey, subnetToCreate)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Create cluster subnet with EXTERNAL ipv6 access type to trigger user error.
+	test.MustCreateDualStackClusterSubnet(t, l4c.ctx.Cloud, "EXTERNAL")
 
 	newSvc := test.NewL4ILBDualStackService(8080, api_v1.ProtocolTCP, []api_v1.IPFamily{api_v1.IPv4Protocol, api_v1.IPv6Protocol}, api_v1.ServiceExternalTrafficPolicyTypeCluster)
 	addILBService(l4c, newSvc)
@@ -736,22 +716,12 @@ func TestProcessUpdateILBIPFamilies(t *testing.T) {
 			l4c := newServiceController(t, newFakeGCE())
 			l4c.enableDualStack = true
 
-			// Create cluster subnet with Internal IPV6 range. Mock GCE uses subnet with empty string name.
-			clusterSubnetName := ""
-			subnetKey := meta.RegionalKey(clusterSubnetName, l4c.ctx.Cloud.Region())
-			subnetToCreate := &compute.Subnetwork{
-				Ipv6AccessType: "INTERNAL",
-				StackType:      "IPV4_IPV6",
-			}
-			err := l4c.ctx.Cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), subnetKey, subnetToCreate)
-			if err != nil {
-				t.Fatal(err)
-			}
+			test.MustCreateDualStackClusterSubnet(t, l4c.ctx.Cloud, "INTERNAL")
 
 			svc := test.NewL4ILBDualStackService(8080, api_v1.ProtocolTCP, tc.initialIPFamilies, api_v1.ServiceExternalTrafficPolicyTypeCluster)
 			addILBService(l4c, svc)
 			addNEG(l4c, svc)
-			err = l4c.sync(getKeyForSvc(svc, t))
+			err := l4c.sync(getKeyForSvc(svc, t))
 			if err != nil {
 				t.Errorf("Failed to sync newly added service %s, err %v", svc.Name, err)
 			}

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -1569,6 +1569,18 @@ func TestCreateDeleteDualStackNetLBService(t *testing.T) {
 			svc.Spec.IPFamilies = tc.ipFamilies
 			addNetLBService(controller, svc)
 
+			// Create cluster subnet with Internal IPV6 range. Mock GCE uses subnet with empty string name.
+			clusterSubnetName := ""
+			subnetKey := meta.RegionalKey(clusterSubnetName, controller.ctx.Cloud.Region())
+			subnetToCreate := &compute.Subnetwork{
+				Ipv6AccessType: "EXTERNAL",
+				StackType:      "IPV4_IPV6",
+			}
+			err := controller.ctx.Cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), subnetKey, subnetToCreate)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			prevMetrics, err := test.GetL4NetLBLatencyMetric()
 			if err != nil {
 				t.Errorf("Error getting L4 NetLB latency metrics err: %v", err)

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -1569,17 +1569,7 @@ func TestCreateDeleteDualStackNetLBService(t *testing.T) {
 			svc.Spec.IPFamilies = tc.ipFamilies
 			addNetLBService(controller, svc)
 
-			// Create cluster subnet with Internal IPV6 range. Mock GCE uses subnet with empty string name.
-			clusterSubnetName := ""
-			subnetKey := meta.RegionalKey(clusterSubnetName, controller.ctx.Cloud.Region())
-			subnetToCreate := &compute.Subnetwork{
-				Ipv6AccessType: "EXTERNAL",
-				StackType:      "IPV4_IPV6",
-			}
-			err := controller.ctx.Cloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), subnetKey, subnetToCreate)
-			if err != nil {
-				t.Fatal(err)
-			}
+			test.MustCreateDualStackClusterSubnet(t, controller.ctx.Cloud, "EXTERNAL")
 
 			prevMetrics, err := test.GetL4NetLBLatencyMetric()
 			if err != nil {

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -321,15 +321,9 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 
 	// If service requires IPv6 LoadBalancer -- verify that Subnet with Internal IPv6 ranges is used.
 	if l4.enableDualStack && utils.NeedsIPv6(l4.Service) {
-		subnetName := l4.subnetName()
-		hasIPv6SubnetRange, err := utils.SubnetHasIPv6Range(l4.cloud, subnetName, subnetInternalIPv6AccessType)
+		err := l4.serviceSubnetHasInternalIPv6Range()
 		if err != nil {
 			result.Error = err
-			return result
-		}
-		if !hasIPv6SubnetRange {
-			klog.Infof("Subnet %s for IPv6 Service %s/%s does not have internal IPv6 ranges", subnetName, l4.Service.Namespace, l4.Service.Name)
-			result.Error = utils.NewUserError(fmt.Errorf("subnet %s does not have internal IPv6 ranges, required for IPv6 Service", subnetName))
 			return result
 		}
 	}

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -41,6 +41,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	subnetInternalIPv6AccessType = "INTERNAL"
+)
+
 // Many of the functions in this file are re-implemented from gce_loadbalancer_internal.go
 // L4 handles the resource creation/deletion/update for a given L4 ILB service.
 type L4 struct {
@@ -282,6 +286,19 @@ func (l4 *L4) getFRNameWithProtocol(protocol string) string {
 	return l4.namer.L4ForwardingRule(l4.Service.Namespace, l4.Service.Name, strings.ToLower(protocol))
 }
 
+func (l4 *L4) subnetName() string {
+	// At first check custom subnet annotation.
+	customSubnetName := annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet()
+	if customSubnetName != "" {
+		return customSubnetName
+	}
+
+	// If no custom subnet in annotation -- use cluster subnet.
+	clusterSubnetURL := l4.cloud.SubnetworkURL()
+	splitURL := strings.Split(clusterSubnetURL, "/")
+	return splitURL[len(splitURL)-1]
+}
+
 // EnsureInternalLoadBalancer ensures that all GCE resources for the given loadbalancer service have
 // been created. It returns a LoadBalancerStatus with the updated ForwardingRule IP address.
 func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service) *L4ILBSyncResult {
@@ -300,6 +317,21 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	// But this is still the easiest way to identify create vs update in the common case.
 	if len(svc.Status.LoadBalancer.Ingress) > 0 {
 		result.SyncType = SyncTypeUpdate
+	}
+
+	// If service requires IPv6 LoadBalancer -- verify that Subnet with Internal IPv6 ranges is used.
+	if l4.enableDualStack && utils.NeedsIPv6(l4.Service) {
+		subnetName := l4.subnetName()
+		hasIPv6SubnetRange, err := utils.SubnetHasIPv6Range(l4.cloud, subnetName, subnetInternalIPv6AccessType)
+		if err != nil {
+			result.Error = err
+			return result
+		}
+		if !hasIPv6SubnetRange {
+			klog.Infof("Subnet %s for IPv6 Service %s/%s does not have internal IPv6 ranges", subnetName, l4.Service.Namespace, l4.Service.Name)
+			result.Error = utils.NewUserError(fmt.Errorf("subnet %s does not have internal IPv6 ranges, required for IPv6 Service", subnetName))
+			return result
+		}
 	}
 
 	hcLink := l4.provideHealthChecks(nodeNames, result)

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -134,6 +134,21 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 
 	l4netlb.Service = svc
 
+	// If service requires IPv6 LoadBalancer -- verify that Subnet with External IPv6 ranges is used.
+	if l4netlb.enableDualStack && utils.NeedsIPv6(svc) {
+		subnetName := l4netlb.ipv6SubnetName()
+		hasIPv6SubnetRange, err := utils.SubnetHasIPv6Range(l4netlb.cloud, subnetName, subnetExternalIPv6AccessType)
+		if err != nil {
+			result.Error = err
+			return result
+		}
+		if !hasIPv6SubnetRange {
+			klog.Infof("Subnet %s for IPv6 Service %s/%s does not have external IPv6 ranges", subnetName, l4netlb.Service.Namespace, l4netlb.Service.Name)
+			result.Error = utils.NewUserError(fmt.Errorf("subnet %s does not have external IPv6 ranges, required for IPv6 Service", subnetName))
+			return result
+		}
+	}
+
 	hcLink := l4netlb.provideHealthChecks(nodeNames, result)
 	if result.Error != nil {
 		return result

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -136,15 +136,9 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 
 	// If service requires IPv6 LoadBalancer -- verify that Subnet with External IPv6 ranges is used.
 	if l4netlb.enableDualStack && utils.NeedsIPv6(svc) {
-		subnetName := l4netlb.ipv6SubnetName()
-		hasIPv6SubnetRange, err := utils.SubnetHasIPv6Range(l4netlb.cloud, subnetName, subnetExternalIPv6AccessType)
+		err := l4netlb.serviceSubnetHasExternalIPv6Range()
 		if err != nil {
 			result.Error = err
-			return result
-		}
-		if !hasIPv6SubnetRange {
-			klog.Infof("Subnet %s for IPv6 Service %s/%s does not have external IPv6 ranges", subnetName, l4netlb.Service.Namespace, l4netlb.Service.Name)
-			result.Error = utils.NewUserError(fmt.Errorf("subnet %s does not have external IPv6 ranges, required for IPv6 Service", subnetName))
 			return result
 		}
 	}

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	context2 "context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -538,4 +539,23 @@ func InstancesListToNameSet(instancesList []*compute.InstanceWithNamedPorts) (se
 		instancesSet.Insert(parsedInstanceURL.Key.Name)
 	}
 	return instancesSet, nil
+}
+
+func MustCreateDualStackClusterSubnet(t *testing.T, gcecloud *gce.Cloud, ipv6AccessType string) {
+	t.Helper()
+	// Mock GCE uses subnet with empty string name.
+	MustCreateDualStackSubnet(t, gcecloud, "", ipv6AccessType)
+}
+func MustCreateDualStackSubnet(t *testing.T, gcecloud *gce.Cloud, subnetName, ipv6AccessType string) {
+	t.Helper()
+
+	subnetKey := meta.RegionalKey(subnetName, gcecloud.Region())
+	subnetToCreate := &compute.Subnetwork{
+		Ipv6AccessType: ipv6AccessType,
+		StackType:      "IPV4_IPV6",
+	}
+	err := gcecloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), subnetKey, subnetToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
- Before syncing IPv6 Services, verify if Service subnet has required IPv6 ranges (INTERNAL for ILB and EXTERNAL for NetLB)
- Add unit tests
