### PR TITLE
Remove unused flag --enable-backendconfig-healthcheck

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -100,7 +100,6 @@ var (
 
 		// Feature flags should be named Enablexxx.
 		EnableASMConfigMapBasedConfig            bool
-		EnableBackendConfigHealthCheck           bool
 		EnableDeleteUnusedFrontends              bool
 		EnableFrontendConfig                     bool
 		EnableNonGCPMode                         bool
@@ -275,7 +274,6 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, f enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableServiceMetrics, "enable-service-metrics", false, `Optional, if enabled then the service metrics controller will be run.`)
-	flag.BoolVar(&F.EnableBackendConfigHealthCheck, "enable-backendconfig-healthcheck", false, "Enable configuration of HealthChecks from the BackendConfig")
 	flag.BoolVar(&F.EnablePSC, "enable-psc", false, "Enable PSC controller")
 	flag.BoolVar(&F.EnableIngressGAFields, "enable-ingress-ga-fields", false, "Enable using Ingress Class GA features")
 	flag.StringVar(&F.GKEClusterName, "gke-cluster-name", "", "The name of the GKE cluster this Ingress Controller will be interacting with")


### PR DESCRIPTION
The flag `--enable-backendconfig-healthcheck` was made void in https://github.com/kubernetes/ingress-gce/pull/2099, and the present PR removes it altogether.