### PR TITLE
Disable IAP and CDN BackendConfig for Regional External Ingress

### DIFF
--- a/pkg/controller/translator/translator.go
+++ b/pkg/controller/translator/translator.go
@@ -210,7 +210,7 @@ func (t *Translator) maybeEnableBackendConfig(sp *utils.ServicePort, svc *api_v1
 	// Object in cache could be changed in-flight. Deepcopy to
 	// reduce race conditions.
 	beConfig = beConfig.DeepCopy()
-	if err = backendconfig.Validate(t.KubeClient, beConfig); err != nil {
+	if err = backendconfig.Validate(t.KubeClient, beConfig, sp); err != nil {
 		return errors.ErrBackendConfigValidation{BackendConfig: *beConfig, Err: err}
 	}
 


### PR DESCRIPTION
- This adds validation for backend config to return error if user specifies IAP or CDN with Regional External Ingress