### PR TITLE
Hide Strong Session Affinity code behind a flag (fully) 

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -290,7 +290,7 @@ func (b *Backends) DeleteSignedUrlKey(be *composite.BackendService, keyName stri
 }
 
 // EnsureL4BackendService creates or updates the backend service with the given name.
-func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
+func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, useConnectionTrackingPolicy bool, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
 	start := time.Now()
 	klog.V(2).Infof("EnsureL4BackendService(%v, %v, %v): started", name, scheme, protocol)
 	defer func() {
@@ -312,13 +312,15 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 			name, err)
 	}
 	expectedBS := &composite.BackendService{
-		Name:                     name,
-		Protocol:                 protocol,
-		Description:              desc,
-		HealthChecks:             []string{hcLink},
-		SessionAffinity:          utils.TranslateAffinityType(sessionAffinity),
-		LoadBalancingScheme:      scheme,
-		ConnectionTrackingPolicy: connectionTrackingPolicy,
+		Name:                name,
+		Protocol:            protocol,
+		Description:         desc,
+		HealthChecks:        []string{hcLink},
+		SessionAffinity:     utils.TranslateAffinityType(sessionAffinity),
+		LoadBalancingScheme: scheme,
+	}
+	if useConnectionTrackingPolicy {
+		expectedBS.ConnectionTrackingPolicy = connectionTrackingPolicy
 	}
 	if !network.IsDefault {
 		expectedBS.Network = network.NetworkURL
@@ -344,7 +346,7 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 		return composite.GetBackendService(b.cloud, key, meta.VersionGA, klog.TODO())
 	}
 
-	if backendSvcEqual(expectedBS, bs) {
+	if backendSvcEqual(expectedBS, bs, useConnectionTrackingPolicy) {
 		klog.V(2).Infof("EnsureL4BackendService: backend service %s did not change, skipping update", name)
 		return bs, nil
 	}
@@ -370,14 +372,19 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 // service will not be updated. The list of backends is not checked either,
 // since that is handled by the neg-linker.
 // The list of backends is not checked, since that is handled by the neg-linker.
-func backendSvcEqual(a, b *composite.BackendService) bool {
-	return a.Protocol == b.Protocol &&
+func backendSvcEqual(a, b *composite.BackendService, compareConnectionTracking bool) bool {
+	svcsEqual := a.Protocol == b.Protocol &&
 		a.Description == b.Description &&
 		a.SessionAffinity == b.SessionAffinity &&
-		connectionTrackingPolicyEqual(a.ConnectionTrackingPolicy, b.ConnectionTrackingPolicy) &&
 		a.LoadBalancingScheme == b.LoadBalancingScheme &&
 		utils.EqualStringSets(a.HealthChecks, b.HealthChecks) &&
 		a.Network == b.Network
+
+	if compareConnectionTracking {
+		return svcsEqual && connectionTrackingPolicyEqual(a.ConnectionTrackingPolicy, b.ConnectionTrackingPolicy)
+	}
+
+	return svcsEqual
 }
 
 // connectionTrackingPolicyEqual returns true if both elements are equal

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -40,8 +40,9 @@ const (
 
 // Backends handles CRUD operations for backends.
 type Backends struct {
-	cloud *gce.Cloud
-	namer namer.BackendNamer
+	cloud                       *gce.Cloud
+	namer                       namer.BackendNamer
+	useConnectionTrackingPolicy bool
 }
 
 // Backends is a Pool.
@@ -54,6 +55,19 @@ func NewPool(cloud *gce.Cloud, namer namer.BackendNamer) *Backends {
 	return &Backends{
 		cloud: cloud,
 		namer: namer,
+	}
+}
+
+// NewPoolWithConnectionTrackingPolicy returns a new backend pool.
+// It is similar to NewPool() but has a field for ConnectionTrackingPolicy flag
+// - cloud: implements BackendServices
+// - namer: produces names for backends.
+// - useConnectionTrackingPolicy: specifies the need in Connection Tracking Policy configuration
+func NewPoolWithConnectionTrackingPolicy(cloud *gce.Cloud, namer namer.BackendNamer, useConnectionTrackingPolicy bool) *Backends {
+	return &Backends{
+		cloud:                       cloud,
+		namer:                       namer,
+		useConnectionTrackingPolicy: useConnectionTrackingPolicy,
 	}
 }
 
@@ -290,7 +304,8 @@ func (b *Backends) DeleteSignedUrlKey(be *composite.BackendService, keyName stri
 }
 
 // EnsureL4BackendService creates or updates the backend service with the given name.
-func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, useConnectionTrackingPolicy bool, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
+// TODO(code-elinka): refactor the list of arguments (there are too many now)
+func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinity, scheme string, nm types.NamespacedName, network network.NetworkInfo, connectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy) (*composite.BackendService, error) {
 	start := time.Now()
 	klog.V(2).Infof("EnsureL4BackendService(%v, %v, %v): started", name, scheme, protocol)
 	defer func() {
@@ -319,7 +334,8 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 		SessionAffinity:     utils.TranslateAffinityType(sessionAffinity),
 		LoadBalancingScheme: scheme,
 	}
-	if useConnectionTrackingPolicy {
+	// We need this configuration only for Strong Session Affinity feature
+	if b.useConnectionTrackingPolicy {
 		expectedBS.ConnectionTrackingPolicy = connectionTrackingPolicy
 	}
 	if !network.IsDefault {
@@ -346,7 +362,7 @@ func (b *Backends) EnsureL4BackendService(name, hcLink, protocol, sessionAffinit
 		return composite.GetBackendService(b.cloud, key, meta.VersionGA, klog.TODO())
 	}
 
-	if backendSvcEqual(expectedBS, bs, useConnectionTrackingPolicy) {
+	if backendSvcEqual(expectedBS, bs, b.useConnectionTrackingPolicy) {
 		klog.V(2).Infof("EnsureL4BackendService: backend service %s did not change, skipping update", name)
 		return bs, nil
 	}
@@ -380,6 +396,7 @@ func backendSvcEqual(a, b *composite.BackendService, compareConnectionTracking b
 		utils.EqualStringSets(a.HealthChecks, b.HealthChecks) &&
 		a.Network == b.Network
 
+	// Compare only for backendSvc that uses Strong Session Affinity feature
 	if compareConnectionTracking {
 		return svcsEqual && connectionTrackingPolicyEqual(a.ConnectionTrackingPolicy, b.ConnectionTrackingPolicy)
 	}

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -75,7 +75,7 @@ func TestEnsureL4BackendService(t *testing.T) {
 			hcLink := l4namer.L4HealthCheck(tc.serviceNamespace, tc.serviceName, false)
 			bsName := l4namer.L4Backend(tc.serviceNamespace, tc.serviceName)
 			network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
-			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, connectionTrackingPolicy)
+			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, tc.enableStrongSessionAffinity, connectionTrackingPolicy)
 			if err != nil {
 				t.Errorf("EnsureL4BackendService failed")
 			}
@@ -106,8 +106,14 @@ func TestEnsureL4BackendService(t *testing.T) {
 			if bs.ConnectionDraining == nil || bs.ConnectionDraining.DrainingTimeoutSec != DefaultConnectionDrainingTimeoutSeconds {
 				t.Errorf("BackendService.ConnectionDraining was not populated correctly, want=connection draining with %q, got=%q", DefaultConnectionDrainingTimeoutSeconds, bs.ConnectionDraining)
 			}
-			if diff := cmp.Diff(bs.ConnectionTrackingPolicy, connectionTrackingPolicy); diff != "" {
-				t.Errorf("BackendService.ConnectionTrackingPolicy was not populated correctly, expected to be different: %s", diff)
+			if tc.enableStrongSessionAffinity {
+				if diff := cmp.Diff(bs.ConnectionTrackingPolicy, connectionTrackingPolicy); diff != "" {
+					t.Errorf("BackendService.ConnectionTrackingPolicy was not populated correctly, expected to be different: %s", diff)
+				}
+			} else {
+				if bs.ConnectionTrackingPolicy != nil {
+					t.Errorf("ConnectionTrackingPolicy should not be set for non strong session affinity services.")
+				}
 			}
 		})
 	}
@@ -178,10 +184,11 @@ func TestEnsureL4BackendServiceDoesNotDetachBackends(t *testing.T) {
 // return expected results for two resources compared.
 func TestBackendSvcEqual(t *testing.T) {
 	for _, tc := range []struct {
-		desc              string
-		oldBackendService *composite.BackendService
-		newBackendService *composite.BackendService
-		wantEqual         bool
+		desc                      string
+		oldBackendService         *composite.BackendService
+		newBackendService         *composite.BackendService
+		compareConnectionTracking bool
+		wantEqual                 bool
 	}{
 		{
 			desc:              "Test empty backend services are equal",
@@ -216,7 +223,8 @@ func TestBackendSvcEqual(t *testing.T) {
 			wantEqual: true,
 		},
 		{
-			desc: "Test with changed idle timeout",
+			desc:                      "Test with changed idle timeout",
+			compareConnectionTracking: true,
 			oldBackendService: &composite.BackendService{
 				ConnectionTrackingPolicy: &composite.BackendServiceConnectionTrackingPolicy{
 					IdleTimeoutSec: prolongedIdleTimeout,
@@ -250,7 +258,8 @@ func TestBackendSvcEqual(t *testing.T) {
 			wantEqual: false,
 		},
 		{
-			desc: "Test with changed TrackingMode",
+			desc:                      "Test with changed TrackingMode",
+			compareConnectionTracking: true,
 			oldBackendService: &composite.BackendService{
 				ConnectionTrackingPolicy: &composite.BackendServiceConnectionTrackingPolicy{
 					TrackingMode: perSessionTrackingMode,
@@ -323,11 +332,38 @@ func TestBackendSvcEqual(t *testing.T) {
 			},
 			wantEqual: true,
 		},
+		{
+			desc:                      "Test with ignoring connection tracking",
+			compareConnectionTracking: false,
+			oldBackendService: &composite.BackendService{
+				Description:         "same_description",
+				Protocol:            "TCP",
+				SessionAffinity:     string(v1.ServiceAffinityClientIP),
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				ConnectionTrackingPolicy: &composite.BackendServiceConnectionTrackingPolicy{
+					EnableStrongAffinity: false,
+					IdleTimeoutSec:       defaultIdleTimeout,
+					TrackingMode:         defaultTrackingMode,
+				},
+			},
+			newBackendService: &composite.BackendService{
+				Description:         "same_description",
+				Protocol:            "TCP",
+				SessionAffinity:     string(v1.ServiceAffinityClientIP),
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				ConnectionTrackingPolicy: &composite.BackendServiceConnectionTrackingPolicy{
+					EnableStrongAffinity: true,
+					IdleTimeoutSec:       100,
+					TrackingMode:         "otherTrackingMode",
+				},
+			},
+			wantEqual: true,
+		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			if res := backendSvcEqual(tc.oldBackendService, tc.newBackendService) == tc.wantEqual; !res {
+			if res := backendSvcEqual(tc.oldBackendService, tc.newBackendService, tc.compareConnectionTracking) == tc.wantEqual; !res {
 				t.Errorf("backendSvcEqual() returned %v, expected %v. Diff(oldScv, newSvc): %s",
 					res, tc.wantEqual, cmp.Diff(tc.oldBackendService, tc.newBackendService))
 			}

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -234,7 +234,8 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 	serviceAffinityNone := string(apiv1.ServiceAffinityNone)
 	schemeExternal := string(cloud.SchemeExternal)
 	defaultNetworkInfo := network.NetworkInfo{IsDefault: true}
-	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, false, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
+	var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
+	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, noConnectionTrackingPolicy); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -234,7 +234,7 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 	serviceAffinityNone := string(apiv1.ServiceAffinityNone)
 	schemeExternal := string(cloud.SchemeExternal)
 	defaultNetworkInfo := network.NetworkInfo{IsDefault: true}
-	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
+	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, false, &composite.BackendServiceConnectionTrackingPolicy{}); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -445,7 +445,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, &composite.BackendServiceConnectionTrackingPolicy{})
+	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, false, nil)
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -45,6 +45,10 @@ const (
 	subnetInternalIPv6AccessType = "INTERNAL"
 )
 
+var (
+	noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
+)
+
 // Many of the functions in this file are re-implemented from gce_loadbalancer_internal.go
 // L4 handles the resource creation/deletion/update for a given L4 ILB service.
 type L4 struct {
@@ -445,7 +449,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, false, nil)
+	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, noConnectionTrackingPolicy)
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -86,13 +86,13 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -113,7 +113,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), &composite.BackendServiceConnectionTrackingPolicy{})
+	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -292,7 +292,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, false, &composite.BackendServiceConnectionTrackingPolicy{})
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -86,13 +86,13 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -113,7 +113,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), false, &composite.BackendServiceConnectionTrackingPolicy{})
+	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -292,7 +292,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, false, &composite.BackendServiceConnectionTrackingPolicy{})
+	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, noConnectionTrackingPolicy)
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -308,8 +308,9 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 		syncResult.GCEResourceInError = annotations.BackendServiceResource
 		syncResult.Error = err
 	}
+	needsConnectionTracking := connectionTrackingPolicy != nil
 	var bs *composite.BackendService
-	bs, err = l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), connectionTrackingPolicy)
+	bs, err = l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), needsConnectionTracking, connectionTrackingPolicy)
 	if err != nil {
 		if utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
 			syncResult.GCEResourceInError = annotations.BackendServiceResource


### PR DESCRIPTION
Use `enableStrongSessionAffinity` flag to close access to Strong Session Affinity feature if not needed. 

This change includes: 
* @mmamczur commit 
* my changes to use excisting flag for SSA

Both of commits will be squashed together just before merging. 


That approach is called feature flagging. 
I found an article with more info about it: https://arxiv.org/pdf/1907.06157.pdf