### PR TITLE
Update service annotation + IPs in single API call

### DIFF
--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -103,8 +103,18 @@ func TestEnsureL4BackendService(t *testing.T) {
 
 			hcLink := l4namer.L4HealthCheck(tc.serviceNamespace, tc.serviceName, false)
 			bsName := l4namer.L4Backend(tc.serviceNamespace, tc.serviceName)
-			network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
-			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, tc.protocol, tc.affinityType, tc.schemeType, namespacedName, network, tc.connectionTrackingPolicy, klog.TODO())
+			network := &network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
+			backendParams := L4BackendServiceParams{
+				Name:                     bsName,
+				HealthCheckLink:          hcLink,
+				Protocol:                 tc.protocol,
+				SessionAffinity:          tc.affinityType,
+				Scheme:                   tc.schemeType,
+				NamespacedName:           namespacedName,
+				NetworkInfo:              network,
+				ConnectionTrackingPolicy: tc.connectionTrackingPolicy,
+			}
+			bs, err := backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 			if err != nil {
 				t.Errorf("EnsureL4BackendService failed")
 			}
@@ -162,7 +172,7 @@ func TestEnsureL4BackendServiceDoesNotDetachBackends(t *testing.T) {
 
 			hcLink := l4namer.L4HealthCheck(serviceNamespace, serviceName, false)
 			bsName := l4namer.L4Backend(serviceNamespace, serviceName)
-			network := network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
+			network := &network.NetworkInfo{IsDefault: false, NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"}
 
 			backendName := "testNeg"
 			existingBS := &composite.BackendService{
@@ -189,7 +199,17 @@ func TestEnsureL4BackendServiceDoesNotDetachBackends(t *testing.T) {
 			}
 
 			var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-			bs, err := backendPool.EnsureL4BackendService(bsName, hcLink, "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), namespacedName, network, noConnectionTrackingPolicy, klog.TODO())
+			backendParams := L4BackendServiceParams{
+				Name:                     bsName,
+				HealthCheckLink:          hcLink,
+				Protocol:                 "TCP",
+				SessionAffinity:          string(v1.ServiceAffinityNone),
+				Scheme:                   string(cloud.SchemeInternal),
+				NamespacedName:           namespacedName,
+				NetworkInfo:              network,
+				ConnectionTrackingPolicy: noConnectionTrackingPolicy,
+			}
+			bs, err := backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 			if err != nil {
 				t.Errorf("EnsureL4BackendService failed")
 			}

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -59,7 +59,7 @@ func TestLink(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
@@ -101,7 +101,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -54,7 +54,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeInstancePool := instancegroups.NewManager(&instancegroups.ManagerConfig{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -69,7 +69,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, fakeZone, "test-node")
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockGlobalForwardingRules.InsertHook = loadbalancers.InsertGlobalForwardingRuleHook

--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -97,7 +97,7 @@ func TestSync(t *testing.T) {
 	config.HasSynced = func() bool {
 		return true
 	}
-	config.ZoneGetter = zonegetter.NewZoneGetter(informer, defaultTestSubnetURL)
+	config.ZoneGetter = zonegetter.NewFakeZoneGetter(informer, defaultTestSubnetURL, false)
 
 	controller := NewController(config, logr.Logger{})
 

--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -41,7 +41,7 @@ var defaultNamer = namer.NewNamer("uid1", "fw1", klog.TODO())
 
 func newNodePool(f *FakeInstanceGroups, zone string, maxIGSize int) Manager {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 
 	pool := NewManager(&ManagerConfig{
 		Cloud:      f,

--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -18,7 +18,7 @@ package l4lb
 
 import (
 	"fmt"
-	"reflect"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
@@ -41,9 +41,6 @@ import (
 func computeNewAnnotationsIfNeeded(svc *v1.Service, newAnnotations map[string]string, keysToRemove []string) *metav1.ObjectMeta {
 	newObjectMeta := svc.ObjectMeta.DeepCopy()
 	newObjectMeta.Annotations = mergeAnnotations(newObjectMeta.Annotations, newAnnotations, keysToRemove)
-	if reflect.DeepEqual(svc.Annotations, newObjectMeta.Annotations) {
-		return nil
-	}
 	return newObjectMeta
 }
 
@@ -65,48 +62,47 @@ func mergeAnnotations(existing, lbAnnotations map[string]string, keysToRemove []
 	}
 	return existing
 }
-
-// updateL4ResourcesAnnotations checks if new annotations should be added to service and patch service metadata if needed.
-func updateL4ResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string, logger klog.Logger) error {
-	logger.V(3).Info("Updating annotations of service", "serviceKey", klog.KRef(svc.Namespace, svc.Name))
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4ResourceAnnotationKeys)
-	if newObjectMeta == nil {
-		logger.V(3).Info("Service annotations not changed, skipping patch for service", "serviceKey", klog.KRef(svc.Namespace, svc.Name))
-		return nil
-	}
-	logger.V(3).Info("Patching annotations of service", "serviceKey", klog.KRef(svc.Namespace, svc.Name))
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
-// updateL4DualStackResourcesAnnotations checks if new annotations should be added to dual-stack service and patch service metadata if needed.
-func updateL4DualStackResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string, logger klog.Logger) error {
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4DualStackResourceAnnotationKeys)
-	if newObjectMeta == nil {
-		return nil
-	}
-	logger.V(3).Info("Patching annotations of service", "serviceKey", klog.KRef(svc.Namespace, svc.Name))
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
-func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotationKey string, logger klog.Logger) error {
+func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotationKey string, svcLogger klog.Logger) error {
 	newObjectMeta := svc.ObjectMeta.DeepCopy()
 	if _, ok := newObjectMeta.Annotations[annotationKey]; !ok {
 		return nil
 	}
-
-	logger.V(3).Info("Removing annotation from service", "annotationKey", annotationKey, "serviceKey", klog.KRef(svc.Namespace, svc.Name))
+	svcLogger.V(3).Info("Removing annotation from service", "annotationKey", annotationKey)
 	delete(newObjectMeta.Annotations, annotationKey)
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
-// updateServiceStatus this faction checks if LoadBalancer status changed and patch service if needed.
-func updateServiceStatus(ctx *context.ControllerContext, svc *v1.Service, newStatus *v1.LoadBalancerStatus, logger klog.Logger) error {
-	logger.V(2).Info("Updating service status", "serviceKey", klog.KRef(svc.Namespace, svc.Name), "newStatus", fmt.Sprintf("%+v", newStatus))
+// updateServiceInformation this faction checks if LoadBalancer changed and patch service if needed.
+func updateServiceInformation(ctx *context.ControllerContext, enableDualStack bool, svc *v1.Service, newStatus *v1.LoadBalancerStatus, newL4LBAnnotations map[string]string, svcLogger klog.Logger) error {
+	svcLogger.V(2).Info("Updating service status", "newStatus", fmt.Sprintf("%+v", newStatus))
 	if helpers.LoadBalancerStatusEqual(&svc.Status.LoadBalancer, newStatus) {
-		logger.V(2).Info("New and old statuses are equal, skipping patch", "serviceKey", klog.KRef(svc.Namespace, svc.Name))
+		svcLogger.V(2).Info("New and old statuses are equal, skipping patch")
 		return nil
 	}
-	return patch.PatchServiceLoadBalancerStatus(ctx.KubeClient.CoreV1(), svc, *newStatus)
+
+	var keysToRemove []string
+	if enableDualStack {
+		emitEnsuredDualStackEvent(ctx, svc)
+		keysToRemove = loadbalancers.L4DualStackResourceAnnotationKeys
+	} else {
+		keysToRemove = loadbalancers.L4ResourceAnnotationKeys
+	}
+	svcLogger.V(2).Info("Selected keysToRemove", "keysToRemove", keysToRemove)
+
+	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, keysToRemove)
+	svcLogger.V(2).Info("Computed new service metadata", "newObjectMeta", newObjectMeta)
+
+	return patch.PatchServiceLoadBalancerInformation(ctx.KubeClient.CoreV1(), svc, *newStatus, *newObjectMeta)
+
+}
+
+func emitEnsuredDualStackEvent(ctx *context.ControllerContext, service *v1.Service) {
+	var ipFamilies []string
+	for _, ipFamily := range service.Spec.IPFamilies {
+		ipFamilies = append(ipFamilies, string(ipFamily))
+	}
+	ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
+		"Successfully ensured %v load balancer resources", strings.Join(ipFamilies, " "))
 }
 
 // isHealthCheckDeleted checks if given health check exists in GCE

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -129,7 +129,7 @@ func NewL4NetLBController(
 			if shouldProcess, _ := l4netLBc.shouldProcessService(addSvc, nil, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service added, enqueuing")
 				l4netLBc.ctx.Recorder(addSvc.Namespace).Eventf(addSvc, v1.EventTypeNormal, "ADD", svcKey)
-				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, logger)
+				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, svcLogger)
 				l4netLBc.svcQueue.Enqueue(addSvc)
 				l4netLBc.enqueueTracker.Track()
 			} else {
@@ -145,7 +145,7 @@ func NewL4NetLBController(
 			if shouldProcess, isResync := l4netLBc.shouldProcessService(curSvc, oldSvc, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service updated, enqueuing")
 				if !isResync {
-					l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, curSvc.ResourceVersion, logger)
+					l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, curSvc.ResourceVersion, svcLogger)
 				}
 				l4netLBc.svcQueue.Enqueue(curSvc)
 				l4netLBc.enqueueTracker.Track()
@@ -550,32 +550,12 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 		return syncResult
 	}
 
-	err = updateServiceStatus(lc.ctx, service, syncResult.Status, svcLogger)
+	err = updateServiceInformation(lc.ctx, lc.enableDualStack, service, syncResult.Status, syncResult.Annotations, svcLogger)
 	if err != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Error updating L4 External LoadBalancer, err: %v", err)
 		syncResult.Error = err
 		return syncResult
-	}
-	if lc.enableDualStack {
-		lc.emitEnsuredDualStackEvent(service)
-
-		if err = updateL4DualStackResourcesAnnotations(lc.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
-				"Failed to update annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-			return syncResult
-		}
-	} else {
-		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
-			"Successfully ensured L4 External LoadBalancer resources")
-
-		if err = updateL4ResourcesAnnotations(lc.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
-				"Failed to update annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-			return syncResult
-		}
 	}
 	syncResult.SetMetricsForSuccessfulServiceSync()
 	return syncResult
@@ -675,7 +655,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 		return result
 	}
 
-	if err := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{}, svcLogger); err != nil {
+	if err := updateServiceInformation(lc.ctx, lc.enableDualStack, svc, &v1.LoadBalancerStatus{}, nil, svcLogger); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error resetting L4 External LoadBalancer status to empty, err: %v", err)
 		result.Error = fmt.Errorf("Failed to reset L4 External LoadBalancer status, err: %w", err)
@@ -689,22 +669,6 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 			"Error deleting delete Instance Group from L4 External LoadBalancer, err: %v", err)
 		result.Error = fmt.Errorf("Failed to delete Instance Group, err: %w", err)
 		return result
-	}
-
-	if lc.enableDualStack {
-		if err := updateL4DualStackResourcesAnnotations(lc.ctx, svc, nil, svcLogger); err != nil {
-			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error removing Dual Stack resource annotations: %v", err)
-			result.Error = fmt.Errorf("failed to reset Dual Stack resource annotations, err: %w", err)
-			return result
-		}
-	} else {
-		if err := updateL4ResourcesAnnotations(lc.ctx, svc, nil, svcLogger); err != nil {
-			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error removing resource annotations: %v", err)
-			result.Error = fmt.Errorf("failed to reset resource annotations, err: %w", err)
-			return result
-		}
 	}
 
 	// Finalizer needs to be removed last, because after deleting finalizer service can be deleted and

--- a/pkg/l4lb/updatetype.go
+++ b/pkg/l4lb/updatetype.go
@@ -51,25 +51,25 @@ func (t *serviceVersionsTracker) getVersionsForSvc(svcKey string) *serviceVersio
 
 }
 
-func (t *serviceVersionsTracker) SetLastUpdateSeen(svcKey, version string, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetLastUpdateSeen(svcKey, version string, svcLogger klog.Logger) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 	v.lastSeenUpdateVersion = version
-	logger.V(3).Info("serviceVersionsTracker: SetLastUpdateSeen()", "svcKey", svcKey, "version", version)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetLastUpdateSeen()", "version", version)
 }
 
-func (t *serviceVersionsTracker) SetLastIgnored(svcKey, version string, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetLastIgnored(svcKey, version string, svcLogger klog.Logger) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 	v.lastIgnoredVersion = version
-	logger.V(3).Info("serviceVersionsTracker: SetLastIgnored()", "svcKey", svcKey, "version", version)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetLastIgnored()", "version", version)
 }
 
-func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, wasResync bool, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, wasResync bool, svcLogger klog.Logger) {
 	if wasResync && success {
 		return
 	}
@@ -79,16 +79,16 @@ func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, w
 	v := t.getVersionsForSvc(svcKey)
 	v.lastProcessedUpdateVersion = version
 	v.lastProcessingSuccess = success
-	logger.V(3).Info("serviceVersionsTracker: SetProcessed()", "version", version, "success", success, "wasResync", wasResync)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetProcessed()", "version", version, "success", success, "wasResync", wasResync)
 }
 
-func (t *serviceVersionsTracker) IsResync(svcKey, currentVersion string, logger klog.Logger) bool {
+func (t *serviceVersionsTracker) IsResync(svcKey, currentVersion string, svcLogger klog.Logger) bool {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 
-	logger.V(3).Info("serviceVersionsTracker: IsResync()", "currentVersion", currentVersion, "lastProcessedUpdateVersion", v.lastProcessedUpdateVersion, "lastProcessingSuccess", v.lastProcessingSuccess, "lastSeenUpdate", v.lastSeenUpdateVersion, "lastIgnored", v.lastIgnoredVersion)
+	svcLogger.V(3).Info("serviceVersionsTracker: IsResync()", "currentVersion", currentVersion, "lastProcessedUpdateVersion", v.lastProcessedUpdateVersion, "lastProcessingSuccess", v.lastProcessingSuccess, "lastSeenUpdate", v.lastSeenUpdateVersion, "lastIgnored", v.lastIgnoredVersion)
 
 	if !v.lastProcessingSuccess {
 		return false

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -473,10 +473,17 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	// ensure backend service
-	// TODO(cheungdavid): Create backend logger that contains backendName,
-	// backendVersion, and backendScope before passing to backendPool.EnsureL4BackendService().
-	// See example in backendSyncer.ensureBackendService().
-	bs, err := l4.backendPool.EnsureL4BackendService(bsName, hcLink, string(protocol), string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, l4.network, noConnectionTrackingPolicy, l4.svcLogger)
+	backendParams := backends.L4BackendServiceParams{
+		Name:                     bsName,
+		HealthCheckLink:          hcLink,
+		Protocol:                 string(protocol),
+		SessionAffinity:          string(l4.Service.Spec.SessionAffinity),
+		Scheme:                   string(cloud.SchemeInternal),
+		NamespacedName:           l4.NamespacedName,
+		NetworkInfo:              &l4.network,
+		ConnectionTrackingPolicy: noConnectionTrackingPolicy,
+	}
+	bs, err := l4.backendPool.EnsureL4BackendService(backendParams, l4.svcLogger)
 	if err != nil {
 		result.GCEResourceInError = annotations.BackendServiceResource
 		result.Error = err

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -86,13 +86,24 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
 	bsName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
-	_, err := l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(svc.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
+	backendParams := backends.L4BackendServiceParams{
+		Name:                     bsName,
+		HealthCheckLink:          "",
+		Protocol:                 "TCP",
+		SessionAffinity:          string(svc.Spec.SessionAffinity),
+		Scheme:                   string(cloud.SchemeInternal),
+		NamespacedName:           l4.NamespacedName,
+		NetworkInfo:              network.DefaultNetwork(fakeGCE),
+		ConnectionTrackingPolicy: noConnectionTrackingPolicy,
+	}
+	_, err := l4.backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
 
+	backendParams.SessionAffinity = string(v1.ServiceAffinityNone)
 	// Update the Internal Backend Service with a new ServiceAffinity
-	_, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
+	_, err = l4.backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -113,7 +124,8 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update backend service with new connection draining timeout - err %v", err)
 	}
-	bs, err = l4.backendPool.EnsureL4BackendService(bsName, "", "TCP", string(v1.ServiceAffinityNone), string(cloud.SchemeInternal), l4.NamespacedName, *network.DefaultNetwork(fakeGCE), noConnectionTrackingPolicy, klog.TODO())
+	// ensure the backend back to previous params
+	bs, err = l4.backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to ensure backend service  %s - err %v", bsName, err)
 	}
@@ -292,7 +304,17 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 	if hcResult.Err != nil {
 		t.Errorf("Failed to create healthcheck, err %v", hcResult.Err)
 	}
-	_, err := l4.backendPool.EnsureL4BackendService(lbName, hcResult.HCLink, "TCP", string(l4.Service.Spec.SessionAffinity), string(cloud.SchemeInternal), l4.NamespacedName, *defaultNetwork, noConnectionTrackingPolicy, klog.TODO())
+	backendParams := backends.L4BackendServiceParams{
+		Name:                     lbName,
+		HealthCheckLink:          hcResult.HCLink,
+		Protocol:                 "TCP",
+		SessionAffinity:          string(svc.Spec.SessionAffinity),
+		Scheme:                   string(cloud.SchemeInternal),
+		NamespacedName:           l4.NamespacedName,
+		NetworkInfo:              defaultNetwork,
+		ConnectionTrackingPolicy: noConnectionTrackingPolicy,
+	}
+	_, err := l4.backendPool.EnsureL4BackendService(backendParams, klog.TODO())
 	if err != nil {
 		t.Errorf("Failed to create backendservice, err %v", err)
 	}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -194,7 +194,9 @@ func NewController(
 			podInformer.GetIndexer(),
 			cloud,
 			manager,
+			zoneGetter,
 			enableDualStackNEG,
+			flags.F.EnableMultiSubnetCluster,
 			logger,
 		)
 	} else {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -125,7 +125,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 	}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 
 	return NewController(
 		kubeClient,
@@ -1735,7 +1735,7 @@ func validateServiceAnnotationWithPortInfoMap(t *testing.T, svc *apiv1.Service, 
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode()), klog.TODO())
 	if !sets.NewString(expectZones...).Equal(sets.NewString(zones...)) {
 		t.Errorf("Unexpected zones listed by the predicate function, got %v, want %v", zones, expectZones)
@@ -1816,7 +1816,7 @@ func validateServiceStateAnnotationExceptNames(t *testing.T, svc *apiv1.Service,
 	}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	// This routine is called from tests verifying L7 NEGs.
 	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L7Mode), klog.TODO())
 

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -85,7 +85,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	manager := newSyncerManager(
 		testContext.NegNamer,
 		record.NewFakeRecorder(100),

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -68,7 +68,7 @@ func (p *testPatcher) Eval(t *testing.T, pod string, negKey, bsKey *meta.Key) {
 }
 
 func newFakePoller() *poller {
-	reflector := newTestReadinessReflector(negtypes.NewTestContext())
+	reflector := newTestReadinessReflector(negtypes.NewTestContext(), false)
 	poller := reflector.poller
 	poller.patcher = &testPatcher{}
 	return poller

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -34,14 +34,7 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
-const (
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
-
-	defaultTestSubnet    = "default"
-	nonDefaultTestSubnet = "non-default"
-
-	testServiceNamespace = "test-ns"
-)
+const testServiceNamespace = "test-ns"
 
 // fakeLookUp implements LookUp interface
 type fakeLookUp struct {
@@ -84,7 +77,7 @@ func TestSyncPod(t *testing.T) {
 	nodeLister := fakeContext.NodeInformer.GetIndexer()
 	nodeName := "instance1"
 
-	testReadinessReflector := newTestReadinessReflector(fakeContext, false)
+	testReadinessReflector := newTestReadinessReflector(fakeContext)
 	testReadinessReflector.clock = fakeClock
 	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
 
@@ -97,12 +90,11 @@ func TestSyncPod(t *testing.T) {
 			PodCIDRs: []string{"a:b::/48", "10.100.1.0/24"},
 		},
 	})
-	zonegetter.PopulateFakeNodeInformer(fakeContext.NodeInformer)
 
 	testCases := []struct {
 		desc                string
 		podName             string
-		mutateState         func(*fakeLookUp)
+		mutateState         func()
 		inputKey            string
 		inputNeg            *meta.Key
 		inputBackendService *meta.Key
@@ -111,14 +103,14 @@ func TestSyncPod(t *testing.T) {
 	}{
 		{
 			desc: "empty input",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				testlookUp.readinessGateEnabledNegs = []string{}
 			},
 			expectExists: false,
 		},
 		{
 			desc: "no need to update when pod does not have neg readiness gate",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod1", false, true, true)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -131,9 +123,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod1",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -151,7 +140,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "no need to update 2 when pod already has neg condition status == true",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod2", true, true, true)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -164,9 +153,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod2",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -187,7 +173,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod but there is no Negs associated",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod3", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -200,9 +186,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod3",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -224,7 +207,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: there is NEGs associated but pod is not healthy",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod4", true, false, false)
 				pod.CreationTimestamp = now
 				podLister.Add(pod)
@@ -262,7 +245,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: pod is not attached to health check",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod5", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -276,9 +259,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod5",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -300,7 +280,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "timeout waiting for endpoint to become healthy in NEGs",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod6", true, false, false)
 				pod.CreationTimestamp = now
 				podLister.Add(pod)
@@ -340,7 +320,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: pod is healthy in NEG ",
-			mutateState: func(testlookUp *fakeLookUp) {
+			mutateState: func() {
 				pod := generatePod(testServiceNamespace, "pod7", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -354,9 +334,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod7",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -379,142 +356,22 @@ func TestSyncPod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			for _, enableMultiSubnetCluster := range []bool{true, false} {
-				testReadinessReflector.enableMultiSubnetCluster = enableMultiSubnetCluster
-				tc.mutateState(testlookUp)
-				err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
-				if err != nil {
-					t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect syncPod() return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
-				}
-
-				if tc.expectExists {
-					pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
-					if err != nil {
-						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect GetPod() to return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
-					}
-					// ignore creation timestamp for comparison
-					pod.CreationTimestamp = tc.expectPod.CreationTimestamp
-					if !reflect.DeepEqual(pod, tc.expectPod) {
-						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect pod to be %v, but got %v", tc.desc, enableMultiSubnetCluster, tc.expectPod, pod)
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestSyncPodMultipleSubnets(t *testing.T) {
-	t.Parallel()
-	fakeContext := negtypes.NewTestContext()
-	fakeClock := clocktesting.NewFakeClock(time.Now())
-	client := fakeContext.KubeClient
-	podLister := fakeContext.PodInformer.GetIndexer()
-
-	testReadinessReflector := newTestReadinessReflector(fakeContext, true)
-	testReadinessReflector.clock = fakeClock
-	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
-
-	zonegetter.PopulateFakeNodeInformer(fakeContext.NodeInformer)
-
-	testCases := []struct {
-		desc                string
-		podName             string
-		mutateState         func(*fakeLookUp)
-		inputKey            string
-		inputNeg            *meta.Key
-		inputBackendService *meta.Key
-		expectPod           *v1.Pod
-	}{
-		{
-			desc: "need to update pod: pod belongs to a node without PodCIDR",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, negtypes.TestNoPodCIDRPod, true, false, false)
-				pod.Spec.NodeName = negtypes.TestNoPodCIDRInstance
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, negtypes.TestNoPodCIDRPod),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      negtypes.TestNoPodCIDRPod,
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: negtypes.TestNoPodCIDRInstance,
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Status:  v1.ConditionTrue,
-							Reason:  negReadyReason,
-							Message: fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate),
-						},
-					},
-				},
-			},
-		},
-		{
-			desc: "need to update pod: pod belongs to a node in non-default subnet",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, negtypes.TestNonDefaultSubnetPod, true, false, false)
-				pod.Spec.NodeName = negtypes.TestNonDefaultSubnetInstance
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, negtypes.TestNonDefaultSubnetPod),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      negtypes.TestNonDefaultSubnetPod,
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: negtypes.TestNonDefaultSubnetInstance,
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Status:  v1.ConditionTrue,
-							Reason:  negReadyReason,
-							Message: fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			tc.mutateState(testlookUp)
+			tc.mutateState()
 			err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
 			if err != nil {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
+				t.Errorf("For test case %q, expect syncPod() return nil, but got %v", tc.desc, err)
 			}
 
-			pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
-			}
-			// ignore creation timestamp for comparison
-			pod.CreationTimestamp = tc.expectPod.CreationTimestamp
-			if !reflect.DeepEqual(pod, tc.expectPod) {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
+			if tc.expectExists {
+				pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("For test case %q, expect Get() Pod to return nil, but got %v", tc.desc, err)
+				}
+				// ignore creation timestamp for comparison
+				pod.CreationTimestamp = tc.expectPod.CreationTimestamp
+				if !reflect.DeepEqual(pod, tc.expectPod) {
+					t.Errorf("For test case %q, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
+				}
 			}
 		})
 	}

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -34,7 +34,14 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
-const testServiceNamespace = "test-ns"
+const (
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+
+	defaultTestSubnet    = "default"
+	nonDefaultTestSubnet = "non-default"
+
+	testServiceNamespace = "test-ns"
+)
 
 // fakeLookUp implements LookUp interface
 type fakeLookUp struct {
@@ -77,7 +84,7 @@ func TestSyncPod(t *testing.T) {
 	nodeLister := fakeContext.NodeInformer.GetIndexer()
 	nodeName := "instance1"
 
-	testReadinessReflector := newTestReadinessReflector(fakeContext)
+	testReadinessReflector := newTestReadinessReflector(fakeContext, false)
 	testReadinessReflector.clock = fakeClock
 	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
 
@@ -90,11 +97,12 @@ func TestSyncPod(t *testing.T) {
 			PodCIDRs: []string{"a:b::/48", "10.100.1.0/24"},
 		},
 	})
+	zonegetter.PopulateFakeNodeInformer(fakeContext.NodeInformer)
 
 	testCases := []struct {
 		desc                string
 		podName             string
-		mutateState         func()
+		mutateState         func(*fakeLookUp)
 		inputKey            string
 		inputNeg            *meta.Key
 		inputBackendService *meta.Key
@@ -103,14 +111,14 @@ func TestSyncPod(t *testing.T) {
 	}{
 		{
 			desc: "empty input",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				testlookUp.readinessGateEnabledNegs = []string{}
 			},
 			expectExists: false,
 		},
 		{
 			desc: "no need to update when pod does not have neg readiness gate",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod1", false, true, true)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -123,6 +131,9 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod1",
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -140,7 +151,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "no need to update 2 when pod already has neg condition status == true",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod2", true, true, true)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -153,6 +164,9 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod2",
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -173,7 +187,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod but there is no Negs associated",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod3", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -186,6 +200,9 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod3",
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -207,7 +224,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: there is NEGs associated but pod is not healthy",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod4", true, false, false)
 				pod.CreationTimestamp = now
 				podLister.Add(pod)
@@ -245,7 +262,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: pod is not attached to health check",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod5", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -259,6 +276,9 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod5",
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -280,7 +300,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "timeout waiting for endpoint to become healthy in NEGs",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod6", true, false, false)
 				pod.CreationTimestamp = now
 				podLister.Add(pod)
@@ -320,7 +340,7 @@ func TestSyncPod(t *testing.T) {
 		},
 		{
 			desc: "need to update pod: pod is healthy in NEG ",
-			mutateState: func() {
+			mutateState: func(testlookUp *fakeLookUp) {
 				pod := generatePod(testServiceNamespace, "pod7", true, false, false)
 				podLister.Add(pod)
 				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
@@ -334,6 +354,9 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod7",
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -356,22 +379,142 @@ func TestSyncPod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tc.mutateState()
+			for _, enableMultiSubnetCluster := range []bool{true, false} {
+				testReadinessReflector.enableMultiSubnetCluster = enableMultiSubnetCluster
+				tc.mutateState(testlookUp)
+				err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
+				if err != nil {
+					t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect syncPod() return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
+				}
+
+				if tc.expectExists {
+					pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect GetPod() to return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
+					}
+					// ignore creation timestamp for comparison
+					pod.CreationTimestamp = tc.expectPod.CreationTimestamp
+					if !reflect.DeepEqual(pod, tc.expectPod) {
+						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect pod to be %v, but got %v", tc.desc, enableMultiSubnetCluster, tc.expectPod, pod)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSyncPodMultipleSubnets(t *testing.T) {
+	t.Parallel()
+	fakeContext := negtypes.NewTestContext()
+	fakeClock := clocktesting.NewFakeClock(time.Now())
+	client := fakeContext.KubeClient
+	podLister := fakeContext.PodInformer.GetIndexer()
+
+	testReadinessReflector := newTestReadinessReflector(fakeContext, true)
+	testReadinessReflector.clock = fakeClock
+	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
+
+	zonegetter.PopulateFakeNodeInformer(fakeContext.NodeInformer)
+
+	testCases := []struct {
+		desc                string
+		podName             string
+		mutateState         func(*fakeLookUp)
+		inputKey            string
+		inputNeg            *meta.Key
+		inputBackendService *meta.Key
+		expectPod           *v1.Pod
+	}{
+		{
+			desc: "need to update pod: pod belongs to a node without PodCIDR",
+			mutateState: func(testlookUp *fakeLookUp) {
+				pod := generatePod(testServiceNamespace, negtypes.TestNoPodCIDRPod, true, false, false)
+				pod.Spec.NodeName = negtypes.TestNoPodCIDRInstance
+				podLister.Add(pod)
+				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			},
+			inputKey: keyFunc(testServiceNamespace, negtypes.TestNoPodCIDRPod),
+			inputNeg: nil,
+			expectPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testServiceNamespace,
+					Name:      negtypes.TestNoPodCIDRPod,
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: negtypes.TestNoPodCIDRInstance,
+					ReadinessGates: []v1.PodReadinessGate{
+						{ConditionType: shared.NegReadinessGate},
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:    shared.NegReadinessGate,
+							Status:  v1.ConditionTrue,
+							Reason:  negReadyReason,
+							Message: fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "need to update pod: pod belongs to a node in non-default subnet",
+			mutateState: func(testlookUp *fakeLookUp) {
+				pod := generatePod(testServiceNamespace, negtypes.TestNonDefaultSubnetPod, true, false, false)
+				pod.Spec.NodeName = negtypes.TestNonDefaultSubnetInstance
+				podLister.Add(pod)
+				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			},
+			inputKey: keyFunc(testServiceNamespace, negtypes.TestNonDefaultSubnetPod),
+			inputNeg: nil,
+			expectPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testServiceNamespace,
+					Name:      negtypes.TestNonDefaultSubnetPod,
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: defaultTestSubnet,
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: negtypes.TestNonDefaultSubnetInstance,
+					ReadinessGates: []v1.PodReadinessGate{
+						{ConditionType: shared.NegReadinessGate},
+					},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:    shared.NegReadinessGate,
+							Status:  v1.ConditionTrue,
+							Reason:  negReadyReason,
+							Message: fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tc.mutateState(testlookUp)
 			err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
 			if err != nil {
-				t.Errorf("For test case %q, expect syncPod() return nil, but got %v", tc.desc, err)
+				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
 			}
 
-			if tc.expectExists {
-				pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
-				if err != nil {
-					t.Errorf("For test case %q, expect Get() Pod to return nil, but got %v", tc.desc, err)
-				}
-				// ignore creation timestamp for comparison
-				pod.CreationTimestamp = tc.expectPod.CreationTimestamp
-				if !reflect.DeepEqual(pod, tc.expectPod) {
-					t.Errorf("For test case %q, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
-				}
+			pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
+			}
+			// ignore creation timestamp for comparison
+			pod.CreationTimestamp = tc.expectPod.CreationTimestamp
+			if !reflect.DeepEqual(pod, tc.expectPod) {
+				t.Errorf("For test case %q with multi-subnet cluster enabled, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
 			}
 		})
 	}

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -587,9 +587,6 @@ func generatePod(namespace, name string, hasNegReadinessGate, hasNegCondition, n
 		Spec: v1.PodSpec{
 			NodeName: "instance1",
 		},
-		Spec: v1.PodSpec{
-			NodeName: "instance1",
-		},
 	}
 	if hasNegReadinessGate {
 		ret.Spec.ReadinessGates = []v1.PodReadinessGate{{ConditionType: shared.NegReadinessGate}}

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -579,6 +580,12 @@ func generatePod(namespace, name string, hasNegReadinessGate, hasNegCondition, n
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
+			Labels: map[string]string{
+				utils.LabelNodeSubnet: defaultTestSubnet,
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "instance1",
 		},
 	}
 	if hasNegReadinessGate {

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -587,6 +587,9 @@ func generatePod(namespace, name string, hasNegReadinessGate, hasNegCondition, n
 		Spec: v1.PodSpec{
 			NodeName: "instance1",
 		},
+		Spec: v1.PodSpec{
+			NodeName: "instance1",
+		},
 	}
 	if hasNegReadinessGate {
 		ret.Spec.ReadinessGates = []v1.PodReadinessGate{{ConditionType: shared.NegReadinessGate}}

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -42,7 +42,7 @@ import (
 func TestLocalGetEndpointSet(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default"}
 
@@ -172,7 +172,7 @@ func nodeInterfacesAnnotation(t *testing.T, network, ip string) string {
 func TestClusterGetEndpointSet(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default"}
 	testCases := []struct {
@@ -324,7 +324,7 @@ func TestValidateEndpoints(t *testing.T) {
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
 	nodeLister := testContext.NodeInformer.GetIndexer()

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1532,7 +1532,7 @@ func TestIsZoneChange(t *testing.T) {
 func TestUnknownNodes(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
 	testSubnetwork := cloud.ResourcePath("subnetwork", &meta.Key{Name: "test-subnetwork"})
 	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
@@ -1629,7 +1629,7 @@ func TestEnableDegradedMode(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	negtypes.MockNetworkEndpointAPIs(fakeGCE)
 	fakeCloud := negtypes.NewAdapter(fakeGCE)
@@ -2262,7 +2262,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 	reflector := &readiness.NoopReflector{}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 
 	negsyncer := NewTransactionSyncer(svcPort,
 		record.NewFakeRecorder(100),

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1723,7 +1723,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer)
-	fakeZoneGetter := zonegetter.NewZoneGetter(testContext.NodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, false)
 
 	// Add the pod that corresponds to empty zone instance.
 	podLister.Add(&v1.Pod{

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1723,7 +1723,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewZoneGetter(testContext.NodeInformer, defaultTestSubnetURL)
 
 	// Add the pod that corresponds to empty zone instance.
 	podLister.Add(&v1.Pod{

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -746,365 +746,6 @@ func TestIpsForPod(t *testing.T) {
 	}
 }
 
-// TestValidateEndpointFields validates if toZoneNetworkEndpointMap
-// returns correct type of error with invalid endpoint information
-func TestValidateEndpointFields(t *testing.T) {
-	t.Parallel()
-	nodeInformer := zonegetter.FakeNodeInformer()
-	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
-	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
-	addPodsToLister(podLister, getDefaultEndpointSlices())
-
-	instance1 := negtypes.TestInstance1
-	instance3 := negtypes.TestInstance3
-	instanceNotExist := "non-existent-node"
-	emptyZoneInstance := "empty-zone-instance"
-	zonegetter.AddFakeNodes(zoneGetter, "", emptyZoneInstance)
-
-	emptyNamedPort := ""
-	emptyNodeName := ""
-	port80 := int32(80)
-	protocolTCP := v1.ProtocolTCP
-
-	testCases := []struct {
-		desc              string
-		testEndpointSlice []*discovery.EndpointSlice
-		expectSets        map[string]negtypes.NetworkEndpointSet
-		expectMap         negtypes.EndpointPodMap
-		expectErr         error
-	}{
-		{
-			desc: "endpoints no missing or invalid fields",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &instance1,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod1",
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
-					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
-					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
-			},
-			expectMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
-				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
-			},
-			expectErr: nil,
-		},
-		{
-			desc: "include one endpoint that has missing nodeName",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  nil, // endpoint with missing nodeName
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod1",
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: nil,
-			expectMap:  nil,
-			expectErr:  negtypes.ErrEPNodeMissing,
-		},
-		{
-			desc: "include one endpoint that has empty nodeName",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &emptyNodeName,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod1",
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: nil,
-			expectMap:  nil,
-			expectErr:  negtypes.ErrEPNodeMissing,
-		},
-		{
-			desc: "include one endpoint that has missing pod",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &instance1,
-							TargetRef: nil,
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
-					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
-			},
-			expectMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
-			},
-			expectErr: nil,
-		},
-		{
-			desc: "include one endpoint that does not correspond to an existing pod",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &instance1,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "foo", // this is a non-existing pod
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
-					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
-			},
-			expectMap: negtypes.EndpointPodMap{
-				networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80"): types.NamespacedName{Namespace: testServiceNamespace, Name: "pod4"},
-			},
-			expectErr: nil,
-		},
-		{
-			desc: "include one endpoint that does not correspond to an existing node",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &instanceNotExist,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod1",
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: nil,
-			expectMap:  nil,
-			expectErr:  negtypes.ErrEPNodeNotFound,
-		},
-		{
-			desc: "include one endpoint that corresponds to an empty zone",
-			testEndpointSlice: []*discovery.EndpointSlice{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
-						Namespace: testServiceNamespace,
-						Labels: map[string]string{
-							discovery.LabelServiceName: testServiceName,
-						},
-					},
-					AddressType: "IPv4",
-					Endpoints: []discovery.Endpoint{
-						{
-							Addresses: []string{"10.100.1.1"},
-							NodeName:  &emptyZoneInstance,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod1",
-							},
-						},
-						{
-							Addresses: []string{"10.100.3.1"},
-							NodeName:  &instance3,
-							TargetRef: &v1.ObjectReference{
-								Namespace: testServiceNamespace,
-								Name:      "pod4",
-							},
-						},
-					},
-					Ports: []discovery.EndpointPort{
-						{
-							Name:     &emptyNamedPort,
-							Port:     &port80,
-							Protocol: &protocolTCP,
-						},
-					},
-				},
-			},
-			expectSets: nil,
-			expectMap:  nil,
-			expectErr:  negtypes.ErrEPZoneMissing,
-		},
-	}
-	for _, tc := range testCases {
-		result, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlice), zoneGetter, podLister, "", negtypes.VmIpPortEndpointType, false, klog.TODO())
-		if !errors.Is(err, tc.expectErr) {
-			t.Errorf("For case %q, expect %v error, but got %v.", tc.desc, tc.expectErr, err)
-		}
-		if !reflect.DeepEqual(result.NetworkEndpointSet, tc.expectSets) {
-			t.Errorf("For case %q, expecting endpoint set %v, but got %v.", tc.desc, tc.expectSets, result.NetworkEndpointSet)
-		}
-		if !reflect.DeepEqual(result.EndpointPodMap, tc.expectMap) {
-			t.Errorf("For case %q, expecting endpoint map %v, but got %v.", tc.desc, tc.expectMap, result.EndpointPodMap)
-		}
-	}
-}
-
 func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
@@ -2060,7 +1701,10 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 	}
 }
 
-func TestDegradedModeValidateEndpointInfo(t *testing.T) {
+// TestValidateEndpointFields validates if toZoneNetworkEndpointMap
+// and toZoneNetworkEndpointMapDegradedMode return the correct endpoints and
+// correct type of error with the supplied invalid endpoint information.
+func TestValidateEndpointFields(t *testing.T) {
 	t.Parallel()
 	emptyNamedPort := ""
 	emptyNodeName := ""
@@ -2070,48 +1714,36 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 	instance2 := negtypes.TestInstance2
 	instance3 := negtypes.TestInstance3
 	instance4 := negtypes.TestInstance4
-	nodeInformer := zonegetter.FakeNodeInformer()
-	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	emptyZoneInstance := negtypes.TestEmptyZoneInstance
+	emptyZonePod := "empty-zone-pod" // This should map to emptyZoneInstance.
+	notExistInstance := negtypes.TestNotExistInstance
+
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
 	addPodsToLister(podLister, getDefaultEndpointSlices())
-
 	nodeLister := testContext.NodeInformer.GetIndexer()
-	nodeLister.Add(&v1.Node{
+	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer)
+	fakeZoneGetter := zonegetter.NewZoneGetter(testContext.NodeInformer, defaultTestSubnetURL)
+
+	// Add the pod that corresponds to empty zone instance.
+	podLister.Add(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: instance1,
+			Namespace: testServiceNamespace,
+			Name:      emptyZonePod,
+			Labels: map[string]string{
+				discovery.LabelServiceName: testServiceName,
+				discovery.LabelManagedBy:   managedByEPSControllerValue,
+			},
 		},
-		Spec: v1.NodeSpec{
-			PodCIDR:  "10.100.1.0/24",
-			PodCIDRs: []string{"a:b::/48", "10.100.1.0/24"},
+		Spec: v1.PodSpec{
+			NodeName: emptyZoneInstance,
 		},
-	})
-	nodeLister.Add(&v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: instance2,
-		},
-		Spec: v1.NodeSpec{
-			PodCIDR:  "10.100.2.0/24",
-			PodCIDRs: []string{"a:b::/48", "10.100.2.0/24"},
-		},
-	})
-	nodeLister.Add(&v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: instance3,
-		},
-		Spec: v1.NodeSpec{
-			PodCIDR:  "10.100.3.0/24",
-			PodCIDRs: []string{"a:b::/48", "10.100.3.0/24"},
-		},
-	})
-	nodeLister.Add(&v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: instance4,
-		},
-		Spec: v1.NodeSpec{
-			PodCIDR:  "10.100.4.0/24",
-			PodCIDRs: []string{"a:b::/48", "10.100.4.0/24"},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			PodIP: "10.100.5.1",
+			PodIPs: []v1.PodIP{
+				{IP: "10.100.5.1"},
+			},
 		},
 	})
 
@@ -2129,6 +1761,7 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 		},
 	})
 
+	// endpointMap and podMap contain all correct endpoints.
 	endpointMap := map[string]negtypes.NetworkEndpointSet{
 		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
@@ -2140,19 +1773,83 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 		negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
 	}
 
+	// endpointMapExcluded and podMapExcluded only includes valid endpoints.
+	// In normal mode, we exclude the specific endpoint for cases where an endpoint's pod information is invalid, including:
+	//	1. endpoint has an empty targetRef
+	//  2. endpoint's corresponding pod does not exist
+	//  3. endpoint corresponds to an object that fails pod type assertion
+	//
+	// In degraded mode, we should exclude the invalid endpoint for non-coverable cases(pod invalid or empty zone).
+	// We always inject to first endpoint, so the result only contain the second endpoint.
+	endpointMapExcluded := map[string]negtypes.NetworkEndpointSet{
+		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
+		),
+	}
+	podMapExcluded := negtypes.EndpointPodMap{
+		negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+	}
+
 	testCases := []struct {
-		desc                string
-		testEndpointSlices  []*discovery.EndpointSlice
-		endpointType        negtypes.NetworkEndpointType
-		expectedEndpointMap map[string]negtypes.NetworkEndpointSet
-		expectedPodMap      negtypes.EndpointPodMap
+		desc                            string
+		testEndpointSlices              []*discovery.EndpointSlice
+		expectedEndpointMap             map[string]negtypes.NetworkEndpointSet
+		expectedPodMap                  negtypes.EndpointPodMap
+		expectErr                       error
+		expectedEndpointMapDegradedMode map[string]negtypes.NetworkEndpointSet
+		expectedPodMapDegradedMode      negtypes.EndpointPodMap
 	}{
 		{
-			desc: "contains one endpoint without nodeName, nodeName should be filled",
+			desc: "endpoints with no errors, both calculations should have all endpoints",
 			testEndpointSlices: []*discovery.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
+						Name:      testServiceName,
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.1.2"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod2",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectedEndpointMap:             endpointMap,
+			expectedPodMap:                  podMap,
+			expectErr:                       nil,
+			expectedEndpointMapDegradedMode: endpointMap,
+			expectedPodMapDegradedMode:      podMap,
+		},
+		{
+			desc: "include one endpoint that has missing nodeName, error will be raised in normal mode, nodeName should be filled in degraded mode",
+			testEndpointSlices: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName,
 						Namespace: testServiceNamespace,
 						Labels: map[string]string{
 							discovery.LabelServiceName: testServiceName,
@@ -2187,16 +1884,18 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 					},
 				},
 			},
-			endpointType:        negtypes.VmIpPortEndpointType,
-			expectedEndpointMap: endpointMap,
-			expectedPodMap:      podMap,
+			expectedEndpointMap:             nil,
+			expectedPodMap:                  nil,
+			expectErr:                       negtypes.ErrEPNodeMissing,
+			expectedEndpointMapDegradedMode: endpointMap,
+			expectedPodMapDegradedMode:      podMap,
 		},
 		{
-			desc: "contains one endpoint with empty nodeName, nodeName should be filled",
+			desc: "include one endpoint that has empty nodeName, error will be raised in normal mode, nodeName should be filled in degraded mode",
 			testEndpointSlices: []*discovery.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
+						Name:      testServiceName,
 						Namespace: testServiceNamespace,
 						Labels: map[string]string{
 							discovery.LabelServiceName: testServiceName,
@@ -2231,16 +1930,198 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 					},
 				},
 			},
-			endpointType:        negtypes.VmIpPortEndpointType,
-			expectedEndpointMap: endpointMap,
-			expectedPodMap:      podMap,
+			expectedEndpointMap:             nil,
+			expectedPodMap:                  nil,
+			expectErr:                       negtypes.ErrEPNodeMissing,
+			expectedEndpointMapDegradedMode: endpointMap,
+			expectedPodMapDegradedMode:      podMap,
 		},
 		{
-			desc: "single stack ipv4 endpoints, contains one endpoint with IPv4 address not matching to its pod, endpoint should be removed",
+			desc: "include one endpoint that has missing pod, endpoint should be excluded in both calculations",
 			testEndpointSlices: []*discovery.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-1",
+						Name:      testServiceName,
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: nil,
+						},
+						{
+							Addresses: []string{"10.100.1.2"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod2",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectedEndpointMap:             endpointMapExcluded,
+			expectedPodMap:                  podMapExcluded,
+			expectErr:                       nil,
+			expectedEndpointMapDegradedMode: endpointMapExcluded,
+			expectedPodMapDegradedMode:      podMapExcluded,
+		},
+		{
+			desc: "include one endpoint that does not correspond to an existing pod, endpoint should be excluded in both calculations",
+			testEndpointSlices: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName,
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "foo", // this is a non-existing pod
+							},
+						},
+						{
+							Addresses: []string{"10.100.1.2"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod2",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectedEndpointMap:             endpointMapExcluded,
+			expectedPodMap:                  podMapExcluded,
+			expectErr:                       nil,
+			expectedEndpointMapDegradedMode: endpointMapExcluded,
+			expectedPodMapDegradedMode:      podMapExcluded,
+		},
+		{
+			desc: "include one endpoint that does not correspond to an existing node, error will be raised in normal mode, instance name will be deduced from pod and corrected in degraded mode",
+			testEndpointSlices: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName,
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &notExistInstance,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod1",
+							},
+						},
+						{
+							Addresses: []string{"10.100.1.2"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod2",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectedEndpointMap:             nil,
+			expectedPodMap:                  nil,
+			expectErr:                       negtypes.ErrEPNodeNotFound,
+			expectedEndpointMapDegradedMode: endpointMap,
+			expectedPodMapDegradedMode:      podMap,
+		},
+		{
+			desc: "include one endpoint that corresponds to an empty zone, error will be raised in normal mode, endpoint should be excluded in degraded mode",
+			testEndpointSlices: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName,
+						Namespace: testServiceNamespace,
+						Labels: map[string]string{
+							discovery.LabelServiceName: testServiceName,
+						},
+					},
+					AddressType: "IPv4",
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.100.1.1"},
+							NodeName:  &emptyZoneInstance,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      emptyZonePod,
+							},
+						},
+						{
+							Addresses: []string{"10.100.1.2"},
+							NodeName:  &instance1,
+							TargetRef: &v1.ObjectReference{
+								Namespace: testServiceNamespace,
+								Name:      "pod2",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     &emptyNamedPort,
+							Port:     &port80,
+							Protocol: &protocolTCP,
+						},
+					},
+				},
+			},
+			expectedEndpointMap:             nil,
+			expectedPodMap:                  nil,
+			expectErr:                       negtypes.ErrEPZoneMissing,
+			expectedEndpointMapDegradedMode: endpointMapExcluded,
+			expectedPodMapDegradedMode:      podMapExcluded,
+		},
+		{
+			// Endpoint IP and pod IP check is only performed during degraded
+			// mode, so in normal calculation, endpoints with not matching will
+			// be included.
+			desc: "single stack ipv4 endpoints, contains one endpoint with IPv4 address not matching to its pod, normal mode will include the invalid endpoint, endpoint should be removed in degraded mode",
+			testEndpointSlices: []*discovery.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testServiceName,
 						Namespace: testServiceNamespace,
 						Labels: map[string]string{
 							discovery.LabelServiceName: testServiceName,
@@ -2283,16 +2164,31 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 					},
 				},
 			},
-			endpointType:        negtypes.VmIpPortEndpointType,
-			expectedEndpointMap: endpointMap,
-			expectedPodMap:      podMap,
+			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
+					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
+					negtypes.NetworkEndpoint{IP: "10.100.2.2", Node: instance2, Port: "80"},
+				),
+			},
+			expectedPodMap: negtypes.EndpointPodMap{
+				negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod1"},
+				negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod2"},
+				negtypes.NetworkEndpoint{IP: "10.100.2.2", Node: instance2, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod3"},
+			},
+			expectErr:                       nil,
+			expectedEndpointMapDegradedMode: endpointMap,
+			expectedPodMapDegradedMode:      podMap,
 		},
 		{
-			desc: "dual stack endpoints, contains one endpoint with IPv6 address not matching to its pod, endpoint should be removed",
+			// Endpoint IP and pod IP check is only performed during degraded
+			// mode, so in normal calculation, endpoints with not matching will
+			// be included.
+			desc: "dual stack endpoints, contains one endpoint with IPv6 address not matching to its pod, normal mode will include the invalid endpoint, endpoint should be removed in degraded mode",
 			testEndpointSlices: []*discovery.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-3",
+						Name:      testServiceName,
 						Namespace: testServiceNamespace,
 						Labels: map[string]string{
 							discovery.LabelServiceName: testServiceName,
@@ -2335,7 +2231,7 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      testServiceName + "-4",
+						Name:      testServiceName,
 						Namespace: testServiceNamespace,
 						Labels: map[string]string{
 							discovery.LabelServiceName: testServiceName,
@@ -2377,14 +2273,26 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 					},
 				},
 			},
-			endpointType: negtypes.VmIpPortEndpointType,
 			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
+				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
+					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
+					negtypes.NetworkEndpoint{IP: "10.100.4.4", IPv6: "a:b::4", Node: instance4, Port: "80"},
+				),
+			},
+			expectedPodMap: negtypes.EndpointPodMap{
+				negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod10"},
+				negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod11"},
+				negtypes.NetworkEndpoint{IP: "10.100.4.4", IPv6: "a:b::4", Node: instance4, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod12"},
+			},
+			expectErr: nil,
+			expectedEndpointMapDegradedMode: map[string]negtypes.NetworkEndpointSet{
 				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
 				),
 			},
-			expectedPodMap: negtypes.EndpointPodMap{
+			expectedPodMapDegradedMode: negtypes.EndpointPodMap{
 				negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod10"},
 				negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"}: types.NamespacedName{Namespace: testServiceNamespace, Name: "pod11"},
 			},
@@ -2392,12 +2300,23 @@ func TestDegradedModeValidateEndpointInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, emptyNamedPort, tc.endpointType, true, klog.TODO())
+			result, err := toZoneNetworkEndpointMap(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, emptyNamedPort, negtypes.VmIpPortEndpointType, true, klog.TODO())
+			if !errors.Is(err, tc.expectErr) {
+				t.Errorf("normal mode calculation got error %v, expected %v", err, tc.expectErr)
+			}
 			if !reflect.DeepEqual(result.NetworkEndpointSet, tc.expectedEndpointMap) {
-				t.Errorf("degraded mode endpoint set is not calculated correctly:\ngot %+v,\n expected %+v", result.NetworkEndpointSet, tc.expectedEndpointMap)
+				t.Errorf("normal mode endpoint set is not calculated correctly:\ngot %+v,\n expected %+v", result.NetworkEndpointSet, tc.expectedEndpointMapDegradedMode)
 			}
 			if !reflect.DeepEqual(result.EndpointPodMap, tc.expectedPodMap) {
-				t.Errorf("degraded mode endpoint map is not calculated correctly:\ngot %+v,\n expected %+v", result.EndpointPodMap, tc.expectedPodMap)
+				t.Errorf("normal mode endpoint map is not calculated correctly:\ngot %+v,\n expected %+v", result.EndpointPodMap, tc.expectedPodMapDegradedMode)
+			}
+
+			resultDegradedMode := toZoneNetworkEndpointMapDegradedMode(negtypes.EndpointsDataFromEndpointSlices(tc.testEndpointSlices), fakeZoneGetter, podLister, nodeLister, serviceLister, emptyNamedPort, negtypes.VmIpPortEndpointType, true, klog.TODO())
+			if !reflect.DeepEqual(resultDegradedMode.NetworkEndpointSet, tc.expectedEndpointMapDegradedMode) {
+				t.Errorf("degraded mode endpoint set is not calculated correctly:\ngot %+v,\n expected %+v", resultDegradedMode.NetworkEndpointSet, tc.expectedEndpointMapDegradedMode)
+			}
+			if !reflect.DeepEqual(resultDegradedMode.EndpointPodMap, tc.expectedPodMapDegradedMode) {
+				t.Errorf("degraded mode endpoint map is not calculated correctly:\ngot %+v,\n expected %+v", resultDegradedMode.EndpointPodMap, tc.expectedPodMapDegradedMode)
 			}
 		})
 	}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -495,7 +495,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
 	testEndpointSlice := getDefaultEndpointSlices()
 	addPodsToLister(podLister, testEndpointSlice)
@@ -749,7 +749,7 @@ func TestIpsForPod(t *testing.T) {
 func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	negCloud := negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	negName := "test-neg-name"
 	irrelevantNegName := "irrelevant"
@@ -1565,7 +1565,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer)
-	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
 	addPodsToLister(podLister, getDefaultEndpointSlices())
@@ -1723,7 +1723,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer)
-	fakeZoneGetter := zonegetter.NewZoneGetter(testContext.NodeInformer, defaultTestSubnetURL)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, false)
 
 	// Add the pod that corresponds to empty zone instance.
 	podLister.Add(&v1.Pod{

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -29,20 +29,22 @@ import (
 )
 
 const (
-	TestZone1            = "zone1"
-	TestZone2            = "zone2"
-	TestZone3            = "zone3"
-	TestZone4            = "zone4"
-	TestInstance1        = "instance1"
-	TestInstance2        = "instance2"
-	TestInstance3        = "instance3"
-	TestInstance4        = "instance4"
-	TestInstance5        = "instance5"
-	TestInstance6        = "instance6"
-	TestUnreadyInstance1 = "unready-instance1"
-	TestUnreadyInstance2 = "unready-instance2"
-	TestUpgradeInstance1 = "upgrade-instance1"
-	TestUpgradeInstance2 = "upgrade-instance2"
+	TestZone1             = "zone1"
+	TestZone2             = "zone2"
+	TestZone3             = "zone3"
+	TestZone4             = "zone4"
+	TestInstance1         = "instance1"
+	TestInstance2         = "instance2"
+	TestInstance3         = "instance3"
+	TestInstance4         = "instance4"
+	TestInstance5         = "instance5"
+	TestInstance6         = "instance6"
+	TestUnreadyInstance1  = "unready-instance1"
+	TestUnreadyInstance2  = "unready-instance2"
+	TestUpgradeInstance1  = "upgrade-instance1"
+	TestUpgradeInstance2  = "upgrade-instance2"
+	TestEmptyZoneInstance = "instance-empty-providerID" // This maps to an empty instance in PopulateFakeNodeInformer
+	TestNotExistInstance  = "not-exist-instance"
 )
 
 type FakeNetworkEndpointGroupCloud struct {

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -45,11 +45,6 @@ const (
 	TestUpgradeInstance2  = "upgrade-instance2"
 	TestEmptyZoneInstance = "instance-empty-providerID" // This maps to an empty instance in PopulateFakeNodeInformer
 	TestNotExistInstance  = "not-exist-instance"
-
-	TestNoPodCIDRInstance        = "no-podcidr-instance"
-	TestNoPodCIDRPod             = "no-podcidr-pod"
-	TestNonDefaultSubnetInstance = "non-default-subnet-instance"
-	TestNonDefaultSubnetPod      = "non-default-subnet-pod"
 )
 
 type FakeNetworkEndpointGroupCloud struct {

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -45,6 +45,11 @@ const (
 	TestUpgradeInstance2  = "upgrade-instance2"
 	TestEmptyZoneInstance = "instance-empty-providerID" // This maps to an empty instance in PopulateFakeNodeInformer
 	TestNotExistInstance  = "not-exist-instance"
+
+	TestNoPodCIDRInstance        = "no-podcidr-instance"
+	TestNoPodCIDRPod             = "no-podcidr-pod"
+	TestNonDefaultSubnetInstance = "non-default-subnet-instance"
+	TestNonDefaultSubnetPod      = "non-default-subnet-pod"
 )
 
 type FakeNetworkEndpointGroupCloud struct {

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -754,7 +754,7 @@ func TestNodePredicateForEndpointCalculatorMode(t *testing.T) {
 			predicate := NodeFilterForEndpointCalculatorMode(tc.epCalculatorMode)
 			nodeInformer := zonegetter.FakeNodeInformer()
 			zonegetter.PopulateFakeNodeInformer(nodeInformer)
-			zoneGetter := zonegetter.NewZoneGetter(nodeInformer, defaultTestSubnetURL)
+			zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
 			zones, err := zoneGetter.ListZones(predicate, klog.TODO())
 			if err != nil {
 				t.Errorf("Failed listing zones with predicate, err - %v", err)

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -78,9 +78,10 @@ func PatchServiceObjectMetadata(client coreclient.CoreV1Interface, svc *corev1.S
 
 // PatchServiceLoadBalancerStatus patches the given service's LoadBalancerStatus
 // based on new service's load-balancer status.
-func PatchServiceLoadBalancerStatus(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus) error {
+func PatchServiceLoadBalancerInformation(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus, newObjectMetadata metav1.ObjectMeta) error {
 	newSvc := svc.DeepCopy()
 	newSvc.Status.LoadBalancer = newStatus
+	newSvc.ObjectMeta = newObjectMetadata
 	_, err := svchelpers.PatchService(client, svc, newSvc)
 	return err
 }

--- a/pkg/utils/patch/patch_test.go
+++ b/pkg/utils/patch/patch_test.go
@@ -234,7 +234,7 @@ func TestPatchServiceLoadBalancerStatus(t *testing.T) {
 				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
 			}
 			expectSvc := tc.newMetaFunc(tc.svc)
-			err := PatchServiceLoadBalancerStatus(coreClient, tc.svc, expectSvc.Status.LoadBalancer)
+			err := PatchServiceLoadBalancerInformation(coreClient, tc.svc, expectSvc.Status.LoadBalancer, expectSvc.ObjectMeta)
 			if err != nil {
 				t.Fatalf("PatchServiceLoadBalancerStatus(%s) = %v, want nil", svcKey, err)
 			}

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -33,8 +33,7 @@ import (
 func TestListZones(t *testing.T) {
 	t.Parallel()
 	fakeNodeInformer := FakeNodeInformer()
-	zoneGetter := NewZoneGetter(fakeNodeInformer, defaultTestSubnetURL)
-	zoneGetter.onlyIncludeDefaultSubnetNodes = true
+	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, defaultTestSubnetURL, true)
 	zoneGetter.nodeLister.Add(&apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ReadyNodeWithProviderID",
@@ -281,8 +280,7 @@ func TestListZones(t *testing.T) {
 func TestListNodes(t *testing.T) {
 	t.Parallel()
 	fakeNodeInformer := FakeNodeInformer()
-	zoneGetter := NewZoneGetter(fakeNodeInformer, defaultTestSubnetURL)
-	zoneGetter.onlyIncludeDefaultSubnetNodes = true
+	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, defaultTestSubnetURL, true)
 	zoneGetter.nodeLister.Add(&apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ReadyNodeWithProviderID",
@@ -524,8 +522,7 @@ func TestListNodes(t *testing.T) {
 func TestZoneForNode(t *testing.T) {
 	t.Parallel()
 	fakeNodeInformer := FakeNodeInformer()
-	zoneGetter := NewZoneGetter(fakeNodeInformer, defaultTestSubnetURL)
-	zoneGetter.onlyIncludeDefaultSubnetNodes = true
+	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, defaultTestSubnetURL, true)
 	zoneGetter.nodeLister.Add(&apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "NodeWithValidProviderID",
@@ -791,8 +788,7 @@ func TestNonGCPZoneGetter(t *testing.T) {
 
 func TestIsNodeSelectedByFilter(t *testing.T) {
 	fakeNodeInformer := FakeNodeInformer()
-	zoneGetter := NewZoneGetter(fakeNodeInformer, defaultTestSubnetURL)
-	zoneGetter.onlyIncludeDefaultSubnetNodes = true
+	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, defaultTestSubnetURL, true)
 
 	testCases := []struct {
 		node                    apiv1.Node


### PR DESCRIPTION
In L4 Load Balancer controllers after successful sync we do 2 things:
1. updating the Service Status
2. updating the Service Annotations

Both of those were triggering separate API call, to just patch a service. 

Now, we are updating both Service Status and Annotations in a single API call