### PR TITLE
Fix broadcasting events

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -117,7 +117,7 @@ func NewLoadBalancerController(
 	log = log.WithName("IngressController")
 
 	broadcaster := record.NewBroadcaster()
-	broadcaster.StartLogging(log.Info)
+	broadcaster.StartLogging(klog.Infof)
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{
 		Interface: ctx.KubeClient.CoreV1().Events(""),
 	})


### PR DESCRIPTION
`StartLogging` actually expects logging function that supports formatting string, which is not the case with a context logger