### PR TITLE
Update type metrics

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -436,7 +436,7 @@ func (l4c *L4Controller) sync(key string, svcLogger klog.Logger) error {
 			return nil
 		}
 		l4c.serviceVersions.Delete(key)
-		l4c.publishMetrics(result, namespacedName, svcLogger)
+		l4c.publishMetrics(result, namespacedName, false, svcLogger)
 		return skipUserError(result.Error, svcLogger)
 	}
 	// Check again here, to avoid time-of check, time-of-use race. A service queued by informer could have changed, no
@@ -448,7 +448,7 @@ func (l4c *L4Controller) sync(key string, svcLogger klog.Logger) error {
 			// result will be nil if the service was ignored(due to presence of service controller finalizer).
 			return nil
 		}
-		l4c.publishMetrics(result, namespacedName, svcLogger)
+		l4c.publishMetrics(result, namespacedName, isResync, svcLogger)
 		l4c.serviceVersions.SetProcessed(key, svc.ResourceVersion, result.Error == nil, isResync, svcLogger)
 		return skipUserError(result.Error, svcLogger)
 	}
@@ -548,7 +548,7 @@ func (l4c *L4Controller) needsUpdate(oldService *v1.Service, newService *v1.Serv
 }
 
 // publishMetrics this function sets controller metrics for ILB services and pushed ILB metrics based on sync type.
-func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, namespacedName string, svcLogger klog.Logger) {
+func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, namespacedName string, isResync bool, svcLogger klog.Logger) {
 	if result == nil {
 		return
 	}
@@ -557,13 +557,13 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 		svcLogger.V(2).Info("Internal L4 Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsLegacyState)
 		l4c.ctx.ControllerMetrics.SetL4ILBServiceForLegacyMetric(namespacedName, result.MetricsLegacyState)
 		l4c.ctx.ControllerMetrics.SetL4ILBService(namespacedName, result.MetricsState)
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime)
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync)
 		if l4c.enableDualStack {
 			svcLogger.V(2).Info("Internal L4 DualStack Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsState)
-			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime)
+			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, isResync)
 		}
 		if result.MetricsState.Multinetwork {
-			l4metrics.PublishL4ILBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime)
+			l4metrics.PublishL4ILBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, isResync)
 		}
 
 	case loadbalancers.SyncTypeDelete:
@@ -573,12 +573,12 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 			l4c.ctx.ControllerMetrics.DeleteL4ILBServiceForLegacyMetric(namespacedName)
 			l4c.ctx.ControllerMetrics.DeleteL4ILBService(namespacedName)
 		}
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime)
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false)
 		if l4c.enableDualStack {
-			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime)
+			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, false)
 		}
 		if result.MetricsState.Multinetwork {
-			l4metrics.PublishL4ILBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime)
+			l4metrics.PublishL4ILBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, false)
 		}
 	default:
 		svcLogger.Info("Unknown sync type, skipping metrics for service", "syncType", result.SyncType)

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -78,6 +78,7 @@ type L4NetLBController struct {
 	forwardingRules             ForwardingRulesGetter
 	enableDualStack             bool
 	enableStrongSessionAffinity bool
+	serviceVersions             *serviceVersionsTracker
 
 	logger klog.Logger
 }
@@ -107,6 +108,7 @@ func NewL4NetLBController(
 		forwardingRules:             forwardingrules.New(ctx.Cloud, meta.VersionGA, meta.Regional, logger),
 		enableDualStack:             ctx.EnableL4NetLBDualStack,
 		enableStrongSessionAffinity: ctx.EnableL4StrongSessionAffinity,
+		serviceVersions:             NewServiceVersionsTracker(),
 		logger:                      logger,
 	}
 	var networkLister cache.Indexer
@@ -126,9 +128,10 @@ func NewL4NetLBController(
 			addSvc := obj.(*v1.Service)
 			svcKey := utils.ServiceKeyFunc(addSvc.Namespace, addSvc.Name)
 			svcLogger := logger.WithValues("serviceKey", svcKey)
-			if l4netLBc.shouldProcessService(addSvc, nil, svcLogger) {
+			if shouldProcess, _ := l4netLBc.shouldProcessService(addSvc, nil, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service added, enqueuing")
 				l4netLBc.ctx.Recorder(addSvc.Namespace).Eventf(addSvc, v1.EventTypeNormal, "ADD", svcKey)
+				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, logger)
 				l4netLBc.svcQueue.Enqueue(addSvc)
 				l4netLBc.enqueueTracker.Track()
 			} else {
@@ -141,8 +144,11 @@ func NewL4NetLBController(
 			oldSvc := old.(*v1.Service)
 			svcKey := utils.ServiceKeyFunc(curSvc.Namespace, curSvc.Name)
 			svcLogger := logger.WithValues("serviceKey", svcKey)
-			if l4netLBc.shouldProcessService(curSvc, oldSvc, svcLogger) {
+			if shouldProcess, isResync := l4netLBc.shouldProcessService(curSvc, oldSvc, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service updated, enqueuing")
+				if !isResync {
+					l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, curSvc.ResourceVersion, logger)
+				}
 				l4netLBc.svcQueue.Enqueue(curSvc)
 				l4netLBc.enqueueTracker.Track()
 				return
@@ -265,19 +271,20 @@ func (lc *L4NetLBController) needsUpdate(newSvc, oldSvc *v1.Service) bool {
 }
 
 // shouldProcessService checks if given service should be process by controller
-func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service, svcLogger klog.Logger) bool {
+func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service, svcLogger klog.Logger) (shouldProcess bool, isResync bool) {
 	// Ignore services with LoadBalancerClass set. LoadBalancerClass can't be updated (see the field API doc) so we don't need to worry about cleaning up services that changed the class.
 	if newSvc.Spec.LoadBalancerClass != nil {
 		svcLogger.Info("Ignoring service managed by another controller", "serviceLoadBalancerClass", *newSvc.Spec.LoadBalancerClass)
-		return false
+		return false, false
 	}
 	if !lc.isRBSBasedService(newSvc, svcLogger) && !lc.isRBSBasedService(oldSvc, svcLogger) {
-		return false
+		return false, false
 	}
 	if lc.needsAddition(newSvc, oldSvc) || lc.needsUpdate(newSvc, oldSvc) || lc.needsDeletion(newSvc, svcLogger) {
-		return true
+		return true, false
 	}
-	return lc.needsPeriodicEnqueue(newSvc, oldSvc)
+	needsResync := lc.needsPeriodicEnqueue(newSvc, oldSvc)
+	return needsResync, needsResync
 }
 
 // hasForwardingRuleAnnotation checks if service has forwarding rule with matching name
@@ -445,13 +452,15 @@ func (lc *L4NetLBController) sync(key string, svcLogger klog.Logger) error {
 		svcLogger.V(3).Info("Ignoring sync of legacy target pool service")
 		return nil
 	}
-
+	isResync := lc.serviceVersions.IsResync(key, svc.ResourceVersion, svcLogger)
+	svcLogger.Info("Processing update operation for service", "resync", isResync, "resourceVersion", svc.ResourceVersion)
 	if lc.needsDeletion(svc, svcLogger) {
 		svcLogger.V(3).Info("Deleting L4 External LoadBalancer resources for service")
 		result := lc.garbageCollectRBSNetLB(key, svc, svcLogger)
 		if result == nil {
 			return nil
 		}
+		lc.serviceVersions.Delete(key)
 		lc.publishMetrics(result, svc.Name, svc.Namespace, svcLogger)
 		return result.Error
 	}
@@ -462,6 +471,7 @@ func (lc *L4NetLBController) sync(key string, svcLogger klog.Logger) error {
 			// result will be nil if the service was ignored(due to presence of service controller finalizer).
 			return nil
 		}
+		lc.serviceVersions.SetProcessed(key, svc.ResourceVersion, result.Error == nil, isResync, svcLogger)
 		lc.publishMetrics(result, svc.Name, svc.Namespace, svcLogger)
 		return result.Error
 	}

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -1283,6 +1283,7 @@ func TestShouldProcessService(t *testing.T) {
 		oldSvc        *v1.Service
 		newSvc        *v1.Service
 		shouldProcess bool
+		shouldResync  bool
 	}{
 		{
 			oldSvc:        nil,
@@ -1329,11 +1330,15 @@ func TestShouldProcessService(t *testing.T) {
 			oldSvc:        svcWithRBSAnnotationAndFinalizer,
 			newSvc:        svcWithRBSAnnotationAndFinalizer,
 			shouldProcess: true,
+			shouldResync:  true,
 		},
 	} {
-		result := l4netController.shouldProcessService(testCase.newSvc, testCase.oldSvc, klog.TODO())
+		result, isResync := l4netController.shouldProcessService(testCase.newSvc, testCase.oldSvc, klog.TODO())
 		if result != testCase.shouldProcess {
 			t.Errorf("Old service %v. New service %v. Expected needsUpdate: %t, got: %t", testCase.oldSvc, testCase.newSvc, testCase.shouldProcess, result)
+		}
+		if isResync != testCase.shouldResync {
+			t.Errorf("Old service %v. New service %v. Expected needsResync: %t, got: %t", testCase.oldSvc, testCase.newSvc, testCase.shouldResync, isResync)
 		}
 	}
 }


### PR DESCRIPTION
Add update opeation type to the L4 latency metrics.

This will allow to separate SLO for updates caused by resource changes from the periodic resync operations.