### PR TITLE
Add empty zone check for degraded mode and corresponding testcase.

### DIFF
--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -457,6 +457,12 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 				localEPCount[negtypes.NodeNotFound]++
 				continue
 			}
+			if zone == "" {
+				epLogger.Error(negtypes.ErrEPZoneMissing, "Endpoint's corresponding node has an empty zone, skipping", "nodeName", nodeName)
+				metrics.PublishNegControllerErrorCountMetrics(negtypes.ErrEPZoneMissing, true)
+				localEPCount[negtypes.ZoneMissing]++
+				continue
+			}
 			if zoneNetworkEndpointMap[zone] == nil {
 				zoneNetworkEndpointMap[zone] = negtypes.NewNetworkEndpointSet()
 			}


### PR DESCRIPTION
* Degraded mode should also filter out endpoint with empty zone if there is issue with its dependencies/zoneGetter. Otherwise, it would lead to GCE API error.
* Add this test case by explicitly mapping pod4 to an instance that corresponds to an empty zone.