### PR TITLE
Update service annotation + IPs in single API call

### DIFF
--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -18,7 +18,7 @@ package l4lb
 
 import (
 	"fmt"
-	"reflect"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
@@ -41,9 +41,6 @@ import (
 func computeNewAnnotationsIfNeeded(svc *v1.Service, newAnnotations map[string]string, keysToRemove []string) *metav1.ObjectMeta {
 	newObjectMeta := svc.ObjectMeta.DeepCopy()
 	newObjectMeta.Annotations = mergeAnnotations(newObjectMeta.Annotations, newAnnotations, keysToRemove)
-	if reflect.DeepEqual(svc.Annotations, newObjectMeta.Annotations) {
-		return nil
-	}
 	return newObjectMeta
 }
 
@@ -66,28 +63,6 @@ func mergeAnnotations(existing, lbAnnotations map[string]string, keysToRemove []
 	return existing
 }
 
-// updateL4ResourcesAnnotations checks if new annotations should be added to service and patch service metadata if needed.
-func updateL4ResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string, svcLogger klog.Logger) error {
-	svcLogger.V(3).Info("Updating annotations of service")
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4ResourceAnnotationKeys)
-	if newObjectMeta == nil {
-		svcLogger.V(3).Info("Service annotations not changed, skipping patch for service")
-		return nil
-	}
-	svcLogger.V(3).Info("Patching annotations of service")
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
-// updateL4DualStackResourcesAnnotations checks if new annotations should be added to dual-stack service and patch service metadata if needed.
-func updateL4DualStackResourcesAnnotations(ctx *context.ControllerContext, svc *v1.Service, newL4LBAnnotations map[string]string, svcLogger klog.Logger) error {
-	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, loadbalancers.L4DualStackResourceAnnotationKeys)
-	if newObjectMeta == nil {
-		return nil
-	}
-	svcLogger.V(3).Info("Patching annotations of service")
-	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
-}
-
 func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotationKey string, svcLogger klog.Logger) error {
 	newObjectMeta := svc.ObjectMeta.DeepCopy()
 	if _, ok := newObjectMeta.Annotations[annotationKey]; !ok {
@@ -98,14 +73,37 @@ func deleteAnnotation(ctx *context.ControllerContext, svc *v1.Service, annotatio
 	return patch.PatchServiceObjectMetadata(ctx.KubeClient.CoreV1(), svc, *newObjectMeta)
 }
 
-// updateServiceStatus this faction checks if LoadBalancer status changed and patch service if needed.
-func updateServiceStatus(ctx *context.ControllerContext, svc *v1.Service, newStatus *v1.LoadBalancerStatus, svcLogger klog.Logger) error {
+// updateServiceInformation this faction checks if LoadBalancer changed and patch service if needed.
+func updateServiceInformation(ctx *context.ControllerContext, enableDualStack bool, svc *v1.Service, newStatus *v1.LoadBalancerStatus, newL4LBAnnotations map[string]string, svcLogger klog.Logger) error {
 	svcLogger.V(2).Info("Updating service status", "newStatus", fmt.Sprintf("%+v", newStatus))
 	if helpers.LoadBalancerStatusEqual(&svc.Status.LoadBalancer, newStatus) {
 		svcLogger.V(2).Info("New and old statuses are equal, skipping patch")
 		return nil
 	}
-	return patch.PatchServiceLoadBalancerStatus(ctx.KubeClient.CoreV1(), svc, *newStatus)
+
+	var keysToRemove []string
+	if enableDualStack {
+		emitEnsuredDualStackEvent(ctx, svc)
+		keysToRemove = loadbalancers.L4DualStackResourceAnnotationKeys
+	} else {
+		keysToRemove = loadbalancers.L4ResourceAnnotationKeys
+	}
+	svcLogger.V(2).Info("Selected keysToRemove", "keysToRemove", keysToRemove)
+
+	newObjectMeta := computeNewAnnotationsIfNeeded(svc, newL4LBAnnotations, keysToRemove)
+	svcLogger.V(2).Info("Computed new service metadata", "newObjectMeta", newObjectMeta)
+
+	return patch.PatchServiceLoadBalancerInformation(ctx.KubeClient.CoreV1(), svc, *newStatus, *newObjectMeta)
+
+}
+
+func emitEnsuredDualStackEvent(ctx *context.ControllerContext, service *v1.Service) {
+	var ipFamilies []string
+	for _, ipFamily := range service.Spec.IPFamilies {
+		ipFamilies = append(ipFamilies, string(ipFamily))
+	}
+	ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
+		"Successfully ensured %v load balancer resources", strings.Join(ipFamilies, " "))
 }
 
 // isHealthCheckDeleted checks if given health check exists in GCE

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -129,7 +129,7 @@ func NewL4NetLBController(
 			if shouldProcess, _ := l4netLBc.shouldProcessService(addSvc, nil, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service added, enqueuing")
 				l4netLBc.ctx.Recorder(addSvc.Namespace).Eventf(addSvc, v1.EventTypeNormal, "ADD", svcKey)
-				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, logger)
+				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, svcLogger)
 				l4netLBc.svcQueue.Enqueue(addSvc)
 				l4netLBc.enqueueTracker.Track()
 			} else {
@@ -145,7 +145,7 @@ func NewL4NetLBController(
 			if shouldProcess, isResync := l4netLBc.shouldProcessService(curSvc, oldSvc, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service updated, enqueuing")
 				if !isResync {
-					l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, curSvc.ResourceVersion, logger)
+					l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, curSvc.ResourceVersion, svcLogger)
 				}
 				l4netLBc.svcQueue.Enqueue(curSvc)
 				l4netLBc.enqueueTracker.Track()

--- a/pkg/l4lb/updatetype.go
+++ b/pkg/l4lb/updatetype.go
@@ -51,25 +51,25 @@ func (t *serviceVersionsTracker) getVersionsForSvc(svcKey string) *serviceVersio
 
 }
 
-func (t *serviceVersionsTracker) SetLastUpdateSeen(svcKey, version string, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetLastUpdateSeen(svcKey, version string, svcLogger klog.Logger) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 	v.lastSeenUpdateVersion = version
-	logger.V(3).Info("serviceVersionsTracker: SetLastUpdateSeen()", "svcKey", svcKey, "version", version)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetLastUpdateSeen()", "version", version)
 }
 
-func (t *serviceVersionsTracker) SetLastIgnored(svcKey, version string, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetLastIgnored(svcKey, version string, svcLogger klog.Logger) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 	v.lastIgnoredVersion = version
-	logger.V(3).Info("serviceVersionsTracker: SetLastIgnored()", "svcKey", svcKey, "version", version)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetLastIgnored()", "version", version)
 }
 
-func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, wasResync bool, logger klog.Logger) {
+func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, wasResync bool, svcLogger klog.Logger) {
 	if wasResync && success {
 		return
 	}
@@ -79,16 +79,16 @@ func (t *serviceVersionsTracker) SetProcessed(svcKey, version string, success, w
 	v := t.getVersionsForSvc(svcKey)
 	v.lastProcessedUpdateVersion = version
 	v.lastProcessingSuccess = success
-	logger.V(3).Info("serviceVersionsTracker: SetProcessed()", "version", version, "success", success, "wasResync", wasResync)
+	svcLogger.V(3).Info("serviceVersionsTracker: SetProcessed()", "version", version, "success", success, "wasResync", wasResync)
 }
 
-func (t *serviceVersionsTracker) IsResync(svcKey, currentVersion string, logger klog.Logger) bool {
+func (t *serviceVersionsTracker) IsResync(svcKey, currentVersion string, svcLogger klog.Logger) bool {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
 	v := t.getVersionsForSvc(svcKey)
 
-	logger.V(3).Info("serviceVersionsTracker: IsResync()", "currentVersion", currentVersion, "lastProcessedUpdateVersion", v.lastProcessedUpdateVersion, "lastProcessingSuccess", v.lastProcessingSuccess, "lastSeenUpdate", v.lastSeenUpdateVersion, "lastIgnored", v.lastIgnoredVersion)
+	svcLogger.V(3).Info("serviceVersionsTracker: IsResync()", "currentVersion", currentVersion, "lastProcessedUpdateVersion", v.lastProcessedUpdateVersion, "lastProcessingSuccess", v.lastProcessingSuccess, "lastSeenUpdate", v.lastSeenUpdateVersion, "lastIgnored", v.lastIgnoredVersion)
 
 	if !v.lastProcessingSuccess {
 		return false

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -78,9 +78,10 @@ func PatchServiceObjectMetadata(client coreclient.CoreV1Interface, svc *corev1.S
 
 // PatchServiceLoadBalancerStatus patches the given service's LoadBalancerStatus
 // based on new service's load-balancer status.
-func PatchServiceLoadBalancerStatus(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus) error {
+func PatchServiceLoadBalancerInformation(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus, newObjectMetadata metav1.ObjectMeta) error {
 	newSvc := svc.DeepCopy()
 	newSvc.Status.LoadBalancer = newStatus
+	newSvc.ObjectMeta = newObjectMetadata
 	_, err := svchelpers.PatchService(client, svc, newSvc)
 	return err
 }

--- a/pkg/utils/patch/patch_test.go
+++ b/pkg/utils/patch/patch_test.go
@@ -234,7 +234,7 @@ func TestPatchServiceLoadBalancerStatus(t *testing.T) {
 				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
 			}
 			expectSvc := tc.newMetaFunc(tc.svc)
-			err := PatchServiceLoadBalancerStatus(coreClient, tc.svc, expectSvc.Status.LoadBalancer)
+			err := PatchServiceLoadBalancerInformation(coreClient, tc.svc, expectSvc.Status.LoadBalancer, expectSvc.ObjectMeta)
 			if err != nil {
 				t.Fatalf("PatchServiceLoadBalancerStatus(%s) = %v, want nil", svcKey, err)
 			}


### PR DESCRIPTION
In L4 (ILB and NetLB) controllers after successful sync we do 2 things -- updating .Status.Ingress.LoadBalancerIPs [https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go#L281](https://www.google.com/url?q=https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go%23L281&sa=D&source=buganizer&usg=AOvVaw1z9JzXQLW6ZYSnKdX-0uZG) and updating service annotations [https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go#L290](https://www.google.com/url?q=https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go%23L290&sa=D&source=buganizer&usg=AOvVaw36Ga_tyUdTMMcTqWFX6LVG) (links are for L4 ILB, same can be found in L4 NetLB)

Now, both of those are triggering separate API call, to just patch a service. Technically, we could update these things in a single API call

Having separate api calls is also bug-provoking, the order of calls matters, and currently, for example, if service got IPs updated, we can not be sure if Annotation were also updated. This already triggered some failures in e2e tests, but also even in implementation, when we have some tricky situations when webhook + migration + something else is involved