### PR TITLE
NEG Controller - run syncers per network

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -863,6 +863,7 @@ func (manager *syncerManager) getSyncerKey(namespace, name string, servicePortKe
 		PortTuple:        portInfo.PortTuple,
 		NegType:          networkEndpointType,
 		EpCalculatorMode: calculatorMode,
+		K8sNetwork:       portInfo.NetworkInfo.K8sNetwork,
 	}
 }
 

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -279,10 +279,13 @@ type NegSyncerKey struct {
 	//   The endpoints are nodes selected at random in case of Cluster trafficPolicy(L4ClusterMode).
 	//   The endpoints are nodes running backends of this service in case of Local trafficPolicy(L4LocalMode).
 	EpCalculatorMode EndpointsCalculatorMode
+
+	// K8sNetwork is the name of the network the NEG is in as indicated in the Network CRD resource.
+	K8sNetwork string
 }
 
 func (key NegSyncerKey) String() string {
-	return fmt.Sprintf("%s/%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	return fmt.Sprintf("%s/%s-%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode, key.K8sNetwork)
 }
 
 // GetAPIVersion returns the compute API version to be used in order


### PR DESCRIPTION
This commit adds the service network to the syncer key. The goal is to make the NEG controller differentiate between service ports in different networks. Currently, if the service network changes the NEG controller doesn't know the ports are really different and keeps the old syncers and so is unable to create appropriate NEGs. With this change it properly recognizes the change, cleans up the invalid NEG and creates a new one in the proper network.

When multinet is turned off, the network in the key will always be `default` and it will not affect the logic.