### PR TITLE
NEG controller part - L4 RBS External LB NEG support

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -573,6 +573,7 @@ func createNEGController(ctx *ingctx.ControllerContext, stopCh <-chan struct{}, 
 		lpConfig,
 		flags.F.EnableMultiNetworking,
 		ctx.EnableIngressRegionalExternal,
+		flags.F.EnableL4NetLBNEG,
 		stopCh,
 		logger,
 	)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -116,6 +116,8 @@ var (
 		EnableL4NetLBDualStack                   bool
 		EnableNEGController                      bool
 		EnableL4NEG                              bool
+		EnableL4NetLBNEG                         bool
+		EnableL4NetLBNEGDefault                  bool
 		GateNEGByLock                            bool
 		EnableMultipleIGs                        bool
 		EnableL4StrongSessionAffinity            bool
@@ -281,6 +283,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
 	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
+	flag.BoolVar(&F.EnableL4NetLBNEG, "enable-l4-netlb-neg", false, `Optional, if enabled then the NetLB controller can create L4 NetLB services with NEG backends.`)
+	flag.BoolVar(&F.EnableL4NetLBNEGDefault, "enable-l4-netlb-neg-default", false, `Optional, if enabled then newly created L4 NetLB services will use NEG backends. Has effect only if '--enable-l4-netlb-neg' is set to true.`)
 	flag.BoolVar(&F.GateNEGByLock, "gate-neg-by-lock", false, "If enabled then the NEG controller will be run via leader election with NEG resource lock")
 	flag.BoolVar(&F.EnableIGController, "enable-ig-controller", true, `Optional, if enabled then the IG controller will be run.`)
 	flag.BoolVar(&F.EnablePSC, "enable-psc", false, "Enable PSC controller")

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -237,6 +237,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				manager.enableDualStackNEG,
 				manager.syncerMetrics,
 				&portInfo.NetworkInfo,
+				portInfo.L4LBType,
 			)
 			syncer = negsyncer.NewTransactionSyncer(
 				syncerKey,
@@ -911,6 +912,7 @@ func (manager *syncerManager) getSyncerKey(namespace, name string, servicePortKe
 		PortTuple:        portInfo.PortTuple,
 		NegType:          networkEndpointType,
 		EpCalculatorMode: calculatorMode,
+		L4LBType:         portInfo.L4LBType,
 	}
 }
 

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -84,7 +84,7 @@ const (
 	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
 )
 
-func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce.Cloud) {
+func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce.Cloud, *negtypes.TestContext) {
 	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
@@ -108,13 +108,13 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 		labels.PodLabelPropagationConfig{},
 		klog.TODO(),
 	)
-	return manager, testContext.Cloud
+	return manager, testContext.Cloud, testContext
 }
 
 func TestEnsureAndStopSyncer(t *testing.T) {
 	t.Parallel()
 
-	manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+	manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 	namer := manager.namer
 
 	svcName := "n1"
@@ -336,7 +336,7 @@ func TestEnsureAndStopSyncer(t *testing.T) {
 func TestGarbageCollectionSyncer(t *testing.T) {
 	t.Parallel()
 
-	manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+	manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 	namer := manager.namer
 	namespace := testServiceNamespace
 	name := testServiceName
@@ -386,7 +386,7 @@ func TestGarbageCollectionNEG(t *testing.T) {
 	if _, err := kubeClient.CoreV1().Endpoints(testServiceNamespace).Create(context2.TODO(), getDefaultEndpoint(), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create endpoint: %v", err)
 	}
-	manager, _ := NewTestSyncerManager(kubeClient)
+	manager, _, _ := NewTestSyncerManager(kubeClient)
 	svcPort := int32(80)
 	ports := make(types.PortInfoMap)
 	manager.serviceLister.Add(&v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: testServiceNamespace, Name: testServiceName}})
@@ -442,7 +442,7 @@ func TestReadinessGateEnabledNegs(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := fake.NewSimpleClientset()
-	manager, _ := NewTestSyncerManager(kubeClient)
+	manager, _, _ := NewTestSyncerManager(kubeClient)
 	populateSyncerManager(manager, kubeClient)
 
 	testCases := []struct {
@@ -526,7 +526,7 @@ func TestReadinessGateEnabled(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := fake.NewSimpleClientset()
-	manager, _ := NewTestSyncerManager(kubeClient)
+	manager, _, _ := NewTestSyncerManager(kubeClient)
 	populateSyncerManager(manager, kubeClient)
 
 	testCases := []struct {
@@ -659,7 +659,7 @@ func TestFilterCommonPorts(t *testing.T) {
 	t.Parallel()
 	namer := namer_util.NewNamer(ClusterID, "", klog.TODO())
 	kubeClient := fake.NewSimpleClientset()
-	manager, _ := NewTestSyncerManager(kubeClient)
+	manager, _, _ := NewTestSyncerManager(kubeClient)
 
 	for _, tc := range []struct {
 		desc     string
@@ -728,7 +728,7 @@ func TestFilterCommonPorts(t *testing.T) {
 
 func TestNegCRCreations(t *testing.T) {
 	t.Parallel()
-	manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+	manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 	svcNegClient := manager.svcNegClient
 	namer := manager.namer
 
@@ -950,7 +950,7 @@ func TestNegCRDuplicateCreations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+			manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 			svcNegClient := manager.svcNegClient
 
 			namer := manager.namer
@@ -1075,7 +1075,7 @@ func TestNegCRDeletions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+			manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 			svcNegClient := manager.svcNegClient
 
 			if err := manager.serviceLister.Add(svc); err != nil {
@@ -1339,7 +1339,7 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 				for _, networkEndpointType := range []negtypes.NetworkEndpointType{negtypes.VmIpPortEndpointType, negtypes.NonGCPPrivateEndpointType, negtypes.VmIpEndpointType} {
 
 					kubeClient := fake.NewSimpleClientset()
-					manager, testCloud := NewTestSyncerManager(kubeClient)
+					manager, testCloud, _ := NewTestSyncerManager(kubeClient)
 					svcNegClient := manager.svcNegClient
 
 					if tc.negCrGCError != nil {
@@ -1531,7 +1531,7 @@ func TestSyncNodesConditions(t *testing.T) {
 				return false
 			}
 
-			manager, _ := NewTestSyncerManager(fake.NewSimpleClientset())
+			manager, _, _ := NewTestSyncerManager(fake.NewSimpleClientset())
 
 			syncer := &fakeSyncer{
 				isStopped: tc.syncerStopped,
@@ -1567,6 +1567,142 @@ func TestSyncNodesConditions(t *testing.T) {
 				if syncCalled {
 					t.Errorf("no zone change, sync should not have been called again")
 				}
+			}
+		})
+	}
+}
+
+func TestL4SyncerUpdates(t *testing.T) {
+	t.Parallel()
+
+	type trafficPolicy bool
+	const local trafficPolicy = true
+	const cluster trafficPolicy = false
+
+	// L4 services always use this empty key
+	vmIpPortInfoMapKey := negtypes.PortInfoMapKey{}
+
+	testCases := []struct {
+		desc              string
+		fromLBType        negtypes.L4LBType
+		fromTrafficPolicy trafficPolicy
+		toLBType          negtypes.L4LBType
+		toTrafficPolicy   trafficPolicy
+		expectNewSyncer   bool
+	}{
+		{
+			desc:              "ILB cluster to ILB cluster",
+			fromLBType:        negtypes.L4InternalLB,
+			fromTrafficPolicy: cluster,
+			toLBType:          negtypes.L4InternalLB,
+			toTrafficPolicy:   cluster,
+			expectNewSyncer:   false,
+		},
+		{
+			desc:              "NetLB cluster to NetLB cluster",
+			fromLBType:        negtypes.L4ExternalLB,
+			fromTrafficPolicy: cluster,
+			toLBType:          negtypes.L4ExternalLB,
+			toTrafficPolicy:   cluster,
+			expectNewSyncer:   false,
+		},
+		{
+			desc:              "NetLB local to NetLB cluster",
+			fromLBType:        negtypes.L4ExternalLB,
+			fromTrafficPolicy: local,
+			toLBType:          negtypes.L4ExternalLB,
+			toTrafficPolicy:   cluster,
+			expectNewSyncer:   true,
+		},
+		{
+			desc:              "ILB cluster to ILB local",
+			fromLBType:        negtypes.L4InternalLB,
+			fromTrafficPolicy: cluster,
+			toLBType:          negtypes.L4InternalLB,
+			toTrafficPolicy:   local,
+			expectNewSyncer:   true,
+		},
+		{
+			desc:              "ILB cluster to NetLB cluster",
+			fromLBType:        negtypes.L4InternalLB,
+			fromTrafficPolicy: cluster,
+			toLBType:          negtypes.L4ExternalLB,
+			toTrafficPolicy:   cluster,
+			expectNewSyncer:   true,
+		},
+		{
+			desc:              "NetLB cluster to ILB cluster",
+			fromLBType:        negtypes.L4ExternalLB,
+			fromTrafficPolicy: cluster,
+			toLBType:          negtypes.L4InternalLB,
+			toTrafficPolicy:   cluster,
+			expectNewSyncer:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+
+			manager, _, testContext := NewTestSyncerManager(fake.NewSimpleClientset())
+			defer manager.ShutDown()
+
+			svcNamespace := "ns1"
+			svcName := "svc1"
+			manager.serviceLister.Add(&v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: svcNamespace, Name: svcName}})
+
+			initialPortInfoMap := negtypes.NewPortInfoMapForVMIPNEG(svcNamespace, svcName, testContext.L4Namer, bool(tc.fromTrafficPolicy), defaultNetwork, tc.fromLBType)
+
+			_, _, err := manager.EnsureSyncers(svcNamespace, svcName, initialPortInfoMap)
+			if err != nil {
+				t.Fatalf("manager.EnsureSyncers() err: %v", err)
+			}
+
+			initialSyncer, ok := manager.syncerMap[manager.getSyncerKey(svcNamespace, svcName, vmIpPortInfoMapKey, initialPortInfoMap[vmIpPortInfoMapKey])]
+			if !ok {
+				t.Errorf("initialSyncer for LB type: %s, local: %v, was not created", tc.fromLBType, tc.fromTrafficPolicy)
+			}
+			if initialSyncer.IsStopped() {
+				t.Errorf("initialSyncer for LB type: %s, local: %v, was expected to be running but is is not", tc.fromLBType, tc.fromTrafficPolicy)
+			}
+
+			updatedPortInfoMap := negtypes.NewPortInfoMapForVMIPNEG(svcNamespace, svcName, testContext.L4Namer, bool(tc.toTrafficPolicy), defaultNetwork, tc.toLBType)
+
+			rebuildSvcNegCache(t, manager, manager.svcNegClient, svcNamespace)
+
+			_, _, err = manager.EnsureSyncers(svcNamespace, svcName, updatedPortInfoMap)
+			if err != nil {
+				t.Errorf("manager.EnsureSyncers() err: %v", err)
+			}
+
+			updatedSyncer, ok := manager.syncerMap[manager.getSyncerKey(svcNamespace, svcName, vmIpPortInfoMapKey, updatedPortInfoMap[vmIpPortInfoMapKey])]
+			if !ok {
+				t.Errorf("updatedSyncer for LB type: %s, local: %v, was not created", tc.toLBType, tc.toTrafficPolicy)
+			}
+			if updatedSyncer.IsStopped() {
+				t.Errorf("updatedSyncer for LB type: %s, local: %v, was expected to be running but is is not", tc.toLBType, tc.toTrafficPolicy)
+			}
+			if tc.expectNewSyncer {
+				if !initialSyncer.IsStopped() {
+					t.Errorf("initialSyncer for LB type: %s, local: %v,  should not be running anymore", tc.fromLBType, tc.fromTrafficPolicy)
+				}
+			} else {
+				if initialSyncer != updatedSyncer {
+					t.Errorf("expected that the syncer would not be recreated but it has been")
+				}
+			}
+
+			// Test that when the Ports for service are removed we stop the syncers.
+			emptyPortInfoMap := negtypes.PortInfoMap{}
+			rebuildSvcNegCache(t, manager, manager.svcNegClient, svcNamespace)
+			_, _, err = manager.EnsureSyncers(svcNamespace, svcName, emptyPortInfoMap)
+			if err != nil {
+				t.Errorf("manager.EnsureSyncers() err: %v", err)
+			}
+			if !initialSyncer.IsStopped() {
+				t.Errorf("initialSyncer for LB type: %s, local: %v, should not be running anymore", tc.fromLBType, tc.fromTrafficPolicy)
+			}
+			if !updatedSyncer.IsStopped() {
+				t.Errorf("updatedSyncer for LB type: %s, local: %v, should not be running anymore", tc.toLBType, tc.toTrafficPolicy)
 			}
 		})
 	}

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// TestLocalGetEndpointSet verifies the GetEndpointSet method implemented by the LocalL4ILBEndpointsCalculator.
+// TestLocalGetEndpointSet verifies the GetEndpointSet method implemented by the LocalL4EndpointsCalculator.
 // The L7 implementation is tested in TestToZoneNetworkEndpointMapUtil.
 func TestLocalGetEndpointSet(t *testing.T) {
 	t.Parallel()
@@ -134,7 +134,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	for _, tc := range testCases {
-		ec := NewLocalL4ILBEndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network)
+		ec := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network, negtypes.L4InternalLB)
 		updateNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, tc.nodeReadyStatusMap, nodeInformer.GetIndexer())
 		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 		if err != nil {
@@ -168,7 +168,7 @@ func nodeInterfacesAnnotation(t *testing.T, network, ip string) string {
 	return annotation
 }
 
-// TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4ILBEndpointsCalculator.
+// TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4EndpointsCalculator.
 func TestClusterGetEndpointSet(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
@@ -272,7 +272,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	for _, tc := range testCases {
-		ec := NewClusterL4ILBEndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network)
+		ec := NewClusterL4EndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network, negtypes.L4InternalLB)
 		updateNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, tc.nodeReadyStatusMap, nodeInformer.GetIndexer())
 		retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 		if err != nil {
@@ -352,8 +352,8 @@ func TestValidateEndpoints(t *testing.T) {
 	zoneGetterMSC := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, true)
 	L7EndpointsCalculatorMSC := NewL7EndpointsCalculator(zoneGetterMSC, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics())
 	L7EndpointsCalculatorMSC.enableMultiSubnetCluster = true
-	L4LocalEndpointCalculator := NewLocalL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{})
-	L4ClusterEndpointCalculator := NewClusterL4ILBEndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{})
+	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{}, negtypes.L4InternalLB)
+	L4ClusterEndpointCalculator := NewClusterL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{}, negtypes.L4InternalLB)
 
 	l7TestEPS := []*discovery.EndpointSlice{
 		{

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -34,6 +34,10 @@ const (
 	maxSubsetSizeLocal = 250
 	// Max number of subsets in ExternalTrafficPolicy:Cluster, which is the default mode.
 	maxSubsetSizeDefault = 25
+	// Max number of subsets for NetLB in ExternalTrafficPolicy:Local
+	maxSubsetSizeNetLBLocal = 1000
+	// Max number of subsets for NetLB in ExternalTrafficPolicy:Cluster
+	maxSubsetSizeNetLBCluster = 250
 )
 
 // NodeInfo stores node metadata used to sort nodes and pick a subset.

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -192,15 +192,15 @@ func NewTransactionSyncer(
 	return syncer
 }
 
-func GetEndpointsCalculator(podLister, nodeLister, serviceLister cache.Indexer, zoneGetter *zonegetter.ZoneGetter, syncerKey negtypes.NegSyncerKey, mode negtypes.EndpointsCalculatorMode, logger klog.Logger, enableDualStackNEG bool, syncMetricsCollector *metricscollector.SyncerMetrics, networkInfo *network.NetworkInfo) negtypes.NetworkEndpointsCalculator {
+func GetEndpointsCalculator(podLister, nodeLister, serviceLister cache.Indexer, zoneGetter *zonegetter.ZoneGetter, syncerKey negtypes.NegSyncerKey, mode negtypes.EndpointsCalculatorMode, logger klog.Logger, enableDualStackNEG bool, syncMetricsCollector *metricscollector.SyncerMetrics, networkInfo *network.NetworkInfo, l4LBType negtypes.L4LBType) negtypes.NetworkEndpointsCalculator {
 	serviceKey := strings.Join([]string{syncerKey.Name, syncerKey.Namespace}, "/")
 	if syncerKey.NegType == negtypes.VmIpEndpointType {
 		nodeLister := listers.NewNodeLister(nodeLister)
 		switch mode {
 		case negtypes.L4LocalMode:
-			return NewLocalL4ILBEndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo)
+			return NewLocalL4EndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo, l4LBType)
 		default:
-			return NewClusterL4ILBEndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo)
+			return NewClusterL4EndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo, l4LBType)
 		}
 	}
 	return NewL7EndpointsCalculator(

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -2456,7 +2456,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 		testContext.SvcNegInformer.GetIndexer(),
 		reflector,
 		GetEndpointsCalculator(testContext.PodInformer.GetIndexer(), testContext.NodeInformer.GetIndexer(), testContext.ServiceInformer.GetIndexer(),
-			fakeZoneGetter, svcPort, mode, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics(), &network.NetworkInfo{IsDefault: true}),
+			fakeZoneGetter, svcPort, mode, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics(), &network.NetworkInfo{IsDefault: true}, negtypes.L4InternalLB),
 		string(kubeSystemUID),
 		testContext.SvcNegClient,
 		metricscollector.FakeSyncerMetrics(),

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -724,8 +724,10 @@ func TestEndpointsCalculatorMode(t *testing.T) {
 		portInfoMap PortInfoMap
 		expectMode  EndpointsCalculatorMode
 	}{
-		{"L4 Local Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, true, defaultNetwork), L4LocalMode},
-		{"L4 Cluster Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, false, defaultNetwork), L4ClusterMode},
+		{"L4 ILB Local Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, true, defaultNetwork, L4InternalLB), L4LocalMode},
+		{"L4 ILB Cluster Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, false, defaultNetwork, L4InternalLB), L4ClusterMode},
+		{"L4 NetLB Local Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, true, defaultNetwork, L4ExternalLB), L4LocalMode},
+		{"L4 NetLB Cluster Mode", NewPortInfoMapForVMIPNEG("testns", "testsvc", testContext.L4Namer, false, defaultNetwork, L4ExternalLB), L4ClusterMode},
 		{"L7 Mode", NewPortInfoMap("testns", "testsvc", NewSvcPortTupleSet(SvcPortTuple{Name: "http", Port: 80, TargetPort: "targetPort"}), testContext.NegNamer, false, nil, defaultNetwork), L7Mode},
 		{"Empty tupleset returns L7 Mode", NewPortInfoMap("testns", "testsvc", nil, testContext.NegNamer, false, nil, defaultNetwork), L7Mode},
 	} {

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -41,6 +41,8 @@ const (
 	NegFinalizerKey = "networking.gke.io/neg-finalizer"
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
+	// NetLBFinalizerV3 is the finalizer used by the NEG backed variant of the L4 External LoadBalancer services.
+	NetLBFinalizerV3 = "gke.networking.io/l4-netlb-v3"
 	// LoadBalancerCleanupFinalizer added by original kubernetes service controller. This is not required in L4 RBS/ILB-subsetting services.
 	LoadBalancerCleanupFinalizer = "service.kubernetes.io/load-balancer-cleanup"
 )

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -720,6 +720,11 @@ func HasL4NetLBFinalizerV2(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV2, nil)
 }
 
+// HasL4NetLBFinalizerV3 returns true if the given Service has NetLBFinalizerV3
+func HasL4NetLBFinalizerV3(svc *api_v1.Service) bool {
+	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV3, nil)
+}
+
 func LegacyForwardingRuleName(svc *api_v1.Service) string {
 	return cloudprovider.DefaultLoadBalancerName(svc)
 }


### PR DESCRIPTION
This PR contains changes for the NEG controller to support L4 NetLB services.
The NEG controller will be triggered for NetLBs with the presence of the new netlb V3 finalizer

Also the PortInfo had to be extended to contain the type of L4 LB since the calculators need this info in order to pick the right subset sizes. NetLBs will use larger subsets than ILB. Also this allows to differentiate a NEG syncer for ILB vs one for NetLB, when the service moves between ILB and NetLB the syncer for the old service spec will be stopped and a new one created for the changed service.
 