### PR TITLE
Flag-gate the ingress and firewall controllers.

### DIFF
--- a/cmd/glbc/app/handlers.go
+++ b/cmd/glbc/app/handlers.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/controller"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/version"
 )
@@ -46,7 +45,7 @@ func RunHTTPServer(healthChecker func() context.HealthCheckResults) {
 	klog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", flags.F.HealthzPort), nil))
 }
 
-func RunSIGTERMHandler(lbc *controller.LoadBalancerController, deleteAll bool) {
+func RunSIGTERMHandler(stopCh chan struct{}, exitCh chan error) {
 	// Multiple SIGTERMs will get dropped
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
@@ -55,8 +54,10 @@ func RunSIGTERMHandler(lbc *controller.LoadBalancerController, deleteAll bool) {
 	klog.Infof("Received SIGTERM, shutting down")
 
 	// TODO: Better retries than relying on restartPolicy.
+	close(stopCh)
+
 	exitCode := 0
-	if err := lbc.Stop(deleteAll); err != nil {
+	if err := <-exitCh; err != nil {
 		klog.Infof("Error during shutdown %v", err)
 		exitCode = 1
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -327,7 +327,7 @@ func (lbc *LoadBalancerController) Run() {
 		lbc.exitCh <- lbc.Stop(flags.F.DeleteAllOnQuit)
 	}()
 	klog.Infof("Starting loadbalancer controller")
-	lbc.ingQueue.Run()
+	go lbc.ingQueue.Run()
 
 	<-lbc.stopCh
 	klog.Infof("Shutting down Loadbalancer Controller")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -66,7 +66,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	namer := namer_util.NewNamer(clusterUID, "")
 
 	stopCh := make(chan struct{})
-	shutDownCh := make(chan error)
+	exitCh := make(chan error)
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:             api_v1.NamespaceAll,
 		ResyncPeriod:          1 * time.Minute,
@@ -74,7 +74,7 @@ func newLoadBalancerController() *LoadBalancerController {
 		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
-	lbc := NewLoadBalancerController(ctx, stopCh, shutDownCh)
+	lbc := NewLoadBalancerController(ctx, stopCh, exitCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
 	lbc.instancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      instancegroups.NewEmptyFakeInstanceGroups(),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -66,6 +66,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	namer := namer_util.NewNamer(clusterUID, "")
 
 	stopCh := make(chan struct{})
+	shutDownCh := make(chan error)
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:             api_v1.NamespaceAll,
 		ResyncPeriod:          1 * time.Minute,
@@ -73,7 +74,7 @@ func newLoadBalancerController() *LoadBalancerController {
 		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
-	lbc := NewLoadBalancerController(ctx, stopCh)
+	lbc := NewLoadBalancerController(ctx, stopCh, shutDownCh)
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
 	lbc.instancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      instancegroups.NewEmptyFakeInstanceGroups(),

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -273,7 +273,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
-	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
+	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed.`)
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, f enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableServiceMetrics, "enable-service-metrics", false, `Optional, if enabled then the service metrics controller will be run.`)


### PR DESCRIPTION
* Flag-gate the ingress controller and the firewall controller using run-ingress-controller flag.
* This flag's default value is true, and we have always turned on this flag, so the flag-gate should be a no-op and not breaking any existing tests or features.
* Update the flag usage message.

/assign @swetharepakula 