### PR TITLE
Forward individual ports for NetLB with 5 or less service ports

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -134,6 +134,7 @@ var (
 		EnableMultiSubnetCluster                 bool
 		EnableWeightedL4ILB                      bool
 		EnableWeightedL4NetLB                    bool
+		EnableDiscretePortForwarding             bool
 	}{
 		GCERateLimitScale: 1.0,
 	}
@@ -316,6 +317,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableWeightedL4NetLB, "enable-weighted-l4-netlb", false, "EnableWeighted Load balancing for  L4 NetLB .")
 	flag.Float32Var(&F.KubeClientQPS, "kube-client-qps", 0.0, "The QPS that the controllers' kube client should adhere to through client side throttling. If zero, client will be created with default settings.")
 	flag.IntVar(&F.KubeClientBurst, "kube-client-burst", 0, "The burst QPS that the controllers' kube client should adhere to through client side throttling. If zero, client will be created with default settings.")
+	flag.BoolVar(&F.EnableDiscretePortForwarding, "enable-discrete-port-forwarding", false, "Enable forwarding of individual ports instead of port ranges.")
 }
 
 func Validate() {

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -18,10 +18,11 @@ package loadbalancers
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"net/http"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -34,14 +35,15 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/translator"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 )
 
 const (
-	// maxL4ILBPorts is the maximum number of ports that can be specified in an L4 ILB Forwarding Rule
-	maxL4ILBPorts = 5
+	// maxForwardedPorts is the maximum number of ports that can be specified in an Forwarding Rule
+	maxForwardedPorts = 5
 	// addressAlreadyInUseMessageExternal is the error message string returned by the compute API
 	// when creating an external forwarding rule that uses a conflicting IP address.
 	addressAlreadyInUseMessageExternal = "Specified IP address is in-use and would result in a conflict."
@@ -247,7 +249,7 @@ func (l4 *L4) ensureIPv4ForwardingRule(bsLink string, options gce.ILBOptions, ex
 		AllowGlobalAccess:   options.AllowGlobalAccess,
 		Description:         frDesc,
 	}
-	if len(ports) > maxL4ILBPorts {
+	if len(ports) > maxForwardedPorts {
 		fr.Ports = nil
 		fr.AllPorts = true
 	}
@@ -349,8 +351,10 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 		}()
 	}
 
-	portRange, protocol := utils.MinMaxPortRangeAndProtocol(l4netlb.Service.Spec.Ports)
-
+	svcPorts := l4netlb.Service.Spec.Ports
+	ports := utils.GetPorts(svcPorts)
+	portRange := utils.MinMaxPortRange(svcPorts)
+	protocol := utils.GetProtocol(svcPorts)
 	serviceKey := utils.ServiceKeyFunc(l4netlb.Service.Namespace, l4netlb.Service.Name)
 	frDesc, err := utils.MakeL4LBServiceDescription(serviceKey, ipToUse, version, false, utils.XLB)
 	if err != nil {
@@ -361,11 +365,15 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 		Name:                frName,
 		Description:         frDesc,
 		IPAddress:           ipToUse,
-		IPProtocol:          protocol,
+		IPProtocol:          string(protocol),
 		PortRange:           portRange,
 		LoadBalancingScheme: string(cloud.SchemeExternal),
 		BackendService:      bsLink,
 		NetworkTier:         netTier.ToGCEValue(),
+	}
+	if len(ports) <= maxForwardedPorts && flags.F.EnableDiscretePortForwarding {
+		fr.Ports = ports
+		fr.PortRange = ""
 	}
 
 	if existingFwdRule != nil {
@@ -433,14 +441,31 @@ func Equal(fr1, fr2 *composite.ForwardingRule) (bool, error) {
 	return fr1.IPAddress == fr2.IPAddress &&
 		fr1.IPProtocol == fr2.IPProtocol &&
 		fr1.LoadBalancingScheme == fr2.LoadBalancingScheme &&
-		utils.EqualStringSets(fr1.Ports, fr2.Ports) &&
-		fr1.PortRange == fr2.PortRange &&
+		equalPorts(fr1.Ports, fr2.Ports, fr1.PortRange, fr2.PortRange) &&
 		utils.EqualCloudResourceIDs(id1, id2) &&
 		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
 		fr1.AllPorts == fr2.AllPorts &&
 		equalResourcePaths(fr1.Subnetwork, fr2.Subnetwork) &&
 		equalResourcePaths(fr1.Network, fr2.Network) &&
 		fr1.NetworkTier == fr2.NetworkTier, nil
+}
+
+// equalPorts compares two port ranges or slices of ports. Before comparison,
+// slices of ports are converted into a port range from smallest to largest
+// port. This is done so we don't unnecessarily recreate forwarding rules
+// when upgrading from port ranges to distinct ports, because recreating
+// forwarding rules is traffic impacting.
+func equalPorts(ports1, ports2 []string, portRange1, portRange2 string) bool {
+	if !flags.F.EnableDiscretePortForwarding {
+		return utils.EqualStringSets(ports1, ports2) && portRange1 == portRange2
+	}
+	if len(ports1) != 0 && portRange1 == "" {
+		portRange1 = utils.MinMaxPortRange(ports1)
+	}
+	if len(ports2) != 0 && portRange2 == "" {
+		portRange2 = utils.MinMaxPortRange(ports2)
+	}
+	return portRange1 == portRange2
 }
 
 func equalResourcePaths(rp1, rp2 string) bool {

--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
@@ -113,7 +114,7 @@ func (l4 *L4) buildExpectedIPv6ForwardingRule(bsLink string, options gce.ILBOpti
 		AllowGlobalAccess:   options.AllowGlobalAccess,
 		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
 	}
-	if len(ports) > maxL4ILBPorts {
+	if len(ports) > maxForwardedPorts {
 		fr.Ports = nil
 		fr.AllPorts = true
 	}
@@ -255,18 +256,24 @@ func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse
 	}
 
 	svcPorts := l4netlb.Service.Spec.Ports
-	portRange, protocol := utils.MinMaxPortRangeAndProtocol(svcPorts)
+	ports := utils.GetPorts(svcPorts)
+	portRange := utils.MinMaxPortRange(svcPorts)
+	protocol := utils.GetProtocol(svcPorts)
 	fr := &composite.ForwardingRule{
 		Name:                frName,
 		Description:         frDesc,
 		IPAddress:           ipv6AddressToUse,
-		IPProtocol:          protocol,
+		IPProtocol:          string(protocol),
 		PortRange:           portRange,
 		LoadBalancingScheme: string(cloud.SchemeExternal),
 		BackendService:      bsLink,
 		IpVersion:           IPVersionIPv6,
 		NetworkTier:         netTier.ToGCEValue(),
 		Subnetwork:          subnetworkURL,
+	}
+	if len(ports) <= maxForwardedPorts && flags.F.EnableDiscretePortForwarding {
+		fr.Ports = utils.GetPorts(svcPorts)
+		fr.PortRange = ""
 	}
 
 	return fr, nil
@@ -296,7 +303,7 @@ func EqualIPv6ForwardingRules(fr1, fr2 *composite.ForwardingRule) (bool, error) 
 	}
 	return fr1.IPProtocol == fr2.IPProtocol &&
 		fr1.LoadBalancingScheme == fr2.LoadBalancingScheme &&
-		utils.EqualStringSets(fr1.Ports, fr2.Ports) &&
+		equalPorts(fr1.Ports, fr2.Ports, fr1.PortRange, fr2.PortRange) &&
 		utils.EqualCloudResourceIDs(id1, id2) &&
 		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
 		fr1.AllPorts == fr2.AllPorts &&

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/test"
@@ -103,155 +104,205 @@ func TestGetEffectiveIP(t *testing.T) {
 func TestForwardingRulesEqual(t *testing.T) {
 	t.Parallel()
 
-	fwdRules := []*composite.ForwardingRule{
-		{
-			Name:                "empty-ip-address-fwd-rule",
-			IPAddress:           "",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "tcp-fwd-rule",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "udp-fwd-rule",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "UDP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "global-access-fwd-rule",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			AllowGlobalAccess:   true,
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "fwd-rule-bs-link1",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://compute.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "fwd-rule-bs-link2",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-		},
-		{
-			Name:                "udp-fwd-rule-all-ports",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			AllPorts:            true,
-			IPProtocol:          "UDP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-			NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
-		},
-		{
-			Name:                "fwd-rule-bs-link2-standard-ntier",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-			NetworkTier:         string(cloud.NetworkTierStandard),
-		},
-		{
-			Name:                "fwd-rule-bs-link2-premium-ntier",
-			IPAddress:           "10.0.0.0",
-			Ports:               []string{"123"},
-			IPProtocol:          "TCP",
-			LoadBalancingScheme: string(cloud.SchemeInternal),
-			BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
-			NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
-		},
-	}
-
-	frPortRange1 := &composite.ForwardingRule{
+	fwdRuleTCP := &composite.ForwardingRule{
 		Name:                "tcp-fwd-rule",
 		IPAddress:           "10.0.0.0",
-		PortRange:           "2-3",
+		Ports:               []string{"123"},
 		IPProtocol:          "TCP",
 		LoadBalancingScheme: string(cloud.SchemeInternal),
 		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 	}
-	frPortRange2 := &composite.ForwardingRule{
-		Name:                "tcp-fwd-rule",
+	fwdRuleUDP := &composite.ForwardingRule{
+		Name:                "udp-fwd-rule",
 		IPAddress:           "10.0.0.0",
-		PortRange:           "1-2",
-		IPProtocol:          "TCP",
+		Ports:               []string{"123"},
+		IPProtocol:          "UDP",
 		LoadBalancingScheme: string(cloud.SchemeInternal),
 		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 	}
 
 	for _, tc := range []struct {
-		desc        string
-		oldFwdRule  *composite.ForwardingRule
-		newFwdRule  *composite.ForwardingRule
-		expectEqual bool
+		desc                   string
+		oldFwdRule             *composite.ForwardingRule
+		newFwdRule             *composite.ForwardingRule
+		discretePortForwarding bool
+		expectEqual            bool
 	}{
 		{
-			desc:        "empty ip address does not match valid ip",
-			oldFwdRule:  fwdRules[0],
-			newFwdRule:  fwdRules[1],
+			desc: "empty ip address does not match valid ip",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "empty-ip-address-fwd-rule",
+				IPAddress:           "",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule:  fwdRuleTCP,
 			expectEqual: false,
 		},
 		{
-			desc:        "global access enabled",
-			oldFwdRule:  fwdRules[1],
-			newFwdRule:  fwdRules[3],
+			desc:       "global access enabled",
+			oldFwdRule: fwdRuleTCP,
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "global-access-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				AllowGlobalAccess:   true,
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
 			expectEqual: false,
 		},
 		{
 			desc:        "IP protocol changed",
-			oldFwdRule:  fwdRules[1],
-			newFwdRule:  fwdRules[2],
+			oldFwdRule:  fwdRuleTCP,
+			newFwdRule:  fwdRuleUDP,
 			expectEqual: false,
 		},
 		{
 			desc:        "same forwarding rule",
-			oldFwdRule:  fwdRules[3],
-			newFwdRule:  fwdRules[3],
+			oldFwdRule:  fwdRuleTCP,
+			newFwdRule:  fwdRuleTCP,
 			expectEqual: true,
 		},
 		{
-			desc:        "same forwarding rule, different basepath",
-			oldFwdRule:  fwdRules[4],
-			newFwdRule:  fwdRules[5],
+			desc: "same forwarding rule, different basepath",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "fwd-rule-bs-link1",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://compute.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "fwd-rule-bs-link2",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
 			expectEqual: true,
 		},
 		{
-			desc:        "same forwarding rule, one uses ALL keyword for ports",
-			oldFwdRule:  fwdRules[2],
-			newFwdRule:  fwdRules[6],
+			desc:       "same forwarding rule, one uses ALL keyword for ports",
+			oldFwdRule: fwdRuleUDP,
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "udp-fwd-rule-all-ports",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				AllPorts:            true,
+				IPProtocol:          "UDP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+				NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+			},
 			expectEqual: false,
 		},
 		{
-			desc:        "network tier mismatch",
-			oldFwdRule:  fwdRules[6],
-			newFwdRule:  fwdRules[7],
+			desc: "network tier mismatch",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "fwd-rule-bs-link2-standard-ntier",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+				NetworkTier:         string(cloud.NetworkTierStandard),
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "fwd-rule-bs-link2-premium-ntier",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"123"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+				NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+			},
 			expectEqual: false,
 		},
 		{
-			desc:        "same forwarding rule, different port ranges",
-			oldFwdRule:  frPortRange1,
-			newFwdRule:  frPortRange2,
+			desc: "same forwarding rule, port range mismatch",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				PortRange:           "1-2",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				PortRange:           "2-3",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			expectEqual: false,
+		},
+		{
+			desc: "port range discrete ports disabled",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"1", "3"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				PortRange:           "1-3",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			expectEqual: false,
+		},
+		{
+			desc: "port range discrete ports enabled",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"1", "3"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				PortRange:           "1-3",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			discretePortForwarding: true,
+			expectEqual:            true,
+		},
+		{
+			desc: "same forwarding rule, ports vs port ranges mismatch",
+			oldFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				Ports:               []string{"1", "5"},
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
+			newFwdRule: &composite.ForwardingRule{
+				Name:                "tcp-fwd-rule",
+				IPAddress:           "10.0.0.0",
+				PortRange:           "1-3",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+			},
 			expectEqual: false,
 		},
 		{
@@ -326,6 +377,7 @@ func TestForwardingRulesEqual(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			flags.F.EnableDiscretePortForwarding = tc.discretePortForwarding
 			got, err := Equal(tc.oldFwdRule, tc.newFwdRule)
 			if err != nil {
 				t.Errorf("forwardingRulesEqual(_, _) = %v, want nil error", err)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1191,7 +1191,7 @@ func TestComputeBasePath(t *testing.T) {
 	}
 }
 
-func TestMinMaxPortRangeAndProtocol(t *testing.T) {
+func TestMinMaxPortRange(t *testing.T) {
 
 	for _, tc := range []struct {
 		svcPorts         []api_v1.ServicePort
@@ -1200,55 +1200,46 @@ func TestMinMaxPortRangeAndProtocol(t *testing.T) {
 	}{
 		{
 			svcPorts: []api_v1.ServicePort{
-				{Port: 1, Protocol: "TCP"},
-				{Port: 10, Protocol: "TCP"},
-				{Port: 100, Protocol: "TCP"}},
-			expectedRange:    "1-100",
-			expectedProtocol: "TCP",
+				{Port: 1},
+				{Port: 10},
+				{Port: 100}},
+			expectedRange: "1-100",
 		},
 		{
 			svcPorts: []api_v1.ServicePort{
-				{Port: 10, Protocol: "TCP"},
-				{Port: 1, Protocol: "TCP"},
-				{Port: 50, Protocol: "TCP"},
-				{Port: 100, Protocol: "TCP"},
-				{Port: 90, Protocol: "TCP"}},
-			expectedRange:    "1-100",
-			expectedProtocol: "TCP",
+				{Port: 10},
+				{Port: 1},
+				{Port: 50},
+				{Port: 100},
+				{Port: 90}},
+			expectedRange: "1-100",
 		},
 		{
 			svcPorts: []api_v1.ServicePort{
-				{Port: 10, Protocol: "TCP"}},
-			expectedRange:    "10-10",
-			expectedProtocol: "TCP",
+				{Port: 10}},
+			expectedRange: "10-10",
 		},
 		{
 			svcPorts: []api_v1.ServicePort{
-				{Port: 100, Protocol: "TCP"},
-				{Port: 10, Protocol: "TCP"}},
-			expectedRange:    "10-100",
-			expectedProtocol: "TCP",
+				{Port: 100},
+				{Port: 10}},
+			expectedRange: "10-100",
 		},
 		{
 			svcPorts: []api_v1.ServicePort{
-				{Port: 100, Protocol: "TCP"},
-				{Port: 50, Protocol: "TCP"},
-				{Port: 10, Protocol: "TCP"}},
-			expectedRange:    "10-100",
-			expectedProtocol: "TCP",
+				{Port: 100},
+				{Port: 50},
+				{Port: 10}},
+			expectedRange: "10-100",
 		},
 		{
-			svcPorts:         []api_v1.ServicePort{},
-			expectedRange:    "",
-			expectedProtocol: "",
+			svcPorts:      []api_v1.ServicePort{},
+			expectedRange: "",
 		},
 	} {
-		portsRange, protocol := MinMaxPortRangeAndProtocol(tc.svcPorts)
+		portsRange := MinMaxPortRange(tc.svcPorts)
 		if portsRange != tc.expectedRange {
 			t.Errorf("PortRange mismatch %v != %v", tc.expectedRange, portsRange)
-		}
-		if protocol != tc.expectedProtocol {
-			t.Errorf("protocol mismatch %v != %v", protocol, tc.expectedProtocol)
 		}
 	}
 }


### PR DESCRIPTION
GCE forwarding rules have a limit of 5 forwarded ports. In the external L4 load balancer, we currently turn a set of exposed ports into a port range from minPort to maxPort and forward all ports in the range, which needlessly forwards traffic for ports that are not supposed to be exposed.

With this change, if 5 or less ports are exposed, we expose each distinct, otherwise we use the old mechanism of exposing a port range. This is similar to have the Internal Load Balancer is setup, except the ILB exposes all ports if more than 5 ports need to be exposed.

To avoid recreating forwarding rules when code logic is updated, we treat port ranges and distinct ports that fall into the same port range as equivalent.