### PR TITLE
time.Since with defer should be wrapped in function.

### DIFF
--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -107,7 +107,9 @@ func (c *Controller) Shutdown() {
 func (c *Controller) sync(key string) error {
 	start := time.Now()
 	klog.V(4).Infof("Instance groups controller: Start processing %s", key)
-	defer klog.V(4).Infof("Instance groups controller: Processing key %s took %v", key, time.Since(start))
+	defer func() {
+		klog.V(4).Infof("Instance groups controller: Processing key %s took %v", key, time.Since(start))
+	}()
 
 	nodeNames, err := utils.GetReadyNodeNames(listers.NewNodeLister(c.lister))
 	if err != nil {


### PR DESCRIPTION
* Variables in defer are evaluated at the time we reach defer. In this case, it is evaluated at the beginning of the function. To fix this, the log line should be wrapped in function so the whole function is evaluated at the end.

/assign @swetharepakula 