### PR TITLE
Refactor ServerErrror helper functions

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -304,12 +304,7 @@ func IsGCEServerError(err error) bool {
 	if !errors.As(err, &gerr) {
 		return false
 	}
-	for {
-		if apiErr, ok := err.(*googleapi.Error); ok {
-			return apiErr.Code >= http.StatusInternalServerError
-		}
-		err = errors.Unwrap(err)
-	}
+	return gerr.Code >= http.StatusInternalServerError
 }
 
 // IsK8sServerError returns true if the error is K8s server error
@@ -321,12 +316,7 @@ func IsK8sServerError(err error) bool {
 	if !errors.As(err, &k8serr) {
 		return false
 	}
-	for {
-		if apiErr, ok := err.(*k8serrors.StatusError); ok {
-			return apiErr.ErrStatus.Code >= http.StatusInternalServerError
-		}
-		err = errors.Unwrap(err)
-	}
+	return k8serr.ErrStatus.Code >= http.StatusInternalServerError
 }
 
 // PrettyJson marshals an object in a human-friendly format.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -32,6 +32,7 @@ import (
 	api_v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -1630,6 +1631,102 @@ func TestIsUnsupportedFeatureError(t *testing.T) {
 			}
 			if IsUnsupportedFeatureError(&err, tc.featureName) != tc.expectedReturnValue {
 				t.Errorf("IsUnsupportedFeatureError returned unexpected result: %v, expectations: %v for error: %v", IsUnsupportedFeatureError(&err, tc.featureName), tc.expectedReturnValue, err)
+			}
+		})
+	}
+}
+
+func TestIsGCEServerError(t *testing.T) {
+	testcases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "not a GCE server error",
+			err:  errors.New("error"),
+			want: false,
+		},
+		{
+			desc: "gce error that is not a server error",
+			err:  &googleapi.Error{Code: 100},
+			want: false,
+		},
+		{
+			desc: "gce server error",
+			err:  &googleapi.Error{Code: http.StatusInternalServerError},
+			want: true,
+		},
+		{
+			desc: "wrapped gce server error",
+			err:  fmt.Errorf("errors:%w", &googleapi.Error{Code: http.StatusInternalServerError}),
+			want: true,
+		},
+		{
+			desc: "double wrapped error, with server error as the first",
+			err:  fmt.Errorf("%w:%w", errors.New("error"), &googleapi.Error{Code: http.StatusInternalServerError}),
+			want: true,
+		},
+		{
+			desc: "double wrapped error, with server error as the last",
+			err:  fmt.Errorf("%w:%w", &googleapi.Error{Code: http.StatusInternalServerError}, errors.New("error")),
+			want: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := IsGCEServerError(tc.err)
+			if got != tc.want {
+				t.Errorf("Got %+v, expected %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsK8sServerError(t *testing.T) {
+	testcases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "not a GCE server error",
+			err:  errors.New("error"),
+			want: false,
+		},
+		{
+			desc: "k8s server error that is not a server error",
+			err:  &k8serrors.StatusError{ErrStatus: metav1.Status{Code: 100}},
+			want: false,
+		},
+		{
+			desc: "k8s server error",
+			err:  &k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusInternalServerError}},
+			want: true,
+		},
+		{
+			desc: "wrapped k8s server error",
+			err:  fmt.Errorf("errors:%w", &k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusInternalServerError}}),
+			want: true,
+		},
+		{
+			desc: "double wrapped error, with server error as the first",
+			err:  fmt.Errorf("%w:%w", errors.New("error"), &k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusInternalServerError}}),
+			want: true,
+		},
+		{
+			desc: "double wrapped error, with server error as the last",
+			err:  fmt.Errorf("%w:%w", &k8serrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusInternalServerError}}, errors.New("error")),
+			want: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := IsK8sServerError(tc.err)
+			if got != tc.want {
+				t.Errorf("Got %+v, expected %+v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
 * Remove infinite for loop since errors.As finds the relevant error
 * Add tests to validate the functions work for multi-wrapped errors


/assign @bowei 
/cc @gauravkghildiyal 