### PR TITLE
Refactor L4 metrics reporting

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -165,7 +165,7 @@ func NewControllerContext(
 		ClusterNamer:            clusterNamer,
 		L4Namer:                 namer.NewL4Namer(string(kubeSystemUID), clusterNamer),
 		KubeSystemUID:           kubeSystemUID,
-		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval, flags.F.L4NetLBProvisionDeadline),
+		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval, flags.F.L4NetLBProvisionDeadline, flags.F.EnableL4NetLBDualStack, flags.F.EnableL4ILBDualStack),
 		ControllerContextConfig: config,
 		IngressInformer:         informernetworking.NewIngressInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		ServiceInformer:         informerv1.NewServiceInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -524,11 +524,11 @@ func TestProcessServiceOnUserError(t *testing.T) {
 	if syncResult.Error == nil {
 		t.Fatalf("Failed to generate error when syncing service %s", newSvc.Name)
 	}
-	if !syncResult.MetricsState.IsUserError {
-		t.Errorf("syncResult.MetricsState.IsUserError should be true, got false")
+	if !syncResult.MetricsLegacyState.IsUserError {
+		t.Errorf("syncResult.MetricsLegacyState.IsUserError should be true, got false")
 	}
-	if syncResult.MetricsState.InSuccess {
-		t.Errorf("syncResult.MetricsState.InSuccess should be false, got true")
+	if syncResult.MetricsLegacyState.InSuccess {
+		t.Errorf("syncResult.MetricsLegacyState.InSuccess should be false, got true")
 	}
 }
 
@@ -632,14 +632,14 @@ func TestProcessDualStackServiceOnUserError(t *testing.T) {
 	if syncResult.Error == nil {
 		t.Fatalf("Failed to generate error when syncing service %s", newSvc.Name)
 	}
-	if !syncResult.MetricsState.IsUserError {
-		t.Errorf("syncResult.MetricsState.IsUserError should be true, got false")
+	if !syncResult.MetricsLegacyState.IsUserError {
+		t.Errorf("syncResult.MetricsLegacyState.IsUserError should be true, got false")
 	}
-	if syncResult.MetricsState.InSuccess {
-		t.Errorf("syncResult.MetricsState.InSuccess should be false, got true")
+	if syncResult.MetricsLegacyState.InSuccess {
+		t.Errorf("syncResult.MetricsLegacyState.InSuccess should be false, got true")
 	}
-	if syncResult.DualStackMetricsState.Status != metrics.StatusUserError {
-		t.Errorf("syncResult.DualStackMetricsState.Status should be %s, got %s", metrics.StatusUserError, syncResult.DualStackMetricsState.Status)
+	if syncResult.MetricsState.Status != metrics.StatusUserError {
+		t.Errorf("syncResult.MetricsLegacyState.Status should be %s, got %s", metrics.StatusUserError, syncResult.MetricsState.Status)
 	}
 }
 
@@ -655,16 +655,16 @@ func TestDualStackILBStatusForErrorSync(t *testing.T) {
 	if syncResult.Error == nil {
 		t.Fatalf("Failed to generate error when syncing service %s", newSvc.Name)
 	}
-	if syncResult.MetricsState.IsUserError {
-		t.Errorf("syncResult.MetricsState.IsUserError should be false, got true")
+	if syncResult.MetricsLegacyState.IsUserError {
+		t.Errorf("syncResult.MetricsLegacyState.IsUserError should be false, got true")
 	}
-	if syncResult.MetricsState.InSuccess {
-		t.Errorf("syncResult.MetricsState.InSuccess should be false, got true")
+	if syncResult.MetricsLegacyState.InSuccess {
+		t.Errorf("syncResult.MetricsLegacyState.InSuccess should be false, got true")
 	}
-	if syncResult.DualStackMetricsState.Status != metrics.StatusError {
-		t.Errorf("syncResult.DualStackMetricsState.Status should be %s, got %s", metrics.StatusError, syncResult.DualStackMetricsState.Status)
+	if syncResult.MetricsState.Status != metrics.StatusError {
+		t.Errorf("syncResult.MetricsLegacyState.Status should be %s, got %s", metrics.StatusError, syncResult.MetricsState.Status)
 	}
-	if syncResult.DualStackMetricsState.FirstSyncErrorTime == nil {
+	if syncResult.MetricsState.FirstSyncErrorTime == nil {
 		t.Fatalf("Metric status FirstSyncErrorTime for service %s/%s mismatch, expected: not nil, received: nil", newSvc.Namespace, newSvc.Name)
 	}
 }

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -864,10 +864,10 @@ func TestServiceStatusForErrorSync(t *testing.T) {
 	if syncResult.Error == nil {
 		t.Errorf("Expected error in sync controller")
 	}
-	if syncResult.MetricsState.InSuccess == true {
+	if syncResult.MetricsLegacyState.InSuccess == true {
 		t.Fatalf("Metric status InSuccess for service %s/%s mismatch, expected: true, received: false", svc.Namespace, svc.Name)
 	}
-	if syncResult.MetricsState.FirstSyncErrorTime == nil {
+	if syncResult.MetricsLegacyState.FirstSyncErrorTime == nil {
 		t.Fatalf("Metric status FirstSyncErrorTime for service %s/%s mismatch, expected: not nil, received: nil", svc.Namespace, svc.Name)
 	}
 }
@@ -882,11 +882,11 @@ func TestServiceStatusForSuccessSync(t *testing.T) {
 	if syncResult.Error != nil {
 		t.Errorf("Unexpected error in sync controller")
 	}
-	if syncResult.MetricsState.InSuccess != true {
+	if syncResult.MetricsLegacyState.InSuccess != true {
 		t.Fatalf("Metric status InSuccess for service %s/%s mismatch, expected: false, received: true", svc.Namespace, svc.Name)
 	}
-	if syncResult.MetricsState.FirstSyncErrorTime != nil {
-		t.Fatalf("Metric status FirstSyncErrorTime for service %s/%s mismatch, expected: nil, received: %v", svc.Namespace, svc.Name, syncResult.MetricsState.FirstSyncErrorTime)
+	if syncResult.MetricsLegacyState.FirstSyncErrorTime != nil {
+		t.Fatalf("Metric status FirstSyncErrorTime for service %s/%s mismatch, expected: nil, received: %v", svc.Namespace, svc.Name, syncResult.MetricsLegacyState.FirstSyncErrorTime)
 	}
 }
 
@@ -1664,14 +1664,14 @@ func TestProcessDualStackNetLBServiceOnUserError(t *testing.T) {
 	if syncResult.Error == nil {
 		t.Fatalf("Failed to generate error when syncing service %s", svc.Name)
 	}
-	if !syncResult.MetricsState.IsUserError {
-		t.Errorf("syncResult.MetricsState.IsUserError should be true, got false")
+	if !syncResult.MetricsLegacyState.IsUserError {
+		t.Errorf("syncResult.MetricsLegacyState.IsUserError should be true, got false")
 	}
-	if syncResult.MetricsState.InSuccess {
-		t.Errorf("syncResult.MetricsState.InSuccess should be false, got true")
+	if syncResult.MetricsLegacyState.InSuccess {
+		t.Errorf("syncResult.MetricsLegacyState.InSuccess should be false, got true")
 	}
-	if syncResult.DualStackMetricsState.Status != metrics.StatusUserError {
-		t.Errorf("syncResult.DualStackMetricsState.Status should be %s, got %s", metrics.StatusUserError, syncResult.DualStackMetricsState.Status)
+	if syncResult.MetricsState.Status != metrics.StatusUserError {
+		t.Errorf("syncResult.MetricsState.Status should be %s, got %s", metrics.StatusUserError, syncResult.MetricsState.Status)
 	}
 }
 

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -18,11 +18,12 @@ package loadbalancers
 import (
 	"context"
 	"fmt"
-	"k8s.io/ingress-gce/pkg/network"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	"k8s.io/ingress-gce/pkg/network"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -84,7 +85,7 @@ func TestEnsureL4NetLoadBalancer(t *testing.T) {
 	}
 	l4netlb.Service.Annotations = result.Annotations
 	assertNetLBResources(t, l4netlb, nodeNames)
-	if err := checkMetrics(result.MetricsState /*isManaged = */, true /*isPremium = */, true /*isUserError =*/, false); err != nil {
+	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, true /*isPremium = */, true /*isUserError =*/, false); err != nil {
 		t.Errorf("Metrics error: %v", err)
 	}
 }
@@ -125,7 +126,7 @@ func TestEnsureMultinetL4NetLoadBalancer(t *testing.T) {
 	}
 	l4netlb.Service.Annotations = result.Annotations
 	assertNetLBResources(t, l4netlb, nodeNames)
-	if err := checkMetrics(result.MetricsState /*isManaged = */, true /*isPremium = */, true /*isUserError =*/, false); err != nil {
+	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, true /*isPremium = */, true /*isUserError =*/, false); err != nil {
 		t.Errorf("Metrics error: %v", err)
 	}
 }
@@ -280,7 +281,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	if result.Error != nil {
 		t.Errorf("Failed to ensure loadBalancer, err %v", result.Error)
 	}
-	if err := checkMetrics(result.MetricsState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, false); err != nil {
+	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, false); err != nil {
 		t.Errorf("Metrics error: %v", err)
 	}
 	// Check that service sync will return error if User Address IP Network Tier mismatch with service Network Tier.
@@ -289,7 +290,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	if result.Error == nil || !utils.IsNetworkTierError(result.Error) {
 		t.Errorf("LoadBalancer sync should return Network Tier error, err %v", result.Error)
 	}
-	if err := checkMetrics(result.MetricsState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
+	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
 		t.Errorf("Metrics error: %v", err)
 	}
 	// Check that when network tier annotation will be deleted which will change desired service Network Tier to PREMIUM
@@ -305,7 +306,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	if result.Error == nil || !utils.IsNetworkTierError(result.Error) {
 		t.Errorf("LoadBalancer sync should return Network Tier error, err %v", result.Error)
 	}
-	if err := checkMetrics(result.MetricsState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
+	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
 		t.Errorf("Metrics error: %v", err)
 	}
 }
@@ -1524,7 +1525,7 @@ func createUserStaticIPInPremiumTier(fakeGCE *gce.Cloud, region string) {
 	fakeGCE.ReserveRegionAddress(newAddr, region)
 }
 
-func checkMetrics(m metrics.L4NetLBServiceState, isManaged, isPremium, isUserError bool) error {
+func checkMetrics(m metrics.L4NetLBServiceLegacyState, isManaged, isPremium, isUserError bool) error {
 	if m.IsPremiumTier != isPremium {
 		return fmt.Errorf("L4 NetLB metric premium tier should be %v", isPremium)
 	}

--- a/pkg/metrics/l4_dualstack_metrics.go
+++ b/pkg/metrics/l4_dualstack_metrics.go
@@ -1,11 +1,7 @@
 package metrics
 
 import (
-	"strings"
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -26,149 +22,49 @@ var (
 	)
 )
 
-func InitServiceDualStackMetricsState(svc *corev1.Service, startTime *time.Time) L4DualStackServiceState {
-	state := L4DualStackServiceState{}
-
-	state.IPFamilies = ipFamiliesToString(svc.Spec.IPFamilies)
-
-	state.IPFamilyPolicy = ""
-	if svc.Spec.IPFamilyPolicy != nil {
-		state.IPFamilyPolicy = string(*svc.Spec.IPFamilyPolicy)
-	}
-
-	// Always init status with error, and update with Success when service was provisioned
-	state.Status = StatusError
-	state.FirstSyncErrorTime = startTime
-	return state
-}
-
 func (im *ControllerMetrics) exportL4ILBDualStackMetrics() {
+	// Do not report any dual stack information if it is not enabled.
+	if !im.enableILBDualStack {
+		return
+	}
+	im.Lock()
+	defer im.Unlock()
 	// need to reset, otherwise metrics counted on previous exports will be still stored in a prometheus state
 	l4ILBDualStackCount.Reset()
 
-	ilbDualStackCount := im.computeL4ILBDualStackMetrics()
-	klog.V(3).Infof("Exporting L4 ILB DualStack usage metrics: %#v", ilbDualStackCount)
-	for state, count := range ilbDualStackCount {
+	klog.V(3).Infof("Exporting L4 ILB DualStack usage metrics")
+
+	for key, state := range im.l4ILBServiceMap {
+		klog.V(6).Infof("ILB Service %s has IPFamilies: %v, IPFamilyPolicy: %t, Status: %v", key, state.IPFamilies, state.IPFamilyPolicy, state.Status)
 		l4ILBDualStackCount.With(prometheus.Labels{
 			"ip_families":      state.IPFamilies,
 			"ip_family_policy": state.IPFamilyPolicy,
-			"status":           string(state.Status),
-		}).Set(float64(count))
+			"status":           string(getStatusConsideringPersistentError(&state)),
+		}).Inc()
 	}
+
 	klog.V(3).Infof("L4 ILB DualStack usage metrics exported.")
 }
 
 func (im *ControllerMetrics) exportL4NetLBDualStackMetrics() {
+	// Do not report any dual stack information if it is not enabled.
+	if !im.enableNetLBDualStack {
+		return
+	}
+	im.Lock()
+	defer im.Unlock()
 	// need to reset, otherwise metrics counted on previous exports will be still stored in a prometheus state
 	l4NetLBDualStackCount.Reset()
 
-	netlbDualStackCount := im.computeL4NetLBDualStackMetrics()
-	klog.V(3).Infof("Exporting L4 NetLB DualStack usage metrics: %#v", netlbDualStackCount)
-	for state, count := range netlbDualStackCount {
+	klog.V(3).Infof("Exporting L4 NetLB DualStack usage metrics")
+
+	for key, state := range im.l4NetLBServiceMap {
+		klog.V(6).Infof("NetLB Service %s has IPFamilies: %v, IPFamilyPolicy: %t, Status: %v", key, state.IPFamilies, state.IPFamilyPolicy, state.Status)
 		l4NetLBDualStackCount.With(prometheus.Labels{
 			"ip_families":      state.IPFamilies,
 			"ip_family_policy": state.IPFamilyPolicy,
-			"status":           string(state.Status),
-		}).Set(float64(count))
+			"status":           string(getStatusConsideringPersistentError(&state)),
+		}).Inc()
 	}
 	klog.V(3).Infof("L4 Netlb DualStack usage metrics exported.")
-}
-
-// SetL4ILBDualStackService implements L4ILBMetricsCollector.
-func (im *ControllerMetrics) SetL4ILBDualStackService(svcKey string, state L4DualStackServiceState) {
-	im.Lock()
-	defer im.Unlock()
-
-	if im.l4ILBDualStackServiceMap == nil {
-		klog.Fatalf("L4 ILB DualStack Metrics failed to initialize correctly.")
-	}
-	if state.Status == StatusError {
-		if previousState, ok := im.l4ILBDualStackServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
-			// If service is in Error state and retry timestamp was set then do not update it.
-			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
-		}
-	}
-	im.l4ILBDualStackServiceMap[svcKey] = state
-}
-
-// DeleteL4ILBDualStackService implements L4ILBMetricsCollector.
-func (im *ControllerMetrics) DeleteL4ILBDualStackService(svcKey string) {
-	im.Lock()
-	defer im.Unlock()
-
-	delete(im.l4ILBDualStackServiceMap, svcKey)
-}
-
-// SetL4NetLBDualStackService implements L4NetLBMetricsCollector.
-func (im *ControllerMetrics) SetL4NetLBDualStackService(svcKey string, state L4DualStackServiceState) {
-	im.Lock()
-	defer im.Unlock()
-
-	if im.l4NetLBDualStackServiceMap == nil {
-		klog.Fatalf("L4 NetLB DualStack Metrics failed to initialize correctly.")
-	}
-
-	if state.Status == StatusError {
-		if previousState, ok := im.l4NetLBDualStackServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
-			// If service is in Error state and retry timestamp was set then do not update it.
-			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
-		}
-	}
-	im.l4NetLBDualStackServiceMap[svcKey] = state
-}
-
-// DeleteL4NetLBDualStackService implements L4NetLBMetricsCollector.
-func (im *ControllerMetrics) DeleteL4NetLBDualStackService(svcKey string) {
-	im.Lock()
-	defer im.Unlock()
-
-	delete(im.l4NetLBDualStackServiceMap, svcKey)
-}
-
-// computeL4ILBDualStackMetrics aggregates L4 ILB DualStack metrics in the cache.
-func (im *ControllerMetrics) computeL4ILBDualStackMetrics() map[L4DualStackServiceLabels]int {
-	im.Lock()
-	defer im.Unlock()
-	klog.V(4).Infof("Computing L4 DualStack ILB usage metrics from service state map: %#v", im.l4ILBDualStackServiceMap)
-	counts := map[L4DualStackServiceLabels]int{}
-
-	for key, state := range im.l4ILBDualStackServiceMap {
-		klog.V(6).Infof("ILB Service %s has IPFamilies: %v, IPFamilyPolicy: %t, Status: %v", key, state.IPFamilies, state.IPFamilyPolicy, state.Status)
-		if state.Status == StatusError &&
-			state.FirstSyncErrorTime != nil &&
-			time.Since(*state.FirstSyncErrorTime) >= persistentErrorThresholdTime {
-			state.Status = StatusPersistentError
-		}
-		counts[state.L4DualStackServiceLabels]++
-	}
-	klog.V(4).Info("L4 ILB usage metrics computed.")
-	return counts
-}
-
-// computeL4NetLBDualStackMetrics aggregates L4 NetLB DualStack metrics in the cache.
-func (im *ControllerMetrics) computeL4NetLBDualStackMetrics() map[L4DualStackServiceLabels]int {
-	im.Lock()
-	defer im.Unlock()
-	klog.V(4).Infof("Computing L4 DualStack NetLB usage metrics from service state map: %#v", im.l4NetLBDualStackServiceMap)
-	counts := map[L4DualStackServiceLabels]int{}
-
-	for key, state := range im.l4NetLBDualStackServiceMap {
-		klog.V(6).Infof("NetLB Service %s has IPFamilies: %v, IPFamilyPolicy: %t, Status: %v", key, state.IPFamilies, state.IPFamilyPolicy, state.Status)
-		if state.Status == StatusError &&
-			state.FirstSyncErrorTime != nil &&
-			time.Since(*state.FirstSyncErrorTime) >= persistentErrorThresholdTime {
-			state.Status = StatusPersistentError
-		}
-		counts[state.L4DualStackServiceLabels]++
-	}
-	klog.V(4).Info("L4 NetLB usage metrics computed.")
-	return counts
-}
-
-func ipFamiliesToString(ipFamilies []corev1.IPFamily) string {
-	var ipFamiliesStrings []string
-	for _, ipFamily := range ipFamilies {
-		ipFamiliesStrings = append(ipFamiliesStrings, string(ipFamily))
-	}
-	return strings.Join(ipFamiliesStrings, ",")
 }

--- a/pkg/metrics/l4_legacy_metrics.go
+++ b/pkg/metrics/l4_legacy_metrics.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// Legacy L4 ILB metric. It has only one label "feature" which makes it impossible to intersect on this label and count number of services that are using combination of different features.
+	l4ILBLegacyCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "number_of_l4_ilbs",
+			Help: "Number of L4 ILBs",
+		},
+		[]string{label},
+	)
+	// Legacy L4 NetLB metric. It has only one label "feature" which makes it impossible to intersect on this label and count number of services that are using combination of different features.
+	l4NetLBLegacyCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "number_of_l4_netlbs",
+			Help: "Number of L4 NetLBs",
+		},
+		[]string{label},
+	)
+)
+
+// netLBFeatureCount define metric feature count for L4NetLB controller
+type netLBFeatureCount struct {
+	service            int
+	managedStaticIP    int
+	premiumNetworkTier int
+	success            int
+	inUserError        int
+	inError            int
+}
+
+func (netlbCount *netLBFeatureCount) record() {
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBService.String()}).Set(float64(netlbCount.service))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBStaticIP.String()}).Set(float64(netlbCount.success))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBPremiumNetworkTier.String()}).Set(float64(netlbCount.premiumNetworkTier))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBManagedStaticIP.String()}).Set(float64(netlbCount.managedStaticIP))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBInSuccess.String()}).Set(float64(netlbCount.success))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBInUserError.String()}).Set(float64(netlbCount.inUserError))
+	l4NetLBLegacyCount.With(prometheus.Labels{label: l4NetLBInError.String()}).Set(float64(netlbCount.inError))
+}
+
+// SetL4ILBServiceForLegacyMetric adds service to the L4 ILB Legacy Metrics states map.
+func (im *ControllerMetrics) SetL4ILBServiceForLegacyMetric(svcKey string, state L4ILBServiceLegacyState) {
+	im.Lock()
+	defer im.Unlock()
+
+	if im.l4ILBServiceLegacyMap == nil {
+		klog.Fatalf("L4 ILB Legacy Metrics failed to initialize correctly.")
+	}
+	im.l4ILBServiceLegacyMap[svcKey] = state
+}
+
+// DeleteL4ILBServiceForLegacyMetric deletes service from L4 ILB Legacy Metrics states map.
+func (im *ControllerMetrics) DeleteL4ILBServiceForLegacyMetric(svcKey string) {
+	im.Lock()
+	defer im.Unlock()
+
+	delete(im.l4ILBServiceLegacyMap, svcKey)
+}
+
+// SetL4NetLBServiceForLegacyMetric adds service to the L4 NetLB Legacy Metrics states map.
+func (im *ControllerMetrics) SetL4NetLBServiceForLegacyMetric(svcKey string, state L4NetLBServiceLegacyState) {
+	im.Lock()
+	defer im.Unlock()
+
+	if im.l4NetLBServiceLegacyMap == nil {
+		klog.Fatalf("L4 Net LB Legacy Metrics failed to initialize correctly.")
+	}
+
+	if !state.InSuccess {
+		if previousState, ok := im.l4NetLBServiceLegacyMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
+			// If service is in Error state and retry timestamp was set then do not update it.
+			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
+		}
+	}
+	im.l4NetLBServiceLegacyMap[svcKey] = state
+}
+
+// DeleteL4NetLBServiceForLegacyMetric deletes service from L4 ILB Legacy Metrics states map.
+func (im *ControllerMetrics) DeleteL4NetLBServiceForLegacyMetric(svcKey string) {
+	im.Lock()
+	defer im.Unlock()
+
+	delete(im.l4NetLBServiceLegacyMap, svcKey)
+}
+
+// computeL4ILBLegacyMetrics aggregates L4 ILB metrics in the cache.
+func (im *ControllerMetrics) computeL4ILBLegacyMetrics() map[feature]int {
+	im.Lock()
+	defer im.Unlock()
+	klog.V(4).Infof("Computing L4 ILB usage legacy metrics from service state map: %#v", im.l4ILBServiceLegacyMap)
+	counts := map[feature]int{
+		l4ILBService:      0,
+		l4ILBGlobalAccess: 0,
+		l4ILBCustomSubnet: 0,
+		l4ILBInSuccess:    0,
+		l4ILBInError:      0,
+		l4ILBInUserError:  0,
+	}
+
+	for key, state := range im.l4ILBServiceLegacyMap {
+		klog.V(6).Infof("ILB Service %s has EnabledGlobalAccess: %t, EnabledCustomSubnet: %t, InSuccess: %t", key, state.EnabledGlobalAccess, state.EnabledCustomSubnet, state.InSuccess)
+		counts[l4ILBService]++
+		if !state.InSuccess {
+			if state.IsUserError {
+				counts[l4ILBInUserError]++
+			} else {
+				counts[l4ILBInError]++
+			}
+			// Skip counting other features if the service is in error state.
+			continue
+		}
+		counts[l4ILBInSuccess]++
+		if state.EnabledGlobalAccess {
+			counts[l4ILBGlobalAccess]++
+		}
+		if state.EnabledCustomSubnet {
+			counts[l4ILBCustomSubnet]++
+		}
+	}
+	klog.V(4).Info("L4 ILB usage legacy metrics computed.")
+	return counts
+}
+
+// computeL4NetLBLegacyMetrics aggregates L4 NetLB metrics in the cache.
+func (im *ControllerMetrics) computeL4NetLBLegacyMetrics() netLBFeatureCount {
+	im.Lock()
+	defer im.Unlock()
+	klog.V(4).Infof("Computing L4 NetLB usage legacy metrics from service state map: %#v", im.l4NetLBServiceLegacyMap)
+	var counts netLBFeatureCount
+
+	for key, state := range im.l4NetLBServiceLegacyMap {
+		klog.V(6).Infof("NetLB Service %s has metrics %+v", key, state)
+		counts.service++
+		if state.IsUserError {
+			counts.inUserError++
+			// Skip counting other features if the service is in error state.
+			continue
+		}
+		if !state.InSuccess {
+			if time.Since(*state.FirstSyncErrorTime) >= im.l4NetLBProvisionDeadlineForLegacyMetric {
+				counts.inError++
+			}
+			// Skip counting other features if the service is in error state.
+			continue
+		}
+		counts.success++
+		if state.IsManagedIP {
+			counts.managedStaticIP++
+		}
+		if state.IsPremiumTier {
+			counts.premiumNetworkTier++
+		}
+	}
+	klog.V(4).Info("L4 NetLB usage legacy metrics computed.")
+	return counts
+}
+
+func (im *ControllerMetrics) exportL4LegacyMetrics() {
+	ilbCount := im.computeL4ILBLegacyMetrics()
+	klog.V(3).Infof("Exporting L4 ILB usage legacy metrics: %#v", ilbCount)
+	for feature, count := range ilbCount {
+		l4ILBLegacyCount.With(prometheus.Labels{label: feature.String()}).Set(float64(count))
+	}
+	klog.V(3).Infof("L4 ILB usage legacy metrics exported.")
+
+	netlbCount := im.computeL4NetLBLegacyMetrics()
+	klog.V(3).Infof("Exporting L4 NetLB usage legacy metrics: %#v", netlbCount)
+	netlbCount.record()
+	klog.V(3).Infof("L4 NetLB usage legacy metrics exported.")
+}

--- a/pkg/metrics/l4_legacy_metrics_test.go
+++ b/pkg/metrics/l4_legacy_metrics_test.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	premium             = true
+	standard            = false
+	managed             = true
+	unmanaged           = false
+	isSuccess           = true
+	isError             = false
+	isUserError         = true
+	noUserError         = false
+	enableGlobalAccess  = true
+	disableGlobalAccess = false
+	enableCustomSubnet  = true
+	disableCustomSubnet = false
+)
+
+func TestComputeL4ILBMetrics(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc             string
+		serviceStates    []L4ILBServiceLegacyState
+		expectL4ILBCount map[feature]int
+	}{
+		{
+			desc:          "empty input",
+			serviceStates: []L4ILBServiceLegacyState{},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      0,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    0,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "one l4 ilb service",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    1,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "l4 ilb service in error state",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    0,
+				l4ILBInError:      1,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "l4 ilb service in user error state",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, isUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    0,
+				l4ILBInError:      0,
+				l4ILBInUserError:  1,
+			},
+		},
+		{
+			desc: "global access for l4 ilb service enabled",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 1,
+				l4ILBCustomSubnet: 0,
+				l4ILBInSuccess:    1,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "custom subnet for l4 ilb service enabled",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 0,
+				l4ILBCustomSubnet: 1,
+				l4ILBInSuccess:    1,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "both global access and custom subnet for l4 ilb service enabled",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      1,
+				l4ILBGlobalAccess: 1,
+				l4ILBCustomSubnet: 1,
+				l4ILBInSuccess:    1,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "many l4 ilb services",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      4,
+				l4ILBGlobalAccess: 2,
+				l4ILBCustomSubnet: 2,
+				l4ILBInSuccess:    4,
+				l4ILBInError:      0,
+				l4ILBInUserError:  0,
+			},
+		},
+		{
+			desc: "many l4 ilb services with some in error state",
+			serviceStates: []L4ILBServiceLegacyState{
+				newL4ILBServiceState(disableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isError, noUserError),
+				newL4ILBServiceState(disableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, disableCustomSubnet, isError, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isSuccess, noUserError),
+				newL4ILBServiceState(enableGlobalAccess, enableCustomSubnet, isError, isUserError),
+			},
+			expectL4ILBCount: map[feature]int{
+				l4ILBService:      7,
+				l4ILBGlobalAccess: 2,
+				l4ILBCustomSubnet: 2,
+				l4ILBInSuccess:    4,
+				l4ILBInError:      2,
+				l4ILBInUserError:  1,
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			newMetrics := FakeControllerMetrics()
+			for i, serviceState := range tc.serviceStates {
+				newMetrics.SetL4ILBServiceForLegacyMetric(fmt.Sprint(i), serviceState)
+			}
+			got := newMetrics.computeL4ILBLegacyMetrics()
+			if diff := cmp.Diff(tc.expectL4ILBCount, got); diff != "" {
+				t.Fatalf("Got diff for L4 ILB service counts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newL4ILBServiceState(globalAccess bool, customSubnet bool, inSuccess bool, isUserError bool) L4ILBServiceLegacyState {
+	return L4ILBServiceLegacyState{
+		EnabledGlobalAccess: globalAccess,
+		EnabledCustomSubnet: customSubnet,
+		InSuccess:           inSuccess,
+		IsUserError:         isUserError,
+	}
+}
+
+func TestComputeL4NetLBMetrics(t *testing.T) {
+	t.Parallel()
+
+	currTime := time.Now()
+	before5min := currTime.Add(-5 * time.Minute)
+	before25min := currTime.Add(-25 * time.Minute)
+
+	for _, tc := range []struct {
+		desc               string
+		serviceStates      []L4NetLBServiceLegacyState
+		expectL4NetLBCount netLBFeatureCount
+	}{
+		{
+			desc:          "empty input",
+			serviceStates: []L4NetLBServiceLegacyState{},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            0,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            0,
+				inUserError:        0,
+				inError:            0,
+			},
+		},
+		{
+			desc: "one l4 Netlb service",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isSuccess, unmanaged, noUserError, standard /*resyncTime = */, nil),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            1,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            1,
+				inUserError:        0,
+				inError:            0,
+			},
+		},
+		{
+			desc: "one l4 Netlb service in premium network tier",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isSuccess, unmanaged, premium, noUserError /*resyncTime = */, nil),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            1,
+				managedStaticIP:    0,
+				premiumNetworkTier: 1,
+				success:            1,
+				inUserError:        0,
+				inError:            0,
+			},
+		},
+		{
+			desc: "one l4 Netlb service in premium network tier and managed static ip",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isSuccess, managed, premium, noUserError /*resyncTime = */, nil),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            1,
+				managedStaticIP:    1,
+				premiumNetworkTier: 1,
+				success:            1,
+				inUserError:        0,
+				inError:            0,
+			},
+		},
+		{
+			desc: "l4 Netlb service in error state with timestamp greater than resync period",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isError, unmanaged, standard, noUserError, &before25min),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            1,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            0,
+				inUserError:        0,
+				inError:            1,
+			},
+		},
+		{
+			desc: "l4 Netlb service in error state should not count static ip and network tier",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isError, unmanaged, standard, noUserError, &before25min),
+				newL4NetLBServiceState(isError, managed, premium, noUserError, &before25min),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            2,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            0,
+				inUserError:        0,
+				inError:            2,
+			},
+		},
+		{
+			desc: "two l4 Netlb services with different network tier",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isSuccess, unmanaged, standard, noUserError /*resyncTime = */, nil),
+				newL4NetLBServiceState(isSuccess, unmanaged, premium, noUserError, nil),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            2,
+				managedStaticIP:    0,
+				premiumNetworkTier: 1,
+				success:            2,
+				inUserError:        0,
+			},
+		},
+		{
+			desc: "two l4 Netlb services with user error should not count others features",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isError, unmanaged, standard, isUserError /*resyncTime = */, nil),
+				newL4NetLBServiceState(isError, unmanaged, premium, isUserError, nil),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            2,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            0,
+				inUserError:        2,
+				inError:            0,
+			},
+		},
+		{
+			desc: "Error should be measure only after retry time period",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isError, unmanaged, premium, noUserError, &before5min),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            1,
+				managedStaticIP:    0,
+				premiumNetworkTier: 0,
+				success:            0,
+				inUserError:        0,
+				inError:            0,
+			},
+		},
+		{
+			desc: "multi l4 Netlb services",
+			serviceStates: []L4NetLBServiceLegacyState{
+				newL4NetLBServiceState(isSuccess, unmanaged, standard, noUserError /*resyncTime = */, nil),
+				newL4NetLBServiceState(isSuccess, unmanaged, premium, noUserError, nil),
+				newL4NetLBServiceState(isSuccess, unmanaged, premium, noUserError, nil),
+				newL4NetLBServiceState(isSuccess, managed, premium, noUserError, nil),
+				newL4NetLBServiceState(isSuccess, managed, premium, noUserError, nil),
+				newL4NetLBServiceState(isSuccess, managed, standard, noUserError, nil),
+				newL4NetLBServiceState(isError, managed, premium, noUserError, &before25min),
+				newL4NetLBServiceState(isError, managed, standard, noUserError, &before25min),
+			},
+			expectL4NetLBCount: netLBFeatureCount{
+				service:            8,
+				managedStaticIP:    3,
+				premiumNetworkTier: 4,
+				success:            6,
+				inUserError:        0,
+				inError:            2,
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			newMetrics := FakeControllerMetrics()
+			for i, serviceState := range tc.serviceStates {
+				newMetrics.SetL4NetLBServiceForLegacyMetric(fmt.Sprint(i), serviceState)
+			}
+			got := newMetrics.computeL4NetLBLegacyMetrics()
+			if diff := cmp.Diff(tc.expectL4NetLBCount, got, cmp.AllowUnexported(netLBFeatureCount{})); diff != "" {
+				t.Fatalf("Got diff for L4 NetLB service counts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newL4NetLBServiceState(inSuccess, managed, premium, userError bool, errorTimestamp *time.Time) L4NetLBServiceLegacyState {
+	return L4NetLBServiceLegacyState{
+		IsPremiumTier:      premium,
+		IsManagedIP:        managed,
+		InSuccess:          inSuccess,
+		IsUserError:        userError,
+		FirstSyncErrorTime: errorTimestamp,
+	}
+}
+
+func TestRetryPeriodForL4NetLBServices(t *testing.T) {
+	t.Parallel()
+	currTime := time.Now()
+	before5min := currTime.Add(-5 * time.Minute)
+	before25min := currTime.Add(-25 * time.Minute)
+
+	svcName1 := "svc1"
+	svcName2 := "svc2"
+	newMetrics := FakeControllerMetrics()
+	errorState := newL4NetLBServiceState(isError, managed, premium, noUserError, &currTime)
+	newMetrics.SetL4NetLBServiceForLegacyMetric(svcName1, errorState)
+
+	if err := checkMetricsComputation(newMetrics /*expErrorCount =*/, 0 /*expSvcCount =*/, 1); err != nil {
+		t.Fatalf("Check metrics computation failed err: %v", err)
+	}
+	errorState.FirstSyncErrorTime = &before5min
+	newMetrics.SetL4NetLBServiceForLegacyMetric(svcName1, errorState)
+	state, ok := newMetrics.l4NetLBServiceLegacyMap[svcName1]
+	if !ok {
+		t.Fatalf("state should be set")
+	}
+	if *state.FirstSyncErrorTime == before5min {
+		t.Fatal("Time Should Not be rewrite")
+	}
+	errorState.FirstSyncErrorTime = &before25min
+	newMetrics.SetL4NetLBServiceForLegacyMetric(svcName2, errorState)
+	if err := checkMetricsComputation(newMetrics /*expErrorCount =*/, 1 /*expSvcCount =*/, 2); err != nil {
+		t.Fatalf("Check metrics computation failed err: %v", err)
+	}
+}
+
+func checkMetricsComputation(newMetrics *ControllerMetrics, expErrorCount, expSvcCount int) error {
+	got := newMetrics.computeL4NetLBLegacyMetrics()
+	if got.inError != expErrorCount {
+		return fmt.Errorf("Error count mismatch expected: %v got: %v", expErrorCount, got.inError)
+	}
+	if got.service != expSvcCount {
+		return fmt.Errorf("Service count mismatch expected: %v got: %v", expSvcCount, got.service)
+	}
+	return nil
+}

--- a/pkg/metrics/l4_metrics.go
+++ b/pkg/metrics/l4_metrics.go
@@ -17,196 +17,154 @@ limitations under the License.
 package metrics
 
 import (
-	"sync"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+)
+
+const (
+	l4LabelStatus   = "status"
+	l4LabelMultinet = "multinet"
 )
 
 var (
 	l4ILBCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "number_of_l4_ilbs",
-			Help: "Number of L4 ILBs",
+			Name: "l4_ilbs_count",
+			Help: "Metric containing the number of ILBs that can be filtered by feature labels and status",
 		},
-		[]string{label},
+		[]string{l4LabelStatus, l4LabelMultinet},
 	)
+
 	l4NetLBCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "number_of_l4_netlbs",
-			Help: "Number of L4 NetLBs",
+			Name: "l4_netlbs_count",
+			Help: "Metric containing the number of NetLBs that can be filtered by feature labels and status",
 		},
-		[]string{label},
+		[]string{l4LabelStatus, l4LabelMultinet},
 	)
 )
 
-// netLBFeatureCount define metric feature count for L4NetLB controller
-type netLBFeatureCount struct {
-	service            int
-	managedStaticIP    int
-	premiumNetworkTier int
-	success            int
-	inUserError        int
-	inError            int
+func (im *ControllerMetrics) exportL4Metrics() {
+	im.exportL4ILBsMetrics()
+	im.exportL4NetLBsMetrics()
 }
 
-func (netlbCount *netLBFeatureCount) record() {
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBService.String()}).Set(float64(netlbCount.service))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBStaticIP.String()}).Set(float64(netlbCount.success))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBPremiumNetworkTier.String()}).Set(float64(netlbCount.premiumNetworkTier))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBManagedStaticIP.String()}).Set(float64(netlbCount.managedStaticIP))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBInSuccess.String()}).Set(float64(netlbCount.success))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBInUserError.String()}).Set(float64(netlbCount.inUserError))
-	l4NetLBCount.With(prometheus.Labels{label: l4NetLBInError.String()}).Set(float64(netlbCount.inError))
-}
-
-// l4ControllerMetrics is a struct that holds L4 related metrics
-type l4ControllerMetrics struct {
-	sync.Mutex
-	// l4ILBServiceMap is a map between service key and L4 ILB service state.
-	l4ILBServiceMap map[string]L4ILBServiceState
-	// l4NetLBServiceMap is a map between service key and L4 NetLB service state.
-	l4NetLBServiceMap map[string]L4NetLBServiceState
-	// l4NetLBProvisionDeadline is a time after which a failing NetLB will be marked as persistent error.
-	l4NetLBProvisionDeadline time.Duration
-}
-
-func newL4ontrollerMetrics(l4NetLBProvisionDeadline time.Duration) *l4ControllerMetrics {
-	return &l4ControllerMetrics{
-		l4ILBServiceMap:          make(map[string]L4ILBServiceState),
-		l4NetLBServiceMap:        make(map[string]L4NetLBServiceState),
-		l4NetLBProvisionDeadline: l4NetLBProvisionDeadline,
+func InitServiceMetricsState(svc *corev1.Service, startTime *time.Time, isMultinetwork bool) L4ServiceState {
+	state := L4ServiceState{
+		L4DualStackServiceLabels: L4DualStackServiceLabels{
+			IPFamilies: ipFamiliesToString(svc.Spec.IPFamilies),
+		},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{
+			Multinetwork: isMultinetwork,
+		},
+		// Always init status with error, and update with Success when service was provisioned
+		Status:             StatusError,
+		FirstSyncErrorTime: startTime,
 	}
+	if svc.Spec.IPFamilyPolicy != nil {
+		state.IPFamilyPolicy = string(*svc.Spec.IPFamilyPolicy)
+	}
+
+	return state
 }
 
-// SetL4ILBService implements L4ILBMetricsCollector.
-func (im *ControllerMetrics) SetL4ILBService(svcKey string, state L4ILBServiceState) {
+// SetL4ILBService adds L4 ILB service state to L4 NetLB Metrics states map.
+func (im *ControllerMetrics) SetL4ILBService(svcKey string, state L4ServiceState) {
 	im.Lock()
 	defer im.Unlock()
 
-	if im.l4ControllerMetrics.l4ILBServiceMap == nil {
-		klog.Fatalf("Ingress Metrics failed to initialize correctly.")
+	if im.l4ILBServiceMap == nil {
+		klog.Fatalf("L4 ILB Metrics failed to initialize correctly.")
 	}
-	im.l4ControllerMetrics.l4ILBServiceMap[svcKey] = state
-}
-
-// DeleteL4ILBService implements L4ILBMetricsCollector.
-func (im *ControllerMetrics) DeleteL4ILBService(svcKey string) {
-	im.Lock()
-	defer im.Unlock()
-
-	delete(im.l4ControllerMetrics.l4ILBServiceMap, svcKey)
-}
-
-// SetL4NetLBService adds metric state for given service to map.
-func (im *ControllerMetrics) SetL4NetLBService(svcKey string, state L4NetLBServiceState) {
-	im.Lock()
-	defer im.Unlock()
-
-	if im.l4ControllerMetrics.l4NetLBServiceMap == nil {
-		klog.Fatalf("L4 Net LB Metrics failed to initialize correctly.")
-	}
-
-	if !state.InSuccess {
-		if previousState, ok := im.l4ControllerMetrics.l4NetLBServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
+	if state.Status == StatusError {
+		if previousState, ok := im.l4ILBServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
 			// If service is in Error state and retry timestamp was set then do not update it.
 			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
 		}
 	}
-	im.l4ControllerMetrics.l4NetLBServiceMap[svcKey] = state
+	im.l4ILBServiceMap[svcKey] = state
 }
 
-// DeleteL4NetLBService deletes service from metrics map.
+// DeleteL4ILBService deletes L4 ILB service state from L4 NetLB Metrics states map.
+func (im *ControllerMetrics) DeleteL4ILBService(svcKey string) {
+	im.Lock()
+	defer im.Unlock()
+
+	delete(im.l4ILBServiceMap, svcKey)
+}
+
+// SetL4NetLBService adds L4 NetLB service state to L4 NetLB Metrics states map.
+func (im *ControllerMetrics) SetL4NetLBService(svcKey string, state L4ServiceState) {
+	im.Lock()
+	defer im.Unlock()
+
+	if im.l4NetLBServiceMap == nil {
+		klog.Fatalf("L4 NetLB Metrics failed to initialize correctly.")
+	}
+
+	if state.Status == StatusError {
+		if previousState, ok := im.l4NetLBServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
+			// If service is in Error state and retry timestamp was set then do not update it.
+			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
+		}
+	}
+	im.l4NetLBServiceMap[svcKey] = state
+}
+
+// DeleteL4NetLBService deletes L4 NetLB service state from L4 NetLB Metrics states map.
 func (im *ControllerMetrics) DeleteL4NetLBService(svcKey string) {
 	im.Lock()
 	defer im.Unlock()
 
-	delete(im.l4ControllerMetrics.l4NetLBServiceMap, svcKey)
+	delete(im.l4NetLBServiceMap, svcKey)
 }
 
-// computeL4ILBMetrics aggregates L4 ILB metrics in the cache.
-func (l4 *l4ControllerMetrics) computeL4ILBMetrics() map[feature]int {
-	l4.Lock()
-	defer l4.Unlock()
-	klog.V(4).Infof("Computing L4 ILB usage metrics from service state map: %#v", l4.l4ILBServiceMap)
-	counts := map[feature]int{
-		l4ILBService:      0,
-		l4ILBGlobalAccess: 0,
-		l4ILBCustomSubnet: 0,
-		l4ILBInSuccess:    0,
-		l4ILBInError:      0,
-		l4ILBInUserError:  0,
+func ipFamiliesToString(ipFamilies []corev1.IPFamily) string {
+	var ipFamiliesStrings []string
+	for _, ipFamily := range ipFamilies {
+		ipFamiliesStrings = append(ipFamiliesStrings, string(ipFamily))
 	}
-
-	for key, state := range l4.l4ILBServiceMap {
-		klog.V(6).Infof("ILB Service %s has EnabledGlobalAccess: %t, EnabledCustomSubnet: %t, InSuccess: %t", key, state.EnabledGlobalAccess, state.EnabledCustomSubnet, state.InSuccess)
-		counts[l4ILBService]++
-		if !state.InSuccess {
-			if state.IsUserError {
-				counts[l4ILBInUserError]++
-			} else {
-				counts[l4ILBInError]++
-			}
-			// Skip counting other features if the service is in error state.
-			continue
-		}
-		counts[l4ILBInSuccess]++
-		if state.EnabledGlobalAccess {
-			counts[l4ILBGlobalAccess]++
-		}
-		if state.EnabledCustomSubnet {
-			counts[l4ILBCustomSubnet]++
-		}
-	}
-	klog.V(4).Info("L4 ILB usage metrics computed.")
-	return counts
+	return strings.Join(ipFamiliesStrings, ",")
 }
 
-// computeL4NetLBMetrics aggregates L4 NetLB metrics in the cache.
-func (l4 *l4ControllerMetrics) computeL4NetLBMetrics() netLBFeatureCount {
-	l4.Lock()
-	defer l4.Unlock()
-	klog.V(4).Infof("Computing L4 NetLB usage metrics from service state map: %#v", l4.l4NetLBServiceMap)
-	var counts netLBFeatureCount
-
-	for key, state := range l4.l4NetLBServiceMap {
-		klog.V(6).Infof("NetLB Service %s has metrics %+v", key, state)
-		counts.service++
-		if state.IsUserError {
-			counts.inUserError++
-			// Skip counting other features if the service is in error state.
-			continue
-		}
-		if !state.InSuccess {
-			if time.Since(*state.FirstSyncErrorTime) >= l4.l4NetLBProvisionDeadline {
-				counts.inError++
-			}
-			// Skip counting other features if the service is in error state.
-			continue
-		}
-		counts.success++
-		if state.IsManagedIP {
-			counts.managedStaticIP++
-		}
-		if state.IsPremiumTier {
-			counts.premiumNetworkTier++
-		}
-	}
-	klog.V(4).Info("L4 NetLB usage metrics computed.")
-	return counts
-}
-
-func (l4 *l4ControllerMetrics) export() {
-	ilbCount := l4.computeL4ILBMetrics()
-	klog.V(3).Infof("Exporting L4 ILB usage metrics: %#v", ilbCount)
-	for feature, count := range ilbCount {
-		l4ILBCount.With(prometheus.Labels{label: feature.String()}).Set(float64(count))
+func (im *ControllerMetrics) exportL4ILBsMetrics() {
+	im.Lock()
+	defer im.Unlock()
+	klog.V(3).Infof("Exporting L4 ILB usage metrics for %d services.", len(im.l4ILBServiceMap))
+	l4ILBCount.Reset()
+	for _, svcState := range im.l4ILBServiceMap {
+		l4ILBCount.With(prometheus.Labels{
+			l4LabelStatus:   string(getStatusConsideringPersistentError(&svcState)),
+			l4LabelMultinet: strconv.FormatBool(svcState.Multinetwork),
+		}).Inc()
 	}
 	klog.V(3).Infof("L4 ILB usage metrics exported.")
+}
 
-	netlbCount := l4.computeL4NetLBMetrics()
-	klog.V(3).Infof("Exporting L4 NetLB usage metrics: %#v", netlbCount)
-	netlbCount.record()
+func (im *ControllerMetrics) exportL4NetLBsMetrics() {
+	im.Lock()
+	defer im.Unlock()
+	klog.V(3).Infof("Exporting L4 NetLB usage metrics for %d services.", len(im.l4NetLBServiceMap))
+	l4NetLBCount.Reset()
+	for _, svcState := range im.l4NetLBServiceMap {
+		l4NetLBCount.With(prometheus.Labels{
+			l4LabelStatus:   string(getStatusConsideringPersistentError(&svcState)),
+			l4LabelMultinet: strconv.FormatBool(svcState.Multinetwork),
+		}).Inc()
+	}
 	klog.V(3).Infof("L4 NetLB usage metrics exported.")
+}
+
+func getStatusConsideringPersistentError(state *L4ServiceState) L4ServiceStatus {
+	if state.Status == StatusError &&
+		state.FirstSyncErrorTime != nil &&
+		time.Since(*state.FirstSyncErrorTime) >= persistentErrorThresholdTime {
+		return StatusPersistentError
+	}
+	return state.Status
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -91,17 +91,23 @@ func init() {
 	klog.V(3).Infof("Registering Ingress usage metrics %v and %v, NEG usage metrics %v", ingressCount, servicePortCount, networkEndpointGroupCount)
 	prometheus.MustRegister(ingressCount, servicePortCount, networkEndpointGroupCount)
 
-	klog.V(3).Infof("Registering L4 ILB usage metrics %v", l4ILBCount)
-	prometheus.MustRegister(l4ILBCount)
+	klog.V(3).Infof("Registering L4 ILB usage legacy metrics %v", l4ILBLegacyCount)
+	prometheus.MustRegister(l4ILBLegacyCount)
 
 	klog.V(3).Infof("Registering L4 ILB Dual Stack usage metrics %v", l4ILBDualStackCount)
 	prometheus.MustRegister(l4ILBDualStackCount)
 
-	klog.V(3).Infof("Registering L4 NetLB usage metrics %v", l4NetLBCount)
-	prometheus.MustRegister(l4NetLBCount)
+	klog.V(3).Infof("Registering L4 NetLB usage legacy metrics %v", l4NetLBLegacyCount)
+	prometheus.MustRegister(l4NetLBLegacyCount)
 
 	klog.V(3).Infof("Registering L4 NetLB Dual Stack usage metrics %v", l4NetLBDualStackCount)
 	prometheus.MustRegister(l4NetLBDualStackCount)
+
+	klog.V(3).Infof("Registering L4 ILB usage metrics %v", l4ILBCount)
+	prometheus.MustRegister(l4ILBCount)
+
+	klog.V(3).Infof("Registering L4 NetLB usage metrics %v", l4NetLBCount)
+	prometheus.MustRegister(l4NetLBCount)
 
 	klog.V(3).Infof("Registering PSC usage metrics %v", serviceAttachmentCount)
 	prometheus.MustRegister(serviceAttachmentCount)
@@ -124,12 +130,16 @@ type ControllerMetrics struct {
 	ingressMap map[string]IngressState
 	// negMap is a map between service key to neg state
 	negMap map[string]NegServiceState
-	// l4ControllerMetrics contains data needed to calculate L4 metrics.
-	l4ControllerMetrics *l4ControllerMetrics
-	// l4ILBDualStackServiceMap is a map between service key and L4 ILB DualStack service state.
-	l4ILBDualStackServiceMap map[string]L4DualStackServiceState
-	// l4NetLBDualStackServiceMap is a map between service key and L4 NetLB DualStack service state.
-	l4NetLBDualStackServiceMap map[string]L4DualStackServiceState
+	// l4ILBServiceLegacyMap is a map between service key and L4 ILB service state. It's used in the legacy metric.
+	l4ILBServiceLegacyMap map[string]L4ILBServiceLegacyState
+	// l4NetLBServiceLegacyMap is a map between service key and L4 NetLB service state. It's used in the legacy metric.
+	l4NetLBServiceLegacyMap map[string]L4NetLBServiceLegacyState
+	// l4NetLBProvisionDeadlineForLegacyMetric is a time after which a failing NetLB will be marked as persistent error in the legacy metric.
+	l4NetLBProvisionDeadlineForLegacyMetric time.Duration
+	// l4ILBServiceMap is a map between service key and L4 ILB service state.
+	l4ILBServiceMap map[string]L4ServiceState
+	// l4NetLBServiceMap is a map between service key and L4 NetLB service state.
+	l4NetLBServiceMap map[string]L4ServiceState
 	// pscMap is a map between the service attachment key and PSC state
 	pscMap map[string]pscmetrics.PSCState
 	// ServiceMap track the number of services in this cluster
@@ -137,28 +147,32 @@ type ControllerMetrics struct {
 	//TODO(kl52752) remove mutex and change map to sync.map
 	sync.Mutex
 	// duration between metrics exports
-	metricsInterval time.Duration
-	// Time during which the L4 NetLB service should be provision.
-	l4NetLBProvisionDeadline time.Duration
+	metricsInterval      time.Duration
+	enableILBDualStack   bool
+	enableNetLBDualStack bool
 }
 
 // NewControllerMetrics initializes ControllerMetrics and starts a go routine to compute and export metrics periodically.
-func NewControllerMetrics(exportInterval, l4NetLBProvisionDeadline time.Duration) *ControllerMetrics {
+func NewControllerMetrics(exportInterval, l4NetLBProvisionDeadline time.Duration, enableNetLBDualStack, enableILBDualStack bool) *ControllerMetrics {
 	return &ControllerMetrics{
-		ingressMap:                 make(map[string]IngressState),
-		negMap:                     make(map[string]NegServiceState),
-		l4ILBDualStackServiceMap:   make(map[string]L4DualStackServiceState),
-		l4NetLBDualStackServiceMap: make(map[string]L4DualStackServiceState),
-		pscMap:                     make(map[string]pscmetrics.PSCState),
-		serviceMap:                 make(map[string]struct{}),
-		metricsInterval:            exportInterval,
-		l4ControllerMetrics:        newL4ontrollerMetrics(l4NetLBProvisionDeadline),
+		ingressMap:                              make(map[string]IngressState),
+		negMap:                                  make(map[string]NegServiceState),
+		l4ILBServiceLegacyMap:                   make(map[string]L4ILBServiceLegacyState),
+		l4NetLBServiceLegacyMap:                 make(map[string]L4NetLBServiceLegacyState),
+		l4ILBServiceMap:                         make(map[string]L4ServiceState),
+		l4NetLBServiceMap:                       make(map[string]L4ServiceState),
+		pscMap:                                  make(map[string]pscmetrics.PSCState),
+		serviceMap:                              make(map[string]struct{}),
+		metricsInterval:                         exportInterval,
+		l4NetLBProvisionDeadlineForLegacyMetric: l4NetLBProvisionDeadline,
+		enableILBDualStack:                      enableILBDualStack,
+		enableNetLBDualStack:                    enableNetLBDualStack,
 	}
 }
 
 // FakeControllerMetrics creates new ControllerMetrics with fixed 10 minutes metricsInterval, to be used in tests
 func FakeControllerMetrics() *ControllerMetrics {
-	return NewControllerMetrics(10*time.Minute, 20*time.Minute)
+	return NewControllerMetrics(10*time.Minute, 20*time.Minute, true, true)
 }
 
 // servicePortKey defines a service port uniquely.
@@ -290,7 +304,8 @@ func (im *ControllerMetrics) export() {
 	klog.V(3).Infof("Ingress usage metrics exported.")
 
 	// Export L4 metrics.
-	im.l4ControllerMetrics.export()
+	im.exportL4LegacyMetrics()
+	im.exportL4Metrics()
 
 	im.exportL4ILBDualStackMetrics()
 	im.exportL4NetLBDualStackMetrics()

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -60,9 +60,9 @@ func NewVmIpNegType(trafficPolicyLocal bool) *VmIpNegType {
 	return &VmIpNegType{trafficPolicyLocal: trafficPolicyLocal}
 }
 
-// L4ILBServiceState defines if global access and subnet features are enabled
+// L4ILBServiceLegacyState defines if global access and subnet features are enabled
 // for an L4 ILB service.
-type L4ILBServiceState struct {
+type L4ILBServiceLegacyState struct {
 	// EnabledGlobalAccess specifies if Global Access is enabled.
 	EnabledGlobalAccess bool
 	// EnabledCustomSubNet specifies if Custom Subnet is enabled.
@@ -73,36 +73,43 @@ type L4ILBServiceState struct {
 	IsUserError bool
 }
 
-type L4DualStackServiceStatus string
+type L4ServiceStatus string
 
-const StatusSuccess = L4DualStackServiceStatus("Success")
-const StatusUserError = L4DualStackServiceStatus("UserError")
-const StatusError = L4DualStackServiceStatus("Error")
-const StatusPersistentError = L4DualStackServiceStatus("PersistentError")
+const StatusSuccess = L4ServiceStatus("Success")
+const StatusUserError = L4ServiceStatus("UserError")
+const StatusError = L4ServiceStatus("Error")
+const StatusPersistentError = L4ServiceStatus("PersistentError")
 
-// L4DualStackServiceLabels defines ipFamilies, ipFamilyPolicy and status
+// L4DualStackServiceLabels defines ipFamilies, ipFamilyPolicy
 // of L4 DualStack service
 type L4DualStackServiceLabels struct {
 	// IPFamilies stores spec.ipFamilies of Service
 	IPFamilies string
 	// IPFamilyPolicy specifies spec.IPFamilyPolicy of Service
 	IPFamilyPolicy string
-	// Status specifies status of L4 DualStack Service
-	Status L4DualStackServiceStatus
 }
 
-// L4DualStackServiceState defines ipFamilies, ipFamilyPolicy, status and tracks
-// FirstSyncErrorTime of L4 DualStack service
-type L4DualStackServiceState struct {
+// L4FeaturesServiceLabels defines various properties we want to track for L4 LBs
+type L4FeaturesServiceLabels struct {
+	// Multinetwork specifies if the service is a multinetworked service
+	Multinetwork bool
+}
+
+// L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.
+// FirstSyncErrorTime of an L4 service
+type L4ServiceState struct {
 	L4DualStackServiceLabels
+	L4FeaturesServiceLabels
+	// Status specifies status of an L4 Service
+	Status L4ServiceStatus
 	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
 	FirstSyncErrorTime *time.Time
 }
 
-// L4NetLBServiceState defines if network tier is premium and
+// L4NetLBServiceLegacyState defines if network tier is premium and
 // if static ip address is managed by controller
 // for an L4 NetLB service.
-type L4NetLBServiceState struct {
+type L4NetLBServiceLegacyState struct {
 	// IsManagedIP specifies if Static IP is managed by controller.
 	IsManagedIP bool
 	// IsPremiumTier specifies if network tier for forwarding rule is premium.
@@ -115,9 +122,9 @@ type L4NetLBServiceState struct {
 	FirstSyncErrorTime *time.Time
 }
 
-// InitL4NetLBServiceState sets FirstSyncErrorTime
-func InitL4NetLBServiceState(syncTime *time.Time) L4NetLBServiceState {
-	return L4NetLBServiceState{FirstSyncErrorTime: syncTime}
+// InitL4NetLBServiceLegacyState created and inits the L4NetLBServiceLegacyState struct by setting FirstSyncErrorTime.
+func InitL4NetLBServiceLegacyState(syncTime *time.Time) L4NetLBServiceLegacyState {
+	return L4NetLBServiceLegacyState{FirstSyncErrorTime: syncTime}
 }
 
 // IngressMetricsCollector is an interface to update/delete ingress states in the cache
@@ -141,8 +148,8 @@ type NegMetricsCollector interface {
 // L4ILBMetricsCollector is an interface to update/delete L4 ILb service states
 // in the cache that is used for computing L4 ILB usage metrics.
 type L4ILBMetricsCollector interface {
-	// SetL4ILBService adds/updates L4 ILB service state for given service key.
-	SetL4ILBService(svcKey string, state L4ILBServiceState)
-	// DeleteL4ILBService removes the given L4 ILB service key.
-	DeleteL4ILBService(svcKey string)
+	// SetL4ILBServiceForLegacyMetric adds/updates L4 ILB service state for given service key.
+	SetL4ILBServiceForLegacyMetric(svcKey string, state L4ILBServiceLegacyState)
+	// DeleteL4ILBServiceForLegacyMetric removes the given L4 ILB service key.
+	DeleteL4ILBServiceForLegacyMetric(svcKey string)
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,387 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf *dto.MetricFamily) []Problem {
+	fns := []func(mf *dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, newProblem(mf, "no help text"))
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, newProblem(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit)))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf *dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []Problem
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, newProblem(mf, `non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, newProblem(mf, `non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, newProblem(mf, `non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, newProblem(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename)))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, newProblem(mf, "metric names should not contain ':'"))
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, newProblem(mf, "metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, newProblem(mf, "label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, newProblem(mf, "metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,342 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %w", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// ScrapeAndCompare calls a remote exporter's endpoint which is expected to return some metrics in
+// plain text format. Then it compares it with the results that the `expected` would return.
+// If the `metricNames` is not empty it would filter the comparison only to the given metric names.
+func ScrapeAndCompare(url string, expected io.Reader, metricNames ...string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("scraping metrics failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the scraping target returned a status code other than 200: %d",
+			resp.StatusCode)
+	}
+
+	scraped, err := convertReaderToMetricFamily(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(scraped, wanted, metricNames...)
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	return TransactionalGatherAndCompare(prometheus.ToTransactionalGatherer(g), expected, metricNames...)
+}
+
+// TransactionalGatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func TransactionalGatherAndCompare(g prometheus.TransactionalGatherer, expected io.Reader, metricNames ...string) error {
+	got, done, err := g.Gather()
+	defer done()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(got, wanted, metricNames...)
+}
+
+// convertReaderToMetricFamily would read from a io.Reader object and convert it to a slice of
+// dto.MetricFamily.
+func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) {
+	var tp expfmt.TextParser
+	notNormalized, err := tp.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, fmt.Errorf("converting reader to metric families failed: %w", err)
+	}
+
+	return internal.NormalizeMetricFamilies(notNormalized), nil
+}
+
+// compareMetricFamilies would compare 2 slices of metric families, and optionally filters both of
+// them to the `metricNames` provided.
+func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	return compare(got, expected)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %w", err)
+		}
+	}
+	if diffErr := diff(wantBuf, gotBuf); diffErr != "" {
+		return fmt.Errorf(diffErr)
+	}
+	return nil
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice, array or string. Otherwise it returns an empty string.
+func diff(expected, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
+		return ""
+	}
+
+	var e, a string
+	c := spew.ConfigState{
+		Indent:                  " ",
+		DisablePointerAddresses: true,
+		DisableCapacities:       true,
+		SortKeys:                true,
+	}
+	if et != reflect.TypeOf("") {
+		e = c.Sdump(expected)
+		a = c.Sdump(actual)
+	} else {
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
+	}
+
+	diff, _ := internal.GetUnifiedDiffString(internal.UnifiedDiff{
+		A:        internal.SplitLines(e),
+		B:        internal.SplitLines(a),
+		FromFile: "metric output does not match expectation; want",
+		FromDate: "",
+		ToFile:   "got:",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	if diff == "" {
+		return ""
+	}
+
+	return "\n\nDiff:\n" + diff
+}
+
+// typeAndKind returns the type and kind of the given interface{}
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,6 +159,8 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.3.0
 ## explicit; go 1.9
 github.com/prometheus/client_model/go


### PR DESCRIPTION
The existing L4 metrics are now regarded as legacy and have been renamed as such.
The new L4 metric will follow and share state with DualStack metrics.

this also includes multinet metric label.