### PR TITLE
Enable ServicePort NEGs for L7 RXLB 

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -148,8 +148,8 @@ func maybeEnableNEG(sp *utils.ServicePort, svc *api_v1.Service) error {
 		return errors.ErrBadSvcType{Service: sp.ID.Service, ServiceType: svc.Spec.Type}
 	}
 
-	if sp.L7ILBEnabled {
-		// L7-ILB Requires NEGs
+	if sp.L7ILBEnabled || sp.L7XLBRegionalEnabled {
+		// L7-ILB and L7 Regional XLB require NEGs
 		sp.NEGEnabled = true
 	}
 

--- a/pkg/controller/translator/translator_test.go
+++ b/pkg/controller/translator/translator_test.go
@@ -444,6 +444,34 @@ func TestGetServicePort(t *testing.T) {
 			},
 			wantWarning: true,
 		},
+		{
+			desc: "correct port and config for gce-regional-external",
+			spec: apiv1.ServiceSpec{
+				Type: apiv1.ServiceTypeNodePort,
+				Ports: []apiv1.ServicePort{
+					{Name: "http", Port: 80},
+					{Name: "https", Port: 443},
+					{Name: "otherPort", Port: 12345},
+				},
+			},
+			id:      utils.ServicePortID{Port: v1.ServiceBackendPort{Name: "https"}},
+			params:  getServicePortParams{isL7XLBRegional: true},
+			wantErr: false,
+			wantServicePort: &utils.ServicePort{
+				ID: utils.ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: "default",
+						Name:      "foo",
+					},
+					Port: v1.ServiceBackendPort{Name: "https"},
+				},
+				Port:                 443,
+				PortName:             "https",
+				Protocol:             "HTTP",
+				L7XLBRegionalEnabled: true,
+				NEGEnabled:           true,
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
- In the same manner as for L7 ILB, always enable NEGs on ServicePort
  for L7XLB Regional Ingress
- This is flag-gated, because L7XLBRegionalEnabled is flag-gated