### PR TITLE
IG Manager: return the instance group name once even if it existis in…

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -675,7 +675,7 @@ func TestMCIngressIG(t *testing.T) {
 	if err != nil {
 		t.Errorf("lbc.instancePool.List() = _, %v, want nil", err)
 	}
-	var wantInstanceGroups []string
+	wantInstanceGroups := []string{}
 	if diff := cmp.Diff(wantInstanceGroups, instanceGroups); diff != "" {
 		t.Errorf("lbc.instancePool.List()() mismatch (-want +got):\n%s", diff)
 	}

--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -226,6 +226,8 @@ func (m *manager) Get(name, zone string) (*compute.InstanceGroup, error) {
 }
 
 // List lists the names of all Instance Groups belonging to this cluster.
+// It will return only the names of the groups without the zone. If a group
+// with the same name exists in more than one zone it will be returned only once.
 func (m *manager) List() ([]string, error) {
 	var igs []*compute.InstanceGroup
 
@@ -245,14 +247,14 @@ func (m *manager) List() ([]string, error) {
 		}
 	}
 
-	var names []string
+	names := sets.New[string]()
+
 	for _, ig := range igs {
 		if m.namer.NameBelongsToCluster(ig.Name) {
-			names = append(names, ig.Name)
+			names.Insert(ig.Name)
 		}
 	}
-
-	return names, nil
+	return names.UnsortedList(), nil
 }
 
 // splitNodesByZones takes a list of node names and returns a map of zone:node names.


### PR DESCRIPTION
… many nodes.

The manager sync function assumes the names of the groups are listed without a zone and will attempt to do the add/remove operations in all zones. Before this change, if the group existed in more than one zone it would be returned many times (list will contain the same name a few times). This leads to unnecessary iterations and instances listing - everything would happen N^2 for N=number of zones.