### PR TITLE
fix: Broken links to testgrid dashboard

### DIFF
--- a/docs/contrib/testing.md
+++ b/docs/contrib/testing.md
@@ -13,13 +13,13 @@ tests that run against a release image use both GCE and GKE.
 
 Any test that starts with ingress-gce-* is a test which runs an image of GLBC from HEAD.
 Any other test you see runs a release image of GLBC.
-Check out https://k8s-testgrid.appspot.com/sig-network-gce & https://k8s-testgrid.appspot.com/sig-network-gke
+Check out https://testgrid.k8s.io/sig-network-gce & https://testgrid.k8s.io/sig-network-gke
 for to see the results for these tests.
 
 Every time a PR is merged to ingress-gce, Kubernetes test-infra triggers
 a job that pushes a new image of GLBC for e2e testing. The ingress-gce-* jobs then use
 this image when the test cluster is brought up. You can see the results of this job
-at https://k8s-testgrid.appspot.com/sig-network-gce#ingress-gce-image-push.
+at https://testgrid.k8s.io/sig-network-gce#ingress-gce-image-push.
 
 ## Running E2E tests
 

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -81,9 +81,9 @@ Multiple Ingress controllers can co-exist and key off the `ingress.class` annota
 
 Testing for the Ingress controllers is divided between:
 * Ingress repo: unit tests and pre-submit integration tests run via travis
-* Kubernetes repo: [pre-submit e2e](https://k8s-testgrid.appspot.com/google-gce#gce&include-filter-by-regex=Loadbalancing),
-  [post-merge e2e](https://k8s-testgrid.appspot.com/google-gce#gci-gce-ingress),
-  [per release-branch e2e](https://k8s-testgrid.appspot.com/google-gce#gci-gce-ingress-1.5)
+* Kubernetes repo: [pre-submit e2e](https://testgrid.k8s.io/google-gce#gce&include-filter-by-regex=Loadbalancing),
+  [post-merge e2e](https://testgrid.k8s.io/google-gce#gci-gce-ingress),
+  [per release-branch e2e](https://testgrid.k8s.io/google-gce#gci-gce-ingress-1.5)
 
 The configuration for jenkins e2e tests are located [here](https://github.com/kubernetes/test-infra).
 The Ingress E2Es are located [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/ingress.go),


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Fixes a broken link to testgrid dashboard.

**Which issue(s) this PR fixes:**
This is related to an umbrella issue and fixes a task of the same:
https://github.com/kubernetes/test-infra/issues/30370