### PR TITLE
Create NEG lock availability metrics

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -54,6 +54,7 @@ import (
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/controller"
 	"k8s.io/ingress-gce/pkg/neg"
+	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 
@@ -430,4 +431,12 @@ func runNEGController(ctx *ingctx.ControllerContext, stopCh <-chan struct{}) {
 
 	go negController.Run()
 	klog.V(0).Infof("negController started")
+}
+
+func collectNEGLockAvailabilityMetrics() {
+	for {
+		negmetrics.PublishNegLockAvailabilityMetrics(flags.F.GKEClusterType)
+		klog.Info("Exported NEG controller lock availability metrics.")
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -256,6 +256,16 @@ var (
 		},
 		[]string{"request", "result"},
 	)
+
+	// NEGLockAvailability tracks the how long has the container been running with NEG resource lock
+	NEGLockAvailability = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: negControllerSubsystem,
+			Name:      "neg_lock_availability",
+			Help:      "Time in second since the container has been running with NEG resource lock",
+		},
+		[]string{"cluster_type"},
+	)
 )
 
 var register sync.Once
@@ -279,6 +289,7 @@ func RegisterMetrics() {
 		prometheus.MustRegister(GCERequestLatency)
 		prometheus.MustRegister(K8sRequestCount)
 		prometheus.MustRegister(K8sRequestLatency)
+		prometheus.MustRegister(NEGLockAvailability)
 	})
 }
 
@@ -373,6 +384,10 @@ func PublishK8sRequestCountMetrics(start time.Time, requestType string, err erro
 	}
 	K8sRequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
 	K8sRequestCount.WithLabelValues(requestType, result).Inc()
+}
+
+func PublishNegLockAvailabilityMetrics(clusterType string) {
+	NEGLockAvailability.WithLabelValues(clusterType).Inc()
 }
 
 func getResult(err error) string {


### PR DESCRIPTION
* Tracks how long has a container been running with NEG resource lock.

/assign @swetharepakula 
/cc @bowei 