### PR TITLE
Make PublishNegControllerErrorCountMetrics run in its own goroutine

### DIFF
--- a/pkg/neg/syncers/syncer.go
+++ b/pkg/neg/syncers/syncer.go
@@ -91,7 +91,7 @@ func (s *syncer) Start() error {
 			retryCh := make(<-chan time.Time)
 			err := s.core.sync()
 			if err != nil {
-				metrics.PublishNegControllerErrorCountMetrics(err, false)
+				go metrics.PublishNegControllerErrorCountMetrics(err, false)
 				delay, retryErr := time.Duration(0), error(nil)
 				if !negtypes.IsStrategyQuotaError(err) {
 					delay, retryErr = s.backoff.NextDelay()


### PR DESCRIPTION
* Put PublishNegControllerErrorCountMetrics in its own goroutine because it is running on critial path in syncer.go.