### PR TITLE
Update NEG controller run behavior based on GateNEGByLock flag.

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -114,6 +114,7 @@ var (
 		EnableL4NetLBDualStack                   bool
 		EnableNEGController                      bool
 		EnableL4NEG                              bool
+		GateNEGByLock                            bool
 		EnableMultipleIGs                        bool
 		EnableServiceMetrics                     bool
 		EnableL4StrongSessionAffinity            bool
@@ -270,6 +271,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
 	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
+	flag.BoolVar(&F.GateNEGByLock, "gate-neg-by-lock", false, "If enabled then the NEG controller will be run via leader election with NEG resource lock")
 	flag.BoolVar(&F.EnableIGController, "enable-ig-controller", true, `Optional, if enabled then the IG controller will be run.`)
 	flag.BoolVar(&F.EnableServiceMetrics, "enable-service-metrics", false, `Optional, if enabled then the service metrics controller will be run.`)
 	flag.BoolVar(&F.EnablePSC, "enable-psc", false, "Enable PSC controller")


### PR DESCRIPTION
* If EnableNEGControllerLeaderElection is true, then we will not only collect metrics on NEG lock, but also run NEG Controller with it.
* NEG Controller will also listen to stopCh, and terminate if stopCh is closed.

/assign @swetharepakula 