### PR TITLE
Revert "[Cherry pick #2402 -> 1.26] Add some validations for L4 multinetwork services."

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -61,7 +61,9 @@ func NewNetworksResolver(networkLister, gkeNetworkParamSetLister cache.Indexer, 
 	}
 }
 
-// ServiceNetwork determines the network data to be used for the L4 LB resources.
+// ServiceNetwork determines the network data to be used for the LB resources.
+// This function currently returns only the default network but will provide
+// secondary networks information for multi-networked services in the future.
 func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo, error) {
 	if !nr.enableMultinetworking || nr.networkLister == nil || nr.gkeNetworkParamSetLister == nil {
 		return DefaultNetwork(nr.cloudProvider), nil
@@ -71,12 +73,6 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 	if !ok || networkName == "" || networkName == networkv1.DefaultPodNetworkName {
 		return DefaultNetwork(nr.cloudProvider), nil
 	}
-
-	// TODO: remove this check once DPv2 supports externalTrafficPolicy=Cluster services.
-	if service.Spec.ExternalTrafficPolicy != apiv1.ServiceExternalTrafficPolicyLocal {
-		return nil, utils.NewUserError(fmt.Errorf("multinetwork services with externalTrafficPolicy='%s' are not supported, only externalTrafficPolicy=Local services are supported", service.Spec.ExternalTrafficPolicy))
-	}
-
 	obj, exists, err := nr.networkLister.GetByKey(networkName)
 	if err != nil {
 		return nil, err
@@ -89,9 +85,6 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 		return nil, fmt.Errorf("cannot convert to Network (%T)", obj)
 	}
 	nr.logger.Info("Found network for service", "network", network.Name, "service", service.Name, "namespace", service.Namespace)
-	if network.Spec.Type != networkv1.L3NetworkType {
-		return nil, utils.NewUserError(fmt.Errorf("network.Spec.Type=%s is not supported for multinetwork LoadBalancer services, the only supported network type is L3", network.Spec.Type))
-	}
 	parametersRef := network.Spec.ParametersRef
 	if !refersGKENetworkParamSet(parametersRef) {
 		return nil, utils.NewUserError(fmt.Errorf("network.Spec.ParametersRef does not refer a GKENetworkParamSet resource"))
@@ -107,7 +100,7 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 		return nil, utils.NewUserError(fmt.Errorf("GKENetworkParamSet %s was not found", parametersRef.Name))
 	}
 	gkeNetworkParamSet := gkeParamsObj.(*networkv1.GKENetworkParamSet)
-	if gkeNetworkParamSet == nil {
+	if network == nil {
 		return nil, fmt.Errorf("cannot convert to GKENetworkParamSet (%T)", gkeParamsObj)
 	}
 	netURL := networkURL(nr.cloudProvider, gkeNetworkParamSet.Spec.VPC)

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -43,7 +43,6 @@ func TestServiceNetwork(t *testing.T) {
 			Selector: map[string]string{
 				networkSelector: "secondary-network",
 			},
-			ExternalTrafficPolicy: apiv1.ServiceExternalTrafficPolicyLocal,
 		},
 	}
 	cloud := fakeCloud{}
@@ -116,7 +115,7 @@ func TestServiceNetwork(t *testing.T) {
 					Name: "secondary-network",
 				},
 				Spec: networkv1.NetworkSpec{
-					Type: networkv1.L3NetworkType,
+					Type: "L3",
 					ParametersRef: &networkv1.NetworkParametersReference{
 						Group: networkingGKEGroup,
 						Kind:  "UnsupportedNetworkParams",
@@ -135,7 +134,7 @@ func TestServiceNetwork(t *testing.T) {
 					Name: "secondary-network",
 				},
 				Spec: networkv1.NetworkSpec{
-					Type: networkv1.L3NetworkType,
+					Type: "L3",
 					ParametersRef: &networkv1.NetworkParametersReference{
 						Group:     networkingGKEGroup,
 						Kind:      "GKENetworkParamSet",
@@ -154,73 +153,6 @@ func TestServiceNetwork(t *testing.T) {
 			gkeNetworkParamSet: nil,
 			service:            serviceWithSecondaryNet,
 			wantErr:            "GKENetworkParamSet secondary-network-params was not found",
-		},
-		{
-			desc: "invalid network type L2",
-			network: &networkv1.Network{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "secondary-network",
-				},
-				Spec: networkv1.NetworkSpec{
-					Type: networkv1.L2NetworkType,
-					ParametersRef: &networkv1.NetworkParametersReference{
-						Group: networkingGKEGroup,
-						Kind:  "GKENetworkParamSet",
-						Name:  "secondary-network-params",
-					},
-				},
-			},
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service:            serviceWithSecondaryNet,
-			wantErr:            "network.Spec.Type=L2 is not supported for multinetwork LoadBalancer services, the only supported network type is L3",
-		},
-		{
-			desc: "invalid network type Device",
-			network: &networkv1.Network{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "secondary-network",
-				},
-				Spec: networkv1.NetworkSpec{
-					Type: networkv1.DeviceNetworkType,
-					ParametersRef: &networkv1.NetworkParametersReference{
-						Group: networkingGKEGroup,
-						Kind:  "GKENetworkParamSet",
-						Name:  "secondary-network-params",
-					},
-				},
-			},
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service:            serviceWithSecondaryNet,
-			wantErr:            "network.Spec.Type=Device is not supported for multinetwork LoadBalancer services, the only supported network type is L3",
-		},
-		{
-			desc:               "service with externalTrafficPolicy=Cluster",
-			network:            testNetwork("secondary-network", "secondary-network-params"),
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service: &apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "testService"},
-				Spec: apiv1.ServiceSpec{
-					Selector: map[string]string{
-						networkSelector: "secondary-network",
-					},
-					ExternalTrafficPolicy: apiv1.ServiceExternalTrafficPolicyCluster,
-				},
-			},
-			wantErr: "multinetwork services with externalTrafficPolicy='Cluster' are not supported, only externalTrafficPolicy=Local services are supported",
-		},
-		{
-			desc:               "service with externalTrafficPolicy default",
-			network:            testNetwork("secondary-network", "secondary-network-params"),
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service: &apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "testService"},
-				Spec: apiv1.ServiceSpec{
-					Selector: map[string]string{
-						networkSelector: "secondary-network",
-					},
-				},
-			},
-			wantErr: "multinetwork services with externalTrafficPolicy='' are not supported, only externalTrafficPolicy=Local services are supported",
 		},
 	}
 
@@ -286,7 +218,7 @@ func testNetwork(name, gkeNetworkParamSetName string) *networkv1.Network {
 			Name: name,
 		},
 		Spec: networkv1.NetworkSpec{
-			Type: networkv1.L3NetworkType,
+			Type: "L3",
 			ParametersRef: &networkv1.NetworkParametersReference{
 				Group: networkingGKEGroup,
 				Kind:  "GKENetworkParamSet",


### PR DESCRIPTION
Reverts kubernetes/ingress-gce#2405

Temporarily reverting bug fixes on release-1.26