### PR TITLE
Recognize update type in the L4 controller

### DIFF
--- a/pkg/l4lb/updatetype.go
+++ b/pkg/l4lb/updatetype.go
@@ -1,0 +1,110 @@
+package l4lb
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// serviceVersions is a struct to track the versions of a service.
+// An instance of this struct will be maintained for each service processed
+// by the controller.
+// lastSeenUpdateVersion should be set in the informer callback when the resource
+// is about to be put in the processing queue.
+// lastIgnoredVersion should be set in the informer callback when the resource is ignored.
+// lastProcessedUpdateVersion and lastProcessingSuccess should be set at the end
+// of the processing worker when the processing result is known.
+//
+// When the worker starts to process a service it will be now possible to tell if the operation is a resync or a real update.
+// the logic is
+// isResync = lastProcessingSuccess
+// && (currentVersion == lastProcessedUpdateVersion || currentVersion == lastIgnoredVersion && lastSeenUpdateVersion == lastProcessedUpdateVersion)
+type serviceVersions struct {
+	lastSeenUpdateVersion      string
+	lastProcessedUpdateVersion string
+	lastIgnoredVersion         string
+	lastProcessingSuccess      bool
+}
+
+// serviceVersionsTracker is a util to track the versions of a service and
+// based on them determine if the resource to be processed is a resync or a full
+// update operation.
+
+type serviceVersionsTracker struct {
+	lock     sync.Mutex
+	versions map[string]*serviceVersions
+}
+
+// NewServiceVersionsTracker creates a new service versions tracker.
+func NewServiceVersionsTracker() *serviceVersionsTracker {
+	return &serviceVersionsTracker{versions: make(map[string]*serviceVersions)}
+}
+
+func (t *serviceVersionsTracker) getVersionsForSvc(svcKey string) *serviceVersions {
+	v, ok := t.versions[svcKey]
+	if ok {
+		return v
+	}
+	v = &serviceVersions{}
+	t.versions[svcKey] = v
+	return v
+
+}
+
+func (t *serviceVersionsTracker) SetLastUpdateSeen(svcKey, version string, logger klog.Logger) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	v := t.getVersionsForSvc(svcKey)
+	v.lastSeenUpdateVersion = version
+	logger.V(3).Info("serviceVersionsTracker: SetLastUpdateSeen()", "svcKey", svcKey, "version", version)
+}
+
+func (t *serviceVersionsTracker) SetLastIgnored(svcKey, version string, logger klog.Logger) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	v := t.getVersionsForSvc(svcKey)
+	v.lastIgnoredVersion = version
+	logger.V(3).Info("serviceVersionsTracker: SetLastIgnored()", "svcKey", svcKey, "version", version)
+}
+
+func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, wasResync bool, logger klog.Logger) {
+	if wasResync && success {
+		return
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	v := t.getVersionsForSvc(svcKey)
+	v.lastProcessedUpdateVersion = version
+	v.lastProcessingSuccess = success
+	logger.V(3).Info("serviceVersionsTracker: SetProcessed()", "version", version, "success", success, "wasResync", wasResync)
+}
+
+func (t *serviceVersionsTracker) IsResync(svcKey, currentVersion string, logger klog.Logger) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	v := t.getVersionsForSvc(svcKey)
+
+	logger.V(3).Info("serviceVersionsTracker: IsResync()", "currentVersion", currentVersion, "lastProcessedUpdateVersion", v.lastProcessedUpdateVersion, "lastProcessingSuccess", v.lastProcessingSuccess, "lastSeenUpdate", v.lastSeenUpdateVersion, "lastIgnored", v.lastIgnoredVersion)
+
+	if !v.lastProcessingSuccess {
+		return false
+	}
+	if currentVersion == v.lastProcessedUpdateVersion {
+		return true
+	}
+	if currentVersion == v.lastIgnoredVersion && v.lastSeenUpdateVersion == v.lastProcessedUpdateVersion {
+		return true
+	}
+	return false
+}
+
+func (t *serviceVersionsTracker) Delete(key string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	delete(t.versions, key)
+}

--- a/pkg/l4lb/updatetype_test.go
+++ b/pkg/l4lb/updatetype_test.go
@@ -1,0 +1,112 @@
+package l4lb
+
+import (
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	svcKey = "test/testSvc"
+)
+
+func TestIsResync(t *testing.T) {
+	tests := []struct {
+		desc                 string
+		lastProcessedVersion string
+		lastProcessedSuccess bool
+		lastUpdate           string
+		lastIgnored          string
+		currentVersion       string
+		expectResync         bool
+	}{
+		{
+			desc:           "first version",
+			lastUpdate:     "1",
+			currentVersion: "1",
+			expectResync:   false,
+		},
+		{
+			desc:                 "real update",
+			lastProcessedVersion: "1",
+			lastProcessedSuccess: true,
+			lastUpdate:           "2",
+			currentVersion:       "2",
+			expectResync:         false,
+		},
+		{
+			desc:                 "simple resync",
+			lastProcessedVersion: "2",
+			lastProcessedSuccess: true,
+			lastUpdate:           "2",
+			currentVersion:       "2",
+			expectResync:         true,
+		},
+		{
+			desc:                 "resync after ignored versions",
+			lastProcessedVersion: "2",
+			lastProcessedSuccess: true,
+			lastUpdate:           "2",
+			lastIgnored:          "4",
+			currentVersion:       "4",
+			expectResync:         true,
+		},
+		{
+			desc:                 "update coming after ignored versions",
+			lastProcessedVersion: "1",
+			lastProcessedSuccess: true,
+			lastUpdate:           "4",
+			lastIgnored:          "3",
+			currentVersion:       "4",
+			expectResync:         false,
+		},
+		{
+			desc:                 "retry after failure is not resync",
+			lastProcessedVersion: "2",
+			lastProcessedSuccess: false,
+			lastUpdate:           "2",
+			currentVersion:       "2",
+			expectResync:         false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			versionsTracker := NewServiceVersionsTracker()
+			versionsTracker.SetLastUpdateSeen(svcKey, tc.lastUpdate, klog.TODO())
+			versionsTracker.SetLastIgnored(svcKey, tc.lastIgnored, klog.TODO())
+			versionsTracker.SetProcessed(svcKey, tc.lastProcessedVersion, tc.lastProcessedSuccess, false, klog.TODO())
+
+			if resync := versionsTracker.IsResync(svcKey, tc.currentVersion, klog.TODO()); resync != tc.expectResync {
+				t.Errorf("unexpected result, want resync=%v, got=%v", tc.expectResync, resync)
+			}
+		})
+	}
+}
+
+func TestSetProcessedDoesNotChangeLastProcessedUpdateIfOperationWasResync(t *testing.T) {
+	versionsTracker := NewServiceVersionsTracker()
+	versions := versionsTracker.getVersionsForSvc(svcKey)
+	versions.lastProcessingSuccess = true
+	versions.lastProcessedUpdateVersion = "1"
+
+	versionsTracker.SetProcessed(svcKey, "2", true, true, klog.TODO())
+
+	versions = versionsTracker.getVersionsForSvc(svcKey)
+	if versions.lastProcessedUpdateVersion != "1" {
+		t.Errorf("Expected the version to remain 1 but got=%s", versions.lastProcessedUpdateVersion)
+	}
+}
+
+func TestSetProcessedChangesLastProcessedUpdateIfOperationWasUpdate(t *testing.T) {
+	versionsTracker := NewServiceVersionsTracker()
+	versions := versionsTracker.getVersionsForSvc(svcKey)
+	versions.lastProcessingSuccess = true
+	versions.lastProcessedUpdateVersion = "1"
+
+	versionsTracker.SetProcessed(svcKey, "2", true, false, klog.TODO())
+
+	versions = versionsTracker.getVersionsForSvc(svcKey)
+	if versions.lastProcessedUpdateVersion != "2" {
+		t.Errorf("Expected the version to be updated to 2 but got=%s", versions.lastProcessedUpdateVersion)
+	}
+}


### PR DESCRIPTION
For now this will just log a message with operation type. We will set this in the latency metric as a label.