### PR TITLE
Replace klog with context logging for NEG Controller

### DIFF
--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -21,6 +21,7 @@ import (
 	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 // GroupKey represents a single group for a backend. The implementation of
@@ -74,7 +75,7 @@ type Linker interface {
 
 // NEGGetter is an interface to retrieve NEG object
 type NEGGetter interface {
-	GetNetworkEndpointGroup(name string, zone string, version meta.Version) (*composite.NetworkEndpointGroup, error)
+	GetNetworkEndpointGroup(name string, zone string, version meta.Version, logger klog.Logger) (*composite.NetworkEndpointGroup, error)
 }
 
 // ProbeProvider retrieves a probe struct given a nodePort

--- a/pkg/backends/neg_linker.go
+++ b/pkg/backends/neg_linker.go
@@ -73,7 +73,7 @@ func (nl *negLinker) Link(sp utils.ServicePort, groups []GroupKey) error {
 		negUrl, ok := getNegUrlFromSvcneg(svcNegKey, group.Zone, nl.svcNegLister)
 		if !ok {
 			klog.V(4).Infof("Falling back to use NEG API to retrieve NEG url for NEG %q", negName)
-			neg, err := nl.negGetter.GetNetworkEndpointGroup(negName, group.Zone, version)
+			neg, err := nl.negGetter.GetNetworkEndpointGroup(negName, group.Zone, version, klog.TODO())
 			if err != nil {
 				return err
 			}

--- a/pkg/backends/neg_linker_test.go
+++ b/pkg/backends/neg_linker_test.go
@@ -112,7 +112,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 					if svcPort.VMIPNEGEnabled {
 						neg.NetworkEndpointType = string(negtypes.VmIpEndpointType)
 					}
-					err := fakeNEG.CreateNetworkEndpointGroup(neg, key.Zone)
+					err := fakeNEG.CreateNetworkEndpointGroup(neg, key.Zone, klog.TODO())
 					if err != nil {
 						t.Fatalf("unexpected error creating NEG for svcPort %v: %v", svcPort, err)
 					}

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -488,7 +488,7 @@ func (manager *syncerManager) garbageCollectSyncer() {
 func (manager *syncerManager) garbageCollectNEG() error {
 	// Retrieve aggregated NEG list from cloud
 	// Compare against svcPortMap and Remove unintended NEGs by best effort
-	negList, err := manager.cloud.AggregatedListNetworkEndpointGroup(meta.VersionGA)
+	negList, err := manager.cloud.AggregatedListNetworkEndpointGroup(meta.VersionGA, manager.logger)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve aggregated NEG list: %w", err)
 	}
@@ -685,7 +685,7 @@ func (manager *syncerManager) deleteNegOrReportErr(name, zone string, svcNegCR *
 
 // ensureDeleteNetworkEndpointGroup ensures neg is delete from zone
 func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string, expectedDesc *utils.NegDescription) error {
-	neg, err := manager.cloud.GetNetworkEndpointGroup(name, zone, meta.VersionGA)
+	neg, err := manager.cloud.GetNetworkEndpointGroup(name, zone, meta.VersionGA, manager.logger)
 	if err != nil {
 		if utils.IsNotFoundError(err) || utils.IsHTTPErrorCode(err, http.StatusBadRequest) {
 			manager.logger.V(2).Info("Ignoring error when querying for neg during GC", "negName", name, "zone", zone, "err", err)
@@ -709,7 +709,7 @@ func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string
 	}
 
 	manager.logger.V(2).Info("Deleting NEG", "negName", name, "zone", zone)
-	return manager.cloud.DeleteNetworkEndpointGroup(name, zone, meta.VersionGA)
+	return manager.cloud.DeleteNetworkEndpointGroup(name, zone, meta.VersionGA, manager.logger)
 }
 
 // ensureSvcNegCR ensures that if neg crd is enabled, a Neg CR exists for every

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -397,12 +397,12 @@ func TestGarbageCollectionNEG(t *testing.T) {
 			Version:             version,
 			Name:                negName,
 			NetworkEndpointType: string(networkEndpointType),
-		}, negtypes.TestZone1)
+		}, negtypes.TestZone1, klog.TODO())
 		manager.cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
 			Version:             version,
 			Name:                negName,
 			NetworkEndpointType: string(networkEndpointType),
-		}, negtypes.TestZone2)
+		}, negtypes.TestZone2, klog.TODO())
 
 		svcNeg := &negv1beta1.ServiceNetworkEndpointGroup{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: negName},
@@ -416,7 +416,7 @@ func TestGarbageCollectionNEG(t *testing.T) {
 			t.Fatalf("Failed to GC: %v", err)
 		}
 		for _, zone := range []string{negtypes.TestZone1, negtypes.TestZone2} {
-			negs, _ := manager.cloud.ListNetworkEndpointGroup(zone, version)
+			negs, _ := manager.cloud.ListNetworkEndpointGroup(zone, version, klog.TODO())
 			for _, neg := range negs {
 				if neg.Name == negName {
 					t.Errorf("Expect NEG %q in zone %q to be GCed.", negName, zone)
@@ -1324,7 +1324,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 							Name:                negName,
 							NetworkEndpointType: string(networkEndpointType),
 							Description:         tc.negDesc,
-						}, zone)
+						}, zone, klog.TODO())
 					}
 
 					gcPortInfo := negtypes.PortInfo{PortTuple: negtypes.SvcPortTuple{Port: port80}, NegName: negName}
@@ -1360,7 +1360,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 
 					if !tc.negsExist {
 						for _, zone := range []string{negtypes.TestZone1, negtypes.TestZone2} {
-							fakeNegCloud.DeleteNetworkEndpointGroup(negName, zone, version)
+							fakeNegCloud.DeleteNetworkEndpointGroup(negName, zone, version, klog.TODO())
 						}
 					}
 
@@ -1380,7 +1380,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 						t.Errorf("expected GC to error")
 					}
 
-					negs, err := fakeNegCloud.AggregatedListNetworkEndpointGroup(version)
+					negs, err := fakeNegCloud.AggregatedListNetworkEndpointGroup(version, klog.TODO())
 					if err != nil {
 						t.Errorf("failed getting negs from cloud: %s", err)
 					}
@@ -1533,7 +1533,7 @@ func (s *fakeSyncer) IsShuttingDown() bool { return false }
 func getNegObjectRefs(t *testing.T, cloud negtypes.NetworkEndpointGroupCloud, zones []string, negName string, version meta.Version) []negv1beta1.NegObjectReference {
 	var negRefs []negv1beta1.NegObjectReference
 	for _, zone := range zones {
-		neg, err := cloud.GetNetworkEndpointGroup(negName, zone, version)
+		neg, err := cloud.GetNetworkEndpointGroup(negName, zone, version, klog.TODO())
 		if err != nil {
 			t.Errorf("failed to get neg %s, from zone %s", negName, zone)
 			continue

--- a/pkg/neg/readiness/poller.go
+++ b/pkg/neg/readiness/poller.go
@@ -119,7 +119,7 @@ func (p *poller) RegisterNegEndpoints(key negMeta, endpointMap negtypes.Endpoint
 // It returns false if there is no endpoints needed to be polled, returns true if otherwise.
 // Assumes p.lock is held when calling this method.
 func (p *poller) registerNegEndpoints(key negMeta, endpointMap negtypes.EndpointPodMap) bool {
-	endpointsToPoll := needToPoll(key.SyncerKey, endpointMap, p.lookup, p.podLister)
+	endpointsToPoll := needToPoll(key.SyncerKey, endpointMap, p.lookup, p.podLister, p.logger)
 	if len(endpointsToPoll) == 0 {
 		delete(p.pollMap, key)
 		return false

--- a/pkg/neg/readiness/poller.go
+++ b/pkg/neg/readiness/poller.go
@@ -160,7 +160,7 @@ func (p *poller) Poll(key negMeta) (retry bool, err error) {
 
 	p.logger.V(2).Info("polling NEG", "neg", key.Name, "negZone", key.Zone)
 	// TODO(freehan): filter the NEs that are in interest once the API supports it
-	res, err := p.negCloud.ListNetworkEndpoints(key.Name, key.Zone /*showHealthStatus*/, true, key.SyncerKey.GetAPIVersion())
+	res, err := p.negCloud.ListNetworkEndpoints(key.Name, key.Zone /*showHealthStatus*/, true, key.SyncerKey.GetAPIVersion(), klog.TODO())
 	if err != nil {
 		if negtypes.IsStrategyQuotaError(err) {
 			p.logger.V(4).Error(err, "Failed to ListNetworkEndpoints in NEG", "neg", key.String())

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/ingress-gce/pkg/composite"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
@@ -430,7 +431,7 @@ func TestPoll(t *testing.T) {
 
 	step = "NEG exists, but with no endpoint"
 	// create NEG, but with no endpoint
-	negCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: zone, Version: meta.VersionGA}, zone)
+	negCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: zone, Version: meta.VersionGA}, zone, klog.TODO())
 	pollAndValidate(step, false, true, 0, true, true)
 	pollAndValidate(step, false, true, 0, true, true)
 
@@ -441,7 +442,7 @@ func TestPoll(t *testing.T) {
 		Instance:  instance,
 	}
 
-	negCloud.AttachNetworkEndpoints(negName, zone, []*composite.NetworkEndpoint{ne}, meta.VersionGA)
+	negCloud.AttachNetworkEndpoints(negName, zone, []*composite.NetworkEndpoint{ne}, meta.VersionGA, klog.TODO())
 	// add NE with empty healthy status
 	negtypes.GetNetworkEndpointStore(negCloud).AddNetworkEndpointHealthStatus(*meta.ZonalKey(negName, zone), []negtypes.NetworkEndpointEntry{
 		{

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -566,7 +567,7 @@ func TestNeedToPoll(t *testing.T) {
 		},
 	} {
 		tc.mutateState()
-		ret := needToPoll(key, tc.inputMap, fakeLookUp, podLister)
+		ret := needToPoll(key, tc.inputMap, fakeLookUp, podLister, klog.TODO())
 		if !reflect.DeepEqual(ret, tc.expectOutputMap) {
 			t.Errorf("For test case %q, expect %v, got: %v", tc.desc, tc.expectOutputMap, ret)
 		}

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -239,7 +239,7 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
-	result, err := toZoneNetworkEndpointMap(eds, l.zoneGetter, l.podLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG)
+	result, err := toZoneNetworkEndpointMap(eds, l.zoneGetter, l.podLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG, l.logger)
 	if err == nil { // If current calculation ends up in error, we trigger and emit metrics in degraded mode.
 		l.syncMetricsCollector.UpdateSyncerEPMetrics(l.syncerKey, result.EPCount, result.EPSCount)
 	}
@@ -248,7 +248,7 @@ func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ 
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *L7EndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, _ map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
-	result := toZoneNetworkEndpointMapDegradedMode(eds, l.zoneGetter, l.podLister, l.nodeLister, l.serviceLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG)
+	result := toZoneNetworkEndpointMapDegradedMode(eds, l.zoneGetter, l.podLister, l.nodeLister, l.serviceLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG, l.logger)
 	l.syncMetricsCollector.UpdateSyncerEPMetrics(l.syncerKey, result.EPCount, result.EPSCount)
 	return result.NetworkEndpointSet, result.EndpointPodMap, nil
 }

--- a/pkg/neg/syncers/syncer.go
+++ b/pkg/neg/syncers/syncer.go
@@ -104,7 +104,7 @@ func (s *syncer) Start() error {
 					retryMsg = "(will retry)"
 				}
 
-				if svc := getService(s.serviceLister, s.Namespace, s.Name); svc != nil {
+				if svc := getService(s.serviceLister, s.Namespace, s.Name, s.logger); svc != nil {
 					s.recorder.Eventf(svc, apiv1.EventTypeWarning, "SyncNetworkEndpointGroupFailed", "Failed to sync NEG %q %s: %v", s.NegSyncerKey.NegName, retryMsg, err)
 				}
 			} else {

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -250,7 +250,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	}
 	s.logger.V(2).Info("Sync NEG", "negSyncerKey", s.NegSyncerKey.String(), "endpointsCalculatorMode", s.endpointsCalculator.Mode())
 
-	currentMap, currentPodLabelMap, err := retrieveExistingZoneNetworkEndpointMap(s.NegSyncerKey.NegName, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG)
+	currentMap, currentPodLabelMap, err := retrieveExistingZoneNetworkEndpointMap(s.NegSyncerKey.NegName, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -412,6 +412,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 			s.NegSyncerKey.GetAPIVersion(),
 			s.customName,
 			s.networkInfo,
+			s.logger,
 		)
 		if err != nil {
 			errList = append(errList, err)
@@ -438,7 +439,7 @@ func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints m
 				continue
 			}
 
-			batch, err := makeEndpointBatch(endpointSet, s.NegType, endpointPodLabelMap)
+			batch, err := makeEndpointBatch(endpointSet, s.NegType, endpointPodLabelMap, s.logger)
 			if err != nil {
 				return err
 			}
@@ -564,7 +565,7 @@ func checkEndpointBatchErr(err error, operation transactionOp) error {
 }
 
 func (s *transactionSyncer) recordEvent(eventType, reason, eventDesc string) {
-	if svc := getService(s.serviceLister, s.Namespace, s.Name); svc != nil {
+	if svc := getService(s.serviceLister, s.Namespace, s.Name, s.logger); svc != nil {
 		s.recorder.Eventf(svc, eventType, reason, eventDesc)
 	}
 }

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1540,7 +1540,7 @@ func TestUnknownNodes(t *testing.T) {
 	}
 
 	// Check that unknown zone did not cause endpoints to be removed
-	out, _, err := retrieveExistingZoneNetworkEndpointMap(testNegName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false)
+	out, _, err := retrieveExistingZoneNetworkEndpointMap(testNegName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO())
 	if err != nil {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
@@ -1835,7 +1835,7 @@ func TestEnableDegradedMode(t *testing.T) {
 			(s.syncer.(*syncer)).stopped = false
 			tc.modify(s)
 
-			out, _, err := retrieveExistingZoneNetworkEndpointMap(tc.negName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false)
+			out, _, err := retrieveExistingZoneNetworkEndpointMap(tc.negName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO())
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints")
 			}
@@ -1848,7 +1848,7 @@ func TestEnableDegradedMode(t *testing.T) {
 				t.Errorf("syncInternal returned %v, expected %v", err, tc.expectErr)
 			}
 			err = wait.PollImmediate(time.Second, 3*time.Second, func() (bool, error) {
-				out, _, err = retrieveExistingZoneNetworkEndpointMap(tc.negName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false)
+				out, _, err = retrieveExistingZoneNetworkEndpointMap(tc.negName, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO())
 				if err != nil {
 					return false, nil
 				}
@@ -2282,7 +2282,7 @@ func unionEndpointMap(m1, m2 negtypes.EndpointPodMap) negtypes.EndpointPodMap {
 }
 
 func generateEndpointBatch(endpointSet negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap) map[negtypes.NetworkEndpoint]*composite.NetworkEndpoint {
-	ret, _ := makeEndpointBatch(endpointSet, negtypes.VmIpPortEndpointType, endpointPodLabelMap)
+	ret, _ := makeEndpointBatch(endpointSet, negtypes.VmIpPortEndpointType, endpointPodLabelMap, klog.TODO())
 	return ret
 }
 

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -92,7 +92,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 		}
 
 		// Verify the NEGs are created as expected
-		ret, _ := transactionSyncer.cloud.AggregatedListNetworkEndpointGroup(transactionSyncer.NegSyncerKey.GetAPIVersion())
+		ret, _ := transactionSyncer.cloud.AggregatedListNetworkEndpointGroup(transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 		// Though the test cases below only add instances in zone1 and zone2, NEGs will be created in zone3 or zone4 as well since fakeZoneGetter includes those zones.
 		var expectZones []string
 		if testNegType == negtypes.VmIpEndpointType {
@@ -222,7 +222,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 			}
 
 			for zone, endpoints := range tc.expectEndpoints {
-				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion())
+				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 				if err != nil {
 					t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 				}
@@ -241,10 +241,10 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				}
 			}
 		}
-		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone1, transactionSyncer.NegSyncerKey.GetAPIVersion())
-		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone2, transactionSyncer.NegSyncerKey.GetAPIVersion())
-		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone3, transactionSyncer.NegSyncerKey.GetAPIVersion())
-		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone4, transactionSyncer.NegSyncerKey.GetAPIVersion())
+		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone1, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone2, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone3, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		transactionSyncer.cloud.DeleteNetworkEndpointGroup(transactionSyncer.NegName, negtypes.TestZone4, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 	}
 }
 
@@ -397,7 +397,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		}
 
 		for zone := range tc.addEndpoints {
-			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion())
+			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 			if err != nil {
 				t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -1179,9 +1179,9 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 						Network:             fakeCloud.NetworkURL(),
 						Subnetwork:          fakeCloud.SubnetworkURL(),
 						Description:         tc.negDesc,
-					}, zone)
+					}, zone, klog.TODO())
 				}
-				ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion())
+				ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 				expectedNegRefs = negObjectReferences(ret)
 			}
 			var refs []negv1beta1.NegObjectReference
@@ -1212,7 +1212,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to get NEG from neg client: %s", err)
 			}
-			ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion())
+			ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 			if len(expectedNegRefs) == 0 && !tc.expectErr {
 				expectedNegRefs = negObjectReferences(ret)
 			}
@@ -1255,10 +1255,10 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 
 		negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Delete(context2.TODO(), testNegName, v1.DeleteOptions{})
 
-		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone1, syncer.NegSyncerKey.GetAPIVersion())
-		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, syncer.NegSyncerKey.GetAPIVersion())
-		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone3, syncer.NegSyncerKey.GetAPIVersion())
-		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone4, syncer.NegSyncerKey.GetAPIVersion())
+		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone1, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone3, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone4, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 
 	}
 }
@@ -1348,9 +1348,9 @@ func TestUpdateStatus(t *testing.T) {
 						Network:             fakeCloud.NetworkURL(),
 						Subnetwork:          fakeCloud.SubnetworkURL(),
 						Description:         "",
-					}, testZone1)
+					}, testZone1, klog.TODO())
 
-					_, err = fakeCloud.GetNetworkEndpointGroup(testNegName, testZone1, syncer.NegSyncerKey.GetAPIVersion())
+					_, err = fakeCloud.GetNetworkEndpointGroup(testNegName, testZone1, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 					if err != nil {
 						t.Errorf("failed to get neg from cloud: %s ", err)
 					}
@@ -1437,9 +1437,9 @@ func TestIsZoneChange(t *testing.T) {
 					NetworkEndpointType: string(syncer.NegSyncerKey.NegType),
 					Network:             fakeCloud.NetworkURL(),
 					Subnetwork:          fakeCloud.SubnetworkURL(),
-				}, zone)
+				}, zone, klog.TODO())
 			}
-			ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion())
+			ret, _ := fakeCloud.AggregatedListNetworkEndpointGroup(syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 			negRefMap := negObjectReferences(ret)
 			var refs []negv1beta1.NegObjectReference
 			for _, neg := range negRefMap {
@@ -1505,9 +1505,9 @@ func TestUnknownNodes(t *testing.T) {
 	// Create initial NetworkEndpointGroups in cloud
 	var objRefs []negv1beta1.NegObjectReference
 	for zone, endpoint := range testEndpointMap {
-		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, zone)
-		fakeCloud.AttachNetworkEndpoints(testNegName, zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA)
-		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, zone, meta.VersionGA)
+		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, zone, klog.TODO())
+		fakeCloud.AttachNetworkEndpoints(testNegName, zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
+		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, zone, meta.VersionGA, klog.TODO())
 		if err != nil {
 			t.Fatalf("failed to get neg from fake cloud: %s", err)
 		}
@@ -1783,9 +1783,9 @@ func TestEnableDegradedMode(t *testing.T) {
 			// Create initial NetworkEndpointGroups in cloud
 			var objRefs []negv1beta1.NegObjectReference
 			for zone, endpoint := range testEndpointMap {
-				fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: tc.negName, Version: meta.VersionGA}, zone)
-				fakeCloud.AttachNetworkEndpoints(tc.negName, zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA)
-				neg, err := fakeCloud.GetNetworkEndpointGroup(tc.negName, zone, meta.VersionGA)
+				fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: tc.negName, Version: meta.VersionGA}, zone, klog.TODO())
+				fakeCloud.AttachNetworkEndpoints(tc.negName, zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
+				neg, err := fakeCloud.GetNetworkEndpointGroup(tc.negName, zone, meta.VersionGA, klog.TODO())
 				if err != nil {
 					t.Fatalf("failed to get neg from fake cloud: %s", err)
 				}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -107,7 +107,7 @@ func calculateNetworkEndpointDifference(targetMap, currentMap map[string]negtype
 }
 
 // getService retrieves service object from serviceLister based on the input Namespace and Name
-func getService(serviceLister cache.Indexer, namespace, name string) *apiv1.Service {
+func getService(serviceLister cache.Indexer, namespace, name string, logger klog.Logger) *apiv1.Service {
 	if serviceLister == nil {
 		return nil
 	}
@@ -116,22 +116,23 @@ func getService(serviceLister cache.Indexer, namespace, name string) *apiv1.Serv
 		return service.(*apiv1.Service)
 	}
 	if err != nil {
-		klog.Errorf("Failed to retrieve service %s/%s from store: %v", namespace, name, err)
+		logger.Error(err, "Failed to retrieve service from store", "namespace", namespace, "name", name)
 		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 	return nil
 }
 
 // ensureNetworkEndpointGroup ensures corresponding NEG is configured correctly in the specified zone.
-func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName, kubeSystemUID, port string, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version, customName bool, networkInfo network.NetworkInfo) (negv1beta1.NegObjectReference, error) {
+func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName, kubeSystemUID, port string, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version, customName bool, networkInfo network.NetworkInfo, logger klog.Logger) (negv1beta1.NegObjectReference, error) {
+	negLogger := logger.WithValues("negName", negName, "zone", zone)
 	var negRef negv1beta1.NegObjectReference
 	neg, err := cloud.GetNetworkEndpointGroup(negName, zone, version)
 	if err != nil {
 		if !utils.IsNotFoundError(err) {
-			klog.Errorf("Failed to get Neg %q in zone %q: %s", negName, zone, err)
+			negLogger.Error(err, "Failed to get Neg")
 			return negRef, err
 		}
-		klog.V(4).Infof("Neg %q in zone %q was not found: %s", negName, zone, err)
+		negLogger.Info("Neg was not found", "err", err)
 		metrics.PublishNegControllerErrorCountMetrics(err, true)
 	}
 
@@ -146,11 +147,11 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 			Port:        port,
 		}
 		if customName && neg.Description == "" {
-			klog.Errorf("Found Neg with custom name %s but empty description", negName)
+			negLogger.Error(nil, "Found Neg with custom name but empty description")
 			return negv1beta1.NegObjectReference{}, fmt.Errorf("neg name %s is already in use, found a custom named neg with an empty description", negName)
 		}
 		if matches, err := utils.VerifyDescription(expectedDesc, neg.Description, negName, zone); !matches {
-			klog.Errorf("Neg Name %s is already in use: %s", negName, err)
+			negLogger.Error(err, "Neg Name is already in use")
 			return negv1beta1.NegObjectReference{}, fmt.Errorf("neg name %s is already in use, found conflicting description: %w", negName, err)
 		}
 
@@ -161,13 +162,13 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 				!utils.EqualResourceIDs(neg.Subnetwork, networkInfo.SubnetworkURL)) {
 
 			needToCreate = true
-			klog.V(2).Infof("NEG %q in %q does not match network and subnetwork of the cluster. Deleting NEG.", negName, zone)
+			negLogger.Info("NEG does not match network and subnetwork of the cluster. Deleting NEG")
 			err = cloud.DeleteNetworkEndpointGroup(negName, zone, version)
 			if err != nil {
 				return negRef, err
 			}
 			if recorder != nil && serviceLister != nil {
-				if svc := getService(serviceLister, svcNamespace, svcName); svc != nil {
+				if svc := getService(serviceLister, svcNamespace, svcName, logger); svc != nil {
 					recorder.Eventf(svc, apiv1.EventTypeNormal, "Delete", "Deleted NEG %q for %s in %q.", negName, negServicePortName, zone)
 				}
 			}
@@ -175,7 +176,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 	}
 
 	if needToCreate {
-		klog.V(2).Infof("Creating NEG %q for %s in %q.", negName, negServicePortName, zone)
+		negLogger.Info("Creating NEG", "negServicePortName", negServicePortName)
 		var subnetwork string
 		switch networkEndpointType {
 		case negtypes.NonGCPPrivateEndpointType:
@@ -205,7 +206,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 			return negRef, err
 		}
 		if recorder != nil && serviceLister != nil {
-			if svc := getService(serviceLister, svcNamespace, svcName); svc != nil {
+			if svc := getService(serviceLister, svcNamespace, svcName, logger); svc != nil {
 				recorder.Eventf(svc, apiv1.EventTypeNormal, "Create", "Created NEG %q for %s in %q.", negName, negServicePortName, zone)
 			}
 		}
@@ -215,7 +216,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 		var err error
 		neg, err = cloud.GetNetworkEndpointGroup(negName, zone, version)
 		if err != nil {
-			klog.Errorf("Error while retrieving %q in zone %q: %v after initialization", negName, zone, err)
+			negLogger.Error(err, "Error while retrieving NEG after initialization")
 			return negRef, err
 		}
 	}
@@ -236,14 +237,14 @@ type ZoneNetworkEndpointMapResult struct {
 }
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
-func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG bool) (ZoneNetworkEndpointMapResult, error) {
+func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, podLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG bool, logger klog.Logger) (ZoneNetworkEndpointMapResult, error) {
 	zoneNetworkEndpointMap := map[string]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	ipsForPod := ipsForPod(eds)
 	globalEPCount := make(negtypes.StateCountMap)
 	globalEPSCount := make(negtypes.StateCountMap)
 	if eds == nil {
-		klog.Errorf("Endpoint object is nil")
+		logger.Error(nil, "Endpoint object is nil")
 		return ZoneNetworkEndpointMapResult{
 			NetworkEndpointSet: zoneNetworkEndpointMap,
 			EndpointPodMap:     networkEndpointPodMap,
@@ -271,25 +272,30 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 		localEPCount := make(negtypes.StateCountMap)
 		globalEPSCount[negtypes.Total] += 1
 		for _, endpointAddress := range ed.Addresses {
+			epLogger := logger.WithValues(
+				"endpoint", endpointAddress.Addresses,
+				"endpointSliceNamespace", ed.Meta.Namespace,
+				"endpointSliceName", ed.Meta.Name,
+			)
 			if !enableDualStackNEG && endpointAddress.AddressType != discovery.AddressTypeIPv4 {
-				klog.Infof("Skipping non IPv4 address: %q, in endpoint slice %s/%s", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				epLogger.Info("Skipping non IPv4 address")
 				continue
 			}
 			globalEPCount[negtypes.Total] += 1
 			zone, _, getZoneErr := getEndpointZone(endpointAddress, zoneGetter)
 			if getZoneErr != nil {
-				klog.Errorf("Detected unexpected error when getting zone for endpoint %q in endpoint slice %s/%s: %v", getZoneErr, endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				epLogger.Error(getZoneErr, "Detected unexpected error when getting zone for endpoint")
 				return ZoneNetworkEndpointMapResult{}, fmt.Errorf("unexpected error when getting zone for endpoint %q in endpoint slice %s/%s: %w", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, getZoneErr)
 			}
 
 			_, _, getPodErr := getEndpointPod(endpointAddress, podLister)
 			if getPodErr != nil {
 				if flags.F.EnableDegradedMode {
-					klog.Errorf("Detected unexpected error when getting pod for endpoint %q in endpoint slice %s/%s: %v", getPodErr, endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+					epLogger.Error(getPodErr, "Detected unexpected error when getting pod for endpoint")
 					// when degraded mode is enabled, we want to trigger degraded mode so return the error
 					return ZoneNetworkEndpointMapResult{}, fmt.Errorf("unexpected error when getting pod for endpoint %q in endpoint slice %s/%s: %w", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, getPodErr)
 				}
-				klog.V(2).Infof("Endpoint %q in endpoint slice %s/%s does not have an associated pod. Skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				epLogger.V(2).Info("Endpoint does not have an associated pod. Skipping")
 				continue
 			}
 			if zoneNetworkEndpointMap[zone] == nil {
@@ -303,6 +309,11 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 				// accidental diffs resulting from different formats.
 				networkEndpoint.IPv6 = parseIPAddress(podIPs.IPv6)
 			}
+			neLogger := epLogger.WithValues(
+				"ipv4Address", networkEndpoint.IP,
+				"ipv6Address", networkEndpoint.IPv6,
+				"enableDualStackNEG", enableDualStackNEG,
+			)
 			if networkEndpointType == negtypes.NonGCPPrivateEndpointType {
 				// Non-GCP network endpoints don't have associated nodes.
 				networkEndpoint.Node = ""
@@ -313,7 +324,7 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 			if existingPod, contains := networkEndpointPodMap[networkEndpoint]; contains {
 				localEPCount[negtypes.Duplicate] += 1
 				if existingPod.Name < endpointAddress.TargetRef.Name {
-					klog.Infof("Found duplicate endpoints [%v, %v] when processing endpoint slice %s/%s, save the pod information from the alphabetically higher pod", networkEndpoint.IP, networkEndpoint.IPv6, ed.Meta.Namespace, ed.Meta.Name)
+					neLogger.Info("Found duplicate endpoints when processing endpoint slice, save the pod information from the alphabetically higher pod", "ignoredPod", endpointAddress.TargetRef.Name, "usePod", existingPod.Name)
 					continue // if existing name is alphabetically lower than current one, continue and don't replace
 				}
 			}
@@ -322,11 +333,11 @@ func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter negtypes.
 		mergeWithGlobalCounts(localEPCount, globalEPCount, globalEPSCount)
 	}
 	if !foundMatchingPort {
-		klog.Errorf("Service port name %q was not found in the endpoints object %+v", servicePortName, eds)
+		logger.Error(nil, "Service port name was not found in the endpoints object", "servicePortName", servicePortName, "endpointsObject", eds)
 	}
 
 	if len(zoneNetworkEndpointMap) == 0 || len(networkEndpointPodMap) == 0 {
-		klog.V(3).Infof("Generated empty endpoint maps (zoneNetworkEndpointMap: %+v, networkEndpointPodMap: %v) from Endpoints object: %+v", zoneNetworkEndpointMap, networkEndpointPodMap, eds)
+		logger.V(3).Info("Generated empty endpoint maps from Endpoints object", "zoneNetworkEndpointMap", zoneNetworkEndpointMap, "networkEndpointPodMap", networkEndpointPodMap, "endpointsObject", eds)
 	}
 	return ZoneNetworkEndpointMapResult{
 		NetworkEndpointSet: zoneNetworkEndpointMap,
@@ -392,7 +403,7 @@ func getEndpointPod(endpointAddress negtypes.AddressData, podLister cache.Indexe
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
 // we will not raise error in degraded mode for misconfigured endpoints, instead they will be filtered directly
-func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, podLister, nodeLister, serviceLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG bool) ZoneNetworkEndpointMapResult {
+func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGetter negtypes.ZoneGetter, podLister, nodeLister, serviceLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG bool, logger klog.Logger) ZoneNetworkEndpointMapResult {
 	zoneNetworkEndpointMap := map[string]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	ipsForPod := ipsForPod(eds)
@@ -414,14 +425,19 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 		serviceName := ed.Meta.Labels[discovery.LabelServiceName]
 		isCustomEPS := ed.Meta.Labels[discovery.LabelManagedBy] != managedByEPSControllerValue
 		for _, endpointAddress := range ed.Addresses {
+			epLogger := logger.WithValues(
+				"endpoint", endpointAddress.Addresses,
+				"endpointSliceNamespace", ed.Meta.Namespace,
+				"endpointSliceName", ed.Meta.Name,
+			)
 			if !enableDualStackNEG && endpointAddress.AddressType != discovery.AddressTypeIPv4 {
-				klog.Infof("Skipping non IPv4 address in degraded mode: %q, in endpoint slice %s/%s", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name)
+				epLogger.Info("Skipping non IPv4 address in degraded mode")
 				continue
 			}
 			globalEPCount[negtypes.Total] += 1
 			pod, getPodStat, getPodErr := getEndpointPod(endpointAddress, podLister)
 			if getPodErr != nil {
-				klog.Errorf("Endpoint %q in endpoint slice %s/%s receives error when getting pod: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, getPodErr)
+				epLogger.Error(getPodErr, "Endpoint receives error when getting pod, skipping")
 				metrics.PublishNegControllerErrorCountMetrics(getPodErr, true)
 				for state, count := range getPodStat {
 					localEPCount[state] += count
@@ -430,13 +446,13 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			}
 			nodeName := pod.Spec.NodeName
 			if nodeName == "" {
-				klog.Errorf("For endpoint %q in endpoint slice %s/%s, its corresponding pod %s does not have valid nodeName: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, pod.Name, negtypes.ErrEPNodeMissing)
+				epLogger.Error(negtypes.ErrEPNodeMissing, "Endpoint's corresponding pod does not have valid nodeName, skipping", "podName", pod.Name)
 				localEPCount[negtypes.NodeMissing]++
 				continue
 			}
 			zone, getZoneErr := zoneGetter.GetZoneForNode(nodeName)
 			if getZoneErr != nil {
-				klog.Errorf("For endpoint %q in endpoint slice %s/%s, its corresponding node %q does not have valid zone information: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, nodeName, getZoneErr)
+				epLogger.Error(getZoneErr, "Endpoint's corresponding node does not have valid zone information, skipping", "nodeName", nodeName)
 				metrics.PublishNegControllerErrorCountMetrics(getZoneErr, true)
 				localEPCount[negtypes.NodeNotFound]++
 				continue
@@ -448,7 +464,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			podIPs := ipsForPod[types.NamespacedName{Namespace: endpointAddress.TargetRef.Namespace, Name: endpointAddress.TargetRef.Name}]
 			// TODO(cheungdavid): Remove this validation when single stack ipv6 endpoint is supported
 			if parseIPAddress(podIPs.IP) == "" {
-				klog.Errorf("For endpoint %q in endpoint slice %s/%s, it has an invalid IPv4 address: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, pod.ObjectMeta.Name, negtypes.ErrEPIPInvalid)
+				epLogger.Error(negtypes.ErrEPIPInvalid, "Endpoint has an invalid IPv4 address, skipping", "podName", pod.ObjectMeta.Name)
 				localEPCount[negtypes.IPInvalid]++
 				continue
 			}
@@ -458,17 +474,22 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 				// accidental diffs resulting from different formats.
 				networkEndpoint.IPv6 = parseIPAddress(podIPs.IPv6)
 			}
+			neLogger := epLogger.WithValues(
+				"ipv4Address", networkEndpoint.IP,
+				"ipv6Address", networkEndpoint.IPv6,
+				"enableDualStackNEG", enableDualStackNEG,
+			)
 			// endpoint address should match to the IP of its pod
 			checkIPErr := podContainsEndpointAddress(networkEndpoint, pod)
 			if checkIPErr != nil {
-				klog.Errorf("Endpoint %q in endpoint slice %s/%s has at least one IP that not match to its pod %s: %v, skipping", networkEndpoint.IP, ed.Meta.Namespace, ed.Meta.Name, pod.Name, checkIPErr)
+				neLogger.Error(checkIPErr, "Endpoint has at least one IP that not match to its pod, skipping", "podName", pod.Name)
 				metrics.PublishNegControllerErrorCountMetrics(checkIPErr, true)
 				localEPCount[negtypes.IPNotFromPod] += 1
 				continue
 			}
-			validatePodStat, validateErr := validatePod(pod, nodeLister, serviceLister, networkEndpoint, serviceName, isCustomEPS)
+			validatePodStat, validateErr := validatePod(pod, nodeLister, serviceLister, networkEndpoint, serviceName, isCustomEPS, logger)
 			if validateErr != nil {
-				klog.Errorf("Endpoint %q in endpoint slice %s/%s correponds to an invalid pod: %v, skipping", endpointAddress.Addresses, ed.Meta.Namespace, ed.Meta.Name, validateErr)
+				neLogger.Error(validateErr, "Endpoint correponds to an invalid pod, skipping")
 				metrics.PublishNegControllerErrorCountMetrics(validateErr, true)
 				for state, count := range validatePodStat {
 					localEPCount[state] += count
@@ -485,7 +506,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 			if existingPod, contains := networkEndpointPodMap[networkEndpoint]; contains {
 				localEPCount[negtypes.Duplicate] += 1
 				if existingPod.Name < endpointAddress.TargetRef.Name {
-					klog.Infof("Found duplicate endpoints [%v, %v] when processing endpoint slice %s/%s, save the pod information from the alphabetically higher pod", networkEndpoint.IP, networkEndpoint.IPv6, ed.Meta.Namespace, ed.Meta.Name)
+					neLogger.Info("Found duplicate endpoints when processing endpoint slice, save the pod information from the alphabetically higher pod", "ignoredPod", endpointAddress.TargetRef.Name, "usePod", existingPod.Name)
 					continue // if existing name is alphabetically lower than current one, continue and don't replace
 				}
 			}
@@ -508,7 +529,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 // 2. corresponds to a non-existent node
 // 3. have an IP that matches to a podIP, but is outside of the node's allocated IP range
 // 4. has labels not matching to its service's label selector
-func validatePod(pod *apiv1.Pod, nodeLister, serviceLister cache.Indexer, networkEndpoint negtypes.NetworkEndpoint, serviceName string, isCustomEPS bool) (negtypes.StateCountMap, error) {
+func validatePod(pod *apiv1.Pod, nodeLister, serviceLister cache.Indexer, networkEndpoint negtypes.NetworkEndpoint, serviceName string, isCustomEPS bool, logger klog.Logger) (negtypes.StateCountMap, error) {
 	count := make(negtypes.StateCountMap)
 	// Terminal Pod means a pod is in PodFailed or PodSucceeded phase
 	phase := pod.Status.Phase
@@ -530,7 +551,7 @@ func validatePod(pod *apiv1.Pod, nodeLister, serviceLister cache.Indexer, networ
 		count[negtypes.IPOutOfPodCIDR]++
 		return count, err
 	}
-	service := getService(serviceLister, pod.ObjectMeta.Namespace, serviceName)
+	service := getService(serviceLister, pod.ObjectMeta.Namespace, serviceName, logger)
 	if service == nil {
 		count[negtypes.OtherError]++
 		return count, negtypes.ErrEPServiceNotFound
@@ -646,7 +667,7 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map
-func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool) (map[string]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, error) {
+func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger) (map[string]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, error) {
 	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
 	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
 	zones, err := zoneGetter.ListZones(utils.AllNodesPredicate)
@@ -668,7 +689,7 @@ func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.
 			// It is possible for a NEG to be missing in a zone without candidate nodes. Log and ignore this error.
 			// NEG not found in a candidate zone is an error.
 			if utils.IsNotFoundError(err) && !candidateZonesMap.Has(zone) {
-				klog.Infof("Ignoring NotFound error for NEG %q in zone %q", negName, zone)
+				logger.Info("Ignoring NotFound error for NEG", "negName", negName, "zone", zone)
 				metrics.PublishNegControllerErrorCountMetrics(err, true)
 				continue
 			}
@@ -692,7 +713,7 @@ func retrieveExistingZoneNetworkEndpointMap(negName string, zoneGetter negtypes.
 
 // makeEndpointBatch return a batch of endpoint from the input and remove the endpoints from input set
 // The return map has the encoded endpoint as key and GCE network endpoint object as value
-func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.NetworkEndpointType, endpointPodLabelMap labels.EndpointPodLabelMap) (map[negtypes.NetworkEndpoint]*composite.NetworkEndpoint, error) {
+func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.NetworkEndpointType, endpointPodLabelMap labels.EndpointPodLabelMap, logger klog.Logger) (map[negtypes.NetworkEndpoint]*composite.NetworkEndpoint, error) {
 	endpointBatch := map[negtypes.NetworkEndpoint]*composite.NetworkEndpoint{}
 
 	for i := 0; i < MAX_NETWORK_ENDPOINTS_PER_BATCH; i++ {
@@ -719,7 +740,7 @@ func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.N
 			if flags.F.EnableNEGLabelPropagation {
 				annotations, ok := endpointPodLabelMap[networkEndpoint]
 				if !ok {
-					klog.Infof("Can not find annotations for endpoint %v from endpointPodLabelMap.", networkEndpoint)
+					logger.Info("Can not find annotations for endpoint from endpointPodLabelMap", "endpoint", networkEndpoint, "endpointPodLabelMap", endpointPodLabelMap)
 				} else {
 					cloudNetworkEndpoint.Annotations = annotations
 				}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -42,6 +42,7 @@ import (
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 func TestEncodeDecodeEndpoint(t *testing.T) {
@@ -419,6 +420,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				tc.apiVersion,
 				false,
 				tc.networkInfo,
+				klog.TODO(),
 			)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
@@ -476,6 +478,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				tc.apiVersion,
 				false,
 				tc.networkInfo,
+				klog.TODO(),
 			)
 
 			if err != nil {
@@ -611,7 +614,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			gotResult, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), zoneGetter, podLister, tc.portName, tc.networkEndpointType, tc.enableDualStackNEG)
+			gotResult, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()), zoneGetter, podLister, tc.portName, tc.networkEndpointType, tc.enableDualStackNEG, klog.TODO())
 			if err != nil {
 				t.Errorf("toZoneNetworkEndpointMap() = err %v, want no error", err)
 			}
@@ -1082,7 +1085,7 @@ func TestValidateEndpointFields(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		result, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlice), zoneGetter, podLister, "", negtypes.VmIpPortEndpointType, false)
+		result, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlice), zoneGetter, podLister, "", negtypes.VmIpPortEndpointType, false, klog.TODO())
 		if !errors.Is(err, tc.expectErr) {
 			t.Errorf("For case %q, expect %v error, but got %v.", tc.desc, tc.expectErr, err)
 		}
@@ -1419,7 +1422,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc.mutate(negCloud)
 		// tc.mode of "" will result in the default node predicate being selected, which is ok for this test.
-		endpointSets, annotationMap, err := retrieveExistingZoneNetworkEndpointMap(negName, zoneGetter, negCloud, meta.VersionGA, tc.mode, false)
+		endpointSets, annotationMap, err := retrieveExistingZoneNetworkEndpointMap(negName, zoneGetter, negCloud, meta.VersionGA, tc.mode, false, klog.TODO())
 
 		if tc.expectErr {
 			if err == nil {
@@ -1519,7 +1522,7 @@ func TestMakeEndpointBatch(t *testing.T) {
 
 			endpointSet, endpointMap, endpointPodLabelMap := genTestEndpoints(tc.endpointNum, negType, flags.F.EnableNEGLabelPropagation)
 
-			out, err := makeEndpointBatch(endpointSet, negType, endpointPodLabelMap)
+			out, err := makeEndpointBatch(endpointSet, negType, endpointPodLabelMap, klog.TODO())
 
 			if err != nil {
 				t.Errorf("Expect err = nil, but got %v", err)
@@ -1590,6 +1593,7 @@ func TestNameUniqueness(t *testing.T) {
 		apiVersion,
 		false,
 		networkInfo,
+		klog.TODO(),
 	)
 	if err != nil {
 		t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -1620,6 +1624,7 @@ func TestNameUniqueness(t *testing.T) {
 		apiVersion,
 		false,
 		networkInfo,
+		klog.TODO(),
 	)
 
 	if err == nil {
@@ -1667,6 +1672,7 @@ func TestNegObjectCrd(t *testing.T) {
 			apiVersion,
 			false,
 			networkInfo,
+			klog.TODO(),
 		)
 		if err != nil {
 			t.Errorf("Errored while ensuring network endpoint groups: %s", err)
@@ -1708,6 +1714,7 @@ func TestNegObjectCrd(t *testing.T) {
 			apiVersion,
 			false,
 			networkInfo,
+			klog.TODO(),
 		)
 
 		if err != nil {
@@ -1878,6 +1885,7 @@ func TestNEGRecreate(t *testing.T) {
 			apiVersion,
 			tc.customName,
 			networkInfo,
+			klog.TODO(),
 		)
 		if !tc.expectError && err != nil {
 			t.Errorf("TestCase: %s, Errored while ensuring network endpoint groups: %s", tc.desc, err)
@@ -2030,7 +2038,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, tc.portName, tc.networkEndpointType, false)
+			result := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, tc.portName, tc.networkEndpointType, false, klog.TODO())
 			if !reflect.DeepEqual(result.NetworkEndpointSet, tc.expectedEndpointMap) {
 				t.Errorf("degraded mode endpoint set is not calculated correctly:\ngot %+v,\n expected %+v", result.NetworkEndpointSet, tc.expectedEndpointMap)
 			}
@@ -2362,7 +2370,7 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, emptyNamedPort, tc.endpointType, true)
+			result := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, emptyNamedPort, tc.endpointType, true, klog.TODO())
 			if !reflect.DeepEqual(result.NetworkEndpointSet, tc.expectedEndpointMap) {
 				t.Errorf("degraded mode endpoint set is not calculated correctly:\ngot %+v,\n expected %+v", result.NetworkEndpointSet, tc.expectedEndpointMap)
 			}
@@ -2701,7 +2709,7 @@ func TestValidatePod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			if _, got := validatePod(tc.pod, nodeLister, serviceLister, tc.networkEndpoint, tc.serviceName, tc.isCustomEPS); !errors.Is(got, tc.expectErr) {
+			if _, got := validatePod(tc.pod, nodeLister, serviceLister, tc.networkEndpoint, tc.serviceName, tc.isCustomEPS, klog.TODO()); !errors.Is(got, tc.expectErr) {
 				t.Errorf("validatePod() = %t, expected %t\n", got, tc.expectErr)
 			}
 		})

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -426,7 +426,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				t.Errorf("unexpected error: %s", err)
 			}
 
-			neg, err := fakeCloud.GetNetworkEndpointGroup(tc.negName, testZone, tc.apiVersion)
+			neg, err := fakeCloud.GetNetworkEndpointGroup(tc.negName, testZone, tc.apiVersion, klog.TODO())
 			if err != nil {
 				t.Errorf("Failed to retrieve NEG %q: %v", tc.negName, err)
 			}
@@ -1136,22 +1136,22 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc: "neg only exists in one of the zone",
 			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
-				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone1)
+				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone1, klog.TODO())
 			},
 			expectErr: true,
 		},
 		{
 			desc: "neg only exists in one of the zone plus irrelevant negs",
 			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
-				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: irrelevantNegName, Version: meta.VersionGA}, negtypes.TestZone2)
+				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: irrelevantNegName, Version: meta.VersionGA}, negtypes.TestZone2, klog.TODO())
 			},
 			expectErr: true,
 		},
 		{
 			desc: "empty negs exists in all 3 zones",
 			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
-				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone2)
-				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone4)
+				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone2, klog.TODO())
+				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(),
@@ -1173,7 +1173,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 							"foo": "bar",
 						},
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(endpoint1),
@@ -1199,7 +1199,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 							"foo": "bar",
 						},
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
@@ -1239,7 +1239,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 							"foo": "bar",
 						},
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
@@ -1282,7 +1282,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 						IpAddress: testIP7,
 						Port:      testPort,
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
@@ -1325,7 +1325,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 						IpAddress: testIP4,
 						Port:      testPort,
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
@@ -1369,7 +1369,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 						IpAddress: testIP5,
 						Port:      testPort,
 					},
-				}, meta.VersionGA)
+				}, meta.VersionGA, klog.TODO())
 			},
 			// set mode to L4 since this scenario applies more to VM_IP NEGs.
 			mode: negtypes.L4LocalMode,
@@ -1413,7 +1413,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc: "NEG does not exist in a zone where endpoints exist(mimics user deleting NEG manually)",
 			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
-				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, meta.VersionGA)
+				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, meta.VersionGA, klog.TODO())
 			},
 			expectErr: true,
 		},
@@ -1599,7 +1599,7 @@ func TestNameUniqueness(t *testing.T) {
 		t.Errorf("Errored while ensuring network endpoint groups: %s", err)
 	}
 
-	neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion)
+	neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to retrieve NEG %q: %v", negName, err)
 	}
@@ -1678,7 +1678,7 @@ func TestNegObjectCrd(t *testing.T) {
 			t.Errorf("Errored while ensuring network endpoint groups: %s", err)
 		}
 
-		neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion)
+		neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion, klog.TODO())
 		if err != nil {
 			t.Errorf("Failed to retrieve NEG %q: %v", negName, err)
 		}
@@ -1867,7 +1867,7 @@ func TestNEGRecreate(t *testing.T) {
 			Network:             tc.network,
 			Subnetwork:          tc.subnetwork,
 			Description:         tc.negDescription,
-		}, testZone)
+		}, testZone, klog.TODO())
 
 		// Ensure with the correct network and subnet
 		_, err := ensureNetworkEndpointGroup(
@@ -1893,7 +1893,7 @@ func TestNEGRecreate(t *testing.T) {
 			t.Errorf("TestCase: %s, Expected error when ensure network endpoint groups", tc.desc)
 		}
 
-		neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion)
+		neg, err := fakeCloud.GetNetworkEndpointGroup(negName, testZone, apiVersion, klog.TODO())
 		if err != nil {
 			t.Errorf("TestCase: %s, Failed to retrieve NEG %q: %v", tc.desc, negName, err)
 		}

--- a/pkg/neg/types/cloudprovideradapter_test.go
+++ b/pkg/neg/types/cloudprovideradapter_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/composite"
@@ -43,7 +44,7 @@ func TestAggregatedListNetworkEndpointGroup(t *testing.T) {
 
 	neg := &composite.NetworkEndpointGroup{Name: neg1, Version: meta.VersionGA}
 	zone := zone1
-	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone); err != nil {
+	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone, klog.TODO()); err != nil {
 		t.Fatalf("Got CreateNetworkEndpointGroup(%v, %v) = %v, want nil", neg, zone, err)
 	}
 
@@ -51,7 +52,7 @@ func TestAggregatedListNetworkEndpointGroup(t *testing.T) {
 
 	neg = &composite.NetworkEndpointGroup{Name: neg2, Version: meta.VersionGA}
 	zone = zone2
-	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone); err != nil {
+	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone, klog.TODO()); err != nil {
 		t.Fatalf("Got CreateNetworkEndpointGroup(%v, %v) = %v, want nil", neg, zone, err)
 	}
 
@@ -59,13 +60,13 @@ func TestAggregatedListNetworkEndpointGroup(t *testing.T) {
 
 	neg = &composite.NetworkEndpointGroup{Name: neg1, Version: meta.VersionGA}
 	zone = zone2
-	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone); err != nil {
+	if err := fakeCloud.CreateNetworkEndpointGroup(neg, zone, klog.TODO()); err != nil {
 		t.Fatalf("Got CreateNetworkEndpointGroup(%v, %v) = %v, want nil", neg, zone, err)
 	}
 
 	validateAggregatedList(t, fakeCloud, 2, map[string][]string{zone1: {neg1}, zone2: {neg1, neg2}})
 
-	if err := fakeCloud.DeleteNetworkEndpointGroup(neg1, zone1, meta.VersionGA); err != nil {
+	if err := fakeCloud.DeleteNetworkEndpointGroup(neg1, zone1, meta.VersionGA, klog.TODO()); err != nil {
 		t.Fatalf("Got DeleteNetworkEndpointGroup(%v, %v) = %v, want nil", neg1, zone1, err)
 	}
 
@@ -73,7 +74,7 @@ func TestAggregatedListNetworkEndpointGroup(t *testing.T) {
 }
 
 func validateAggregatedList(t *testing.T, adapter NetworkEndpointGroupCloud, expectZoneNum int, expectZoneNegs map[string][]string) {
-	ret, err := adapter.AggregatedListNetworkEndpointGroup(meta.VersionGA)
+	ret, err := adapter.AggregatedListNetworkEndpointGroup(meta.VersionGA, klog.TODO())
 	if err != nil {
 		t.Errorf("Expect AggregatedListNetworkEndpointGroup to return nil error, but got %v", err)
 	}

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -146,7 +147,7 @@ func NewFakeNetworkEndpointGroupCloud(subnetwork, network string) NetworkEndpoin
 	}
 }
 
-func (f *FakeNetworkEndpointGroupCloud) GetNetworkEndpointGroup(name string, zone string, version meta.Version) (*composite.NetworkEndpointGroup, error) {
+func (f *FakeNetworkEndpointGroupCloud) GetNetworkEndpointGroup(name string, zone string, version meta.Version, _ klog.Logger) (*composite.NetworkEndpointGroup, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	negs, ok := f.NetworkEndpointGroups[zone]
@@ -164,13 +165,13 @@ func networkEndpointKey(name, zone string) string {
 	return fmt.Sprintf("%s-%s", zone, name)
 }
 
-func (f *FakeNetworkEndpointGroupCloud) ListNetworkEndpointGroup(zone string, version meta.Version) ([]*composite.NetworkEndpointGroup, error) {
+func (f *FakeNetworkEndpointGroupCloud) ListNetworkEndpointGroup(zone string, version meta.Version, _ klog.Logger) ([]*composite.NetworkEndpointGroup, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.NetworkEndpointGroups[zone], nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) AggregatedListNetworkEndpointGroup(version meta.Version) (map[*meta.Key]*composite.NetworkEndpointGroup, error) {
+func (f *FakeNetworkEndpointGroupCloud) AggregatedListNetworkEndpointGroup(version meta.Version, _ klog.Logger) (map[*meta.Key]*composite.NetworkEndpointGroup, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	result := make(map[*meta.Key]*composite.NetworkEndpointGroup)
@@ -182,7 +183,7 @@ func (f *FakeNetworkEndpointGroupCloud) AggregatedListNetworkEndpointGroup(versi
 	return result, nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) CreateNetworkEndpointGroup(neg *composite.NetworkEndpointGroup, zone string) error {
+func (f *FakeNetworkEndpointGroupCloud) CreateNetworkEndpointGroup(neg *composite.NetworkEndpointGroup, zone string, _ klog.Logger) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	neg.SelfLink = cloud.NewNetworkEndpointGroupsResourceID("mock-project", zone, neg.Name).SelfLink(meta.VersionAlpha)
@@ -194,7 +195,7 @@ func (f *FakeNetworkEndpointGroupCloud) CreateNetworkEndpointGroup(neg *composit
 	return nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) DeleteNetworkEndpointGroup(name string, zone string, version meta.Version) error {
+func (f *FakeNetworkEndpointGroupCloud) DeleteNetworkEndpointGroup(name string, zone string, version meta.Version, _ klog.Logger) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.NetworkEndpoints, networkEndpointKey(name, zone))
@@ -215,14 +216,14 @@ func (f *FakeNetworkEndpointGroupCloud) DeleteNetworkEndpointGroup(name string, 
 	return nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) AttachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version) error {
+func (f *FakeNetworkEndpointGroupCloud) AttachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version, _ klog.Logger) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.NetworkEndpoints[networkEndpointKey(name, zone)] = append(f.NetworkEndpoints[networkEndpointKey(name, zone)], endpoints...)
 	return nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) DetachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version) error {
+func (f *FakeNetworkEndpointGroupCloud) DetachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version, _ klog.Logger) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	newList := []*composite.NetworkEndpoint{}
@@ -243,7 +244,7 @@ func (f *FakeNetworkEndpointGroupCloud) DetachNetworkEndpoints(name, zone string
 	return nil
 }
 
-func (f *FakeNetworkEndpointGroupCloud) ListNetworkEndpoints(name, zone string, showHealthStatus bool, version meta.Version) ([]*composite.NetworkEndpointWithHealthStatus, error) {
+func (f *FakeNetworkEndpointGroupCloud) ListNetworkEndpoints(name, zone string, showHealthStatus bool, version meta.Version, _ klog.Logger) ([]*composite.NetworkEndpointWithHealthStatus, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	ret := []*composite.NetworkEndpointWithHealthStatus{}

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 // ZoneGetter is an interface for retrieve zone related information
@@ -30,14 +31,14 @@ type ZoneGetter interface {
 
 // NetworkEndpointGroupCloud is an interface for managing gce network endpoint group.
 type NetworkEndpointGroupCloud interface {
-	GetNetworkEndpointGroup(name string, zone string, version meta.Version) (*composite.NetworkEndpointGroup, error)
-	ListNetworkEndpointGroup(zone string, version meta.Version) ([]*composite.NetworkEndpointGroup, error)
-	AggregatedListNetworkEndpointGroup(version meta.Version) (map[*meta.Key]*composite.NetworkEndpointGroup, error)
-	CreateNetworkEndpointGroup(neg *composite.NetworkEndpointGroup, zone string) error
-	DeleteNetworkEndpointGroup(name string, zone string, version meta.Version) error
-	AttachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version) error
-	DetachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version) error
-	ListNetworkEndpoints(name, zone string, showHealthStatus bool, version meta.Version) ([]*composite.NetworkEndpointWithHealthStatus, error)
+	GetNetworkEndpointGroup(name string, zone string, version meta.Version, logger klog.Logger) (*composite.NetworkEndpointGroup, error)
+	ListNetworkEndpointGroup(zone string, version meta.Version, logger klog.Logger) ([]*composite.NetworkEndpointGroup, error)
+	AggregatedListNetworkEndpointGroup(version meta.Version, logger klog.Logger) (map[*meta.Key]*composite.NetworkEndpointGroup, error)
+	CreateNetworkEndpointGroup(neg *composite.NetworkEndpointGroup, zone string, logger klog.Logger) error
+	DeleteNetworkEndpointGroup(name string, zone string, version meta.Version, logger klog.Logger) error
+	AttachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version, logger klog.Logger) error
+	DetachNetworkEndpoints(name, zone string, endpoints []*composite.NetworkEndpoint, version meta.Version, logger klog.Logger) error
+	ListNetworkEndpoints(name, zone string, showHealthStatus bool, version meta.Version, logger klog.Logger) ([]*composite.NetworkEndpointWithHealthStatus, error)
 	NetworkURL() string
 	SubnetworkURL() string
 	NetworkProjectID() string


### PR DESCRIPTION
This PR is the continuation of https://github.com/kubernetes/ingress-gce/pull/1746(contextual logging for components
in NEG controller).
* Functions will accept a logger object from its caller, so the prefix will be determined based on the caller objects.