### PR TITLE
Add validating Default 404 service in e2e tests

### DIFF
--- a/pkg/fuzz/default_validator_env.go
+++ b/pkg/fuzz/default_validator_env.go
@@ -18,6 +18,7 @@ package fuzz
 
 import (
 	"context"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,6 +109,13 @@ func (e *DefaultValidatorEnv) Services() (map[string]*v1.Service, error) {
 	for _, s := range sl.Items {
 		ret[s.Name] = s.DeepCopy()
 	}
+
+	// Add default-http-backend service, that belongs to different (kube-system) namespace.
+	defaultBackend, err := e.k8s.CoreV1().Services(kubeSystemNS).Get(context.TODO(), defaultHTTPBackend, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ret[defaultBackend.Name] = defaultBackend.DeepCopy()
 	return ret, nil
 }
 

--- a/pkg/fuzz/helpers.go
+++ b/pkg/fuzz/helpers.go
@@ -116,6 +116,18 @@ func ServiceMapFromIngress(ing *networkingv1.Ingress) ServiceMap {
 
 	if defaultBackend := ing.Spec.DefaultBackend; defaultBackend != nil {
 		ret[HostPath{}] = defaultBackend
+	} else {
+		// If default backend is not specified, ingress will use default-http-backend
+		// service.
+		ret[HostPath{}] = &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: defaultHTTPBackend,
+				Port: networkingv1.ServiceBackendPort{
+					Name:   "http",
+					Number: 80,
+				},
+			},
+		}
 	}
 
 	for _, rule := range ing.Spec.Rules {

--- a/pkg/fuzz/helpers_test.go
+++ b/pkg/fuzz/helpers_test.go
@@ -73,6 +73,15 @@ func TestServiceMapFromIngress(t *testing.T) {
 				HostPath{"test1.com", "/foo"}: &networkingv1.IngressBackend{
 					Service: &networkingv1.IngressServiceBackend{Name: "s", Port: networkingv1.ServiceBackendPort{Number: 80}},
 				},
+				HostPath{}: &networkingv1.IngressBackend{
+					Service: &networkingv1.IngressServiceBackend{
+						Name: defaultHTTPBackend,
+						Port: networkingv1.ServiceBackendPort{
+							Name:   "http",
+							Number: 80,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -87,6 +96,15 @@ func TestServiceMapFromIngress(t *testing.T) {
 				},
 				HostPath{"test1.com", "/bar"}: &networkingv1.IngressBackend{
 					Service: &networkingv1.IngressServiceBackend{Name: "s", Port: networkingv1.ServiceBackendPort{Number: 80}},
+				},
+				HostPath{}: &networkingv1.IngressBackend{
+					Service: &networkingv1.IngressServiceBackend{
+						Name: defaultHTTPBackend,
+						Port: networkingv1.ServiceBackendPort{
+							Name:   "http",
+							Number: 80,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/fuzz/validator.go
+++ b/pkg/fuzz/validator.go
@@ -309,21 +309,27 @@ func (v *IngressValidator) CheckPaths(ctx context.Context, vr *IngressResult) er
 		wg     sync.WaitGroup
 	)
 	for _, scheme := range v.attribs.schemes() {
-		if v.ing.Spec.DefaultBackend != nil {
-			klog.V(2).Infof("Checking default backend for Ingress %s/%s", v.ing.Namespace, v.ing.Name)
-			// Capture variables for the thunk.
-			result := &PathResult{Scheme: scheme}
-			vr.Paths = append(vr.Paths, result)
-			scheme := scheme
-			ctx, cancelFunc := context.WithTimeout(ctx, v.attribs.RequestTimeout)
-			defer cancelFunc()
-			f := func() {
-				result.Err = v.checkPath(ctx, scheme, "", pathForDefaultBackend)
-				wg.Done()
-			}
-			thunks = append(thunks, f)
-			wg.Add(1)
+		// If DefaultBackend is specified -- expect to get 200 response code (that's
+		// just the defaultbackend we've chosen to use in e2e tests).
+		expectedDefaultBackendResponseCode := 200
+		if v.ing.Spec.DefaultBackend == nil {
+			// if DefaultBackend is not specified in spec -- ingress controller will use
+			// default 404 service as a default backend.
+			expectedDefaultBackendResponseCode = 404
 		}
+		klog.V(2).Infof("Checking default backend for Ingress %s/%s to return code %d", v.ing.Namespace, v.ing.Name, expectedDefaultBackendResponseCode)
+		// Capture variables for the thunk.
+		result := &PathResult{Scheme: scheme}
+		vr.Paths = append(vr.Paths, result)
+		scheme := scheme
+		ctx, cancelFunc := context.WithTimeout(ctx, v.attribs.RequestTimeout)
+		defer cancelFunc()
+		f := func() {
+			result.Err = v.checkPathForExpectedResponseCode(ctx, scheme, "", pathForDefaultBackend, expectedDefaultBackendResponseCode)
+			wg.Done()
+		}
+		thunks = append(thunks, f)
+		wg.Add(1)
 
 		for _, rule := range v.ing.Spec.Rules {
 			if rule.HTTP == nil {
@@ -362,8 +368,15 @@ func (v *IngressValidator) CheckPaths(ctx context.Context, vr *IngressResult) er
 	return nil
 }
 
-// checkPath performs a check for scheme://host/path.
+// checkPath performs a check for requests to scheme://host/path to return 200
+// response.
 func (v *IngressValidator) checkPath(ctx context.Context, scheme, host, path string) error {
+	return v.checkPathForExpectedResponseCode(ctx, scheme, host, path, 200)
+}
+
+// checkPathForExpectedResponseCode performs a check for requests to
+// scheme://host/path to return expected response code.
+func (v *IngressValidator) checkPathForExpectedResponseCode(ctx context.Context, scheme, host, path string, expectedResponseCode int) error {
 	if v.Vip() == nil {
 		return fmt.Errorf("ingress %s/%s does not have a VIP", v.ing.Namespace, v.ing.Name)
 	}
@@ -416,8 +429,8 @@ func (v *IngressValidator) checkPath(ctx context.Context, scheme, host, path str
 		}
 	}
 
-	if doStandardCheck && resp.StatusCode != 200 {
-		return fmt.Errorf("ingress %s/%s: GET %q: %d, want 200", v.ing.Namespace, v.ing.Name, url, resp.StatusCode)
+	if doStandardCheck && resp.StatusCode != expectedResponseCode {
+		return fmt.Errorf("ingress %s/%s: GET %q: %d, want %d", v.ing.Namespace, v.ing.Name, url, resp.StatusCode, expectedResponseCode)
 	}
 
 	return nil


### PR DESCRIPTION
- Before, if Ingress.Spec didn't specify default backend -- we wouldn't check it at all
- Add a verification, that will check that if DefaultBackend is not specified -- we get a 404 error


/assign @swetharepakula @spencerhance 

Verified with running e2e tests locally