### PR TITLE
Use latest golangci-lint

### DIFF
--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -29,7 +29,7 @@ export PATH=$GOBIN:$PATH
 # Install golangci-lint
 echo "Installing golangci-lint"
 echo
-go install github.com/golangci/golangci-lint/cmd/golangci-lint > /dev/null
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest > /dev/null
 cd "../.."
 
 export GOLANGCI_LINT_CACHE=$PWD/.cache


### PR DESCRIPTION
https://github.com/kubernetes/ingress-gce/pull/2280 needs latest golangci-lint, which seems to work for tests only in a separate PR.