### PR TITLE
Fix: IAP cannot be disabled

### DIFF
--- a/pkg/backends/features/iap.go
+++ b/pkg/backends/features/iap.go
@@ -102,13 +102,13 @@ func diffIAP(desired, curr *composite.BackendService, logger klog.Logger) bool {
 // switchingToDefault returns an error if the IAP configuration is switching from credentials to default.
 // TODO: remove validation when the IAP API supports this transition
 func switchingToDefault(desired, curr *composite.BackendService) error {
-	// EnsureIAP (only caller for switchingToDefault) is validates that desired is not empty,
-	// therefore only check if curr is nil.
-	if curr.Iap == nil {
+	if !desired.Iap.Enabled {
 		return nil
 	}
 
-	if !desired.Iap.Enabled {
+	// EnsureIAP (only caller for switchingToDefault) is validates that desired is not empty,
+	// therefore only check if curr is nil.
+	if curr.Iap == nil {
 		return nil
 	}
 

--- a/pkg/backends/features/iap.go
+++ b/pkg/backends/features/iap.go
@@ -108,6 +108,10 @@ func switchingToDefault(desired, curr *composite.BackendService) error {
 		return nil
 	}
 
+	if !desired.Iap.Enabled {
+		return nil
+	}
+
 	// Due to the validation earlier in the sync both Oauth2 fields will be empty or both are set
 	// so only one field needs to be checked.
 	desiredIsEmpty := desired.Iap.Oauth2ClientId == ""

--- a/pkg/backends/features/iap_test.go
+++ b/pkg/backends/features/iap_test.go
@@ -263,6 +263,34 @@ func TestEnsureIAP(t *testing.T) {
 			updateExpected: false,
 			expectErr:      true,
 		},
+		{
+			desc: "enabled is changed to false, update needed",
+			sp: utils.ServicePort{
+				BackendConfig: &backendconfigv1.BackendConfig{
+					Spec: backendconfigv1.BackendConfigSpec{
+						Iap: &backendconfigv1.IAPConfig{
+							Enabled: false,
+						},
+					},
+				},
+			},
+			be: &composite.BackendService{
+				Iap: &composite.BackendServiceIAP{
+					Enabled:                  true,
+					Oauth2ClientId:           "foo",
+					Oauth2ClientSecretSha256: fmt.Sprintf("%x", sha256.Sum256([]byte("baz"))),
+				},
+			},
+			wantBE: &composite.BackendService{
+				Iap: &composite.BackendServiceIAP{
+					Enabled:                  false,
+					Oauth2ClientId:           "",
+					Oauth2ClientSecretSha256: "",
+				},
+			},
+			updateExpected: true,
+			expectErr:      false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Issue Overview

Currently when [disabling IAP](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#iap-turn-off) with the following BackendConfig,

```yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: iap-backendconfig
spec:
  iap:
    enabled: false
```

it results with a following sync error:

```
Error syncing to GCP: error running backend syncing routine: Errored updating IAP Settings for service default/sample-svc: Cannot switch to default OAuth once IAP credentials have been set
```

### Issue Details

This is because when `spec.iap.enabled: false` is applied, the validation is skipped and `beConfig.Spec.Iap.OAuthClientCredentials` won't be fulfilled properly ([code](https://github.com/kubernetes/ingress-gce/blob/42314e4164b9323f8c50838c7d418729e23e6cd9/pkg/backendconfig/validation.go#L68-L71)), so `switchingToDefault` function always uses the blank OAuth client credentials and returns the error [here](https://github.com/kubernetes/ingress-gce/blob/42314e4164b9323f8c50838c7d418729e23e6cd9/pkg/backends/features/iap.go#L117).

This might be a regression that was introduced by [this commit](https://github.com/kubernetes/ingress-gce/commit/986681a0f3e8d3ca8db985d1b49a49a38830d91f).

### About this PR

This PR added the validation in `switchingToDefault` so that it can continue updating the IAP setting when it's disabled.

I tested this change with manual l7-lb-controller deployment and disabling IAP succeeded with the following logs.

```
[2024-07-15 21:10:39.058 JST] "Iap `enabled` setting changed: " logger="IngressController.SyncBackends.EnsureIAP" ingressKey="default/sample-ingress" syncId=750146048 backendServiceName="k8s1-f9080803-default-sample-svc-443-b069e533" backendVersion="ga" backendScope="global" port=0 service="default/sample-svc" from=true to=false 

[2024-07-15 21:10:39.058 JST] "Updated IAP settings" logger="IngressController.SyncBackends.EnsureIAP" ingressKey="default/sample-ingress" syncId=750146048 backendServiceName="k8s1-f9080803-default-sample-svc-443-b069e533" backendVersion="ga" backendScope="global" port=0 service="default/sample-svc" 

[2024-07-15 21:10:39.058 JST] "Updating ga BackendService" logger="IngressController.SyncBackends" ingressKey="default/sample-ingress" syncId=750146048 backendServiceName="k8s1-f9080803-default-sample-svc-443-b069e533" backendVersion="ga" backendScope="global" port=0 name="k8s1-f9080803-default-sample-svc-443-b069e533" 
```
