### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,3 +21,6 @@ linters-settings:
     exclude-functions:
       - (*flag.FlagSet).Parse
       - k8s.io/apimachinery/pkg/util/wait.PollUntil
+
+run:
+  timeout: 3m


### PR DESCRIPTION
- Sometimes CI fails timing out on golangci-lint
- Increase timeout to 3 minutes (1 minute is default, used before)

Failure example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/ingress-gce/2357/pull-ingress-gce-verify/1725606439445073920

/assign @spencerhance @swetharepakula 