### PR TITLE
[Cherry-pick #2599 -> 1.30] Skip marking NEG readiness gate as ready until nodeName is set for msc, and add new error state for node without PodCIDR.

### DIFF
--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -382,6 +382,10 @@ func getEndpointZone(endpointAddress negtypes.AddressData, zoneGetter *zonegette
 		count[negtypes.NodeNotFound]++
 		return zone, count, fmt.Errorf("%w: %v", negtypes.ErrEPNodeNotFound, err)
 	}
+	if errors.Is(err, zonegetter.ErrNodePodCIDRNotSet) {
+		count[negtypes.NodePodCIDRNotSet]++
+		return zone, count, fmt.Errorf("%w: %w", negtypes.ErrEPNodePodCIDRNotSet, err)
+	}
 	// providerID missing in node or zone information missing in providerID.
 	if errors.Is(err, zonegetter.ErrProviderIDNotFound) || errors.Is(err, zonegetter.ErrSplitProviderID) {
 		count[negtypes.ZoneMissing]++

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -48,6 +48,7 @@ const (
 	TestUpgradeInstance1  = "upgrade-instance1"
 	TestUpgradeInstance2  = "upgrade-instance2"
 	TestNotExistInstance  = "not-exist-instance"
+	TestNotExistPod       = "not-exist-pod"
 	TestEmptyZoneInstance = "instance-empty-providerID" // This maps to an empty instance in PopulateFakeNodeInformer
 	TestEmptyZonePod      = "pod-empty-providerID"
 

--- a/pkg/neg/types/states.go
+++ b/pkg/neg/types/states.go
@@ -24,6 +24,7 @@ const (
 	PodLabelMismatch       = State("PodLabelMismatch")
 	NodeMissing            = State("NodeMissing")
 	NodeNotFound           = State("NodeNotFound")
+	NodePodCIDRNotSet      = State("NodePodCIDRNotSet")
 	ZoneMissing            = State("ZoneMissing")
 	IPInvalid              = State("IPInvalid")
 	IPNotFromPod           = State("IPNotFromPod")

--- a/pkg/neg/types/sync_errors.go
+++ b/pkg/neg/types/sync_errors.go
@@ -21,6 +21,7 @@ const (
 	ReasonEPCountsDiffer            = Reason("EPCountsDiffer")
 	ReasonEPNodeMissing             = Reason("EPNodeMissing")
 	ReasonEPNodeNotFound            = Reason("EPNodeNotFound")
+	ReasonEPNodePodCIDRNotSet       = Reason("EPNodePodCIDRNotSet")
 	ReasonEPNodeTypeAssertionFailed = Reason("EPNodeTypeAssertionFailed")
 	ReasonEPPodMissing              = Reason("EPPodMissing")
 	ReasonEPPodNotFound             = Reason("EPPodNotFound")
@@ -60,6 +61,11 @@ var (
 	ErrEPNodeNotFound = NegSyncError{
 		Err:          errors.New("endpoint corresponds to an non-existing node"),
 		Reason:       ReasonEPNodeNotFound,
+		IsErrorState: true,
+	}
+	ErrEPNodePodCIDRNotSet = NegSyncError{
+		Err:          errors.New("endpoint corresponds to a node with PodCIDR not set"),
+		Reason:       ReasonEPNodePodCIDRNotSet,
 		IsErrorState: true,
 	}
 	ErrEPNodeTypeAssertionFailed = NegSyncError{


### PR DESCRIPTION
Cherry-pick #2599 to 1.30.

/assign @swetharepakula 