### PR TITLE
Reset error state even when degraded mode is not enabled.

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -313,13 +313,17 @@ func (s *transactionSyncer) syncInternalImpl() error {
 			s.logger.Info("Using degraded mode endpoint calculation")
 			targetMap = degradedTargetMap
 			endpointPodMap = degradedPodMap
-			if len(notInDegraded) == 0 && len(onlyInDegraded) == 0 {
-				s.logger.Info("Resetting error state")
-				s.resetErrorState()
-			}
 		} else {
 			s.logger.Info("Using normal mode endpoint calculation")
 		}
+	}
+	// When the flags are not enabled, error state should be reset when no
+	// error occurs in the sync.
+	// notInDegraded and onlyInDegraded are not populated when the flags are
+	// not enabled, so they would always be empty and reset error state.
+	if len(notInDegraded) == 0 && len(onlyInDegraded) == 0 {
+		s.logger.Info("Resetting error state")
+		s.resetErrorState()
 	}
 	s.logStats(targetMap, "desired NEG endpoints")
 

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1811,7 +1811,7 @@ func TestEnableDegradedMode(t *testing.T) {
 			negName:              "neg-8",
 			testEndpointSlices:   validEndpointSlice,
 			expectedEndpoints:    updateSucceedEndpoints,
-			expectedInErrorState: true, // if degraded mode is disabled, we don't reset error state, but we won't have different behaviors based on error state either
+			expectedInErrorState: false,
 			expectErr:            nil,
 		},
 		{


### PR DESCRIPTION
* Make sure error state is reset when there is no change in normal and degraded mode calculation.
* This allows errorState to be cleared when enableDegradedMode is false.