### PR TITLE
[Cherry-pick #1967 -> 1.19] Replace fetch from apiserver with informer cache while processing SvcNeg

### DIFF
--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -398,6 +398,7 @@ func TestEnableNEGServiceWithL4ILB(t *testing.T) {
 	if err = controller.serviceLister.Update(svc); err != nil {
 		t.Fatalf("Failed to update service lister: %v", err)
 	}
+	rebuildSvcNegCache(t, manager, manager.svcNegClient, testServiceNamespace)
 	if err = controller.processService(svcKey); err != nil {
 		t.Fatalf("Failed to process updated L4 ILB srvice: %v", err)
 	}

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -653,17 +652,17 @@ func (manager *syncerManager) ensureSvcNegCR(svcKey serviceKey, portInfo negtype
 		},
 	}
 
-	negCR, err := manager.svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcKey.namespace).Get(context.Background(), portInfo.NegName, metav1.GetOptions{})
+	obj, exists, err = manager.svcNegLister.GetByKey(fmt.Sprintf("%s/%s", svcKey.namespace, portInfo.NegName))
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("Error retrieving existing negs: %s", err)
-		}
-
+		return fmt.Errorf("Error retrieving existing negs: %s", err)
+	}
+	if !exists {
 		// Neg does not exist so create it
 		_, err = manager.svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcKey.namespace).Create(context.Background(), &newCR, metav1.CreateOptions{})
 		klog.V(2).Infof("Created ServiceNetworkEndpointGroup CR for neg %s/%s", svcKey.namespace, portInfo.NegName)
 		return err
 	}
+	negCR := obj.(*negv1beta1.ServiceNetworkEndpointGroup)
 
 	needUpdate, err := ensureNegCRLabels(negCR, labels)
 	if err != nil {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -246,6 +246,7 @@ func TestEnsureAndStopSyncer(t *testing.T) {
 		} else {
 			if tc.expectEnsureError {
 				if err := wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
+					rebuildSvcNegCache(t, manager, manager.svcNegClient, tc.namespace)
 					if _, _, err := manager.EnsureSyncers(tc.namespace, tc.name, tc.portInfoMap); err != nil {
 						return false, nil
 					}
@@ -255,6 +256,7 @@ func TestEnsureAndStopSyncer(t *testing.T) {
 				}
 			} else {
 				// Expect EnsureSyncers returns successfully immediately
+				rebuildSvcNegCache(t, manager, manager.svcNegClient, tc.namespace)
 				if _, _, err := manager.EnsureSyncers(tc.namespace, tc.name, tc.portInfoMap); err != nil {
 					t.Errorf("For case %q, failed to ensure syncer %s/%s-%v: %v", tc.desc, tc.namespace, tc.name, tc.portInfoMap, err)
 				}
@@ -778,6 +780,7 @@ func TestNegCRCreations(t *testing.T) {
 		t.Errorf("expect service key %q to be registered", svcKey.Key())
 	}
 
+	rebuildSvcNegCache(t, manager, svcNegClient, svcNamespace)
 	// Second call of EnsureSyncers shouldn't cause any changes or errors
 	if _, _, err := manager.EnsureSyncers(svcNamespace, svcName, expectedPortInfoMap); err != nil {
 		t.Errorf("failed to ensure syncer after creating %s/%s-%v: %v", svcNamespace, svcName, expectedPortInfoMap, err)
@@ -801,10 +804,12 @@ func TestNegCRCreations(t *testing.T) {
 		}
 	}
 
+	rebuildSvcNegCache(t, manager, svcNegClient, svcNamespace)
 	// EnsureSyncers should recreate the deleted CRs
 	if _, _, err := manager.EnsureSyncers(svcNamespace, svcName, expectedPortInfoMap); err != nil {
 		t.Errorf("failed to ensure syncer after creating %s/%s-%v: %v", svcNamespace, svcName, expectedPortInfoMap, err)
 	}
+	rebuildSvcNegCache(t, manager, svcNegClient, svcNamespace)
 
 	for _, expectedInfo := range expectedPortInfoMap {
 		neg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcKey.namespace).Get(context2.TODO(), expectedInfo.NegName, metav1.GetOptions{})
@@ -987,6 +992,7 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 				map[negtypes.SvcPortTuple]string{svcTuple1: customNegName},
 			)
 
+			rebuildSvcNegCache(t, manager, manager.svcNegClient, namespace)
 			_, _, err := manager.EnsureSyncers(namespace, svc1.Name, portInfoMap)
 			if tc.expectErr && err == nil {
 				t.Errorf("expected error when ensuring syncer %s/%s %+v", namespace, svc1.Name, portInfoMap)
@@ -1818,4 +1824,11 @@ func populateSvcNegCache(t *testing.T, manager *syncerManager, svcNegClient svcn
 		negCR := cr
 		manager.svcNegLister.Add(&negCR)
 	}
+}
+
+// rebuildSvcNegCache will clear the the manager's svcNeg cache and repopulate
+// it with items from the provided `namespace` using the `svcNegClient`
+func rebuildSvcNegCache(t *testing.T, manager *syncerManager, svcNegClient svcnegclient.Interface, namespace string) {
+	manager.svcNegLister.Replace([]any{}, "")
+	populateSvcNegCache(t, manager, svcNegClient, namespace)
 }


### PR DESCRIPTION
Cherry pick of #1967.

/assign @swetharepakula 
/hold