### PR TITLE
[Cherry-pick #2186 -> 1.22] Include proxy-only subnet with purpose=REGIONAL_MANAGED_PROXY when generating firewall rules for Ingress

### DIFF
--- a/pkg/loadbalancers/features/l7ilb.go
+++ b/pkg/loadbalancers/features/l7ilb.go
@@ -44,7 +44,7 @@ func ILBSubnetSourceRange(cloud *gce.Cloud, region string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error comparing subnets: %v", err)
 		}
-		if subnet.Role == "ACTIVE" && subnet.Purpose == "INTERNAL_HTTPS_LOAD_BALANCER" && sameNetwork {
+		if subnet.Role == "ACTIVE" && (subnet.Purpose == "INTERNAL_HTTPS_LOAD_BALANCER" || subnet.Purpose == "REGIONAL_MANAGED_PROXY") && sameNetwork {
 			klog.V(3).Infof("Found L7-ILB Subnet %s - %s", subnet.Name, subnet.IpCidrRange)
 			return subnet.IpCidrRange, nil
 		}


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#2204

/assign @swetharepakula
/hold