### PR TITLE
Update k8s-cloud-provider to 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module k8s.io/ingress-gce
 go 1.20
 
 require (
-	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.6.0
 	github.com/kr/pretty v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ cloud.google.com/go/compute v1.23.1/go.mod h1:CqB3xpmPKKt3OJpW2ndFIXnA9A4xAy/F3X
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 h1:lwL1vLWmdBJ5h+StMEN6+GMz1J/Y0yUU3RDv+QBy+Q4=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0/go.mod h1:UTfhBnADaj2rybPT049NScSh7Eall3u2ib43wmz3deg=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0 h1:5slI4ZAsvkgpVEfrKZGlvcpeYTv2roIbDzK6zvJYhwY=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0/go.mod h1:TFNxHb9YGSjLB86UWy5BQCgVTXQscyy/X5tC/2olieA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta/compute_services.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta/compute_services.go
@@ -140,6 +140,7 @@ var ComputeServices = []*ServiceInfo{
 			"GetHealth",
 			"Patch",
 			"Update",
+			"SetSecurityPolicy",
 		},
 	},
 	{
@@ -153,6 +154,7 @@ var ComputeServices = []*ServiceInfo{
 			"GetHealth",
 			"Patch",
 			"Update",
+			"SetSecurityPolicy",
 		},
 	},
 	{
@@ -166,6 +168,7 @@ var ComputeServices = []*ServiceInfo{
 			"GetHealth",
 			"Patch",
 			"Update",
+			"SetSecurityPolicy",
 		},
 	},
 	{

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/service.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/service.go
@@ -24,9 +24,7 @@ import (
 
 	alpha "google.golang.org/api/compute/v0.alpha"
 	beta "google.golang.org/api/compute/v0.beta"
-	compute "google.golang.org/api/compute/v1"
 	ga "google.golang.org/api/compute/v1"
-	"google.golang.org/api/networkservices/v1"
 	networkservicesga "google.golang.org/api/networkservices/v1"
 	networkservicesbeta "google.golang.org/api/networkservices/v1beta1"
 	"google.golang.org/api/option"
@@ -56,7 +54,7 @@ func NewService(ctx context.Context, client *http.Client, pr ProjectRouter, rl R
 	if err != nil {
 		return nil, err
 	}
-	ga, err := compute.NewService(ctx, option.WithHTTPClient(client))
+	ga, err := ga.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +113,7 @@ func (s *Service) wrapOperation(anyOp any) (operation, error) {
 			s: s, projectID: r.ProjectID,
 			key: r.Key,
 		}, nil
-	case *networkservices.Operation:
+	case *networkservicesga.Operation:
 		result, err := parseNetworkServiceOpURL(o.Name)
 		if err != nil {
 			return nil, fmt.Errorf("wrapOperation: %w", err)

--- a/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/utils.go
+++ b/vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/utils.go
@@ -139,7 +139,6 @@ func (r *ResourceID) String() string {
 // <ver>/projects/ path or legacy one <api_group>.googleapis.com/<ver>/projects/.
 // Unfortunately it cannot predict what comes before the API
 // group since that is configurable via SetAPIDomain.
-// legacyApiGroupRegex is used to extract API Group from legacy path in format
 var apiGroupRegex = regexp.MustCompile(`([a-z]*)(\.googleapis\.com)?\/(alpha|beta|v1|v1alpha1|v1beta1)/projects`)
 
 // ParseResourceURL parses resource URLs of the following formats:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ cloud.google.com/go/compute/internal
 # cloud.google.com/go/compute/metadata v0.2.3
 ## explicit; go 1.19
 cloud.google.com/go/compute/metadata
-# github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0
+# github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0
 ## explicit; go 1.20
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter


### PR DESCRIPTION
- This will add Patch Methods for HttpsTargetProxy which are needed for RXLB

/assign @spencerhance @swetharepakula 