### PR TITLE
Fix thc metric invisible when zero and not decreasing to 0

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -498,6 +498,7 @@ func initializeCounts() (map[feature]int, map[feature]int) {
 			clientIPAffinity:          0,
 			cookieAffinity:            0,
 			customRequestHeaders:      0,
+			transparentHealthChecks:   0,
 		}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -959,6 +959,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				servicePort:               0,
 				externalServicePort:       0,
 				neg:                       0,
+				transparentHealthChecks:   0,
 			},
 		},
 		{
@@ -1011,6 +1012,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				servicePort:               2,
 				externalServicePort:       0,
 				neg:                       2,
+				transparentHealthChecks:   0,
 			},
 		},
 		{
@@ -1137,6 +1139,7 @@ func TestComputeIngressMetrics(t *testing.T) {
 				servicePort:               5,
 				externalServicePort:       3,
 				neg:                       3,
+				transparentHealthChecks:   0,
 			},
 		},
 	} {


### PR DESCRIPTION
The feature `transparentHealthChecks` was not been added to `initializeCounts()` in `pkg/metrics/metrics.go` within https://github.com/kubernetes/ingress-gce/pull/2195. This resulted in a buggy behaviour as in the comment to the `initializeCounts()` function.