### PR TITLE
Do not compare connection tracking setting in a Backend Service if st…

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -288,7 +288,7 @@ func (b *Backends) DeleteSignedUrlKey(be *composite.BackendService, keyName stri
 }
 
 // EnsureL4BackendService creates or updates the backend service with the given name.
-func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
+func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, useConnectionTrackingPolicy bool, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
 	start := time.Now()
 	klog.V(2).Infof("EnsureL4BackendService(%v, %v, %v): started", name, scheme, protocol)
 	defer func() {
@@ -310,13 +310,15 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 			name, err)
 	}
 	expectedBS := &composite.BackendService{
-		Name:                     name,
-		Protocol:                 protocol,
-		Description:              desc,
-		HealthChecks:             []string{hcLink},
-		SessionAffinity:          utils.TranslateAffinityType(sessionAffinity),
-		LoadBalancingScheme:      scheme,
-		ConnectionTrackingPolicy: connectionTrackingPolicy,
+		Name:                name,
+		Protocol:            protocol,
+		Description:         desc,
+		HealthChecks:        []string{hcLink},
+		SessionAffinity:     utils.TranslateAffinityType(sessionAffinity),
+		LoadBalancingScheme: scheme,
+	}
+	if useConnectionTrackingPolicy {
+		expectedBS.ConnectionTrackingPolicy = connectionTrackingPolicy
 	}
 	if !network.IsDefault {
 		expectedBS.Network = network.NetworkURL
@@ -342,7 +344,7 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 		return composite.GetBackendService(b.cloud, key, meta.VersionGA)
 	}
 
-	if backendSvcEqual(expectedBS, bs) {
+	if backendSvcEqual(expectedBS, bs, useConnectionTrackingPolicy) {
 		klog.V(2).Infof("EnsureL4BackendService: backend service %s did not change, skipping update", name)
 		return bs, nil
 	}
@@ -366,14 +368,19 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 // service will not be updated. The list of backends is not checked either,
 // since that is handled by the neg-linker.
 // The list of backends is not checked, since that is handled by the neg-linker.
-func backendSvcEqual(a, b *composite.BackendService) bool {
-	return a.Protocol == b.Protocol &&
+func backendSvcEqual(a, b *composite.BackendService, compareConnectionTracking bool) bool {
+	svcsEqual := a.Protocol == b.Protocol &&
 		a.Description == b.Description &&
 		a.SessionAffinity == b.SessionAffinity &&
-		connectionTrackingPolicyEqual(a.ConnectionTrackingPolicy, b.ConnectionTrackingPolicy) &&
 		a.LoadBalancingScheme == b.LoadBalancingScheme &&
 		utils.EqualStringSets(a.HealthChecks, b.HealthChecks) &&
 		a.Network == b.Network
+
+	if compareConnectionTracking {
+		return svcsEqual && connectionTrackingPolicyEqual(a.ConnectionTrackingPolicy, b.ConnectionTrackingPolicy)
+	}
+
+	return svcsEqual
 }
 
 // connectionTrackingPolicyEqual returns true if both elements are equal

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -234,7 +234,7 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 	serviceAffinityNone := string(apiv1.ServiceAffinityNone)
 	schemeExternal := string(cloud.SchemeExternal)
 	defaultNetworkInfo := network.NetworkInfo{IsDefault: true}
-	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
+	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, false, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -445,7 +445,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, &composite.BackendServiceConnectionTrackingPolicy{})
+	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, false, nil)
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -85,13 +85,13 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -112,7 +112,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -291,7 +291,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -308,8 +308,9 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 		syncResult.GCEResourceInError = annotations.BackendServiceResource
 		syncResult.Error = err
 	}
+	needsConnectionTracking := connectionTrackingPolicy != nil
 	var bs *composite.BackendService
-	bs, err = l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), connectionTrackingPolicy)
+	bs, err = l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), needsConnectionTracking, connectionTrackingPolicy)
 	if err != nil {
 		if utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
 			syncResult.GCEResourceInError = annotations.BackendServiceResource


### PR DESCRIPTION
…rong session affinity is not used.

We should not set connection tracking at all if strong session affinity is not used. Also don't compare these fields if SSA is not needed to avoid problem with GCE returning defaults we don't expect.