### PR TITLE
[Cherry-pick #2042] Add comparing PortRange in forwarding rules Equal function

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -450,6 +450,7 @@ func Equal(fr1, fr2 *composite.ForwardingRule) (bool, error) {
 		fr1.IPProtocol == fr2.IPProtocol &&
 		fr1.LoadBalancingScheme == fr2.LoadBalancingScheme &&
 		utils.EqualStringSets(fr1.Ports, fr2.Ports) &&
+		fr1.PortRange == fr2.PortRange &&
 		id1.Equal(id2) &&
 		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
 		fr1.AllPorts == fr2.AllPorts &&

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -178,6 +178,23 @@ func TestForwardingRulesEqual(t *testing.T) {
 		},
 	}
 
+	frPortRange1 := &composite.ForwardingRule{
+		Name:                "tcp-fwd-rule",
+		IPAddress:           "10.0.0.0",
+		PortRange:           "2-3",
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+	frPortRange2 := &composite.ForwardingRule{
+		Name:                "tcp-fwd-rule",
+		IPAddress:           "10.0.0.0",
+		PortRange:           "1-2",
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+	}
+
 	for _, tc := range []struct {
 		desc       string
 		oldFwdRule *composite.ForwardingRule
@@ -224,6 +241,12 @@ func TestForwardingRulesEqual(t *testing.T) {
 			desc:       "network tier mismatch",
 			oldFwdRule: fwdRules[6],
 			newFwdRule: fwdRules[7],
+			expect:     false,
+		},
+		{
+			desc:       "same forwarding rule, different port ranges",
+			oldFwdRule: frPortRange1,
+			newFwdRule: frPortRange2,
 			expect:     false,
 		},
 	} {


### PR DESCRIPTION
This fixes bug in RBS that forwarding rule is not getting updated on port updates