### PR TITLE
ignore errors if adding a node results in "400: memberAlreadyExists"

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -293,7 +293,8 @@ func (m *manager) add(groupName string, names []string) error {
 	var errs []error
 	for zone, nodeNames := range m.splitNodesByZone(names) {
 		m.logger.V(1).Info("Adding nodes to instance group in zone", "nodeCount", len(nodeNames), "name", groupName, "zone", zone)
-		if err := m.cloud.AddInstancesToInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames)); err != nil {
+		err := m.cloud.AddInstancesToInstanceGroup(groupName, zone, m.getInstanceReferences(zone, nodeNames))
+		if err != nil && !utils.IsMemberAlreadyExistsError(err) {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -198,6 +198,13 @@ func IsInUsedByError(err error) bool {
 	}
 	return strings.Contains(apiErr.Message, "being used by")
 }
+func IsMemberAlreadyExistsError(err error) bool {
+	apiErr, ok := err.(*googleapi.Error)
+	if !ok || apiErr.Code != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(apiErr.Message, "memberAlreadyExists")
+}
 
 // IsNetworkTierMismatchGCEError checks if error is a GCE network tier mismatch for external IP
 func IsNetworkTierMismatchGCEError(err error) bool {


### PR DESCRIPTION
this will also prevent requeing of the same service

