### PR TITLE
Detect unexpected updates in RBS NetLB Controller

### DIFF
--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -245,7 +245,7 @@ func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backe
 		NetworkInfo:              &network.NetworkInfo{IsDefault: true},
 		ConnectionTrackingPolicy: nil,
 	}
-	if _, err := backendPool.EnsureL4BackendService(backendParams, klog.TODO()); err != nil {
+	if _, _, err := backendPool.EnsureL4BackendService(backendParams, klog.TODO()); err != nil {
 		t.Fatalf("Error creating backend service %v", err)
 	}
 }

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -43,17 +43,17 @@ type FirewallParams struct {
 	Network           network.NetworkInfo
 }
 
-func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParams, sharedRule bool, fwLogger klog.Logger) error {
+func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParams, sharedRule bool, fwLogger klog.Logger) (utils.ResourceSyncStatus, error) {
 	fwLogger = fwLogger.WithValues("l4Type", params.L4Type.ToString())
 	fa := NewFirewallAdapter(cloud)
 	existingFw, err := fa.GetFirewall(params.Name)
 	if err != nil && !utils.IsNotFoundError(err) {
-		return err
+		return utils.ResourceResync, err
 	}
 
 	nodeTags, err := cloud.GetNodeTags(params.NodeNames)
 	if err != nil {
-		return err
+		return utils.ResourceResync, err
 	}
 	fwDesc, err := utils.MakeL4LBFirewallDescription(nsName, params.IP, meta.VersionGA, sharedRule)
 	if err != nil {
@@ -82,14 +82,14 @@ func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParam
 			gcloudCmd := gce.FirewallToGCloudCreateCmd(expectedFw, cloud.NetworkProjectID())
 
 			fwLogger.V(3).Info("EnsureL4FirewallRule: Could not create L4 firewall on XPN cluster. Raising event for cmd", "err", err, "gcloudCmd", gcloudCmd)
-			return newFirewallXPNError(err, gcloudCmd)
+			return utils.ResourceUpdate, newFirewallXPNError(err, gcloudCmd)
 		}
-		return err
+		return utils.ResourceUpdate, err
 	}
 
 	// Don't compare the "description" field for shared firewall rules
 	if firewallRuleEqual(expectedFw, existingFw, sharedRule) {
-		return nil
+		return utils.ResourceResync, nil
 	}
 
 	fwLogger.V(2).Info("EnsureL4FirewallRule: patching L4 firewall")
@@ -97,9 +97,9 @@ func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParam
 	if utils.IsForbiddenError(err) && cloud.OnXPN() {
 		gcloudCmd := gce.FirewallToGCloudUpdateCmd(expectedFw, cloud.NetworkProjectID())
 		fwLogger.V(3).Info("EnsureL4FirewallRule: Could not patch L4 firewall on XPN cluster. Raising event for cmd", "err", err, "gcloudCmd", gcloudCmd)
-		return newFirewallXPNError(err, gcloudCmd)
+		return utils.ResourceUpdate, newFirewallXPNError(err, gcloudCmd)
 	}
-	return err
+	return utils.ResourceUpdate, err
 }
 
 func EnsureL4FirewallRuleDeleted(cloud *gce.Cloud, fwName string, fwLogger klog.Logger) error {
@@ -148,25 +148,25 @@ func allowRulesEqual(a *compute.FirewallAllowed, b *compute.FirewallAllowed) boo
 		utils.EqualStringSets(a.Ports, b.Ports)
 }
 
-func ensureFirewall(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) error {
+func ensureFirewall(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) (utils.ResourceSyncStatus, error) {
 	nsName := utils.ServiceKeyFunc(svc.Namespace, svc.Name)
-	err := EnsureL4FirewallRule(cloud, nsName, params, shared, fwLogger)
+	updateStatus, err := EnsureL4FirewallRule(cloud, nsName, params, shared, fwLogger)
 	if err != nil {
 		if fwErr, ok := err.(*FirewallXPNError); ok {
 			recorder.Eventf(svc, v1.EventTypeNormal, "XPN", fwErr.Message)
-			return nil
+			return updateStatus, nil
 		}
-		return err
+		return updateStatus, err
 	}
-	return nil
+	return updateStatus, nil
 }
 
 // EnsureL4LBFirewallForHc creates or updates firewall rule for shared or non-shared health check to nodes
-func EnsureL4LBFirewallForHc(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) error {
+func EnsureL4LBFirewallForHc(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) (utils.ResourceSyncStatus, error) {
 	return ensureFirewall(svc, shared, params, cloud, recorder, fwLogger)
 }
 
 // EnsureL4LBFirewallForNodes creates or updates firewall rule for LB traffic to nodes
-func EnsureL4LBFirewallForNodes(svc *v1.Service, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) error {
+func EnsureL4LBFirewallForNodes(svc *v1.Service, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) (utils.ResourceSyncStatus, error) {
 	return ensureFirewall(svc /*shared = */, false, params, cloud, recorder, fwLogger)
 }

--- a/pkg/firewalls/firewalls_l4_test.go
+++ b/pkg/firewalls/firewalls_l4_test.go
@@ -2,8 +2,9 @@ package firewalls
 
 import (
 	"context"
-	"k8s.io/klog/v2"
 	"testing"
+
+	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
@@ -20,14 +21,16 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 		t.Errorf("Failed making the description, err=%v", err)
 	}
 	tests := []struct {
-		desc   string
-		nsName string
-		params *FirewallParams
-		shared bool
-		want   *compute.Firewall
+		desc         string
+		nsName       string
+		params       *FirewallParams
+		shared       bool
+		existingRule *compute.Firewall
+		want         *compute.Firewall
+		expectUpdate utils.ResourceSyncStatus
 	}{
 		{
-			desc:   "default setup",
+			desc:   "default ensure",
 			nsName: utils.ServiceKeyFunc("test-ns", "test-name"),
 			params: &FirewallParams{
 				Name: "test-firewall",
@@ -60,6 +63,58 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 					},
 				},
 			},
+			expectUpdate: utils.ResourceUpdate,
+		},
+		{
+			desc:   "default setup no udpate",
+			nsName: utils.ServiceKeyFunc("test-ns", "test-name"),
+			params: &FirewallParams{
+				Name: "test-firewall",
+				IP:   "10.0.0.1",
+				SourceRanges: []string{
+					"10.1.2.8/29",
+				},
+				DestinationRanges: []string{
+					"10.1.2.16/29",
+				},
+				PortRanges: []string{"8080"},
+				NodeNames:  []string{"k8s-test-node"},
+				Protocol:   "TCP",
+				L4Type:     utils.ILB,
+				Network:    network.NetworkInfo{IsDefault: true},
+			},
+			shared: false,
+			existingRule: &compute.Firewall{
+				Name:    "test-firewall",
+				Network: "",
+				SourceRanges: []string{
+					"10.1.2.8/29",
+				},
+				TargetTags:  []string{"k8s-test"},
+				Description: firewallDescription,
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "tcp",
+						Ports:      []string{"8080"},
+					},
+				},
+			},
+			want: &compute.Firewall{
+				Name:    "test-firewall",
+				Network: "",
+				SourceRanges: []string{
+					"10.1.2.8/29",
+				},
+				TargetTags:  []string{"k8s-test"},
+				Description: firewallDescription,
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "tcp",
+						Ports:      []string{"8080"},
+					},
+				},
+			},
+			expectUpdate: utils.ResourceResync,
 		},
 		{
 			desc:   "non default network",
@@ -95,6 +150,7 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 					},
 				},
 			},
+			expectUpdate: utils.ResourceUpdate,
 		},
 	}
 	for _, tc := range tests {
@@ -102,7 +158,11 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 			// Add some instance to act as the node so that target tags in the firewall can be resolved.
 			createVMInstanceWithTag(t, fakeGCE, "k8s-test")
-			if err := EnsureL4FirewallRule(fakeGCE, tc.nsName, tc.params, tc.shared, klog.TODO()); err != nil {
+			if tc.existingRule != nil {
+				fakeGCE.CreateFirewall(tc.existingRule)
+			}
+			updateDone, err := EnsureL4FirewallRule(fakeGCE, tc.nsName, tc.params, tc.shared, klog.TODO())
+			if err != nil {
 				t.Errorf("EnsureL4FirewallRule() failed, err=%v", err)
 			}
 			firewall, err := fakeGCE.GetFirewall(tc.params.Name)
@@ -111,6 +171,9 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, firewall, cmpopts.IgnoreFields(compute.Firewall{}, "SelfLink")); diff != "" {
 				t.Errorf("EnsureL4FirewallRule() diff -want +got\n%v\n", diff)
+			}
+			if updateDone != tc.expectUpdate {
+				t.Errorf("EnsureL4FirewallRule() expectedUpdate: %v, but the update was: %v", tc.expectUpdate, updateDone)
 			}
 		})
 	}

--- a/pkg/healthchecksl4/healthchecksl4.go
+++ b/pkg/healthchecksl4/healthchecksl4.go
@@ -133,18 +133,20 @@ func (l4hc *l4HealthChecks) EnsureHealthCheckWithDualStackFirewalls(svc *corev1.
 	}
 	hcLogger.V(3).Info("L4 Healthcheck", "expectedPath", hcPath, "expectedPort", hcPort)
 
-	hcLink, err := l4hc.ensureHealthCheck(hcName, namespacedName, sharedHC, hcPath, hcPort, scope, l4Type, hcLogger)
+	hcLink, wasUpdate, err := l4hc.ensureHealthCheck(hcName, namespacedName, sharedHC, hcPath, hcPort, scope, l4Type, hcLogger)
 	if err != nil {
 		hcLogger.Error(err, "Error while ensuring hc")
 		return &EnsureHealthCheckResult{
 			GceResourceInError: annotations.HealthcheckResource,
 			Err:                err,
+			WasUpdated:         utils.ResourceResync,
 		}
 	}
 
 	hcResult := &EnsureHealthCheckResult{
-		HCName: hcName,
-		HCLink: hcLink,
+		HCName:     hcName,
+		HCLink:     hcLink,
+		WasUpdated: wasUpdate,
 	}
 
 	if needsIPv4 {
@@ -160,7 +162,7 @@ func (l4hc *l4HealthChecks) EnsureHealthCheckWithDualStackFirewalls(svc *corev1.
 	return hcResult
 }
 
-func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType, hcLogger klog.Logger) (string, error) {
+func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.NamespacedName, shared bool, path string, port int32, scope meta.KeyType, l4Type utils.L4LBType, hcLogger klog.Logger) (string, utils.ResourceSyncStatus, error) {
 	start := time.Now()
 	hcLogger.V(2).Info("Ensuring healthcheck for service", "shared", shared, "path", path, "port", port, "scope", scope, "l4Type", l4Type.ToString())
 	defer func() {
@@ -169,7 +171,7 @@ func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.Names
 
 	hc, err := l4hc.hcProvider.Get(hcName, scope)
 	if err != nil {
-		return "", err
+		return "", utils.ResourceResync, err
 	}
 
 	var region string
@@ -183,27 +185,27 @@ func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.Names
 		hcLogger.V(2).Info("Creating healthcheck for service", "shared", shared, "expectedHealthcheck", expectedHC)
 		err = l4hc.hcProvider.Create(expectedHC)
 		if err != nil {
-			return "", err
+			return "", utils.ResourceResync, err
 		}
 		selfLink, err := l4hc.hcProvider.SelfLink(expectedHC.Name, scope)
 		if err != nil {
-			return "", err
+			return "", utils.ResourceResync, err
 		}
-		return selfLink, nil
+		return selfLink, utils.ResourceUpdate, nil
 	}
 	selfLink := hc.SelfLink
 	if !needToUpdateHealthChecks(hc, expectedHC) {
 		// nothing to do
 		hcLogger.V(3).Info("Healthcheck already exists and does not require update")
-		return selfLink, nil
+		return selfLink, utils.ResourceResync, nil
 	}
 	mergeHealthChecks(hc, expectedHC)
 	hcLogger.V(2).Info("Updating healthcheck for service", "updatedHealthcheck", expectedHC)
 	err = l4hc.hcProvider.Update(expectedHC.Name, scope, expectedHC)
 	if err != nil {
-		return selfLink, err
+		return selfLink, utils.ResourceUpdate, err
 	}
-	return selfLink, err
+	return selfLink, utils.ResourceUpdate, err
 }
 
 // ensureIPv4Firewall rule for `svc`.
@@ -229,7 +231,8 @@ func (l4hc *l4HealthChecks) ensureIPv4Firewall(svc *corev1.Service, namer namer.
 		NodeNames:    nodeNames,
 		Network:      svcNetwork,
 	}
-	err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
+	wasUpdated, err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
+	hcResult.WasFirewallUpdated = wasUpdated == utils.ResourceUpdate || hcResult.WasFirewallUpdated == utils.ResourceUpdate
 	if err != nil {
 		fwLogger.Error(err, "Error ensuring IPv4 Firewall for health check for service")
 		hcResult.GceResourceInError = annotations.FirewallForHealthcheckResource
@@ -257,7 +260,8 @@ func (l4hc *l4HealthChecks) ensureIPv6Firewall(svc *corev1.Service, namer namer.
 		NodeNames:    nodeNames,
 		Network:      svcNetwork,
 	}
-	err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
+	wasUpdated, err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
+	hcResult.WasFirewallUpdated = wasUpdated == utils.ResourceUpdate || hcResult.WasFirewallUpdated == utils.ResourceUpdate
 	if err != nil {
 		fwLogger.Error(err, "Error ensuring IPv6 Firewall for health check for service")
 		hcResult.GceResourceInError = annotations.FirewallForHealthcheckIPv6Resource

--- a/pkg/healthchecksl4/healthchecksl4_test.go
+++ b/pkg/healthchecksl4/healthchecksl4_test.go
@@ -17,11 +17,22 @@ limitations under the License.
 package healthchecksl4
 
 import (
-	"k8s.io/klog/v2"
+	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
+
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -430,5 +441,253 @@ func TestNewHealthCheck(t *testing.T) {
 		if hc.Scope != v.scope {
 			t.Errorf("HealthCheck Scope mismatch! %v != %v", hc.Scope, v.scope)
 		}
+	}
+}
+
+func TestEnsureHealthCheck(t *testing.T) {
+	namespacedName := types.NamespacedName{Name: "svcName", Namespace: "svcNamespace"}
+	testClusterValues := gce.DefaultTestClusterValues()
+	hcName := "testHCname"
+	hcDefaultPath := "/healthz"
+	testCases := []struct {
+		desc       string
+		existingHC *composite.HealthCheck
+		port       int32
+		shared     bool
+		scope      meta.KeyType
+		l4Type     utils.L4LBType
+		wantHC     *composite.HealthCheck
+		wantUpdate utils.ResourceSyncStatus
+	}{
+		{
+			desc:       "create for XLB",
+			existingHC: nil,
+			port:       80,
+			shared:     false,
+			scope:      meta.Global,
+			l4Type:     utils.XLB,
+			wantHC:     newL4HealthCheck(hcName, namespacedName, false, hcDefaultPath, 80, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantUpdate: utils.ResourceUpdate,
+		},
+		{
+			desc:       "create for ILB",
+			existingHC: nil,
+			port:       80,
+			shared:     true,
+			scope:      meta.Regional,
+			l4Type:     utils.ILB,
+			wantHC:     newL4HealthCheck(hcName, namespacedName, true, hcDefaultPath, 80, utils.ILB, meta.Regional, testClusterValues.Region, klog.TODO()),
+			wantUpdate: utils.ResourceUpdate,
+		},
+		{
+			desc:       "no update",
+			existingHC: newL4HealthCheck(hcName, namespacedName, false, hcDefaultPath, 80, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			port:       80,
+			shared:     false,
+			scope:      meta.Global,
+			l4Type:     utils.XLB,
+			wantHC:     newL4HealthCheck(hcName, namespacedName, false, hcDefaultPath, 80, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantUpdate: utils.ResourceResync,
+		},
+		{
+			desc:       "update ILB to XLB",
+			existingHC: newL4HealthCheck(hcName, namespacedName, false, hcDefaultPath, 80, utils.ILB, meta.Regional, testClusterValues.Region, klog.TODO()),
+			port:       80,
+			shared:     false,
+			scope:      meta.Global,
+			l4Type:     utils.XLB,
+			wantHC:     newL4HealthCheck(hcName, namespacedName, false, hcDefaultPath, 80, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantUpdate: utils.ResourceUpdate,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			hcs := NewL4HealthChecks(fakeGCE, &record.FakeRecorder{}, klog.TODO())
+
+			if tc.existingHC != nil {
+				err := hcs.hcProvider.Create(tc.existingHC)
+				if err != nil {
+					t.Errorf("hcProvider.Create() err=%v", err)
+				}
+			}
+
+			_, updated, err := hcs.ensureHealthCheck(hcName, namespacedName, tc.shared, hcDefaultPath, tc.port, tc.scope, tc.l4Type, klog.TODO())
+			if err != nil {
+				t.Errorf("ensureHealthCheck() err=%v", err)
+			}
+			if updated != tc.wantUpdate {
+				t.Errorf("ensureHealthCheck() unexpected 'updated' value, want=%v, got=%v", tc.wantUpdate, updated)
+			}
+			resultHC, err := hcs.hcProvider.Get(hcName, tc.scope)
+			if err != nil {
+				t.Errorf("hcProvider.Get() err=-%v", err)
+			}
+			if diff := cmp.Diff(tc.wantHC, resultHC, cmpopts.IgnoreFields(composite.HealthCheck{}, "SelfLink", "Region", "Scope", "Version")); diff != "" {
+				t.Errorf("created HC differs: diff -want +got\n%v\n", diff)
+			}
+		})
+	}
+}
+
+func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
+	l4Namer := namer.NewL4Namer("test", namer.NewNamer("testCluster", "testFirewall", klog.TODO()))
+	testClusterValues := gce.DefaultTestClusterValues()
+	hcDefaultPath := "/healthz"
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "serviceName", Namespace: "serviceNamespace", UID: types.UID("1")},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:     8080,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Type:                  "LoadBalancer",
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+			HealthCheckNodePort:   1234,
+		},
+	}
+	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+	fwDescription, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(svc.Namespace, svc.Name), "", meta.VersionGA, false)
+	if err != nil {
+		t.Errorf("utils.MakeL4LBFirewallDescription() err=%v", err)
+	}
+	expectedFw := &compute.Firewall{
+		Name:         l4Namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, false),
+		Description:  fwDescription,
+		Network:      testClusterValues.NetworkURL,
+		SourceRanges: gce.L4LoadBalancerSrcRanges(),
+		TargetTags:   []string{"k8s-test"},
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "tcp",
+				Ports:      []string{"1234"},
+			},
+		},
+	}
+	fwThatNeedsUpdate := &compute.Firewall{
+		Name:         l4Namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, false),
+		Description:  fwDescription,
+		Network:      testClusterValues.NetworkURL,
+		SourceRanges: []string{"10.0.0.0/16"},
+		TargetTags:   []string{"k8s-test"},
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "tcp",
+				Ports:      []string{"1234"},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc             string
+		existingHC       *composite.HealthCheck
+		existingFirewall *compute.Firewall
+		svc              *corev1.Service
+		wantHC           *composite.HealthCheck
+		wantFirewall     *compute.Firewall
+		needIPv6         bool
+		wantUpdate       utils.ResourceSyncStatus
+		wantUpdateFw     utils.ResourceSyncStatus
+	}{
+		{
+			desc:         "create",
+			svc:          svc,
+			wantHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall: expectedFw,
+			wantUpdate:   utils.ResourceUpdate,
+			wantUpdateFw: utils.ResourceUpdate,
+		},
+		{
+			desc:             "no update",
+			svc:              svc,
+			existingHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			existingFirewall: expectedFw,
+			wantHC:           newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall:     expectedFw,
+			wantUpdate:       utils.ResourceResync,
+			wantUpdateFw:     utils.ResourceResync,
+		},
+		{
+			desc:             "update only FW",
+			svc:              svc,
+			existingHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			existingFirewall: fwThatNeedsUpdate,
+			wantHC:           newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall:     expectedFw,
+			wantUpdate:       utils.ResourceResync,
+			wantUpdateFw:     utils.ResourceUpdate,
+		},
+		{
+			desc:             "add ipv6",
+			svc:              svc,
+			existingHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			existingFirewall: expectedFw,
+			needIPv6:         true,
+			wantHC:           newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall:     expectedFw,
+			wantUpdate:       utils.ResourceResync,
+			wantUpdateFw:     utils.ResourceUpdate,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(testClusterValues)
+			nodeNames := []string{"k8s-test-node"}
+			createVMInstanceWithTag(t, fakeGCE, "k8s-test")
+			defaultNetwork := network.DefaultNetwork(fakeGCE)
+			hcs := NewL4HealthChecks(fakeGCE, &record.FakeRecorder{}, klog.TODO())
+			if tc.existingHC != nil {
+				err := hcs.hcProvider.Create(tc.existingHC)
+				if err != nil {
+					t.Errorf("hcProvider.Create() err=%v", err)
+				}
+			}
+			if tc.existingFirewall != nil {
+				fakeGCE.CreateFirewall(tc.existingFirewall)
+			}
+
+			result := hcs.EnsureHealthCheckWithDualStackFirewalls(svc, l4Namer, false, meta.Global, utils.XLB, nodeNames, true, tc.needIPv6, *defaultNetwork, klog.TODO())
+			if result.Err != nil {
+				t.Errorf("hcs.EnsureHealthCheckWithDualStackFirewalls() err=%v", result.Err)
+			}
+			if result.WasUpdated != tc.wantUpdate {
+				t.Errorf("result.WasUpdated want=%v, got=%v", tc.wantUpdate, result.WasUpdated)
+			}
+			if result.WasFirewallUpdated != tc.wantUpdateFw {
+				t.Errorf("result.WasFirewallUpdated want=%v, got=%v", tc.wantUpdateFw, result.WasFirewallUpdated)
+			}
+			resultHC, err := hcs.hcProvider.Get(result.HCName, meta.Global)
+			if err != nil {
+				t.Errorf("hcProvider.Get() err=-%v", err)
+			}
+			if diff := cmp.Diff(tc.wantHC, resultHC, cmpopts.IgnoreFields(composite.HealthCheck{}, "SelfLink", "Region", "Scope", "Version")); diff != "" {
+				t.Errorf("created HC differs: diff -want +got\n%v\n", diff)
+			}
+			firewall, err := fakeGCE.GetFirewall(result.HCFirewallRuleName)
+			if err != nil {
+				t.Errorf("GetFirewall() err=-%v", err)
+			}
+			if diff := cmp.Diff(tc.wantFirewall, firewall, cmpopts.IgnoreFields(compute.Firewall{}, "SelfLink", "SourceRanges")); diff != "" {
+				t.Errorf("created Firewall differs: diff -want +got\n%v\n", diff)
+			}
+		})
+	}
+}
+
+func createVMInstanceWithTag(t *testing.T, fakeGCE *gce.Cloud, tag string) {
+	err := fakeGCE.Compute().Instances().Insert(context.Background(),
+		meta.ZonalKey("k8s-test-node", fakeGCE.LocalZone()),
+		&compute.Instance{
+			Name: "test-node",
+			Zone: "us-central1-b",
+			Tags: &compute.Tags{
+				Items: []string{tag},
+			},
+		})
+	if err != nil {
+		t.Errorf("failed to create instance err=%v", err)
 	}
 }

--- a/pkg/healthchecksl4/interfaces.go
+++ b/pkg/healthchecksl4/interfaces.go
@@ -29,6 +29,8 @@ type EnsureHealthCheckResult struct {
 	HCFirewallRuleIPv6Name string
 	GceResourceInError     string
 	Err                    error
+	WasUpdated             utils.ResourceSyncStatus
+	WasFirewallUpdated     utils.ResourceSyncStatus
 }
 
 type healthChecksProvider interface {

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -495,6 +495,12 @@ func (lc *L4NetLBController) sync(key string, svcLogger klog.Logger) error {
 		}
 		lc.serviceVersions.SetProcessed(key, svc.ResourceVersion, result.Error == nil, isResync, svcLogger)
 		lc.publishMetrics(result, svc.Name, svc.Namespace, isResync, svcLogger)
+		svcLogger.V(3).Info("Resources modified in the sync", "modifiedResources", result.GCEResourceUpdate.String(), "wasResync", isResync)
+		if isResync {
+			if result.GCEResourceUpdate.WereAnyResourcesModified() {
+				svcLogger.V(3).Error(nil, "Resources were modified but this was not expected for a resync.", "modifiedResources", result.GCEResourceUpdate.String())
+			}
+		}
 		return result.Error
 	}
 	svcLogger.V(3).Info("Ignoring sync of service, neither delete nor ensure needed.")

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -777,6 +777,7 @@ func (lc *L4NetLBController) publishSyncMetrics(result *loadbalancers.L4NetLBSyn
 	if result.MetricsState.Multinetwork {
 		l4metrics.PublishL4NetLBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, isResync)
 	}
+	l4metrics.PublishL4SyncDetails(l4NetLBControllerName, result.Error == nil, isResync, result.GCEResourceUpdate.WereAnyResourcesModified())
 	if result.Error == nil {
 		l4metrics.PublishL4NetLBSyncSuccess(result.SyncType, result.StartTime, isResync)
 		return

--- a/pkg/loadbalancers/forwarding_rules_test.go
+++ b/pkg/loadbalancers/forwarding_rules_test.go
@@ -2,6 +2,7 @@ package loadbalancers
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -15,7 +16,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
@@ -413,10 +416,321 @@ func TestL4CreateExternalForwardingRuleAddressAlreadyInUse(t *testing.T) {
 	fakeGCE.ReserveRegionAddress(addr, fakeGCE.Region())
 	insertError := &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.IPAddress': '1.1.1.1'. Specified IP address is in-use and would result in a conflict., invalid"}
 	fakeGCE.Compute().(*cloud.MockGCE).MockForwardingRules.InsertHook = test.InsertForwardingRuleErrorHook(insertError)
-	_, _, err := l4.ensureIPv4ForwardingRule("link")
+	_, _, _, err := l4.ensureIPv4ForwardingRule("link")
 
 	require.Error(t, err)
 	assert.True(t, utils.IsIPConfigurationError(err))
+}
+
+func TestL4CreateExternalForwardingRule(t *testing.T) {
+	serviceNamespace := "testNs"
+	serviceName := "testSvc"
+
+	bsLink := "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1"
+
+	testCases := []struct {
+		desc         string
+		svc          *corev1.Service
+		namedAddress *compute.Address
+		wantRule     *composite.ForwardingRule
+	}{
+		{
+			desc: "create",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			wantRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+		},
+		{
+			desc: "create with port range and network tier",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1"), Annotations: map[string]string{annotations.NetworkTierAnnotationKey: string(cloud.NetworkTierStandard)}},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolUDP,
+						},
+						{
+							Port:     8085,
+							Protocol: corev1.ProtocolUDP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			wantRule: &composite.ForwardingRule{
+				PortRange:           "8080-8085",
+				IPProtocol:          "UDP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierStandard.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+		},
+		{
+			desc: "create with assigned IP",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type:           "LoadBalancer",
+					LoadBalancerIP: "1.1.1.1",
+				},
+			},
+			wantRule: &composite.ForwardingRule{
+				IPAddress:           "1.1.1.1",
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "1.1.1.1", utils.XLB),
+			},
+		},
+		{
+			desc:         "create with named address",
+			namedAddress: &compute.Address{Name: "my-addr", Address: "1.2.3.4", AddressType: string(cloud.SchemeExternal)},
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1"), Annotations: map[string]string{annotations.StaticL4AddressesAnnotationKey: "my-addr"}},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			wantRule: &composite.ForwardingRule{
+				IPAddress:           "1.2.3.4",
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "1.2.3.4", utils.XLB),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			l4 := L4NetLB{
+				cloud:           fakeGCE,
+				forwardingRules: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
+				Service:         tc.svc,
+			}
+			tc.wantRule.Name = utils.LegacyForwardingRuleName(tc.svc)
+			if tc.namedAddress != nil {
+				fakeGCE.ReserveRegionAddress(tc.namedAddress, fakeGCE.Region())
+			}
+			fr, _, updated, err := l4.ensureIPv4ForwardingRule(bsLink)
+
+			if err != nil {
+				t.Errorf("ensureIPv4ForwardingRule() err=%v", err)
+			}
+			if !updated {
+				t.Errorf("ensureIPv4ForwardingRule() was supposed to return updated but did not")
+			}
+
+			if diff := cmp.Diff(tc.wantRule, fr, cmpopts.IgnoreFields(composite.ForwardingRule{}, "SelfLink", "Region", "Scope")); diff != "" {
+				t.Errorf("ensureIPv4ForwardingRule() diff -want +got\n%v\n", diff)
+			}
+		})
+	}
+}
+
+func TestL4CreateExternalForwardingRuleUpdate(t *testing.T) {
+	serviceNamespace := "testNs"
+	serviceName := "testSvc"
+
+	bsLink := "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1"
+
+	testCases := []struct {
+		desc         string
+		svc          *corev1.Service
+		namedAddress *compute.Address
+		existingRule *composite.ForwardingRule
+		wantRule     *composite.ForwardingRule
+		wantUpdate   utils.ResourceSyncStatus
+		wantErrMsg   string
+	}{
+		{
+			desc: "no update",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantUpdate: utils.ResourceResync,
+		},
+		{
+			desc: "update ports",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+						{
+							Port:     8082,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantRule: &composite.ForwardingRule{
+				PortRange:           "8080-8082",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantUpdate: utils.ResourceUpdate,
+		},
+		{
+			desc: "network mismatch error",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1"), Annotations: map[string]string{annotations.NetworkTierAnnotationKey: string(cloud.NetworkTierStandard)}},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantRule: &composite.ForwardingRule{
+				PortRange:           "8080-8080",
+				IPProtocol:          "TCP",
+				LoadBalancingScheme: string(cloud.SchemeExternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "", utils.XLB),
+			},
+			wantUpdate: utils.ResourceResync,
+			wantErrMsg: "Network tier mismatch for resource",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			l4 := L4NetLB{
+				cloud:           fakeGCE,
+				forwardingRules: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
+				Service:         tc.svc,
+				recorder:        &record.FakeRecorder{},
+			}
+			tc.wantRule.Name = utils.LegacyForwardingRuleName(tc.svc)
+			tc.existingRule.Name = utils.LegacyForwardingRuleName(tc.svc)
+			if tc.existingRule != nil {
+				l4.forwardingRules.Create(tc.existingRule)
+			}
+			if tc.namedAddress != nil {
+				fakeGCE.ReserveRegionAddress(tc.namedAddress, fakeGCE.Region())
+			}
+			fr, _, updated, err := l4.ensureIPv4ForwardingRule(bsLink)
+
+			if err != nil && tc.wantErrMsg == "" {
+				t.Errorf("ensureIPv4ForwardingRule() err=%v", err)
+			}
+			if tc.wantErrMsg != "" {
+				if err == nil {
+					t.Errorf("ensureIPv4ForwardingRule() wanted error with msg=%q but got none", tc.wantErrMsg)
+				} else if !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("ensureIPv4ForwardingRule() wanted error with msg=%q but got err=%v", tc.wantErrMsg, err)
+				}
+				return
+			}
+			if updated != tc.wantUpdate {
+				t.Errorf("ensureIPv4ForwardingRule() wanted updated=%v but got=%v", tc.wantUpdate, updated)
+			}
+
+			if diff := cmp.Diff(tc.wantRule, fr, cmpopts.IgnoreFields(composite.ForwardingRule{}, "SelfLink", "Region", "Scope")); diff != "" {
+				t.Errorf("ensureIPv4ForwardingRule() diff -want +got\n%v\n", diff)
+			}
+		})
+	}
 }
 
 func TestL4EnsureIPv4ForwardingRuleAddressAlreadyInUse(t *testing.T) {
@@ -500,7 +814,7 @@ func TestL4EnsureIPv4ForwardingRule(t *testing.T) {
 		Version:             meta.VersionGA,
 		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		AllowGlobalAccess:   false,
-		Description:         ilbServiceDescription(t, serviceName, serviceNamespace, "1.1.1.1"),
+		Description:         l4ServiceDescription(t, serviceName, serviceNamespace, "1.1.1.1", utils.ILB),
 	}
 	if diff := cmp.Diff(wantForwardingRule, forwardingRule, cmpopts.IgnoreFields(composite.ForwardingRule{}, "SelfLink", "Region", "Scope")); diff != "" {
 		t.Errorf("ensureIPv4ForwardingRule() diff -want +got\n%v\n", diff)
@@ -508,9 +822,9 @@ func TestL4EnsureIPv4ForwardingRule(t *testing.T) {
 
 }
 
-func ilbServiceDescription(t *testing.T, svcName, svcNamespace, ipToUse string) string {
+func l4ServiceDescription(t *testing.T, svcName, svcNamespace, ipToUse string, lbType utils.L4LBType) string {
 	description, err := utils.MakeL4LBServiceDescription(utils.ServiceKeyFunc(svcNamespace, svcName), ipToUse,
-		meta.VersionGA, false, utils.ILB)
+		meta.VersionGA, false, lbType)
 	if err != nil {
 		t.Errorf("utils.MakeL4LBServiceDescription() failed, err=%v", err)
 	}

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -491,7 +491,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 		ConnectionTrackingPolicy: noConnectionTrackingPolicy,
 		LocalityLbPolicy:         localityLbPolicy,
 	}
-	bs, err := l4.backendPool.EnsureL4BackendService(backendParams, l4.svcLogger)
+	bs, _, err := l4.backendPool.EnsureL4BackendService(backendParams, l4.svcLogger)
 	if err != nil {
 		if utils.IsUnsupportedFeatureError(err, string(backends.LocalityLBPolicyMaglev)) {
 			result.GCEResourceInError = annotations.BackendServiceResource
@@ -639,7 +639,7 @@ func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, resu
 		Network:           l4.network,
 	}
 
-	err = firewalls.EnsureL4LBFirewallForNodes(l4.Service, &nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
+	_, err = firewalls.EnsureL4LBFirewallForNodes(l4.Service, &nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
 	if err != nil {
 		result.GCEResourceInError = annotations.FirewallRuleResource
 		result.Error = err

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -150,7 +150,7 @@ func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, resu
 		Network:           l4.network,
 	}
 
-	err = firewalls.EnsureL4LBFirewallForNodes(l4.Service, &ipv6nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
+	_, err = firewalls.EnsureL4LBFirewallForNodes(l4.Service, &ipv6nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
 	if err != nil {
 		result.GCEResourceInError = annotations.FirewallRuleIPv6Resource
 		result.Error = err

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -18,6 +18,7 @@ package loadbalancers
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -85,6 +86,46 @@ type L4NetLBSyncResult struct {
 	MetricsState       metrics.L4ServiceState
 	SyncType           string
 	StartTime          time.Time
+	GCEResourceUpdate  ResourceUpdates
+}
+
+type ResourceUpdates struct {
+	backendServiceUpdate   utils.ResourceSyncStatus
+	forwardingRuleUpdate   utils.ResourceSyncStatus
+	healthCheckUpdate      utils.ResourceSyncStatus
+	firewallForNodesUpdate utils.ResourceSyncStatus
+	firewallForHCUpdate    utils.ResourceSyncStatus
+}
+
+func (ru *ResourceUpdates) WereAnyResourcesModified() bool {
+	return ru.forwardingRuleUpdate == utils.ResourceUpdate ||
+		ru.backendServiceUpdate == utils.ResourceUpdate ||
+		ru.healthCheckUpdate == utils.ResourceUpdate ||
+		ru.firewallForNodesUpdate == utils.ResourceUpdate ||
+		ru.firewallForHCUpdate == utils.ResourceUpdate
+}
+
+func (ru *ResourceUpdates) String() string {
+	if ru.WereAnyResourcesModified() {
+		var modifiedResources []string
+		if ru.forwardingRuleUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "forwarding rule")
+		}
+		if ru.backendServiceUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "backend service")
+		}
+		if ru.healthCheckUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "health check")
+		}
+		if ru.firewallForNodesUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "nodes firewall")
+		}
+		if ru.firewallForHCUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "health check firewall")
+		}
+		return strings.Join(modifiedResources, ",")
+	}
+	return "-"
 }
 
 func NewL4SyncResult(syncType string, svc *corev1.Service, isMultinet bool, enabledStrongSessionAffinity bool) *L4NetLBSyncResult {
@@ -265,6 +306,8 @@ func (l4netlb *L4NetLB) provideHealthChecks(nodeNames []string, result *L4NetLBS
 func (l4netlb *L4NetLB) provideDualStackHealthChecks(nodeNames []string, result *L4NetLBSyncResult) string {
 	sharedHC := !helpers.RequestsOnlyLocalTraffic(l4netlb.Service)
 	hcResult := l4netlb.healthChecks.EnsureHealthCheckWithDualStackFirewalls(l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB, nodeNames, utils.NeedsIPv4(l4netlb.Service), utils.NeedsIPv6(l4netlb.Service), l4netlb.networkInfo, l4netlb.svcLogger)
+	result.GCEResourceUpdate.healthCheckUpdate = hcResult.WasUpdated
+	result.GCEResourceUpdate.firewallForHCUpdate = hcResult.WasFirewallUpdated
 	if hcResult.Err != nil {
 		result.GCEResourceInError = hcResult.GceResourceInError
 		result.Error = hcResult.Err
@@ -284,6 +327,8 @@ func (l4netlb *L4NetLB) provideDualStackHealthChecks(nodeNames []string, result 
 func (l4netlb *L4NetLB) provideIPv4HealthChecks(nodeNames []string, result *L4NetLBSyncResult) string {
 	sharedHC := !helpers.RequestsOnlyLocalTraffic(l4netlb.Service)
 	hcResult := l4netlb.healthChecks.EnsureHealthCheckWithFirewall(l4netlb.Service, l4netlb.namer, sharedHC, l4netlb.scope, utils.XLB, nodeNames, l4netlb.networkInfo, l4netlb.svcLogger)
+	result.GCEResourceUpdate.healthCheckUpdate = hcResult.WasUpdated
+	result.GCEResourceUpdate.firewallForHCUpdate = hcResult.WasFirewallUpdated
 	if hcResult.Err != nil {
 		result.GCEResourceInError = hcResult.GceResourceInError
 		result.Error = hcResult.Err
@@ -327,7 +372,8 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 		LocalityLbPolicy:         localityLbPolicy,
 	}
 
-	bs, err := l4netlb.backendPool.EnsureL4BackendService(backendParams, l4netlb.svcLogger)
+	bs, wasUpdate, err := l4netlb.backendPool.EnsureL4BackendService(backendParams, l4netlb.svcLogger)
+	syncResult.GCEResourceUpdate.backendServiceUpdate = wasUpdate
 	if err != nil {
 		if utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
 			syncResult.GCEResourceInError = annotations.BackendServiceResource
@@ -362,7 +408,8 @@ func (l4netlb *L4NetLB) ensureDualStackResources(result *L4NetLBSyncResult, node
 // - IPv4 Forwarding Rule
 // - IPv4 Firewall
 func (l4netlb *L4NetLB) ensureIPv4Resources(result *L4NetLBSyncResult, nodeNames []string, bsLink string) {
-	fr, ipAddrType, err := l4netlb.ensureIPv4ForwardingRule(bsLink)
+	fr, ipAddrType, wasUpdate, err := l4netlb.ensureIPv4ForwardingRule(bsLink)
+	result.GCEResourceUpdate.forwardingRuleUpdate = wasUpdate
 	if err != nil {
 		// User can misconfigure the forwarding rule if Network Tier will not match service level Network Tier.
 		result.GCEResourceInError = annotations.ForwardingRuleResource
@@ -418,7 +465,7 @@ func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress st
 		NodeNames:         nodeNames,
 		Network:           l4netlb.networkInfo,
 	}
-	result.Error = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &nodesFWRParams, l4netlb.cloud, l4netlb.recorder, fwLogger)
+	result.GCEResourceUpdate.firewallForNodesUpdate, result.Error = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &nodesFWRParams, l4netlb.cloud, l4netlb.recorder, fwLogger)
 	if result.Error != nil {
 		result.GCEResourceInError = annotations.FirewallRuleResource
 		result.Error = err

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -346,7 +346,7 @@ func TestEnsureNetLBFirewallDestinations(t *testing.T) {
 		IP:                "1.2.3.4",
 	}
 
-	err := firewalls.EnsureL4FirewallRule(l4netlb.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false, klog.TODO())
+	_, err := firewalls.EnsureL4FirewallRule(l4netlb.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false, klog.TODO())
 	if err != nil {
 		t.Errorf("Unexpected error %v when ensuring firewall rule %s for svc %+v", err, fwName, svc)
 	}
@@ -357,7 +357,7 @@ func TestEnsureNetLBFirewallDestinations(t *testing.T) {
 	oldDestinationRanges := existingFirewall.DestinationRanges
 
 	fwrParams.DestinationRanges = []string{"30.0.0.0/20"}
-	err = firewalls.EnsureL4FirewallRule(l4netlb.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false, klog.TODO())
+	_, err = firewalls.EnsureL4FirewallRule(l4netlb.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false, klog.TODO())
 	if err != nil {
 		t.Errorf("Unexpected error %v when ensuring firewall rule %s for svc %+v", err, fwName, svc)
 	}

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -40,7 +40,8 @@ const (
 // - IPv6 Firewall
 // it also adds IPv6 address to LB status
 func (l4netlb *L4NetLB) ensureIPv6Resources(syncResult *L4NetLBSyncResult, nodeNames []string, bsLink string) {
-	ipv6fr, err := l4netlb.ensureIPv6ForwardingRule(bsLink)
+	ipv6fr, wasUpdate, err := l4netlb.ensureIPv6ForwardingRule(bsLink)
+	syncResult.GCEResourceUpdate.forwardingRuleUpdate = wasUpdate
 	if err != nil {
 		l4netlb.svcLogger.Error(err, "ensureIPv6Resources: Failed to create ipv6 forwarding rule")
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
@@ -137,7 +138,8 @@ func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []st
 		Network:           l4netlb.networkInfo,
 	}
 
-	err = firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &ipv6nodesFWRParams, l4netlb.cloud, l4netlb.recorder, fwLogger)
+	wasUpdate, err := firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &ipv6nodesFWRParams, l4netlb.cloud, l4netlb.recorder, fwLogger)
+	syncResult.GCEResourceUpdate.firewallForNodesUpdate = wasUpdate
 	if err != nil {
 		fwLogger.Error(err, "Failed to ensure ipv6 nodes firewall for L4 NetLB")
 		syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource

--- a/pkg/utils/syncstatus.go
+++ b/pkg/utils/syncstatus.go
@@ -1,0 +1,13 @@
+package utils
+
+// ResourceSyncStatus tracks the updates done to the GCE resources in the Ensure functions.
+type ResourceSyncStatus bool
+
+const (
+
+	// ResourceResync when the existing resource was already present and already in a good state.
+	ResourceResync ResourceSyncStatus = false
+
+	// ResourceUpdate when the resource had to be created or updated (an update call to GCE was made).
+	ResourceUpdate ResourceSyncStatus = true
+)


### PR DESCRIPTION
This PR contains code that propagates information about updates to any GCE resources for L4 RBS Net LBs.

There already is code that predicts if the ensure LB operation is a periodic resync or a real update (or create).
The idea here is to join this together with the actual operations on GCE resources done.
If the operation was predicted to be a periodic resync we want this to be exposed in a metric. This then can be observed on a fleet level (preferably per version), any significant increases should potentially be investigated.

