### PR TITLE
Update service annotation + IPs in single API call

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -320,41 +319,14 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 		syncResult.Error = err
 		return syncResult
 	}
-	err = updateServiceStatus(l4c.ctx, service, syncResult.Status, svcLogger)
+	err = updateServiceInformation(l4c.ctx, l4c.enableDualStack, service, syncResult.Status, syncResult.Annotations, svcLogger)
 	if err != nil {
 		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
-			"Error updating load balancer status: %v", err)
+			"Error updating Service status and GCP resource annotations: %v", err)
 		syncResult.Error = err
 		return syncResult
 	}
-	if l4c.enableDualStack {
-		l4c.emitEnsuredDualStackEvent(service)
-		if err = updateL4DualStackResourcesAnnotations(l4c.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
-				"Failed to update Dual Stack annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set Dual Stack resource annotations, err: %w", err)
-			return syncResult
-		}
-	} else {
-		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
-			"Successfully ensured load balancer resources")
-		if err = updateL4ResourcesAnnotations(l4c.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
-				"Failed to update annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-			return syncResult
-		}
-	}
 	return syncResult
-}
-
-func (l4c *L4Controller) emitEnsuredDualStackEvent(service *v1.Service) {
-	var ipFamilies []string
-	for _, ipFamily := range service.Spec.IPFamilies {
-		ipFamilies = append(ipFamilies, string(ipFamily))
-	}
-	l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
-		"Successfully ensured %v load balancer resources", strings.Join(ipFamilies, " "))
 }
 
 func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svcLogger klog.Logger) *loadbalancers.L4ILBSyncResult {
@@ -381,30 +353,15 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 		l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancerFailed", "Error deleting load balancer: %v", result.Error)
 		return result
 	}
-	// Reset the loadbalancer status first, before resetting annotations.
-	// Other controllers(like service-controller) will process the service update if annotations change, but will ignore a service status change.
-	// Following this order avoids a race condition when a service is changed from LoadBalancer type Internal to External.
-	if err := updateServiceStatus(l4c.ctx, svc, &v1.LoadBalancerStatus{}, svcLogger); err != nil {
+
+	// Reset the loadbalancer status and annotations.
+	emptyAnnotationMap := map[string]string{}
+	emptyLoadBalancerStatus := &v1.LoadBalancerStatus{}
+	if err := updateServiceInformation(l4c.ctx, l4c.enableDualStack, svc, emptyLoadBalancerStatus, emptyAnnotationMap, svcLogger); err != nil {
 		l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-			"Error resetting load balancer status to empty: %v", err)
-		result.Error = fmt.Errorf("failed to reset ILB status, err: %w", err)
+			"Error cleaning Service status and GCP resource annotations: %v", err)
+		result.Error = fmt.Errorf("failed to clean ILB statu and GCP resource annotations, err: %w", err)
 		return result
-	}
-	// Also remove any ILB annotations from the service metadata
-	if l4c.enableDualStack {
-		if err := updateL4DualStackResourcesAnnotations(l4c.ctx, svc, nil, svcLogger); err != nil {
-			l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error resetting DualStack resource annotations for load balancer: %v", err)
-			result.Error = fmt.Errorf("failed to reset DualStack resource annotations, err: %w", err)
-			return result
-		}
-	} else {
-		if err := updateL4ResourcesAnnotations(l4c.ctx, svc, nil, svcLogger); err != nil {
-			l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error resetting resource annotations for load balancer: %v", err)
-			result.Error = fmt.Errorf("failed to reset resource annotations, err: %w", err)
-			return result
-		}
 	}
 
 	if err := common.EnsureDeleteServiceFinalizer(svc, common.ILBFinalizerV2, l4c.ctx.KubeClient, svcLogger); err != nil {

--- a/pkg/l4lb/l4lbcommon_test.go
+++ b/pkg/l4lb/l4lbcommon_test.go
@@ -1,13 +1,46 @@
 package l4lb
 
 import (
+	context2 "context"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-gce/pkg/utils/common"
+	"k8s.io/klog/v2"
 )
+
+func GetDefaultAnnotations() map[string]string {
+	return map[string]string{
+		"other_annotations":                     "ok",
+		"networking.gke.io/load-balancer-type":  "Internal",
+		"service.kubernetes.io/backend-service": "ok",
+	}
+}
+
+// NewL4ILBService creates a Service of type LoadBalancer with the Internal annotation.
+func NewL4ILBService(onlyLocal bool, port int) *v1.Service {
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc1",
+			Namespace:   "default",
+			Annotations: GetDefaultAnnotations(),
+		},
+		Spec: v1.ServiceSpec{
+			Type:            v1.ServiceTypeLoadBalancer,
+			SessionAffinity: v1.ServiceAffinityClientIP,
+			Ports: []v1.ServicePort{
+				{Name: "testport", Port: int32(port), Protocol: "TCP"},
+			},
+		},
+	}
+	if onlyLocal {
+		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	}
+	return svc
+}
 
 func TestFinalizerWasRemovedUnexpectedly(t *testing.T) {
 	testCases := []struct {
@@ -138,6 +171,109 @@ func TestFinalizerWasRemovedUnexpectedly(t *testing.T) {
 			if gotResult != tc.expectedResult {
 				t.Errorf("finalizerWasRemoved(oldSvc=%v, newSvc=%v, finalizer=%s) returned %v, but expected %v", tc.oldService, tc.newService, tc.finalizerName, gotResult, tc.expectedResult)
 			}
+		})
+	}
+}
+
+func TestUpdateServiceInformation(t *testing.T) {
+	testCases := []struct {
+		desc                string
+		enableDualStack     bool
+		newStatus           *v1.LoadBalancerStatus
+		newAnnotations      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			desc:            "Add annotations",
+			enableDualStack: true,
+			newStatus:       nil,
+			newAnnotations: map[string]string{
+				"service.kubernetes.io/firewall-rule-ipv6": "ok",
+				"service.kubernetes.io/backend-service":    "ok",
+				"networking.gke.io/load-balancer-type":     "Internal",
+			},
+			expectedAnnotations: map[string]string{
+				"other_annotations":                        "ok",
+				"networking.gke.io/load-balancer-type":     "Internal",
+				"service.kubernetes.io/backend-service":    "ok",
+				"service.kubernetes.io/firewall-rule-ipv6": "ok",
+			},
+		},
+		{
+			desc:            "Reset annotations",
+			enableDualStack: false,
+			newStatus:       nil,
+			newAnnotations:  map[string]string{},
+			expectedAnnotations: map[string]string{
+				"other_annotations":                    "ok",
+				"networking.gke.io/load-balancer-type": "Internal",
+			},
+		},
+		{
+			desc:            "Only change status",
+			enableDualStack: false,
+			newStatus: &v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "127.0.0.1",
+					},
+				},
+			},
+			newAnnotations:      GetDefaultAnnotations(),
+			expectedAnnotations: GetDefaultAnnotations(),
+		},
+		{
+			desc:            "Change status and reset Annotations",
+			enableDualStack: false,
+			newStatus: &v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "127.0.0.1",
+					},
+				},
+			},
+			newAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"other_annotations":                    "ok",
+				"networking.gke.io/load-balancer-type": "Internal",
+			},
+		},
+		{
+			desc:            "Remove annotations",
+			enableDualStack: true,
+			newStatus:       nil,
+			newAnnotations: map[string]string{
+				"service.kubernetes.io/firewall-rule-ipv6": "ok",
+			},
+			expectedAnnotations: map[string]string{
+				"other_annotations":                        "ok",
+				"networking.gke.io/load-balancer-type":     "Internal",
+				"service.kubernetes.io/firewall-rule-ipv6": "ok",
+			},
+		},
+	}
+
+	logger := klog.TODO()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+
+			l4c := newServiceController(t, newFakeGCE())
+
+			svc := NewL4ILBService(true, 8080)
+			addILBService(l4c, svc)
+
+			newSvc, err := l4c.client.CoreV1().Services(svc.Namespace).Get(context2.TODO(), svc.Name, metav1.GetOptions{})
+
+			// l4c.processServiceCreateOrUpdate(svc, logger)
+			err = updateServiceInformation(l4c.ctx, tc.enableDualStack, newSvc, tc.newStatus, tc.newAnnotations, logger)
+
+			newSvc, err = l4c.client.CoreV1().Services(svc.Namespace).Get(context2.TODO(), svc.Name, metav1.GetOptions{})
+			if tc.newStatus != nil {
+				assert.Equal(t, *tc.newStatus, newSvc.Status.LoadBalancer)
+			}
+			assert.Equal(t, tc.expectedAnnotations, newSvc.ObjectMeta.Annotations)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -587,44 +586,15 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 		return syncResult
 	}
 
-	err = updateServiceStatus(lc.ctx, service, syncResult.Status, svcLogger)
+	err = updateServiceInformation(lc.ctx, lc.enableDualStack, service, syncResult.Status, syncResult.Annotations, svcLogger)
 	if err != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Error updating L4 External LoadBalancer, err: %v", err)
 		syncResult.Error = err
 		return syncResult
 	}
-	if lc.enableDualStack {
-		lc.emitEnsuredDualStackEvent(service)
-
-		if err = updateL4DualStackResourcesAnnotations(lc.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
-				"Failed to update annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-			return syncResult
-		}
-	} else {
-		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
-			"Successfully ensured L4 External LoadBalancer resources")
-
-		if err = updateL4ResourcesAnnotations(lc.ctx, service, syncResult.Annotations, svcLogger); err != nil {
-			lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
-				"Failed to update annotations for load balancer, err: %v", err)
-			syncResult.Error = fmt.Errorf("failed to set resource annotations, err: %w", err)
-			return syncResult
-		}
-	}
 	syncResult.SetMetricsForSuccessfulServiceSync()
 	return syncResult
-}
-
-func (lc *L4NetLBController) emitEnsuredDualStackEvent(service *v1.Service) {
-	var ipFamilies []string
-	for _, ipFamily := range service.Spec.IPFamilies {
-		ipFamilies = append(ipFamilies, string(ipFamily))
-	}
-	lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeNormal, "SyncLoadBalancerSuccessful",
-		"Successfully ensured %v External LoadBalancer resources", strings.Join(ipFamilies, " "))
 }
 
 func (lc *L4NetLBController) ensureBackendLinking(service *v1.Service, linkType backendLinkType, svcLogger klog.Logger) error {
@@ -714,7 +684,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 		return result
 	}
 
-	if err := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{}, svcLogger); err != nil {
+	if err := updateServiceInformation(lc.ctx, lc.enableDualStack, svc, &v1.LoadBalancerStatus{}, nil, svcLogger); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
 			"Error resetting L4 External LoadBalancer status to empty, err: %v", err)
 		result.Error = fmt.Errorf("Failed to reset L4 External LoadBalancer status, err: %w", err)
@@ -728,22 +698,6 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 			"Error deleting delete Instance Group from L4 External LoadBalancer, err: %v", err)
 		result.Error = fmt.Errorf("Failed to delete Instance Group, err: %w", err)
 		return result
-	}
-
-	if lc.enableDualStack {
-		if err := updateL4DualStackResourcesAnnotations(lc.ctx, svc, nil, svcLogger); err != nil {
-			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error removing Dual Stack resource annotations: %v", err)
-			result.Error = fmt.Errorf("failed to reset Dual Stack resource annotations, err: %w", err)
-			return result
-		}
-	} else {
-		if err := updateL4ResourcesAnnotations(lc.ctx, svc, nil, svcLogger); err != nil {
-			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteLoadBalancer",
-				"Error removing resource annotations: %v", err)
-			result.Error = fmt.Errorf("failed to reset resource annotations, err: %w", err)
-			return result
-		}
 	}
 
 	// Finalizer needs to be removed last, because after deleting finalizer service can be deleted and

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -723,7 +723,7 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 			newSvcObjectMeta := service.ObjectMeta.DeepCopy()
 			delete(newSvcObjectMeta.Annotations, annotations.NEGStatusKey)
 			c.logger.V(2).Info("Removing NEG status annotation from service", "service", klog.KRef(namespace, name))
-			return patch.PatchServiceObjectMetadata(c.client.CoreV1(), service, *newSvcObjectMeta)
+			return patch.PatchServiceObjectMetadata(c.client.CoreV1(), service, newSvcObjectMeta)
 		}
 		// service doesn't have the expose NEG annotation and doesn't need update
 		return nil
@@ -745,7 +745,7 @@ func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap neg
 	}
 	newSvcObjectMeta.Annotations[annotations.NEGStatusKey] = annotation
 	c.logger.V(2).Info("Updating NEG visibility annotation on service", "annotation", annotation, "service", klog.KRef(namespace, name))
-	return patch.PatchServiceObjectMetadata(c.client.CoreV1(), service, *newSvcObjectMeta)
+	return patch.PatchServiceObjectMetadata(c.client.CoreV1(), service, newSvcObjectMeta)
 }
 
 func (c *Controller) handleErr(err error, key interface{}) {

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -107,7 +107,7 @@ func EnsureServiceFinalizer(service *corev1.Service, key string, kubeClient kube
 	updatedObjectMeta.Finalizers = append(updatedObjectMeta.Finalizers, key)
 
 	svcLogger.V(2).Info("Adding finalizer to service", "finalizerKey", key)
-	return patch.PatchServiceObjectMetadata(kubeClient.CoreV1(), service, *updatedObjectMeta)
+	return patch.PatchServiceObjectMetadata(kubeClient.CoreV1(), service, updatedObjectMeta)
 }
 
 // removeFinalizer patches the service to remove finalizer.
@@ -121,5 +121,5 @@ func EnsureDeleteServiceFinalizer(service *corev1.Service, key string, kubeClien
 	updatedObjectMeta.Finalizers = slice.RemoveString(updatedObjectMeta.Finalizers, key, nil)
 
 	svcLogger.V(2).Info("Removing finalizer from service", "finalizerKey", key)
-	return patch.PatchServiceObjectMetadata(kubeClient.CoreV1(), service, *updatedObjectMeta)
+	return patch.PatchServiceObjectMetadata(kubeClient.CoreV1(), service, updatedObjectMeta)
 }

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -69,18 +69,26 @@ func MergePatchBytes(old, cur interface{}) ([]byte, error) {
 
 // PatchServiceObjectMetadata patches the given service's metadata based on new
 // service metadata.
-func PatchServiceObjectMetadata(client coreclient.CoreV1Interface, svc *corev1.Service, newObjectMetadata metav1.ObjectMeta) error {
-	newSvc := svc.DeepCopy()
-	newSvc.ObjectMeta = newObjectMetadata
-	_, err := svchelpers.PatchService(client, svc, newSvc)
-	return err
+func PatchServiceObjectMetadata(client coreclient.CoreV1Interface, svc *corev1.Service, newObjectMetadata *metav1.ObjectMeta) error {
+	return PatchServiceLoadBalancerInformation(client, svc, nil, newObjectMetadata)
 }
 
-// PatchServiceLoadBalancerStatus patches the given service's LoadBalancerStatus
-// based on new service's load-balancer status.
-func PatchServiceLoadBalancerStatus(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus corev1.LoadBalancerStatus) error {
+// PatchServiceLoadBalancerInformation patches the given service's LoadBalancerStatus and ObjectMetadata
+// based on new service's load-balancer status and metadata.
+func PatchServiceLoadBalancerInformation(client coreclient.CoreV1Interface, svc *corev1.Service, newStatus *corev1.LoadBalancerStatus, newObjectMetadata *metav1.ObjectMeta) error {
+	if client == nil || svc == nil {
+		return fmt.Errorf("it was not possible to upload service information, nil client or service provided")
+	}
+
 	newSvc := svc.DeepCopy()
-	newSvc.Status.LoadBalancer = newStatus
+	if newStatus != nil {
+		newSvc.Status.LoadBalancer = *newStatus
+	}
+
+	if newObjectMetadata != nil {
+		newSvc.ObjectMeta = *newObjectMetadata
+	}
+
 	_, err := svchelpers.PatchService(client, svc, newSvc)
 	return err
 }

--- a/pkg/utils/patch/patch_test.go
+++ b/pkg/utils/patch/patch_test.go
@@ -102,7 +102,7 @@ func TestJSONMergePatchBytes(t *testing.T) {
 	}
 }
 
-func TestPatchServiceObjectMetadata(t *testing.T) {
+func TestPatchServiceLoadBalancerInformation(t *testing.T) {
 	for _, tc := range []struct {
 		desc        string
 		svc         *apiv1.Service
@@ -180,9 +180,9 @@ func TestPatchServiceObjectMetadata(t *testing.T) {
 				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
 			}
 			expectSvc := tc.newMetaFunc(tc.svc)
-			err := PatchServiceObjectMetadata(coreClient, tc.svc, expectSvc.ObjectMeta)
+			err := PatchServiceObjectMetadata(coreClient, tc.svc, &expectSvc.ObjectMeta)
 			if err != nil {
-				t.Fatalf("PatchServiceObjectMetadata(%s) = %v, want nil", svcKey, err)
+				t.Fatalf("PatchServiceLoadBalancerInformation(%s) = %v, want nil", svcKey, err)
 			}
 
 			gotSvc, err := coreClient.Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
@@ -234,7 +234,7 @@ func TestPatchServiceLoadBalancerStatus(t *testing.T) {
 				t.Fatalf("Create(%s) = %v, want nil", svcKey, err)
 			}
 			expectSvc := tc.newMetaFunc(tc.svc)
-			err := PatchServiceLoadBalancerStatus(coreClient, tc.svc, expectSvc.Status.LoadBalancer)
+			err := PatchServiceLoadBalancerInformation(coreClient, tc.svc, &expectSvc.Status.LoadBalancer, &expectSvc.ObjectMeta)
 			if err != nil {
 				t.Fatalf("PatchServiceLoadBalancerStatus(%s) = %v, want nil", svcKey, err)
 			}


### PR DESCRIPTION
In L4 (ILB and NetLB) controllers after successful sync we do 2 things -- updating .Status.Ingress.LoadBalancerIPs [https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go#L281](https://www.google.com/url?q=https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go%23L281&sa=D&source=buganizer&usg=AOvVaw1z9JzXQLW6ZYSnKdX-0uZG) and updating service annotations [https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go#L290](https://www.google.com/url?q=https://github.com/kubernetes/ingress-gce/blob/05316396ac12cf8e538339bfdfaa30826b08664d/pkg/l4lb/l4controller.go%23L290&sa=D&source=buganizer&usg=AOvVaw36Ga_tyUdTMMcTqWFX6LVG) (links are for L4 ILB, same can be found in L4 NetLB)

Now, both of those are triggering separate API call, to just patch a service. Technically, we could update these things in a single API call

Having separate api calls is also bug-provoking, the order of calls matters, and currently, for example, if service got IPs updated, we can not be sure if Annotation were also updated. This already triggered some failures in e2e tests, but also even in implementation, when we have some tricky situations when webhook + migration + something else is involved