### PR TITLE
[Cherry-pick #2480 -> 1.28] Make sure we don't create ILBs if reading legacy forwarding rule failed

### DIFF
--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -282,7 +282,7 @@ func (l4 *L4) ensureIPv4ForwardingRule(bsLink string, options gce.ILBOptions, ex
 		return nil, err
 	}
 	if fr == nil {
-		return nil, fmt.Errorf("forwarding Rule %s not found", fr.Name)
+		return nil, fmt.Errorf("forwarding Rule %s not found", frName)
 	}
 	return fr, nil
 }


### PR DESCRIPTION
We should create ILB if legacy forwarding rule does not exist (404) or has a different scheme than expected

Plus tiny panic fix
