### PR TITLE
Call init function in metrics.go

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,7 +121,7 @@ func (netlbCount *netLBFeatureCount) record() {
 }
 
 // init registers ingress usage metrics.
-func init() {
+func Init() {
 	klog.V(3).Infof("Registering Ingress usage metrics %v and %v, NEG usage metrics %v", ingressCount, servicePortCount, networkEndpointGroupCount)
 	prometheus.MustRegister(ingressCount, servicePortCount, networkEndpointGroupCount)
 
@@ -218,6 +218,7 @@ func (spk servicePortKey) string() string {
 }
 
 func (im *ControllerMetrics) Run(stopCh <-chan struct{}) {
+	Init()
 	klog.V(3).Infof("Ingress Metrics initialized. Metrics will be exported at an interval of %v", im.metricsInterval)
 	// Compute and export metrics periodically.
 	go func() {


### PR DESCRIPTION
As far as I can tell:
 * `func init()` in `metrics.go` is never called,
 * certain metrics are not exported:

1. `number_of_ingresses`
2. `number_of_l4_ilbs`
3. `number_of_l4_netlbs`
4. `number_of_negs`
5. `number_of_service_attachments`
6. `number_of_service_ports`
7. `number_of_services`
8. `component_version`

Calling `init()` seems to fix the above problem.