### PR TITLE
Add instance group resize metrics

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	metrics "k8s.io/ingress-gce/pkg/instancegroups/metrics"
+
 	"google.golang.org/api/compute/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/ingress-gce/pkg/events"
@@ -339,6 +341,7 @@ func (m *manager) Sync(nodes []string) (err error) {
 
 		start := time.Now()
 		if len(removeNodes) != 0 {
+			metrics.PublishInstanceGroupRemove(len(removeNodes))
 			err = m.remove(igName, removeNodes, zone)
 			m.logger.V(2).Info("Remove finished", "name", igName, "err", err, "timeTaken", time.Now().Sub(start), "removeNodes", events.TruncatedStringList(removeNodes))
 			if err != nil {
@@ -348,6 +351,7 @@ func (m *manager) Sync(nodes []string) (err error) {
 
 		start = time.Now()
 		if len(addNodes) != 0 {
+			metrics.PublishInstanceGroupAdd(len(addNodes))
 			err = m.add(igName, addNodes, zone)
 			m.logger.V(2).Info("Add finished", "name", igName, "err", err, "timeTaken", time.Now().Sub(start), "addNodes", events.TruncatedStringList(addNodes))
 			if err != nil {

--- a/pkg/instancegroups/metrics/metrics.go
+++ b/pkg/instancegroups/metrics/metrics.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+)
+
+const (
+	AddOperationTypeLabel    = "Add"
+	RemoveOperationTypeLabel = "Remove"
+)
+
+var (
+	instanceGroupEventSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "instance_group_event_size",
+			Help:    "Size of adding or removing events attempted on instance groups",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 15),
+		},
+		[]string{"operation_type"},
+	)
+	instanceGroupEventCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "instance_group_event_count",
+			Help: "Count of adding or removing events attempted on instance groups",
+		},
+		[]string{"operation_type"},
+	)
+)
+
+// init metrics.
+func init() {
+	klog.V(3).Infof("Registering Instance Group event size metric: %v", instanceGroupEventSize)
+	prometheus.MustRegister(instanceGroupEventSize)
+	klog.V(3).Infof("Registering Instance Group event count metric: %v", instanceGroupEventCount)
+	prometheus.MustRegister(instanceGroupEventCount)
+}
+
+// PublishInstanceGroupAdd counts how many times with attempt to add nodes to an instance group and the number of nodes present in each attempt.
+func PublishInstanceGroupAdd(count int) {
+	instanceGroupEventSize.WithLabelValues(AddOperationTypeLabel).Observe((float64(count)))
+	instanceGroupEventCount.WithLabelValues(AddOperationTypeLabel).Inc()
+}
+
+// PublishInstanceGroupRemove counts how many times with attempt to remove nodes to an instance group and the number of nodes present in each attempt.
+func PublishInstanceGroupRemove(count int) {
+	instanceGroupEventSize.WithLabelValues(RemoveOperationTypeLabel).Observe((float64(count)))
+	instanceGroupEventCount.WithLabelValues(RemoveOperationTypeLabel).Inc()
+}


### PR DESCRIPTION
Add instance group resize metrics.

- An histogram that tracks how many nodes we are adding or removing.
- A counter that tracks the number of adds and removes we are attempting.