### PR TITLE
Add a check for removed l4 finalizers

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -471,6 +471,8 @@ func (l4c *L4Controller) needsDeletion(svc *v1.Service) bool {
 
 // needsUpdate checks if load balancer needs to be updated due to change in attributes.
 func (l4c *L4Controller) needsUpdate(oldService *v1.Service, newService *v1.Service) bool {
+	warnL4FinalizerRemoved(l4c.ctx, oldService, newService)
+
 	oldSvcWantsILB, oldType := annotations.WantsL4ILB(oldService)
 	newSvcWantsILB, newType := annotations.WantsL4ILB(newService)
 	recorder := l4c.ctx.Recorder(oldService.Namespace)

--- a/pkg/l4lb/l4lbcommon_test.go
+++ b/pkg/l4lb/l4lbcommon_test.go
@@ -1,0 +1,143 @@
+package l4lb
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+func TestFinalizerWasRemovedUnexpectedly(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		oldService     *v1.Service
+		newService     *v1.Service
+		finalizerName  string
+		expectedResult bool
+	}{
+		{
+			desc:           "Clean service",
+			oldService:     &v1.Service{},
+			newService:     &v1.Service{},
+			finalizerName:  "random",
+			expectedResult: false,
+		},
+		{
+			desc: "Empty finalizers",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{},
+				},
+			},
+			finalizerName:  "random",
+			expectedResult: false,
+		},
+		{
+			desc: "Changed L4 Finalizer",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.LegacyILBFinalizer, "random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random", "gke.networking.io/l4-ilb-v1-fake"},
+				},
+			},
+			finalizerName:  common.LegacyILBFinalizer,
+			expectedResult: true,
+		},
+		{
+			desc: "Removed L4 Finalizer",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.LegacyILBFinalizer, "random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random"},
+				},
+			},
+			finalizerName:  common.LegacyILBFinalizer,
+			expectedResult: true,
+		},
+		{
+			desc: "Added L4 ILB v2 Finalizer",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random", common.ILBFinalizerV2},
+				},
+			},
+			finalizerName:  common.ILBFinalizerV2,
+			expectedResult: false,
+		},
+		{
+			desc: "Service with NetLB Finalizer hasn't changed",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.NetLBFinalizerV2, "random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random", common.NetLBFinalizerV2},
+				},
+			},
+			finalizerName:  common.NetLBFinalizerV2,
+			expectedResult: false,
+		},
+		{
+			desc: "Finalizer was removed but given name is wrong",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.NetLBFinalizerV2, "random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"random"},
+				},
+			},
+			finalizerName:  common.ILBFinalizerV2,
+			expectedResult: false,
+		},
+		{
+			desc: "Finalizer was removed and service to be deleted",
+			oldService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.NetLBFinalizerV2, "random"},
+				},
+			},
+			newService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Date(2024, 12, 30, 0, 0, 0, 0, time.Local)},
+					Finalizers:        []string{common.ILBFinalizerV2},
+				},
+			},
+			finalizerName:  common.ILBFinalizerV2,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotResult := finalizerWasRemovedUnexpectedly(tc.oldService, tc.newService, tc.finalizerName)
+			if gotResult != tc.expectedResult {
+				t.Errorf("finalizerWasRemoved(oldSvc=%v, newSvc=%v, finalizer=%s) returned %v, but expected %v", tc.oldService, tc.newService, tc.finalizerName, gotResult, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -278,6 +278,9 @@ func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service, sv
 		svcLogger.Info("Ignoring service managed by another controller", "serviceLoadBalancerClass", *newSvc.Spec.LoadBalancerClass)
 		return false, false
 	}
+
+	warnL4FinalizerRemoved(lc.ctx, oldSvc, newSvc)
+
 	if !lc.isRBSBasedService(newSvc, svcLogger) && !lc.isRBSBasedService(oldSvc, svcLogger) {
 		return false, false
 	}

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -41,6 +41,8 @@ const (
 	NegFinalizerKey = "networking.gke.io/neg-finalizer"
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
+	// LoadBalancerCleanupFinalizer added by original kubernetes service controller. This is not required in L4 RBS/ILB-subsetting services.
+	LoadBalancerCleanupFinalizer = "service.kubernetes.io/load-balancer-cleanup"
 )
 
 // IsDeletionCandidate is true if the passed in meta contains an ingress finalizer.


### PR DESCRIPTION
Sometimes users remove finalizers and it affects
garbage collection. We want to emit a warning event in that case and record it within a new metric l4LBRemovedFinalizers.