### PR TITLE
Add L7 Regional XLB to IsGCEIngress, depending on the flag

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -414,6 +414,8 @@ func IsGCEIngress(ing *networkingv1.Ingress) bool {
 		return true
 	case annotations.GceL7ILBIngressClass:
 		return true
+	case annotations.GceL7XLBRegionalIngressClass:
+		return flags.F.EnableIngressRegionalExternal
 	default:
 		return false
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -650,10 +650,11 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 func TestIsGCEIngress(t *testing.T) {
 	var wrongClassName = "wrong-class"
 	testCases := []struct {
-		desc             string
-		ingress          *networkingv1.Ingress
-		ingressClassFlag string
-		expected         bool
+		desc                   string
+		ingress                *networkingv1.Ingress
+		ingressClassFlag       string
+		xlbRegionalEnabledFlag bool
+		expected               bool
 	}{
 		{
 			desc: "No ingress class",
@@ -733,6 +734,30 @@ func TestIsGCEIngress(t *testing.T) {
 			ingressClassFlag: "right-class",
 			expected:         true,
 		},
+		{
+			desc: "L7 XLB Regional ingress class with flag disabled",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.GceL7XLBRegionalIngressClass,
+					},
+				},
+			},
+			xlbRegionalEnabledFlag: false,
+			expected:               false,
+		},
+		{
+			desc: "L7 XLB Regional ingress class with flag enabled",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.IngressClassKey: annotations.GceL7XLBRegionalIngressClass,
+					},
+				},
+			},
+			xlbRegionalEnabledFlag: true,
+			expected:               true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -740,6 +765,7 @@ func TestIsGCEIngress(t *testing.T) {
 			if tc.ingressClassFlag != "" {
 				flags.F.IngressClass = tc.ingressClassFlag
 			}
+			flags.F.EnableIngressRegionalExternal = tc.xlbRegionalEnabledFlag
 
 			result := IsGCEIngress(tc.ingress)
 			if result != tc.expected {


### PR DESCRIPTION
- IsGCEIngress is used in different controllers to filter ingresses that ingress-gce should handle
- Return true only if flag is enabled. Adding dependency on the global flag

I don't like being dependent on the global flag, but this looks not extremely bad here. But if you ask, I can refactor, just I would need to pass this flag to different controllers

/assign @spencerhance 