### PR TITLE
Add a waitGroup to wait for controllers to finish cleaning up.

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -295,8 +295,9 @@ func makeLeaderElectionConfig(ctx *ingctx.ControllerContext, client clientset.In
 
 func runControllers(ctx *ingctx.ControllerContext) {
 	stopCh := make(chan struct{})
+	exitCh := make(chan error)
 	ctx.Init()
-	lbc := controller.NewLoadBalancerController(ctx, stopCh, klog.TODO())
+	lbc := controller.NewLoadBalancerController(ctx, stopCh, exitCh, klog.TODO())
 	if ctx.EnableASMConfigMap {
 		ctx.ASMConfigController.RegisterInformer(ctx.ConfigMapInformer, func() {
 			// We want to trigger a restart, don't have to clean up all the resources.
@@ -395,7 +396,7 @@ func runControllers(ctx *ingctx.ControllerContext) {
 		go negController.Run(stopCh)
 		klog.V(0).Infof("negController started")
 	}
-	go app.RunSIGTERMHandler(lbc, flags.F.DeleteAllOnQuit)
+	go app.RunSIGTERMHandler(stopCh, exitCh)
 
 	go fwc.Run()
 	klog.V(0).Infof("firewall controller started")
@@ -420,7 +421,9 @@ func runControllers(ctx *ingctx.ControllerContext) {
 		klog.V(0).Infof("L4NetLB controller started")
 		go l4netlbController.Run()
 	}
-	lbc.Run()
+	go lbc.Run()
+	// Keep the program running until TERM signal.
+	<-stopCh
 	for {
 		klog.Warning("Handled quit, awaiting pod deletion.")
 		time.Sleep(30 * time.Second)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -71,6 +71,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	namer := namer_util.NewNamer(clusterUID, "")
 
 	stopCh := make(chan struct{})
+	exitCh := make(chan error)
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:             api_v1.NamespaceAll,
 		ResyncPeriod:          1 * time.Minute,
@@ -78,7 +79,7 @@ func newLoadBalancerController() *LoadBalancerController {
 		HealthCheckPath:       "/",
 	}
 	ctx := context.NewControllerContext(nil, kubeClient, backendConfigClient, nil, nil, nil, nil, nil, nil, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig)
-	lbc := NewLoadBalancerController(ctx, stopCh, klog.TODO())
+	lbc := NewLoadBalancerController(ctx, stopCh, exitCh, klog.TODO())
 	// TODO(rramkumar): Fix this so we don't have to override with our fake
 	lbc.instancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      instancegroups.NewEmptyFakeInstanceGroups(),

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -270,7 +270,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableNonGCPMode, "enable-non-gcp-mode", false, "Set to true when running on a non-GCP cluster.")
 	flag.BoolVar(&F.EnableDeleteUnusedFrontends, "enable-delete-unused-frontends", false, "Enable deleting unused gce frontend resources.")
 	flag.BoolVar(&F.EnableV2FrontendNamer, "enable-v2-frontend-namer", false, "Enable v2 ingress frontend naming policy.")
-	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, whether or not to run IngressController as part of glbc. If set to false, ingress resources will not be processed. Only the L4 Service controller will be run, if that flag is set to true.`)
+	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, if enabled then the ingress controller will be run.`)
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -150,7 +150,6 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		testContext.NumGCWorkers,
 		// TODO(freehan): enable readiness reflector for unit tests
 		false, // enableReadinessReflector
-		true,  // runIngress
 		runL4, //runL4Controller
 		false, //enableNonGcpMode
 		testContext.EnableDualStackNEG,


### PR DESCRIPTION
* Add a waitGroup in runControllers to make sure when Ingress controller is not running, other controllers(NEG controller) have time to finish cleaning up.
* This is particularly necessary if NEG controller is separated from other controllers.
* This change is required based on the change in #2414.