### PR TITLE
Revert "[Cherry-pick #2134]  Delete finalizer last in L4 RBS controller"

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -346,7 +346,6 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service) *lo
 			return result
 		}
 	}
-
 	if err := common.EnsureDeleteServiceFinalizer(svc, common.ILBFinalizerV2, l4c.ctx.KubeClient); err != nil {
 		l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
 			"Error removing finalizer from load balancer: %v", err)

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -612,6 +612,14 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service)
 		return result
 	}
 
+	if err := common.EnsureDeleteServiceFinalizer(svc, common.NetLBFinalizerV2, lc.ctx.KubeClient); err != nil {
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
+			"Error removing finalizer from L4 External LoadBalancer, err: %v", err)
+		result.Error = fmt.Errorf("Failed to remove L4 External LoadBalancer finalizer, err: %w", err)
+		return result
+	}
+
+	// IMPORTANT: Remove LB annotations from the Service LAST, cause changing service fields are emitted as service update to other controllers
 	if lc.enableDualStack {
 		if err := deleteL4RBSDualStackAnnotations(lc.ctx, svc); err != nil {
 			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
@@ -626,15 +634,6 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service)
 			result.Error = fmt.Errorf("failed to reset resource annotations, err: %w", err)
 			return result
 		}
-	}
-
-	// Finalizer needs to be removed last, because after deleting finalizer service can be deleted and
-	// updating annotations or other manipulations will fail
-	if err := common.EnsureDeleteServiceFinalizer(svc, common.NetLBFinalizerV2, lc.ctx.KubeClient); err != nil {
-		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed",
-			"Error removing finalizer from L4 External LoadBalancer, err: %v", err)
-		result.Error = fmt.Errorf("Failed to remove L4 External LoadBalancer finalizer, err: %w", err)
-		return result
 	}
 
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletedLoadBalancer", "Deleted L4 External LoadBalancer")


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#2225

It does not have a approval and I think the problem is the annotation removal, if we are going to delete the Service we don't need to remove the annotations first AFAIK