### PR TITLE
Refactor IsGLBCIngress IsGCEIngress

### DIFF
--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -117,21 +117,21 @@ func NewFirewallController(
 	ctx.IngressInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			addIng := obj.(*v1.Ingress)
-			if !utils.IsGCEIngress(addIng) && !utils.IsGCEMultiClusterIngress(addIng) {
+			if !utils.IsGLBCIngress(addIng) {
 				return
 			}
 			fwc.queue.Enqueue(queueKey)
 		},
 		DeleteFunc: func(obj interface{}) {
 			delIng := obj.(*v1.Ingress)
-			if !utils.IsGCEIngress(delIng) && !utils.IsGCEMultiClusterIngress(delIng) {
+			if !utils.IsGLBCIngress(delIng) {
 				return
 			}
 			fwc.queue.Enqueue(queueKey)
 		},
 		UpdateFunc: func(old, cur interface{}) {
 			curIng := cur.(*v1.Ingress)
-			if !utils.IsGCEIngress(curIng) && !utils.IsGCEMultiClusterIngress(curIng) {
+			if !utils.IsGLBCIngress(curIng) {
 				return
 			}
 			fwc.queue.Enqueue(queueKey)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -248,8 +248,6 @@ the pod secrets for creating a Kubernetes client.`)
 		`Namespace to watch for Ingress/Services/Endpoints.`)
 	flag.BoolVar(&F.Version, "version", false,
 		`Print the version of the controller and exit`)
-	flag.StringVar(&F.IngressClass, "ingress-class", "",
-		`If set, overrides what ingress classes are managed by the controller.`)
 	flag.Var(&F.NodePortRanges, "node-port-ranges", `Node port/port-ranges whitelisted for the
 L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-500`)
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,7 +40,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/slice"
 	"k8s.io/klog/v2"
@@ -400,9 +399,6 @@ func EqualResourceIDs(a, b string) bool {
 // controller.
 func IsGCEIngress(ing *networkingv1.Ingress) bool {
 	class := annotations.FromIngress(ing).IngressClass()
-	if flags.F.IngressClass != "" && class == flags.F.IngressClass {
-		return true
-	}
 
 	switch class {
 	case "":


### PR DESCRIPTION
- Split IsGCEIngress into IsGCEL7XLBIngress , IsGCEL7ILBIngress
- Use IsGLBCIngress where possible

Should not change any logic, only code consistency refactoring

should be merged after https://github.com/kubernetes/ingress-gce/pull/2286