### PR TITLE
Pull out SIGTERMHandler, flag-gate ingress and firewall controller, and run L7 NEG as default

### DIFF
--- a/cmd/glbc/app/handlers.go
+++ b/cmd/glbc/app/handlers.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/ingress-gce/pkg/context"
-	"k8s.io/ingress-gce/pkg/controller"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/version"
 )
@@ -46,7 +45,7 @@ func RunHTTPServer(healthChecker func() context.HealthCheckResults) {
 	klog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", flags.F.HealthzPort), nil))
 }
 
-func RunSIGTERMHandler(lbc *controller.LoadBalancerController) {
+func RunSIGTERMHandler(closeStopCh func()) {
 	// Multiple SIGTERMs will get dropped
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
@@ -54,7 +53,7 @@ func RunSIGTERMHandler(lbc *controller.LoadBalancerController) {
 	<-signalChan
 	klog.Infof("Received SIGTERM, shutting down")
 
-	lbc.Stop()
+	closeStopCh()
 	os.Exit(0)
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -264,7 +264,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
-	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
+	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, if enabled then the ingress controller will be run.`)
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)


### PR DESCRIPTION
* Pull out SIGTERM Handler so it is independent from the ingress controller and only closes closeCh when TERM signal is received.
* Run ingress controller in its own goroutine.
* Add a waitgroup to ensure cleanups are properly executed after close.
* Exit when cleanups are finished or 30 seconds timeout is reached. Instead of waiting on cleanup indefenitely, this avoids possible hanging of the program.
* Flag-gate ingress and firewall controller using runIngressController flag.

/assign @swetharepakula 