### PR TITLE
Revert "Reduce e2e test polling time for Unreachable"

### DIFF
--- a/pkg/e2e/helpers.go
+++ b/pkg/e2e/helpers.go
@@ -64,8 +64,7 @@ import (
 const (
 	ingressPollInterval = 30 * time.Second
 	// TODO(shance): Find a way to lower this timeout
-	ingressPollTimeout            = 45 * time.Minute
-	ingressUnreachablePollTimeout = 10 * time.Minute
+	ingressPollTimeout = 45 * time.Minute
 
 	gclbDeletionInterval = 30 * time.Second
 	// TODO(smatti): Change this back to 15 when the issue
@@ -149,12 +148,7 @@ func UpgradeTestWaitForIngress(s *Sandbox, ing *networkingv1.Ingress, options *W
 // We expect the ingress to be unreachable at first as LB is
 // still programming itself (i.e 404's / 502's)
 func WaitForIngress(s *Sandbox, ing *networkingv1.Ingress, fc *frontendconfigv1beta1.FrontendConfig, options *WaitForIngressOptions) (*networkingv1.Ingress, error) {
-	pollTimeout := ingressPollTimeout
-	if options != nil && options.ExpectUnreachable {
-		pollTimeout = ingressUnreachablePollTimeout
-	}
-
-	err := wait.Poll(ingressPollInterval, pollTimeout, func() (bool, error) {
+	err := wait.Poll(ingressPollInterval, ingressPollTimeout, func() (bool, error) {
 		var err error
 		crud := adapter.IngressCRUD{C: s.f.Clientset}
 		ing, err = crud.Get(s.Namespace, ing.Name)


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#2370


The timeout is still short for this test. Even though we are testing unreachable, the load balancer needs more than 10 minutes in order for all the relevant resources to be created.

Right now tests are failing because they never reach [here](https://github.com/kubernetes/ingress-gce/blob/master/pkg/e2e/helpers.go#L170-L173) within 10 minutes which can only happen when the Ingress stabilizes.