### PR TITLE
Add metric with timestamp of last sync item by l4 controllers

### DIFF
--- a/cmd/e2e-test/regional_xlb_test.go
+++ b/cmd/e2e-test/regional_xlb_test.go
@@ -449,7 +449,7 @@ func TestRegionalXLBILBTransition(t *testing.T) {
 			}
 
 			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
-				t.Error(err)
+				t.Errorf("e2e.CheckGCLB(%v, %d, %d) returned error %v for ingress %s/%s after transition", gclb, tc.numForwardingRules, tc.numBackendServices, ing1.Namespace, tc.ing.Name, err)
 			}
 
 			tc.ingUpdate.Namespace = s.Namespace
@@ -487,7 +487,7 @@ func TestRegionalXLBILBTransition(t *testing.T) {
 			}
 
 			if err = e2e.CheckGCLB(gclb2, tc.numForwardingRulesUpdate, tc.numBackendServicesUpdate); err != nil {
-				t.Error(err)
+				t.Errorf("e2e.CheckGCLB(%v, %d, %d) returned error %v for ingress %s/%s after transition", gclb2, tc.numForwardingRulesUpdate, tc.numBackendServicesUpdate, s.Namespace, tc.ingUpdate.Name, err)
 			}
 
 			deleteOptions := &fuzz.GCLBDeleteOptions{

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -404,6 +404,8 @@ func (l4c *L4Controller) syncWrapper(key string) error {
 
 func (l4c *L4Controller) sync(key string) error {
 	l4c.syncTracker.Track()
+	l4metrics.PublishL4controllerLastSyncTime(l4ILBControllerName)
+
 	svc, exists, err := l4c.ctx.Services().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("Failed to lookup service for key %s : %w", key, err)

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -423,6 +423,8 @@ func (lc *L4NetLBController) syncWrapper(key string) error {
 
 func (lc *L4NetLBController) sync(key string) error {
 	lc.syncTracker.Track()
+	l4metrics.PublishL4controllerLastSyncTime(l4NetLBControllerName)
+
 	svc, exists, err := lc.ctx.Services().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to lookup L4 External LoadBalancer service for key %s : %w", key, err)

--- a/pkg/l4lb/metrics/metrics.go
+++ b/pkg/l4lb/metrics/metrics.go
@@ -37,6 +37,7 @@ const (
 	L4netlbLegacyToRBSMigrationPreventedMetricName = "l4_netlb_legacy_to_rbs_migration_prevented_count"
 	l4failedHealthCheckName                        = "l4_failed_healthcheck_count"
 	l4ControllerHealthCheckName                    = "l4_controller_healthcheck"
+	l4LastSyncTimeName                             = "l4_last_sync_time"
 )
 
 var (
@@ -144,6 +145,13 @@ var (
 		},
 		[]string{"type"}, // currently, can be migration or race
 	)
+	l4LastSyncTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: l4LastSyncTimeName,
+			Help: "Timestamp of last sync started by controller",
+		},
+		[]string{"controller_name"},
+	)
 )
 
 // init registers l4 ilb and netlb sync metrics.
@@ -164,6 +172,8 @@ func init() {
 	prometheus.MustRegister(l4FailedHealthCheckCount)
 	klog.V(3).Infof("Registering L4 controller healthcheck metric: %v", l4ControllerHealthCheck)
 	prometheus.MustRegister(l4ControllerHealthCheck)
+	klog.V(3).Infof("Registering L4 controller last processed item time metric: %v", l4LastSyncTime)
+	prometheus.MustRegister(l4LastSyncTime)
 }
 
 // PublishILBSyncMetrics exports metrics related to the L4 ILB sync.
@@ -258,4 +268,9 @@ func IncreaseL4NetLBLegacyToRBSMigrationAttempts() {
 // IncreaseL4NetLBTargetPoolRaceWithRBS increases l4NetLBLegacyToRBSPrevented metric for race condition between controllers
 func IncreaseL4NetLBTargetPoolRaceWithRBS() {
 	l4NetLBLegacyToRBSPrevented.WithLabelValues("race").Inc()
+}
+
+// PublishL4controllerLastSyncTime records timestamp when L4 controller STARTED to sync an item
+func PublishL4controllerLastSyncTime(controllerName string) {
+	l4LastSyncTime.WithLabelValues(controllerName).SetToCurrentTime()
 }


### PR DESCRIPTION
The metric was proposed by our SRE when we discussed  improvements in the component.


This metric gives better observability than l4_failed_healthcheck_count / l4_controller_healthcheck

