### PR TITLE
Do not consider forbidden errors within the PSC controllers sync metrics

### DIFF
--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -750,7 +750,10 @@ func SvcAttachmentKeyFunc(namespace, name string) string {
 func filterError(err error) error {
 	var apiError *googleapi.Error
 	if errors.As(err, &apiError) {
-		if utils.IsHTTPErrorCode(apiError, http.StatusNotFound) || utils.IsHTTPErrorCode(apiError, http.StatusBadRequest) {
+		// The following errors are ignored because they frequently occur due to
+		// user-misconfiguration and usually do not point to some infrastructure
+		// problem.
+		if utils.IsHTTPErrorCode(apiError, http.StatusNotFound) || utils.IsHTTPErrorCode(apiError, http.StatusBadRequest) || utils.IsHTTPErrorCode(apiError, http.StatusForbidden) {
 			return nil
 		}
 	}

--- a/pkg/psc/controller_test.go
+++ b/pkg/psc/controller_test.go
@@ -952,6 +952,11 @@ func TestFilterError(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			desc:          "wrapped google api forbidden request error",
+			err:           fmt.Errorf("wrap 1: %w", fmt.Errorf("wrap 2: %w", &googleapi.Error{Code: http.StatusForbidden})),
+			expectedError: nil,
+		},
+		{
 			desc:          "wrapped google api bad gateway error",
 			err:           wrappedBadGatewayErr,
 			expectedError: wrappedBadGatewayErr,


### PR DESCRIPTION
/assign @swetharepakula 

NOTES:

```
Previously, we used to see less of 403 forbidden errors because we
always used to look for subnets in the same project as the GKE clusters
project, in which case the service-account always had permissions. This
meant that for Shared VPC use cases, we used to incorrectly look for the
subnet in the service project and not in the host project.

After the changes introduced in commit
https://github.com/kubernetes/ingress-gce/commit/12ee6f29c07f6542a49e4abd82a36a8046999612#diff-aacf8e53dbfd73dd635a4d6615f52725b9f2b1ebcdbb25efae5a6bae20201fd7
within the file vendor/k8s.io/cloud-provider-gcp/providers/gce/support.go, we
now corrected the behaviour for Shared VPC where we now start looking for the
subnet in the host project. But this often leads to 403 forbidden errors because
it requires the user to have explicitly given the GKE service-account
permissions on the Shared VPC host project, which the customers often forget to
do.
```