### PR TITLE
Introduce enable-l4-neg flag and use it to flag-gate L4 NEGs.

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -417,7 +417,6 @@ func createNEGController(ctx *ingctx.ControllerContext, stopCh <-chan struct{}) 
 			klog.Errorf("Failed tp retrieve pod label propagation config: %v", err)
 		}
 	}
-	enableNEGsForNetLB := flags.F.RunL4NetLBController && flags.F.EnableMultiNetworking
 	// TODO: Refactor NEG to use cloud mocks so ctx.Cloud can be referenced within NewController.
 	negController := neg.NewController(
 		ctx.KubeClient,
@@ -441,7 +440,7 @@ func createNEGController(ctx *ingctx.ControllerContext, stopCh <-chan struct{}) 
 		flags.F.NegGCPeriod,
 		flags.F.NumNegGCWorkers,
 		flags.F.EnableReadinessReflector,
-		flags.F.RunL4Controller || enableNEGsForNetLB,
+		flags.F.EnableL4NEG,
 		flags.F.EnableNonGCPMode,
 		flags.F.EnableDualStackNEG,
 		enableAsm,

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -113,6 +113,7 @@ var (
 		EnableL4ILBDualStack                     bool
 		EnableL4NetLBDualStack                   bool
 		EnableNEGController                      bool
+		EnableL4NEG                              bool
 		EnableMultipleIGs                        bool
 		EnableServiceMetrics                     bool
 		EnableL4StrongSessionAffinity            bool
@@ -268,6 +269,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
+	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
 	flag.BoolVar(&F.EnableIGController, "enable-ig-controller", true, `Optional, if enabled then the IG controller will be run.`)
 	flag.BoolVar(&F.EnableServiceMetrics, "enable-service-metrics", false, `Optional, if enabled then the service metrics controller will be run.`)
 	flag.BoolVar(&F.EnablePSC, "enable-psc", false, "Enable PSC controller")


### PR DESCRIPTION
* NEG controller should not have logic to understand which controllers are running.
* Introduce enable-l4-neg to flag-gate L4 NEG processing. Its value will be determined from the manifest level.