### PR TITLE
Add Strong Session Affinity for L4 Metric State

### DIFF
--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -79,10 +79,11 @@ type L4ILBSyncResult struct {
 
 func NewL4ILBSyncResult(syncType string, startTime time.Time, svc *corev1.Service, isMultinetService bool) *L4ILBSyncResult {
 	result := &L4ILBSyncResult{
-		Annotations:  make(map[string]string),
-		StartTime:    startTime,
-		SyncType:     syncType,
-		MetricsState: metrics.InitServiceMetricsState(svc, &startTime, isMultinetService),
+		Annotations: make(map[string]string),
+		StartTime:   startTime,
+		SyncType:    syncType,
+		// Internal Load Balancer doesn't support strong session affinity (passing `false` all along)
+		MetricsState: metrics.InitServiceMetricsState(svc, &startTime, isMultinetService, false),
 	}
 
 	// If service already has an IP assigned, treat it as an update instead of a new Loadbalancer.

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -93,6 +93,8 @@ type L4DualStackServiceLabels struct {
 type L4FeaturesServiceLabels struct {
 	// Multinetwork specifies if the service is a multinetworked service
 	Multinetwork bool
+	// StrongSessionAffinity is true if String Session Affinity is enabled
+	StrongSessionAffinity bool
 }
 
 // L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.


### PR DESCRIPTION
Strong Session Affinity (SSA) is a parameter of NetLB service that could be enabled and should be presented in metrics to report:
* amount of services with SSA
* diffirentiate UserError from other ones for such services.