### PR TITLE
Clean leftover comment for Strong Session Affinity

### DIFF
--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -294,8 +294,6 @@ func (l4netlb *L4NetLB) connectionTrackingPolicy() (*composite.BackendServiceCon
 	connectionTrackingPolicy := composite.BackendServiceConnectionTrackingPolicy{}
 	connectionTrackingPolicy.EnableStrongAffinity = true
 	connectionTrackingPolicy.TrackingMode = backends.PerSessionTrackingMode
-	// verified l4netlb.Service.Spec.SessionAffinityConfig is not null in
-	// checkStrongSessionAffinityRequirements()
 	connectionTrackingPolicy.IdleTimeoutSec = int64(*l4netlb.Service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
 	return &connectionTrackingPolicy, nil
 }


### PR DESCRIPTION
Backend Service has a leftover comment about
Strong Session Affinity check that should be removed.

The checkStrongSessionAffinityRequirements was run in EnsureFrontend() before that