### PR TITLE
Disable go linter for 1.20 branch

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -59,16 +59,3 @@ echo "Installing golangci-lint"
 echo
 go install github.com/golangci/golangci-lint/cmd/golangci-lint > /dev/null
 cd "../.."
-
-export GOLANGCI_LINT_CACHE=$PWD/.cache
-echo -n "Checking linters: "
-ERRS=$(golangci-lint run ${TARGETS} 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL"
-    echo "${ERRS}"
-    echo
-    exit 1
-fi
-rm -rf $GOLANGCI_LINT_CACHE
-echo "PASS"
-echo


### PR DESCRIPTION
 * The linter on this branch is returning errors but the same code on other branches do not produce lint errors.
 * Since this branch will not have any more feature development and will only contain bug fixes, disable the linter for this branch only


/assign @gauravkghildiyal 
/cc @bowei 