### PR TITLE
Update metrics bucket to distinguish 0 and 1.

### DIFF
--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -164,8 +164,8 @@ var (
 			Subsystem: negControllerSubsystem,
 			Name:      "degraded_mode_correctness",
 			Help:      "Number of endpoints differed between current endpoint calculation and degraded mode calculation",
-			// custom buckets - [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 20),
+			// custom buckets - [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, +Inf]
+			Buckets: append([]float64{0}, prometheus.ExponentialBuckets(1, 2, 20)...),
 		},
 		[]string{
 			"neg_type",      // type of neg

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1908,13 +1908,37 @@ func TestCheckEndpointBatchErr(t *testing.T) {
 			endpointOperation: detachOp,
 			expectErr:         negtypes.ErrInvalidEPDetach,
 		},
+		{
+			desc:              "Wrapped googleapi server error",
+			err:               fmt.Errorf("%w: wrapped error", serverError),
+			endpointOperation: attachOp,
+			expectErr:         serverError,
+		},
+		{
+			desc:              "Wrapped googleapi attach request error",
+			err:               fmt.Errorf("%w: wrapped error", requestError),
+			endpointOperation: attachOp,
+			expectErr:         negtypes.ErrInvalidEPAttach,
+		},
+		{
+			desc:              "Double wrapped googleapi server error",
+			err:               fmt.Errorf("%w: %w", serverError, errors.New("wrapped error")),
+			endpointOperation: attachOp,
+			expectErr:         serverError,
+		},
+		{
+			desc:              "Double wrapped googleapi request error",
+			err:               fmt.Errorf("%w: %w", requestError, errors.New("wrapped error")),
+			endpointOperation: attachOp,
+			expectErr:         negtypes.ErrInvalidEPAttach,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			endpointBatchErr := checkEndpointBatchErr(tc.err, tc.endpointOperation)
 			if !errors.Is(endpointBatchErr, tc.expectErr) {
-				t.Errorf("checkEndpointBatchErr() = %t, expected %t", endpointBatchErr, tc.expectErr)
+				t.Errorf("checkEndpointBatchErr() = %v, expected %v", endpointBatchErr, tc.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
* Add additional logging for degraded mode behavior.
* Update logging bucket so we can distinguish endpoint diff 0 from endpoint diff 1 in degraded mode correctness metric.
* Update error checking in checkEndpointBatchErr.