### PR TITLE
Replicate dependencies for neg usage metrics migration.

### DIFF
--- a/pkg/neg/metrics/metricscollector/features.go
+++ b/pkg/neg/metrics/metricscollector/features.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+type feature string
+
+func (f feature) String() string {
+	return string(f)
+}
+
+const (
+	neg            = feature("NEG")
+	standaloneNeg  = feature("StandaloneNEG")
+	ingressNeg     = feature("IngressNEG")
+	asmNeg         = feature("AsmNEG")
+	vmIpNeg        = feature("VmIpNEG")
+	vmIpNegLocal   = feature("VmIpNegLocal")
+	vmIpNegCluster = feature("VmIpNegCluster")
+	customNamedNeg = feature("CustomNamedNEG")
+	// negInSuccess feature specifies that syncers were created for the Neg
+	negInSuccess = feature("NegInSuccess")
+	// negInError feature specifies that an error occurring in ensuring Neg Syncer
+	negInError = feature("NegInError")
+)

--- a/pkg/neg/metrics/metricscollector/metrics.go
+++ b/pkg/neg/metrics/metricscollector/metrics.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package metricscollector
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	negtypes "k8s.io/ingress-gce/pkg/neg/types"
-)
+import "github.com/prometheus/client_golang/prometheus"
 
 const (
 	negControllerSubsystem = "neg_controller"
@@ -157,22 +154,3 @@ var (
 		[]string{"feature"},
 	)
 )
-
-type syncerState struct {
-	lastSyncResult negtypes.Reason
-	inErrorState   bool
-}
-
-type syncerStateCount map[syncerState]int
-
-// LabelPropagationStat contains stats related to label propagation.
-type LabelPropagationStats struct {
-	EndpointsWithAnnotation int
-	NumberOfEndpoints       int
-}
-
-// LabelPropagationMetrics contains aggregated label propagation related metrics.
-type LabelPropagationMetrics struct {
-	EndpointsWithAnnotation int
-	NumberOfEndpoints       int
-}

--- a/pkg/neg/metrics/metricscollector/metrics.go
+++ b/pkg/neg/metrics/metricscollector/metrics.go
@@ -148,6 +148,14 @@ var (
 		},
 		[]string{"location", "endpoint_type"},
 	)
+
+	networkEndpointGroupCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "number_of_negs",
+			Help: "Number of NEGs",
+		},
+		[]string{"feature"},
+	)
 )
 
 type syncerState struct {

--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -62,11 +62,6 @@ type SyncerMetricsCollector interface {
 	DeleteNegService(svcKey string)
 }
 
-type negLocTypeKey struct {
-	location     string
-	endpointType string
-}
-
 type SyncerMetrics struct {
 	clock clock.Clock
 	// duration between metrics exports

--- a/pkg/neg/metrics/metricscollector/metrics_collector_test.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector_test.go
@@ -404,6 +404,121 @@ func TestComputeNegCounts(t *testing.T) {
 	}
 }
 
+func TestComputeNegMetrics(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc           string
+		negStates      []NegServiceState
+		expectNegCount map[feature]int
+	}{
+		{
+			"empty input",
+			[]NegServiceState{},
+			map[feature]int{
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         0,
+				neg:            0,
+				vmIpNeg:        0,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 0,
+				customNamedNeg: 0,
+				negInSuccess:   0,
+				negInError:     0,
+			},
+		},
+		{
+			"one neg service",
+			[]NegServiceState{
+				newNegState(0, 0, 1, 0, 1, 0, nil),
+			},
+			map[feature]int{
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         1,
+				neg:            1,
+				vmIpNeg:        0,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 0,
+				customNamedNeg: 0,
+				negInSuccess:   1,
+				negInError:     0,
+			},
+		},
+		{
+			"vm primary ip neg in traffic policy cluster mode",
+			[]NegServiceState{
+				newNegState(0, 0, 1, 0, 1, 0, &VmIpNegType{trafficPolicyLocal: false}),
+			},
+			map[feature]int{
+				standaloneNeg:  0,
+				ingressNeg:     0,
+				asmNeg:         1,
+				neg:            2,
+				vmIpNeg:        1,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 1,
+				customNamedNeg: 0,
+				negInSuccess:   1,
+				negInError:     0,
+			},
+		},
+		{
+			"custom named neg",
+			[]NegServiceState{
+				newNegState(1, 0, 0, 1, 1, 0, nil),
+			},
+			map[feature]int{
+				standaloneNeg:  1,
+				ingressNeg:     0,
+				asmNeg:         0,
+				neg:            1,
+				vmIpNeg:        0,
+				vmIpNegLocal:   0,
+				vmIpNegCluster: 0,
+				customNamedNeg: 1,
+				negInSuccess:   1,
+				negInError:     0,
+			},
+		},
+		{
+			"many neg services",
+			[]NegServiceState{
+				newNegState(0, 0, 1, 0, 1, 0, nil),
+				newNegState(0, 1, 0, 0, 0, 1, &VmIpNegType{trafficPolicyLocal: false}),
+				newNegState(5, 0, 0, 0, 3, 2, &VmIpNegType{trafficPolicyLocal: true}),
+				newNegState(5, 3, 2, 0, 2, 3, nil),
+			},
+			map[feature]int{
+				standaloneNeg:  10,
+				ingressNeg:     4,
+				asmNeg:         3,
+				neg:            19,
+				vmIpNeg:        2,
+				vmIpNegLocal:   1,
+				vmIpNegCluster: 1,
+				customNamedNeg: 0,
+				negInSuccess:   6,
+				negInError:     6,
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			newMetrics := FakeSyncerMetrics()
+			for i, negState := range tc.negStates {
+				newMetrics.SetNegService(fmt.Sprint(i), negState)
+			}
+
+			gotNegCount := newMetrics.computeNegMetrics()
+			if diff := cmp.Diff(tc.expectNegCount, gotNegCount); diff != "" {
+				t.Errorf("Got diff for NEG counts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 type fakeClock struct {
 	clock.Clock
 	curTime time.Time
@@ -423,5 +538,17 @@ func syncerKeyWithPort(i int32, port int32) types.NegSyncerKey {
 		Name:      fmt.Sprintf("name-%v", i),
 		NegName:   fmt.Sprintf("neg-name-%v", i),
 		PortTuple: types.SvcPortTuple{Port: port},
+	}
+}
+
+func newNegState(standalone, ingress, asm, customNamed, success, err int, negType *VmIpNegType) NegServiceState {
+	return NegServiceState{
+		IngressNeg:     ingress,
+		StandaloneNeg:  standalone,
+		AsmNeg:         asm,
+		VmIpNeg:        negType,
+		CustomNamedNeg: customNamed,
+		SuccessfulNeg:  success,
+		ErrorNeg:       err,
 	}
 }

--- a/pkg/neg/metrics/metricscollector/types.go
+++ b/pkg/neg/metrics/metricscollector/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package metricscollector
 
+import (
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+)
+
 // NegServiceState contains all the neg usage associated with one service
 type NegServiceState struct {
 	// standaloneNeg is the count of standalone NEG
@@ -38,6 +42,30 @@ type NegServiceState struct {
 // local traffic (or service external policy set to local).
 type VmIpNegType struct {
 	trafficPolicyLocal bool
+}
+
+type negLocTypeKey struct {
+	location     string
+	endpointType string
+}
+
+type syncerState struct {
+	lastSyncResult negtypes.Reason
+	inErrorState   bool
+}
+
+type syncerStateCount map[syncerState]int
+
+// LabelPropagationStat contains stats related to label propagation.
+type LabelPropagationStats struct {
+	EndpointsWithAnnotation int
+	NumberOfEndpoints       int
+}
+
+// LabelPropagationMetrics contains aggregated label propagation related metrics.
+type LabelPropagationMetrics struct {
+	EndpointsWithAnnotation int
+	NumberOfEndpoints       int
 }
 
 // NewVmIpNegType returns a new VmIpNegType.

--- a/pkg/neg/metrics/metricscollector/types.go
+++ b/pkg/neg/metrics/metricscollector/types.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+// NegServiceState contains all the neg usage associated with one service
+type NegServiceState struct {
+	// standaloneNeg is the count of standalone NEG
+	StandaloneNeg int
+	// ingressNeg is the count of NEGs created for ingress
+	IngressNeg int
+	// asmNeg is the count of NEGs created for ASM
+	AsmNeg int
+	// VmIpNeg specifies if a service uses GCE_VM_IP NEG.
+	VmIpNeg *VmIpNegType
+	// CustomNamedNeg is the count of standalone negs with custom names
+	CustomNamedNeg int
+	// SuccessfulNeg is the count of successful NEG syncer creations
+	SuccessfulNeg int
+	// SuccessfulNeg is the count of errors in NEG syncer creations
+	ErrorNeg int
+}
+
+// VmIpNegType contains whether a GCE_VM_IP NEG is requesting for
+// local traffic (or service external policy set to local).
+type VmIpNegType struct {
+	trafficPolicyLocal bool
+}
+
+// NewVmIpNegType returns a new VmIpNegType.
+func NewVmIpNegType(trafficPolicyLocal bool) *VmIpNegType {
+	return &VmIpNegType{trafficPolicyLocal: trafficPolicyLocal}
+}


### PR DESCRIPTION
* NEG usage metrics will be pulled from pkg/metrics to pkg/neg/metrics, and emit via NEG metrics collector.
* In this PR, only dependencies are replicated. No behavior change is introduced.
* Existing types and constants will be cleaned up in #2407.

/assign @swetharepakula 