### PR TITLE
Add metrics for Transparent Health Checks

### DIFF
--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -88,6 +88,9 @@ const (
 	customRequestHeaders      = feature("CustomRequestHeaders")
 	customHealthChecks        = feature("CustomHealthChecks")
 
+	// Transparent Health Checks feature
+	transparentHealthChecks = feature("TransparentHC")
+
 	// FrontendConfig Features
 	sslPolicy      = feature("SSLPolicy")
 	httpsRedirects = feature("HTTPSRedirects")
@@ -282,6 +285,10 @@ func featuresForServicePort(sp utils.ServicePort) []feature {
 	if sp.NEGEnabled {
 		klog.V(6).Infof("NEG is enabled for service port %s", svcPortKey)
 		features = append(features, neg)
+	}
+	if sp.THCConfiguration.THCOptInOnSvc {
+		klog.V(6).Infof("Transparent Health Checks configured for service port %s.", svcPortKey)
+		features = append(features, transparentHealthChecks)
 	}
 	if sp.BackendConfig == nil {
 		klog.V(4).Infof("Features for Service port %s: %v", svcPortKey, features)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -665,9 +665,10 @@ func updateIngressCount(ingCount map[feature]int, features map[feature]bool) {
 // not to the ingress that references this service-port.
 func isServiceFeature(ftr feature) bool {
 	serviceFeatures := map[feature]bool{
-		servicePort:         true,
-		externalServicePort: true,
-		internalServicePort: true,
+		servicePort:             true,
+		externalServicePort:     true,
+		internalServicePort:     true,
+		transparentHealthChecks: true,
 	}
 	return serviceFeatures[ftr]
 }


### PR DESCRIPTION
The present PR adds a label for ServicePort metrics counting ServicePorts with Transparent Health Checks enabled.