### PR TITLE
Introduce separate backend naming scheme for RXLB Ingress

### DIFF
--- a/pkg/backends/neg_linker.go
+++ b/pkg/backends/neg_linker.go
@@ -65,7 +65,7 @@ func (nl *negLinker) Link(sp utils.ServicePort, groups []GroupKey) error {
 		// Otherwise, get the name from svc port.
 		negName := group.Name
 		if negName == "" {
-			negName = sp.BackendName()
+			negName = sp.NEGName()
 		}
 
 		negUrl := ""

--- a/pkg/backends/neg_linker_test.go
+++ b/pkg/backends/neg_linker_test.go
@@ -88,6 +88,15 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 					TargetPort:   intstr.FromString(port),
 					NEGEnabled:   true,
 					BackendNamer: defaultNamer},
+				{
+					ID:                   utils.ServicePortID{Service: svc},
+					Port:                 80,
+					NodePort:             30001,
+					Protocol:             annotations.ProtocolHTTP,
+					TargetPort:           intstr.FromString(port),
+					NEGEnabled:           true,
+					L7XLBRegionalEnabled: true,
+					BackendNamer:         defaultNamer},
 			} {
 				// Mimic how the syncer would create the backend.
 				if _, err := linker.backendPool.Create(svcPort, "fake-healthcheck-link", klog.TODO()); err != nil {
@@ -99,14 +108,14 @@ func TestLinkBackendServiceToNEG(t *testing.T) {
 				if tc.populateSvcNeg {
 					linker.svcNegLister.Add(v1beta1.ServiceNetworkEndpointGroup{Status: v1beta1.ServiceNetworkEndpointGroupStatus{
 						NetworkEndpointGroups: []v1beta1.NegObjectReference{
-							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/mock-project/zones/zone1/networkEndpointGroups/%s", svcPort.BackendName())},
-							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/mock-project/zones/zone2/networkEndpointGroups/%s", svcPort.BackendName())},
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/mock-project/zones/zone1/networkEndpointGroups/%s", svcPort.NEGName())},
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/mock-project/zones/zone2/networkEndpointGroups/%s", svcPort.NEGName())},
 						},
 					}})
 				}
 				for _, key := range zones {
 					neg := &composite.NetworkEndpointGroup{
-						Name:    svcPort.BackendName(),
+						Name:    svcPort.NEGName(),
 						Version: version,
 					}
 					if svcPort.VMIPNEGEnabled {

--- a/pkg/healthchecks/healthchecks_test.go
+++ b/pkg/healthchecks/healthchecks_test.go
@@ -387,7 +387,7 @@ func TestNewHealthCheckFromServicePort(t *testing.T) {
 					RequestPath:       "/",
 				},
 				HealthCheck: computealpha.HealthCheck{
-					Name:               "k8s1-uid1-ns2-svc2-80-c8109fc7",
+					Name:               "k8s1-uid1-e-ns2-svc2-80-c8109fc7",
 					CheckIntervalSec:   int64((15 * time.Second).Seconds()),
 					TimeoutSec:         int64((15 * time.Second).Seconds()),
 					HealthyThreshold:   1,

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -57,6 +57,9 @@ type BackendNamer interface {
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
+	// RXLBBackendName returns the Regional External Ingress backend name,
+	// based on the service namespace, name and target port.
+	RXLBBackendName(namespace, name string, port int32) string
 	// L4Backend returns the name for L4 LB backend resources, based on the service namespace and name.
 	// It supports ILB with subsetting enabled (VM_IP_NEGs) and NetLB with RBS enabled.
 	// The second output parameter indicates if the namer is supported.

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -413,7 +413,7 @@ func (n *Namer) UrlMap(lbName LoadBalancerName) string {
 	return truncate(fmt.Sprintf("%v-%v-%v", n.prefix, urlMapPrefix, lbName))
 }
 
-// UrlMap returns the name for the UrlMap for a given load balancer.
+// RedirectUrlMap returns the name for the UrlMap for a given load balancer.
 func (n *Namer) RedirectUrlMap(lbName LoadBalancerName) string {
 	return truncate(fmt.Sprintf("%v-%v-%v", n.prefix, redirectMapPrefix, lbName))
 }
@@ -441,6 +441,22 @@ func (n *Namer) NEG(namespace, name string, port int32) string {
 	truncName := truncFields[1]
 	truncPort := truncFields[2]
 	return fmt.Sprintf("%s-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, negSuffix(n.shortUID(), namespace, name, portStr, ""))
+}
+
+// RXLBBackendName returns the gce Backend name based on the service namespace, name
+// and target port. Naming convention:
+//
+//	{prefix}{version}-{clusterid}-e-{namespace}-{name}-{service port}-{hash}
+//
+// Output name is at most 63 characters.
+func (n *Namer) RXLBBackendName(namespace, name string, port int32) string {
+	portStr := fmt.Sprintf("%v", port)
+	// minus 2, as we added "-e" to prefix
+	truncFields := TrimFieldsEvenly(maxNEGDescriptiveLabel-2, namespace, name, portStr)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	truncPort := truncFields[2]
+	return fmt.Sprintf("%s-e-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, negSuffix(n.shortUID(), namespace, name, portStr, ""))
 }
 
 // IsNEG returns true if the name is a NEG owned by this cluster.

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -88,7 +88,7 @@ func (sp *ServicePort) BackendName() string {
 	if sp.L7XLBRegionalEnabled {
 		return sp.BackendNamer.RXLBBackendName(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
 	} else if sp.NEGEnabled || sp.VMIPNEGEnabled || sp.L4RBSEnabled {
-		// L4, and ILB, GXLB Ingresses are using NEG Name for all backend resources.
+		// L4 ILB and RBS (with NEGs), Ingress ILB and GXLB are using NEG Name for all backend resources.
 		return sp.NEGName()
 	}
 	return sp.BackendNamer.IGBackend(sp.NodePort)
@@ -100,7 +100,6 @@ func (sp *ServicePort) NEGName() string {
 		return sp.BackendNamer.L4Backend(sp.ID.Service.Namespace, sp.ID.Service.Name)
 	}
 	return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
-
 }
 
 // IGName returns the name of the instance group which would be used for this ServicePort.

--- a/pkg/utils/serviceport.go
+++ b/pkg/utils/serviceport.go
@@ -85,13 +85,22 @@ func (sp *ServicePort) GetDescription() Description {
 
 // BackendName returns the name of the backend which would be used for this ServicePort.
 func (sp *ServicePort) BackendName() string {
-	if sp.NEGEnabled {
-		return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
-	} else if sp.VMIPNEGEnabled || sp.L4RBSEnabled {
+	if sp.L7XLBRegionalEnabled {
+		return sp.BackendNamer.RXLBBackendName(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
+	} else if sp.NEGEnabled || sp.VMIPNEGEnabled || sp.L4RBSEnabled {
+		// L4, and ILB, GXLB Ingresses are using NEG Name for all backend resources.
+		return sp.NEGName()
+	}
+	return sp.BackendNamer.IGBackend(sp.NodePort)
+}
+
+func (sp *ServicePort) NEGName() string {
+	if sp.VMIPNEGEnabled || sp.L4RBSEnabled {
 		// Use L4 Backend name for both Internal and External LoadBalancers
 		return sp.BackendNamer.L4Backend(sp.ID.Service.Namespace, sp.ID.Service.Name)
 	}
-	return sp.BackendNamer.IGBackend(sp.NodePort)
+	return sp.BackendNamer.NEG(sp.ID.Service.Namespace, sp.ID.Service.Name, sp.Port)
+
 }
 
 // IGName returns the name of the instance group which would be used for this ServicePort.

--- a/pkg/utils/serviceport_test.go
+++ b/pkg/utils/serviceport_test.go
@@ -1,0 +1,296 @@
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+)
+
+func TestNEGName(t *testing.T) {
+	shortNamespace := "namespace"
+	shortName := "name"
+	longNamespace := "namespacenamespacenamespacenamespacenamespace"
+	longName := "namenamenamenamenamenamenamenamename"
+
+	defaultNamer := namer.NewNamer("uid1", "")
+	l4Namer := namer.NewL4Namer("uid1", defaultNamer)
+
+	testCases := []struct {
+		desc        string
+		svcPort     ServicePort
+		wantNEGName string
+	}{
+		{
+			desc: "short L4 ILB",
+			svcPort: ServicePort{
+				VMIPNEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantNEGName: "k8s2-rrsi7zsy-namespace-name-v6mfehls",
+		},
+		{
+			desc: "long L4 ILB",
+			svcPort: ServicePort{
+				VMIPNEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantNEGName: "k8s2-rrsi7zsy-namespacenamespacename-namenamenamenamen-mxpkshn0",
+		},
+		{
+			desc: "short L4 RBS",
+			svcPort: ServicePort{
+				L4RBSEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantNEGName: "k8s2-rrsi7zsy-namespace-name-v6mfehls",
+		},
+		{
+			desc: "long L4 RBS",
+			svcPort: ServicePort{
+				L4RBSEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantNEGName: "k8s2-rrsi7zsy-namespacenamespacename-namenamenamenamen-mxpkshn0",
+		},
+		{
+			desc: "short Ingress",
+			svcPort: ServicePort{
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantNEGName: "k8s1-uid1-namespace-name-123-35a3c5b0",
+		},
+		{
+			desc: "long Ingress",
+			svcPort: ServicePort{
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantNEGName: "k8s1-uid1-namespacenamespacenam-namenamenamename-1-e3670135",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gotName := tc.svcPort.NEGName()
+
+			if gotName != tc.wantNEGName {
+				t.Errorf("Wrong NEGName for svcPort %v. Got: %s, want: %s", tc.svcPort, gotName, tc.wantNEGName)
+			}
+		})
+	}
+}
+
+func TestBackendName(t *testing.T) {
+	shortNamespace := "namespace"
+	shortName := "name"
+	longNamespace := "namespacenamespacenamespacenamespacenamespace"
+	longName := "namenamenamenamenamenamenamenamename"
+
+	defaultNamer := namer.NewNamer("uid1", "")
+	l4Namer := namer.NewL4Namer("uid1", defaultNamer)
+
+	testCases := []struct {
+		desc            string
+		svcPort         ServicePort
+		wantBackendName string
+	}{
+		{
+			desc: "short L4 ILB",
+			svcPort: ServicePort{
+				VMIPNEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantBackendName: "k8s2-rrsi7zsy-namespace-name-v6mfehls",
+		},
+		{
+			desc: "long L4 ILB",
+			svcPort: ServicePort{
+				VMIPNEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantBackendName: "k8s2-rrsi7zsy-namespacenamespacename-namenamenamenamen-mxpkshn0",
+		},
+		{
+			desc: "short L4 RBS with NEG",
+			svcPort: ServicePort{
+				L4RBSEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantBackendName: "k8s2-rrsi7zsy-namespace-name-v6mfehls",
+		},
+		{
+			desc: "long L4 RBS with NEG",
+			svcPort: ServicePort{
+				L4RBSEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: l4Namer,
+			},
+			wantBackendName: "k8s2-rrsi7zsy-namespacenamespacename-namenamenamenamen-mxpkshn0",
+		},
+		{
+			desc: "short RXLB Ingress",
+			svcPort: ServicePort{
+				L7XLBRegionalEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s1-uid1-e-namespace-name-123-35a3c5b0",
+		},
+		{
+			desc: "long RXLB Ingress",
+			svcPort: ServicePort{
+				L7XLBRegionalEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s1-uid1-e-namespacenamespacena-namenamenamenam-1-e3670135",
+		},
+		{
+			desc: "short Ingress",
+			svcPort: ServicePort{
+				NEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s1-uid1-namespace-name-123-35a3c5b0",
+		},
+		{
+			desc: "long Ingress",
+			svcPort: ServicePort{
+				NEGEnabled: true,
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s1-uid1-namespacenamespacenam-namenamenamename-1-e3670135",
+		},
+		{
+			desc: "short Instance Group",
+			svcPort: ServicePort{
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: shortNamespace,
+						Name:      shortName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s-be-0--uid1",
+		},
+		{
+			desc: "long Instance Group",
+			svcPort: ServicePort{
+				ID: ServicePortID{
+					Service: types.NamespacedName{
+						Namespace: longNamespace,
+						Name:      longName,
+					},
+				},
+				BackendNamer: defaultNamer,
+				Port:         123,
+			},
+			wantBackendName: "k8s-be-0--uid1",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gotName := tc.svcPort.BackendName()
+
+			if gotName != tc.wantBackendName {
+				t.Errorf("Wrong BackendName for svcPort %v. Got: %s, want: %s", tc.svcPort, gotName, tc.wantBackendName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- This is required to share the same service between RXLB and ILB. Frontend resources already have separate names (they depend on the ingress)

/assign @spencerhance 