### PR TITLE
Create firewall if it doesn't exist during periodic resync.

### DIFF
--- a/pkg/firewalls/fakes.go
+++ b/pkg/firewalls/fakes.go
@@ -30,6 +30,7 @@ type fakeFirewallsProvider struct {
 	networkURL       string
 	onXPN            bool
 	fwReadOnly       bool
+	getFirewallHook  func(name string) (*compute.Firewall, error)
 }
 
 // NewFakeFirewallsProvider creates a fake for firewall rules.
@@ -44,6 +45,10 @@ func NewFakeFirewallsProvider(onXPN bool, fwReadOnly bool) *fakeFirewallsProvide
 }
 
 func (ff *fakeFirewallsProvider) GetFirewall(name string) (*compute.Firewall, error) {
+	if ff.getFirewallHook != nil {
+		return ff.getFirewallHook(name)
+	}
+
 	rule, exists := ff.fw[name]
 	if exists {
 		return rule, nil

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -532,6 +532,11 @@ func FakeGoogleAPIRequestEntityTooLargeError() *googleapi.Error {
 	return &googleapi.Error{Code: http.StatusRequestEntityTooLarge}
 }
 
+// FakeGoogleAPIRequestServerError creates a StatusInternalServerError error with type googleapi.Error
+func FakeGoogleAPIRequestServerError() *googleapi.Error {
+	return &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
 func InstancesListToNameSet(instancesList []*compute.InstanceWithNamedPorts) (sets.String, error) {
 	instancesSet := sets.NewString()
 	for _, instance := range instancesList {


### PR DESCRIPTION
GetFirewall could fail for reasons other than notFound, and treating them all as notFound could lead to error during CreateFirewall(StatusConflict).