### PR TITLE
Add contextual logging for Backend pools. 

### DIFF
--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -104,7 +104,7 @@ func TestEnsureL4BackendService(t *testing.T) {
 			hcLink := l4namer.L4HealthCheck(tc.serviceNamespace, tc.serviceName, false)
 			bsName := l4namer.L4Backend(tc.serviceNamespace, tc.serviceName)
 			network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
-			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, tc.connectionTrackingPolicy)
+			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, tc.connectionTrackingPolicy, klog.TODO())
 			if err != nil {
 				t.Errorf("EnsureL4BackendService failed")
 			}
@@ -189,7 +189,7 @@ func TestEnsureL4BackendServiceDoesNotDetachBackends(t *testing.T) {
 			}
 
 			var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), namespacedName, network, noConnectionTrackingPolicy)
+			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), namespacedName, network, noConnectionTrackingPolicy, klog.TODO())
 			if err != nil {
 				t.Errorf("EnsureL4BackendService failed")
 			}

--- a/pkg/backends/features/iap.go
+++ b/pkg/backends/features/iap.go
@@ -31,9 +31,9 @@ var switchingToDefaultError = errors.New("Cannot switch to default OAuth once IA
 // EnsureIAP reads the IAP configuration specified in the BackendConfig
 // and applies it to the BackendService if it is stale. It returns true
 // if there were existing settings on the BackendService that were overwritten.
-func EnsureIAP(sp utils.ServicePort, be *composite.BackendService, logger klog.Logger) (bool, error) {
+func EnsureIAP(sp utils.ServicePort, be *composite.BackendService, beLogger klog.Logger) (bool, error) {
 	// TODO: Update when context logging is enabled to ensure no duplicate keys
-	logger = logger.WithName("EnsureIAP").WithValues("service", klog.KRef(sp.ID.Service.Namespace, sp.ID.Service.Name))
+	beLogger = beLogger.WithName("EnsureIAP").WithValues("service", klog.KRef(sp.ID.Service.Namespace, sp.ID.Service.Name))
 	if sp.BackendConfig.Spec.Iap == nil {
 		return false, nil
 	}
@@ -41,16 +41,16 @@ func EnsureIAP(sp utils.ServicePort, be *composite.BackendService, logger klog.L
 	applyIAPSettings(sp, beTemp)
 
 	if err := switchingToDefault(beTemp, be); err != nil {
-		logger.Error(err, "Errored updating IAP settings")
+		beLogger.Error(err, "Errored updating IAP settings")
 		return false, fmt.Errorf("Errored updating IAP Settings for service %s/%s: %w", sp.ID.Service.Namespace, sp.ID.Service.Name, err)
 	}
 
-	if diffIAP(beTemp, be, logger) {
+	if diffIAP(beTemp, be, beLogger) {
 		applyIAPSettings(sp, be)
-		logger.Info("Updated IAP settings")
+		beLogger.Info("Updated IAP settings")
 		return true, nil
 	}
-	logger.Info("Detected no change in IAP Settings")
+	beLogger.Info("Detected no change in IAP Settings")
 	return false, nil
 }
 

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -91,7 +91,10 @@ func (igl *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) er
 	// ig_linker only supports L7 HTTP(s) External Load Balancer
 	// Hardcoded here since IGs are not supported for non GA-Global right now
 	// TODO(shance): find a way to remove hardcoded values
-	be, err := igl.backendPool.Get(sp.BackendName(), meta.VersionGA, meta.Global)
+	// TODO(cheungdavid): Create ig linker logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.Get().
+	// See example in backendSyncer.ensureBackendService().
+	be, err := igl.backendPool.Get(sp.BackendName(), meta.VersionGA, meta.Global, klog.TODO())
 	if err != nil {
 		return err
 	}
@@ -126,7 +129,10 @@ func (igl *instanceGroupLinker) Link(sp utils.ServicePort, groups []GroupKey) er
 		newBackends := backendsForIGs(addIGs, bm)
 		be.Backends = append(originalIGBackends, newBackends...)
 
-		if err := igl.backendPool.Update(be); err != nil {
+		// TODO(cheungdavid): Create ig linker logger that contains backendName,
+		// backendVersion, and backendScope before passing to backendPool.Get().
+		// See example in backendSyncer.ensureBackendService().
+		if err := igl.backendPool.Update(be, klog.TODO()); err != nil {
 			if utils.IsHTTPErrorCode(err, http.StatusBadRequest) {
 				klog.V(2).Infof("Updating backend service backends with balancing mode %v failed, will try another mode. err:%v", bm, err)
 				errs = append(errs, err.Error())

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
 )
 
 const defaultZone = "zone-a"
@@ -76,7 +77,7 @@ func TestLink(t *testing.T) {
 	}
 
 	// Mimic the syncer creating the backend.
-	linker.backendPool.Create(sp, "fake-health-check-link")
+	linker.backendPool.Create(sp, "fake-health-check-link", klog.TODO())
 
 	if err := linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {
 		t.Fatalf("%v", err)
@@ -132,7 +133,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 		}
 
 		// Mimic the syncer creating the backend.
-		linker.backendPool.Create(sp, "fake-health-check-link")
+		linker.backendPool.Create(sp, "fake-health-check-link", klog.TODO())
 
 		if err := linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {
 			t.Fatalf("%v", err)
@@ -152,7 +153,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 				t.Fatalf("Wrong balancing mode, expected %v got %v", modes[(i+1)%len(modes)], b.BalancingMode)
 			}
 		}
-		linker.backendPool.Delete(sp.BackendName(), features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp))
+		linker.backendPool.Delete(sp.BackendName(), features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp), klog.TODO())
 	}
 }
 

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
 )
 
 type Jig struct {
@@ -91,7 +92,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 
-	if err := jig.syncer.Sync([]utils.ServicePort{sp}); err != nil {
+	if err := jig.syncer.Sync([]utils.ServicePort{sp}, klog.TODO()); err != nil {
 		t.Fatalf("Did not expect error when syncing backend with port %v", sp.NodePort)
 	}
 	if err := jig.linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {
@@ -119,7 +120,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 
-	if err := jig.syncer.Sync([]utils.ServicePort{sp}); err != nil {
+	if err := jig.syncer.Sync([]utils.ServicePort{sp}, klog.TODO()); err != nil {
 		t.Fatalf("Did not expect error when syncing backend with port %v", sp.NodePort)
 	}
 	if err := jig.linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {
@@ -164,7 +165,7 @@ func TestSyncChaosMonkey(t *testing.T) {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v, err %v", sp, err)
 	}
 
-	if err := jig.syncer.Sync([]utils.ServicePort{sp}); err != nil {
+	if err := jig.syncer.Sync([]utils.ServicePort{sp}, klog.TODO()); err != nil {
 		t.Fatalf("Did not expect error when syncing backend with port %v, err: %v", sp.NodePort, err)
 	}
 	if err := jig.linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {
@@ -197,7 +198,7 @@ func TestSyncChaosMonkey(t *testing.T) {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 
-	if err := jig.syncer.Sync([]utils.ServicePort{sp}); err != nil {
+	if err := jig.syncer.Sync([]utils.ServicePort{sp}, klog.TODO()); err != nil {
 		t.Fatalf("Did not expect error when syncing backend with port %v", sp.NodePort)
 	}
 	if err := jig.linker.Link(sp, []GroupKey{{Zone: defaultZone}}); err != nil {

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -35,21 +35,21 @@ type GroupKey struct {
 // Backend Services.
 type Pool interface {
 	// Get a composite BackendService given a required version.
-	Get(name string, version meta.Version, scope meta.KeyType) (*composite.BackendService, error)
+	Get(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (*composite.BackendService, error)
 	// Create a composite BackendService and returns it.
-	Create(sp utils.ServicePort, hcLink string) (*composite.BackendService, error)
+	Create(sp utils.ServicePort, hcLink string, logger klog.Logger) (*composite.BackendService, error)
 	// Update a BackendService given the composite type.
-	Update(be *composite.BackendService) error
+	Update(be *composite.BackendService, logger klog.Logger) error
 	// Delete a BackendService given its name.
-	Delete(name string, version meta.Version, scope meta.KeyType) error
+	Delete(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) error
 	// Get the health of a BackendService given its name.
-	Health(name string, version meta.Version, scope meta.KeyType) (string, error)
+	Health(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (string, error)
 	// Get a list of BackendService names that are managed by this pool.
-	List(key *meta.Key, version meta.Version) ([]*composite.BackendService, error)
+	List(key *meta.Key, version meta.Version, logger klog.Logger) ([]*composite.BackendService, error)
 	// Add a SignedUrlKey to a BackendService
-	AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey) error
+	AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, logger klog.Logger) error
 	// Deletes a SignedUrlKey from BackendService
-	DeleteSignedUrlKey(be *composite.BackendService, keyName string) error
+	DeleteSignedUrlKey(be *composite.BackendService, keyName string, logger klog.Logger) error
 }
 
 // Syncer is an interface to sync Kubernetes services to GCE BackendServices.
@@ -58,11 +58,11 @@ type Syncer interface {
 	Init(p ProbeProvider)
 	// Sync a BackendService. Implementations should only create the BackendService
 	// but not its groups.
-	Sync(svcPorts []utils.ServicePort) error
+	Sync(svcPorts []utils.ServicePort, logger klog.Logger) error
 	// GC garbage collects unused BackendService's
-	GC(svcPorts []utils.ServicePort) error
+	GC(svcPorts []utils.ServicePort, logger klog.Logger) error
 	// Status returns the status of a BackendService given its name.
-	Status(name string, version meta.Version, scope meta.KeyType) (string, error)
+	Status(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (string, error)
 	// Shutdown cleans up all BackendService's previously synced.
 	Shutdown() error
 }

--- a/pkg/backends/neg_linker_test.go
+++ b/pkg/backends/neg_linker_test.go
@@ -90,7 +90,7 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 					BackendNamer: defaultNamer},
 			} {
 				// Mimic how the syncer would create the backend.
-				if _, err := linker.backendPool.Create(svcPort, "fake-healthcheck-link"); err != nil {
+				if _, err := linker.backendPool.Create(svcPort, "fake-healthcheck-link", klog.TODO()); err != nil {
 					t.Fatalf("Failed to create backend service to NEG for svcPort %v: %v", svcPort, err)
 				}
 

--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -47,7 +47,10 @@ func (linker *RegionalInstanceGroupLinker) Link(sp utils.ServicePort, projectID 
 		igSelfLink := cloudprovider.SelfLink(meta.VersionGA, projectID, "instanceGroups", key)
 		igLinks = append(igLinks, igSelfLink)
 	}
-	bs, err := linker.backendPool.Get(sp.BackendName(), meta.VersionGA, meta.Regional)
+	// TODO(cheungdavid): Create regional ig linker logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.Get().
+	// See example in backendSyncer.ensureBackendService().
+	bs, err := linker.backendPool.Get(sp.BackendName(), meta.VersionGA, meta.Regional, klog.TODO())
 	if err != nil {
 		return err
 	}
@@ -82,7 +85,7 @@ func (linker *RegionalInstanceGroupLinker) Link(sp utils.ServicePort, projectID 
 	}
 
 	klog.V(3).Infof("Update Backend %s, with %d added backends (total %d).", sp.BackendName(), len(addIGs), len(bs.Backends))
-	if err := linker.backendPool.Update(bs); err != nil {
+	if err := linker.backendPool.Update(bs, klog.TODO()); err != nil {
 		return fmt.Errorf("updating backend service %s for IG failed, err:%w", sp.BackendName(), err)
 	}
 	return nil

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/slice"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -241,7 +242,7 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 	schemeExternal := string(cloud.SchemeExternal)
 	defaultNetworkInfo := network.NetworkInfo{IsDefault: true}
 	var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, noConnectionTrackingPolicy); err != nil {
+	if _, err := backendPool.EnsureL4BackendService(sp.BackendName(), hcLink, protocol, serviceAffinityNone, schemeExternal, namespacedName, defaultNetworkInfo, noConnectionTrackingPolicy, klog.TODO()); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -176,13 +176,13 @@ func TestSync(t *testing.T) {
 
 	for _, sp := range testCases {
 		t.Run(fmt.Sprintf("Port: %v Protocol: %v", sp.NodePort, sp.Protocol), func(t *testing.T) {
-			if err := syncer.Sync([]utils.ServicePort{sp}); err != nil {
+			if err := syncer.Sync([]utils.ServicePort{sp}, klog.TODO()); err != nil {
 				t.Fatalf("Unexpected error when syncing backend with port %v: %v", sp.NodePort, err)
 			}
 			beName := sp.BackendName()
 
 			// Check that the new backend has the right port
-			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp))
+			be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&sp), features.ScopeFromServicePort(&sp), klog.TODO())
 			if err != nil {
 				t.Fatalf("Did not find expected backend with port %v", sp.NodePort)
 			}
@@ -211,10 +211,10 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 	syncer := newTestSyncer(fakeGCE)
 
 	p := utils.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
-	syncer.Sync([]utils.ServicePort{p})
+	syncer.Sync([]utils.ServicePort{p}, klog.TODO())
 	beName := p.BackendName()
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p), klog.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -231,9 +231,9 @@ func TestSyncUpdateHTTPS(t *testing.T) {
 
 	// Update service port to encrypted
 	p.Protocol = annotations.ProtocolHTTPS
-	syncer.Sync([]utils.ServicePort{p})
+	syncer.Sync([]utils.ServicePort{p}, klog.TODO())
 
-	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
+	be, err = syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p), klog.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -255,10 +255,10 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 	syncer := newTestSyncer(fakeGCE)
 
 	p := utils.ServicePort{NodePort: 3000, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
-	syncer.Sync([]utils.ServicePort{p})
+	syncer.Sync([]utils.ServicePort{p}, klog.TODO())
 	beName := p.BackendName()
 
-	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
+	be, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p), klog.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
@@ -275,9 +275,9 @@ func TestSyncUpdateHTTP2(t *testing.T) {
 
 	// Update service port to HTTP2
 	p.Protocol = annotations.ProtocolHTTP2
-	syncer.Sync([]utils.ServicePort{p})
+	syncer.Sync([]utils.ServicePort{p}, klog.TODO())
 
-	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
+	beBeta, err := syncer.backendPool.Get(beName, features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p), klog.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected err retrieving backend service after update: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestGC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := syncer.Sync(ps.existingPorts()); err != nil {
+	if err := syncer.Sync(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.Sync(%+v) = %v, want nil ", ps.existingPorts(), err)
 	}
 
@@ -318,7 +318,7 @@ func TestGC(t *testing.T) {
 	}
 
 	// Run a no-op GC (i.e nothing is actually cleaned up)
-	if err := syncer.GC(ps.existingPorts()); err != nil {
+	if err := syncer.GC(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.GC(%+v) = %v, want nil", ps.existingPorts(), err)
 	}
 
@@ -331,7 +331,7 @@ func TestGC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := syncer.GC(ps.existingPorts()); err != nil {
+	if err := syncer.GC(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.GC(%+v) = %v, want nil", ps.existingPorts(), err)
 	}
 
@@ -359,7 +359,7 @@ func TestGCMixed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := syncer.Sync(ps.existingPorts()); err != nil {
+	if err := syncer.Sync(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.Sync(%+v) = %v, want nil ", ps.existingPorts(), err)
 	}
 
@@ -368,7 +368,7 @@ func TestGCMixed(t *testing.T) {
 	}
 
 	// Run a no-op GC (i.e nothing is actually cleaned up)
-	if err := syncer.GC(ps.existingPorts()); err != nil {
+	if err := syncer.GC(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.GC(%+v) = %v, want nil", ps.existingPorts(), err)
 	}
 
@@ -381,7 +381,7 @@ func TestGCMixed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := syncer.GC(ps.existingPorts()); err != nil {
+	if err := syncer.GC(ps.existingPorts(), klog.TODO()); err != nil {
 		t.Fatalf("syncer.GC(%+v) = %v, want nil", ps.existingPorts(), err)
 	}
 
@@ -487,19 +487,19 @@ func TestSyncQuota(t *testing.T) {
 				return false, nil
 			}
 
-			if err := syncer.Sync(tc.oldPorts); err != nil {
+			if err := syncer.Sync(tc.oldPorts, klog.TODO()); err != nil {
 				t.Errorf("Expected backend pool to add node ports, err: %v", err)
 			}
 
 			// Ensuring these ports again without first Garbage Collecting goes over
 			// the set quota. Expect an error here, until GC is called.
-			err := syncer.Sync(tc.newPorts)
+			err := syncer.Sync(tc.newPorts, klog.TODO())
 			if tc.expectSyncErr && err == nil {
 				t.Errorf("Expect initial sync to go over quota, but received no error")
 			}
 
-			syncer.GC(tc.newPorts)
-			if err := syncer.Sync(tc.newPorts); err != nil {
+			syncer.GC(tc.newPorts, klog.TODO())
+			if err := syncer.Sync(tc.newPorts, klog.TODO()); err != nil {
 				t.Errorf("Expected backend pool to add node ports, err: %v", err)
 			}
 
@@ -517,7 +517,7 @@ func TestSyncNEG(t *testing.T) {
 	syncer := newTestSyncer(fakeGCE)
 
 	svcPort := utils.ServicePort{NodePort: 81, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
-	if err := syncer.Sync([]utils.ServicePort{svcPort}); err != nil {
+	if err := syncer.Sync([]utils.ServicePort{svcPort}, klog.TODO()); err != nil {
 		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
 
@@ -529,7 +529,7 @@ func TestSyncNEG(t *testing.T) {
 
 	// Convert to NEG
 	svcPort.NEGEnabled = true
-	if err := syncer.Sync([]utils.ServicePort{svcPort}); err != nil {
+	if err := syncer.Sync([]utils.ServicePort{svcPort}, klog.TODO()); err != nil {
 		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
 
@@ -539,20 +539,20 @@ func TestSyncNEG(t *testing.T) {
 		t.Fatalf("Failed to get backend service with name %v: %v", negName, err)
 	}
 	// GC should garbage collect the Backend on the old naming schema
-	syncer.GC([]utils.ServicePort{svcPort})
+	syncer.GC([]utils.ServicePort{svcPort}, klog.TODO())
 
-	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), features.ScopeFromServicePort(&svcPort))
+	bs, err := syncer.backendPool.Get(nodePortName, features.VersionFromServicePort(&svcPort), features.ScopeFromServicePort(&svcPort), klog.TODO())
 	if err == nil {
 		t.Fatalf("Expected not to get BackendService with name %v, got: %+v", nodePortName, bs)
 	}
 
 	// Convert back to non-NEG
 	svcPort.NEGEnabled = false
-	if err := syncer.Sync([]utils.ServicePort{svcPort}); err != nil {
+	if err := syncer.Sync([]utils.ServicePort{svcPort}, klog.TODO()); err != nil {
 		t.Errorf("Expected backend pool to add node ports, err: %v", err)
 	}
 
-	syncer.GC([]utils.ServicePort{svcPort})
+	syncer.GC([]utils.ServicePort{svcPort}, klog.TODO())
 
 	_, err = fakeGCE.GetGlobalBackendService(nodePortName)
 	if err != nil {
@@ -565,7 +565,7 @@ func TestShutdown(t *testing.T) {
 	syncer := newTestSyncer(fakeGCE)
 
 	// Sync a backend and verify that it doesn't exist after Shutdown()
-	syncer.Sync([]utils.ServicePort{{NodePort: 80, BackendNamer: defaultNamer}})
+	syncer.Sync([]utils.ServicePort{{NodePort: 80, BackendNamer: defaultNamer}}, klog.TODO())
 	syncer.Shutdown()
 	if _, err := fakeGCE.GetGlobalBackendService(defaultNamer.IGBackend(80)); err == nil {
 		t.Fatalf("%v", err)
@@ -587,8 +587,8 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 			t.Run(
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
-					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort))
+					syncer.Sync([]utils.ServicePort{oldPort}, klog.TODO())
+					be, err := syncer.backendPool.Get(oldPort.BackendName(), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort), klog.TODO())
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -631,8 +631,8 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 			t.Run(
 				fmt.Sprintf("Updating Port:%v Protocol:%v to Port:%v Protocol:%v", oldPort.NodePort, oldPort.Protocol, newPort.NodePort, newPort.Protocol),
 				func(t *testing.T) {
-					syncer.Sync([]utils.ServicePort{oldPort})
-					be, err := syncer.backendPool.Get(oldPort.BackendName(), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort))
+					syncer.Sync([]utils.ServicePort{oldPort}, klog.TODO())
+					be, err := syncer.backendPool.Get(oldPort.BackendName(), features.VersionFromServicePort(&oldPort), features.ScopeFromServicePort(&oldPort), klog.TODO())
 					if err != nil {
 						t.Fatalf("%v", err)
 					}
@@ -659,8 +659,8 @@ func TestEnsureBackendServiceHealthCheckLink(t *testing.T) {
 	syncer := newTestSyncer(fakeGCE)
 
 	p := utils.ServicePort{NodePort: 80, Protocol: annotations.ProtocolHTTP, ID: utils.ServicePortID{Port: networkingv1.ServiceBackendPort{Number: 1}}, BackendNamer: defaultNamer}
-	syncer.Sync([]utils.ServicePort{p})
-	be, err := syncer.backendPool.Get(p.BackendName(), features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p))
+	syncer.Sync([]utils.ServicePort{p}, klog.TODO())
+	be, err := syncer.backendPool.Get(p.BackendName(), features.VersionFromServicePort(&p), features.ScopeFromServicePort(&p), klog.TODO())
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/composite/composite.go
+++ b/pkg/composite/composite.go
@@ -287,19 +287,19 @@ func AddSignedUrlKey(gceCloud *gce.Cloud, key *meta.Key, backendService *Backend
 	}
 }
 
-func DeleteSignedUrlKey(gceCloud *gce.Cloud, key *meta.Key, backendService *BackendService, keyName string) error {
+func DeleteSignedUrlKey(gceCloud *gce.Cloud, key *meta.Key, backendService *BackendService, keyName string, urlKeyLogger klog.Logger) error {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 	mc := metrics.NewMetricContext("BackendService", "deleteSignedUrlKey", key.Region, key.Zone, string(backendService.Version))
 	switch backendService.Version {
 	case meta.VersionAlpha:
-		klog.V(3).Infof("Updating alpha BackendService %v, delete SignedUrlKey %s", key.Name, keyName)
+		urlKeyLogger.Info("Updating alpha BackendService, delete SignedUrlKey")
 		return mc.Observe(gceCloud.Compute().AlphaBackendServices().DeleteSignedUrlKey(ctx, key, keyName))
 	case meta.VersionBeta:
-		klog.V(3).Infof("Updating beta BackendService %v, delete SignedUrlKey %s", key.Name, keyName)
+		urlKeyLogger.Info("Updating beta BackendService, delete SignedUrlKey")
 		return mc.Observe(gceCloud.Compute().BetaBackendServices().DeleteSignedUrlKey(ctx, key, keyName))
 	default:
-		klog.V(3).Infof("Updating ga BackendService %v, delete SignedUrlKey %s", key.Name, keyName)
+		urlKeyLogger.Info("Updating ga BackendService, delete SignedUrlKey")
 		return mc.Observe(gceCloud.Compute().BackendServices().DeleteSignedUrlKey(ctx, key, keyName))
 	}
 }

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -158,7 +158,10 @@ func (l4 *L4) EnsureInternalLoadBalancerDeleted(svc *corev1.Service) *L4ILBSyncR
 
 	// Delete backend service
 	bsName := l4.namer.L4Backend(svc.Namespace, svc.Name)
-	err := utils.IgnoreHTTPNotFound(l4.backendPool.Delete(bsName, meta.VersionGA, meta.Regional))
+	// TODO(cheungdavid): Create backend logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.Delete().
+	// See example in backendSyncer.gc().
+	err := utils.IgnoreHTTPNotFound(l4.backendPool.Delete(bsName, meta.VersionGA, meta.Regional, klog.TODO()))
 	if err != nil {
 		klog.Errorf("Failed to delete backends for internal loadbalancer service %s, err  %v", l4.NamespacedName.String(), err)
 		result.GCEResourceInError = annotations.BackendServiceResource
@@ -364,7 +367,10 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	klog.V(2).Infof("subnetworkURL for service %v/%v: %v", l4.Service.Namespace, l4.Service.Name, subnetworkURL)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	existingBS, err := l4.backendPool.Get(bsName, meta.VersionGA, l4.scope)
+	// TODO(cheungdavid): Create backend logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.Get().
+	// See example in backendSyncer.ensureBackendService().
+	existingBS, err := l4.backendPool.Get(bsName, meta.VersionGA, l4.scope, klog.TODO())
 	if utils.IgnoreHTTPNotFound(err) != nil {
 		klog.Errorf("Failed to lookup existing backend service, ignoring err: %v", err)
 	}
@@ -461,7 +467,10 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, noConnectionTrackingPolicy)
+	// TODO(cheungdavid): Create backend logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.EnsureL4BackendService().
+	// See example in backendSyncer.ensureBackendService().
+	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, noConnectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -86,13 +86,13 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
+	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
+	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -113,7 +113,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy)
+	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -292,7 +292,7 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, noConnectionTrackingPolicy)
+	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, noConnectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -307,7 +307,10 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 	protocol := utils.GetProtocol(servicePorts)
 
 	connectionTrackingPolicy := l4netlb.connectionTrackingPolicy()
-	bs, err := l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), connectionTrackingPolicy)
+	// TODO(cheungdavid): Create backend logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.EnsureL4BackendService().
+	// See example in backendSyncer.ensureBackendService().
+	bs, err := l4netlb.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4netlb.Service.Spec.SessionAffinity), string(cloud.SchemeExternal), l4netlb.NamespacedName, *network.DefaultNetwork(l4netlb.cloud), connectionTrackingPolicy, klog.TODO())
 	if err != nil {
 		if utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
 			syncResult.GCEResourceInError = annotations.BackendServiceResource
@@ -544,7 +547,10 @@ func (l4netlb *L4NetLB) deleteBackendService(result *L4NetLBSyncResult) {
 		klog.V(2).Infof("Finished deleting backend service %s, for L4 NetLB Service %s/%s, time taken", bsName, l4netlb.Service.Namespace, l4netlb.Service.Name, time.Since(start))
 	}()
 
-	err := utils.IgnoreHTTPNotFound(l4netlb.backendPool.Delete(bsName, meta.VersionGA, meta.Regional))
+	// TODO(cheungdavid): Create backend logger that contains backendName,
+	// backendVersion, and backendScope before passing to backendPool.Delete().
+	// See example in backendSyncer.ensureBackendService().
+	err := utils.IgnoreHTTPNotFound(l4netlb.backendPool.Delete(bsName, meta.VersionGA, meta.Regional, klog.TODO()))
 	if err != nil {
 		klog.Errorf("Failed to delete backends for L4 External LoadBalancer service %s - %v", l4netlb.NamespacedName.String(), err)
 		result.GCEResourceInError = annotations.BackendServiceResource

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -461,7 +461,7 @@ func (l7 *L7) getFrontendAnnotations(existing map[string]string) map[string]stri
 }
 
 // GetLBAnnotations returns the annotations of an l7. This includes it's current status.
-func GetLBAnnotations(l7 *L7, existing map[string]string, backendSyncer backends.Syncer) (map[string]string, error) {
+func GetLBAnnotations(l7 *L7, existing map[string]string, backendSyncer backends.Syncer, ingLogger klog.Logger) (map[string]string, error) {
 	backends, err := getBackendNames(l7.um)
 	if err != nil {
 		return nil, err
@@ -469,7 +469,7 @@ func GetLBAnnotations(l7 *L7, existing map[string]string, backendSyncer backends
 	backendState := map[string]string{}
 	for _, beName := range backends {
 		version := l7.Versions().BackendService
-		state, err := backendSyncer.Status(beName, version, l7.scope)
+		state, err := backendSyncer.Status(beName, version, l7.scope, ingLogger)
 		// Don't return error here since we want to keep syncing
 		if err != nil {
 			klog.Errorf("Error syncing backend status for %s - %s - %s: %v", beName, version, l7.scope, err)


### PR DESCRIPTION
* BackendSyncer works like the manager for backends, while backend.go
  contains functions working on individual backends.
* We will do context embedding in backendSyncer when we process each
  backend.
Exmaple:
```
I0131 20:02:35.890028 1904521 syncer.go:62] Sync: backend {ID:default/neg-demo-svc/&ServiceB(14 results) [2237/2826]
80,} NodePort:0 Port:80 PortName:http Protocol:HTTP TargetPort:{Type:0 IntVal:9376 StrVal:} NEGEnabled:true VMIPNEGE
nabled:false L4RBSEnabled:false L7ILBEnabled:false L7XLBRegionalEnabled:false THCConfiguration:{THCOptInOnSvc:false
THCEvents:{THCConfigured:false BackendConfigOverridesTHC:false THCAnnotationWithoutFlag:false THCAnnotationWithoutNE
G:false}} BackendConfig:<nil> BackendNamer:0xc00043d940 MaxRatePerEndpoint:<nil> CapacityScaler:<nil>}
I0201 00:12:43.701529 2206655 gen.go:4354] "IngressController/SyncBackends: Getting ga BackendService" ingressKey="d
efault/neg-demo-ing" backendServiceName="k8s1-89f6839e-default-neg-demo-svc-80-b0c7e439" backendVersion="ga" backend
Scope="global" port=0 name="k8s1-89f6839e-default-neg-demo-svc-80-b0c7e439"
```