### PR TITLE
Refactor multinetwork resolution.

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -223,6 +223,7 @@ func main() {
 		EnableL4ILBDualStack:          flags.F.EnableL4ILBDualStack,
 		EnableL4NetLBDualStack:        flags.F.EnableL4NetLBDualStack,
 		EnableL4StrongSessionAffinity: flags.F.EnableL4StrongSessionAffinity,
+		EnableMultinetworking:         flags.F.EnableMultiNetworking,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, ingParamsClient, svcAttachmentClient, networkClient, cloud, namer, kubeSystemUID, ctxConfig)
 	go app.RunHTTPServer(ctx.HealthCheck)
@@ -380,6 +381,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 		enableAsm,
 		asmServiceNEGSkipNamespaces,
 		lpConfig,
+		flags.F.EnableMultiNetworking,
 		klog.TODO(), // TODO(#1761): Replace this with a top level logger configuration once one is available.
 	)
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -136,6 +136,7 @@ type ControllerContextConfig struct {
 	EnableL4ILBDualStack          bool
 	EnableL4NetLBDualStack        bool
 	EnableL4StrongSessionAffinity bool // flag that enables strong session affinity feature
+	EnableMultinetworking         bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/healthchecksl4/interfaces.go
+++ b/pkg/healthchecksl4/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 )
@@ -11,9 +12,9 @@ import (
 // L4HealthChecks defines methods for creating and deleting health checks (and their firewall rules) for l4 services
 type L4HealthChecks interface {
 	// EnsureHealthCheckWithFirewall creates health check (and firewall rule) for l4 service.
-	EnsureHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string) *EnsureHealthCheckResult
+	EnsureHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string, svcNetwork network.NetworkInfo) *EnsureHealthCheckResult
 	// EnsureHealthCheckWithDualStackFirewalls creates health check (and firewall rule) for l4 service. Handles both IPv4 and IPv6.
-	EnsureHealthCheckWithDualStackFirewalls(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string, needsIPv4 bool, needsIPv6 bool) *EnsureHealthCheckResult
+	EnsureHealthCheckWithDualStackFirewalls(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType, nodeNames []string, needsIPv4 bool, needsIPv6 bool, svcNetwork network.NetworkInfo) *EnsureHealthCheckResult
 	// DeleteHealthCheckWithFirewall deletes health check (and firewall rule) for l4 service.
 	DeleteHealthCheckWithFirewall(svc *v1.Service, namer namer.L4ResourcesNamer, sharedHC bool, scope meta.KeyType, l4Type utils.L4LBType) (string, error)
 	// DeleteHealthCheckWithDualStackFirewalls deletes health check (and firewall rule) for l4 service, deletes IPv6 firewalls if asked.

--- a/pkg/loadbalancers/l4testutils.go
+++ b/pkg/loadbalancers/l4testutils.go
@@ -55,7 +55,7 @@ func verifyAddressNotExists(cloud *gce.Cloud, addressName string) error {
 	return nil
 }
 
-func verifyFirewall(cloud *gce.Cloud, nodeNames []string, firewallName, expectedDescription string, expectedSourceRanges []string) error {
+func verifyFirewall(cloud *gce.Cloud, nodeNames []string, firewallName, expectedDescription string, expectedSourceRanges []string, expectedNetworkURL string) error {
 	firewall, err := cloud.GetFirewall(firewallName)
 	if err != nil {
 		return fmt.Errorf("failed to fetch firewall rule %q - err %w", firewallName, err)
@@ -70,6 +70,9 @@ func verifyFirewall(cloud *gce.Cloud, nodeNames []string, firewallName, expected
 	}
 	if firewall.Description != expectedDescription {
 		return fmt.Errorf("unexpected description in firewall %q - Expected %s, Got %s", firewallName, expectedDescription, firewall.Description)
+	}
+	if firewall.Network != expectedNetworkURL {
+		return fmt.Errorf("unexpected Network in firewall %q - Expected %s, Got %s", firewallName, expectedNetworkURL, firewall.Network)
 	}
 	return nil
 }

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -173,8 +173,8 @@ func TestServiceNetwork(t *testing.T) {
 			if tc.gkeNetworkParamSet != nil {
 				gkeNetworkParamSetIndexer.Add(tc.gkeNetworkParamSet)
 			}
-
-			network, err := ServiceNetwork(tc.service, networkIndexer, gkeNetworkParamSetIndexer, fakeCloud{}, klog.Background())
+			networksResolver := NewNetworksResolver(networkIndexer, gkeNetworkParamSetIndexer, fakeCloud{}, true, klog.Background())
+			network, err := networksResolver.ServiceNetwork(tc.service)
 			if err != nil {
 				if tc.wantErr == "" {
 					t.Fatalf("determining network info returned an error, err=%v", err)


### PR DESCRIPTION
Push network resolution down to `EnsureLB` functions so that the sync result can be returned consistently. Add Resolver interface to avoid passing down network and gkenetworkparamset listers and allow to use fake resolver in tests.