### PR TITLE
Disable IAP and CDN BackendConfig for Regional External Ingress 

### DIFF
--- a/cmd/e2e-test/app_protocols_test.go
+++ b/cmd/e2e-test/app_protocols_test.go
@@ -184,3 +184,165 @@ func TestAppProtocolTransition(t *testing.T) {
 		})
 	}
 }
+
+func TestXLBRegionalAppProtocol(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc          string
+		annotationVal string
+	}{
+		{
+			desc:          "https",
+			annotationVal: `{"https-port":"HTTPS"}`,
+		},
+		{
+			desc:          "http2",
+			annotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.GoogleServiceApplicationProtocolKey: tc.annotationVal,
+				annotations.NEGAnnotationKey:                    negVal.String(),
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestXLBRegionalProtocolTransition(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc             string
+		annotationVal    string
+		newAnnotationVal string
+	}{
+		{
+			desc:             "https",
+			annotationVal:    `{"https-port":"HTTPS"}`,
+			newAnnotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+				annotations.NEGAnnotationKey:              negVal.String(),
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			_, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Update the service with the new app protocol.
+			svcAnnotation = map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.newAnnotationVal,
+				annotations.NEGAnnotationKey:              negVal.String(),
+			}
+
+			// TODO(rramkumar): Replace this with a call to Ensure()
+			if _, err = e2e.CreateEchoService(s, "service-1", svcAnnotation); err != nil {
+				t.Fatalf("Error updating echo service: %v", err)
+			}
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}

--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -210,7 +210,7 @@ func (t *Translator) maybeEnableBackendConfig(sp *utils.ServicePort, svc *api_v1
 	// Object in cache could be changed in-flight. Deepcopy to
 	// reduce race conditions.
 	beConfig = beConfig.DeepCopy()
-	if err = backendconfig.Validate(t.KubeClient, beConfig); err != nil {
+	if err = backendconfig.Validate(t.KubeClient, beConfig, sp); err != nil {
 		return errors.ErrBackendConfigValidation{BackendConfig: *beConfig, Err: err}
 	}
 


### PR DESCRIPTION
- This adds validation for backend config to return error if user
  specifies IAP or CDN with Regional External Ingress