### PR TITLE
Fix NEG degraded mode for L4 externalTrafficPolicy=Local services.

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -122,10 +122,10 @@ func (l *LocalL4ILBEndpointsCalculator) CalculateEndpoints(eds []types.Endpoints
 	return subsetMap, nil, 0, err
 }
 
-func (l *LocalL4ILBEndpointsCalculator) CalculateEndpointsDegradedMode(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
+func (l *LocalL4ILBEndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// this should be the same as CalculateEndpoints for L4 ec
-	subsetMap, _, _, err := l.CalculateEndpoints(nil, currentMap)
-	return subsetMap, nil, err
+	subsetMap, podMap, _, err := l.CalculateEndpoints(eds, currentMap)
+	return subsetMap, podMap, err
 }
 
 func (l *LocalL4ILBEndpointsCalculator) ValidateEndpoints(endpointData []types.EndpointsData, endpointPodMap types.EndpointPodMap, dupCount int) error {
@@ -193,10 +193,10 @@ func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpoints(_ []types.Endpoints
 	return subsetMap, nil, 0, err
 }
 
-func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpointsDegradedMode(_ []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
+func (l *ClusterL4ILBEndpointsCalculator) CalculateEndpointsDegradedMode(eps []types.EndpointsData, currentMap map[string]types.NetworkEndpointSet) (map[string]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// this should be the same as CalculateEndpoints for L4 ec
-	subsetMap, _, _, err := l.CalculateEndpoints(nil, currentMap)
-	return subsetMap, nil, err
+	subsetMap, podMap, _, err := l.CalculateEndpoints(eps, currentMap)
+	return subsetMap, podMap, err
 }
 
 func (l *ClusterL4ILBEndpointsCalculator) ValidateEndpoints(endpointData []types.EndpointsData, endpointPodMap types.EndpointPodMap, dupCount int) error {

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -147,6 +147,13 @@ func TestLocalGetEndpointSet(t *testing.T) {
 		if diff := cmp.Diff(retSet, tc.wantEndpointSets); diff != "" {
 			t.Errorf("For case %q, expecting endpoint set %v, but got %v.\nDiff: (-want +got):\n%s", tc.desc, tc.wantEndpointSets, retSet, diff)
 		}
+		degradedSet, _, err := ec.CalculateEndpointsDegradedMode(tc.endpointsData, nil)
+		if err != nil {
+			t.Errorf("For degraded mode case %q, expect nil error, but got %v.", tc.desc, err)
+		}
+		if diff := cmp.Diff(degradedSet, tc.wantEndpointSets); diff != "" {
+			t.Errorf("For degraded mode case %q, expecting endpoint set %v, but got %v.\nDiff: (-want +got):\n%s", tc.desc, tc.wantEndpointSets, retSet, diff)
+		}
 		deleteNodes(t, tc.nodeNames, transactionSyncer.nodeLister)
 	}
 }
@@ -278,6 +285,13 @@ func TestClusterGetEndpointSet(t *testing.T) {
 		}
 		if !reflect.DeepEqual(retSet, tc.wantEndpointSets) {
 			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.wantEndpointSets, retSet)
+		}
+		degradedSet, _, err := ec.CalculateEndpointsDegradedMode(tc.endpointsData, nil)
+		if err != nil {
+			t.Errorf("For degraded mode case %q, expect nil error, but got %v.", tc.desc, err)
+		}
+		if !reflect.DeepEqual(degradedSet, tc.wantEndpointSets) {
+			t.Errorf("For degraded mode case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.wantEndpointSets, retSet)
 		}
 		deleteNodes(t, tc.nodeNames, transactionSyncer.nodeLister)
 	}


### PR DESCRIPTION
Whenever the NEG controller would go into the degraded mode for L4 LB service with externalTrafficPolicy=Local, the controller would ignore endpoint slice data for NEG endpoints calculation. This would result in detachment of all endpoints and broken LB.