### PR TITLE
New flag for degraded mode metrics collection, and add logging for the selection of endpoint calculation.

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -123,6 +123,7 @@ var (
 		EnableMultiNetworking                    bool
 		MaxIGSize                                int
 		EnableDegradedMode                       bool
+		EnableDegradedModeMetrics                bool
 		EnableDualStackNEG                       bool
 		EnableFirewallCR                         bool
 		DisableFWEnforcement                     bool
@@ -298,7 +299,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.IntVar(&F.MaxIGSize, "max-ig-size", 1000, "Max number of instances in Instance Group")
 	flag.DurationVar(&F.MetricsExportInterval, "metrics-export-interval", 10*time.Minute, `Period for calculating and exporting metrics related to state of managed objects.`)
 	flag.DurationVar(&F.NegMetricsExportInterval, "neg-metrics-export-interval", 5*time.Second, `Period for calculating and exporting internal neg controller metrics, not usage.`)
-	flag.BoolVar(&F.EnableDegradedMode, "enable-degraded-mode", false, `Enable endpoint calculation using degraded mode procedures`)
+	flag.BoolVar(&F.EnableDegradedMode, "enable-degraded-mode", false, `Enable degraded mode endpoint calculation and use results when error state is triggered. enabledDegradedMode also enables degrade mode correctness metrics with or without enabledDegradedModeMetrics.`)
+	flag.BoolVar(&F.EnableDegradedModeMetrics, "enable-degraded-mode-metrics", false, `Enable metrics collection for degraded mode, but uses normal mode calculation result when error state is triggered.`)
 	flag.BoolVar(&F.EnableNEGLabelPropagation, "enable-label-propagation", false, "Enable NEG endpoint label propagation")
 	flag.BoolVar(&F.EnableDualStackNEG, "enable-dual-stack-neg", false, `Enable support for Dual-Stack NEGs within the NEG Controller`)
 	flag.BoolVar(&F.EnableFirewallCR, "enable-firewall-cr", false, "Enable generating firewall CR")

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -296,9 +296,12 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		}
 	}
 
-	if !s.enableDegradedMode && err != nil {
-		return err
-	} else if s.enableDegradedMode {
+	if !s.enableDegradedMode {
+		if err != nil {
+			return err
+		}
+		s.logger.Info("Using normal mode endpoint calculation")
+	} else {
 		if !s.inErrorState() && err != nil {
 			return err // if we encounter an error, we will return and run the next sync in degraded mode
 		}
@@ -306,12 +309,15 @@ func (s *transactionSyncer) syncInternalImpl() error {
 			return degradedModeErr
 		}
 		if s.inErrorState() {
+			s.logger.Info("Using degraded mode endpoint calculation")
 			targetMap = degradedTargetMap
 			endpointPodMap = degradedPodMap
 			if len(notInDegraded) == 0 && len(onlyInDegraded) == 0 {
 				s.logger.Info("Resetting error state")
 				s.resetErrorState()
 			}
+		} else {
+			s.logger.Info("Using normal mode endpoint calculation")
 		}
 	}
 	s.logStats(targetMap, "desired NEG endpoints")


### PR DESCRIPTION
* To avoid changes in code logic, we don't handle degradedMode calculation error outside, but only collect metrics when degraddedModeErr is nil.
* Log if we are using degraded mode endpoint calculation.