### PR TITLE
Add gce-regional ingress class annotation

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -59,10 +59,11 @@ const (
 	// IngressClassKey picks a specific "class" for the Ingress. The controller
 	// only processes Ingresses with this annotation either unset, or set
 	// to either gceIngressClass or the empty string.
-	IngressClassKey      = "kubernetes.io/ingress.class"
-	GceIngressClass      = "gce"
-	GceMultiIngressClass = "gce-multi-cluster"
-	GceL7ILBIngressClass = "gce-internal"
+	IngressClassKey              = "kubernetes.io/ingress.class"
+	GceIngressClass              = "gce"
+	GceMultiIngressClass         = "gce-multi-cluster"
+	GceL7ILBIngressClass         = "gce-internal"
+	GceL7XLBRegionalIngressClass = "gce-regional"
 
 	// Label key to denote which GCE zone a Kubernetes node is in.
 	ZoneKey     = "topology.kubernetes.io/zone"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -433,6 +433,13 @@ func IsGCEL7ILBIngress(ing *networkingv1.Ingress) bool {
 	return class == annotations.GceL7ILBIngressClass
 }
 
+// IsGCEL7XLBRegionalIngress returns true if the given Ingress has
+// ingress.class annotation set to "gce-regional"
+func IsGCEL7XLBRegionalIngress(ing *networkingv1.Ingress) bool {
+	class := annotations.FromIngress(ing).IngressClass()
+	return class == annotations.GceL7XLBRegionalIngressClass
+}
+
 // IsGLBCIngress returns true if the given Ingress should be processed by GLBC
 func IsGLBCIngress(ing *networkingv1.Ingress) bool {
 	return IsGCEIngress(ing) || IsGCEMultiClusterIngress(ing)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -800,6 +800,70 @@ func TestIsGCEL7ILBIngress(t *testing.T) {
 		})
 	}
 }
+func TestIsGCEL7XLBRegionalIngress(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		desc     string
+		ingress  *networkingv1.Ingress
+		expected bool
+	}{
+		{
+			desc: "No ingress class",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc:     "Empty Annotations",
+			ingress:  &networkingv1.Ingress{},
+			expected: false,
+		},
+		{
+			desc: "L7 XLB Regional ingress class",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.GceL7XLBRegionalIngressClass,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "L7 XLB Global ingress class",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.GceIngressClass,
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc: "foo ingress class",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.IngressClassKey: "foo-class",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := IsGCEL7XLBRegionalIngress(tc.ingress)
+			if result != tc.expected {
+				t.Fatalf("want %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
 
 func TestNeedsCleanup(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
- Add "gce-regional" ingress class annotation
- Add GceL7XLBRegionalIngressClass that checks if ingress has
      gce-regional annotation class, and if regional external ingress is
      enabled
- Should be no-op