### PR TITLE
[Cherry-pick #2134]  Delete finalizer last in L4 RBS controller

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -346,6 +346,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service) *lo
 			return result
 		}
 	}
+
 	if err := common.EnsureDeleteServiceFinalizer(svc, common.ILBFinalizerV2, l4c.ctx.KubeClient); err != nil {
 		l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
 			"Error removing finalizer from load balancer: %v", err)


### PR DESCRIPTION
Move deleting the finalizer to the very last part of the sync

Otherwise deleting annotations may result in error and retry

to reviewers:
wait for internal approval on this cherry pick