### PR TITLE
Use same ipv6 podCIDR, and add instance2 to nodeLister.

### DIFF
--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -2071,7 +2071,16 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 		},
 		Spec: v1.NodeSpec{
 			PodCIDR:  "10.100.1.0/24",
-			PodCIDRs: []string{"2001:db8::/48", "10.100.1.0/24"},
+			PodCIDRs: []string{"a:b::/48", "10.100.1.0/24"},
+		},
+	})
+	nodeLister.Add(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instance2,
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR:  "10.100.2.0/24",
+			PodCIDRs: []string{"a:b::/48", "10.100.2.0/24"},
 		},
 	})
 	nodeLister.Add(&v1.Node{


### PR DESCRIPTION
* Add instance2 to nodeLister. It is a missing but necessary setup. We injected error to endpoint using instance2(invalid IP), but if instance2 is not added to nodeLister, it also be filtered for nodeNotFound regardless of whether the IP is invalid.
* Use same ipv6 podCIDR in TestDegradedModeValidateEndpointInfo by updating the ipv6 podCIDR for instance1. Its ipv6 CIDR value does not matter because it is a node for single stack endpoints, whereas instance3 and instance4 are for dual stack endpoints and their ipv6 CIDR do matter. In addition, using different podCIDRs creates unnecessary confusions.