### PR TITLE
Add flag to disable L4 LB ingress firewalls 

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -249,6 +249,7 @@ func main() {
 		EnableIngressRegionalExternal: flags.F.EnableIngressRegionalExternal,
 		EnableWeightedL4ILB:           flags.F.EnableWeightedL4ILB,
 		EnableWeightedL4NetLB:         flags.F.EnableWeightedL4NetLB,
+		DisableL4LBFirewall:           flags.F.DisableL4LBFirewall,
 	}
 	ctx := ingctx.NewControllerContext(kubeConfig, kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, ingParamsClient, svcAttachmentClient, networkClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	go app.RunHTTPServer(ctx.HealthCheck, rootLogger)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -146,6 +146,7 @@ type ControllerContextConfig struct {
 	EnableIngressRegionalExternal bool
 	EnableWeightedL4ILB           bool
 	EnableWeightedL4NetLB         bool
+	DisableL4LBFirewall           bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -127,6 +127,7 @@ var (
 		EnableDualStackNEG                       bool
 		EnableFirewallCR                         bool
 		DisableFWEnforcement                     bool
+		DisableL4LBFirewall                      bool
 		EnableIngressRegionalExternal            bool
 		EnableIngressGlobalExternal              bool
 		OverrideComputeAPIEndpoint               string
@@ -309,6 +310,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableDualStackNEG, "enable-dual-stack-neg", false, `Enable support for Dual-Stack NEGs within the NEG Controller`)
 	flag.BoolVar(&F.EnableFirewallCR, "enable-firewall-cr", false, "Enable generating firewall CR")
 	flag.BoolVar(&F.DisableFWEnforcement, "disable-fw-enforcement", false, "Disable Ingress controller to enforce the firewall rules. If set to true, Ingress Controller stops creating GCE firewall rules. We can only enable this if enable-firewall-cr sets to true.")
+	flag.BoolVar(&F.DisableL4LBFirewall, "disable-l4-lb-fw", false, "Disable enforcement of L4 ILB and L4 NetLB VPC firewall rules. Required for firewall policies.")
 	flag.BoolVar(&F.EnableIngressRegionalExternal, "enable-ingress-regional-external", false, "Enable L7 Ingress Regional External.")
 	flag.BoolVar(&F.EnableIngressGlobalExternal, "enable-ingress-global-external", true, "Enable L7 Ingress Global External. Should be disabled when Regional External is enabled.")
 	flag.StringVar(&F.OverrideComputeAPIEndpoint, "override-compute-api-endpoint", "", "Override endpoint that is used to communicate to GCP compute APIs.")

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -263,14 +263,14 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 	// Use the same function for both create and updates. If controller crashes and restarts,
 	// all existing services will show up as Service Adds.
 	l4ilbParams := &loadbalancers.L4ILBParams{
-		Service:                service,
-		Cloud:                  l4c.ctx.Cloud,
-		Namer:                  l4c.namer,
-		Recorder:               l4c.ctx.Recorder(service.Namespace),
-		DualStackEnabled:       l4c.enableDualStack,
-		NetworkResolver:        l4c.networkResolver,
-		EnableWeightedLB:       l4c.ctx.EnableWeightedL4ILB,
-		DisableIngressFirewall: l4c.ctx.DisableL4LBFirewall,
+		Service:                          service,
+		Cloud:                            l4c.ctx.Cloud,
+		Namer:                            l4c.namer,
+		Recorder:                         l4c.ctx.Recorder(service.Namespace),
+		DualStackEnabled:                 l4c.enableDualStack,
+		NetworkResolver:                  l4c.networkResolver,
+		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
+		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -344,14 +344,14 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 	}()
 
 	l4ilbParams := &loadbalancers.L4ILBParams{
-		Service:                svc,
-		Cloud:                  l4c.ctx.Cloud,
-		Namer:                  l4c.namer,
-		Recorder:               l4c.ctx.Recorder(svc.Namespace),
-		DualStackEnabled:       l4c.enableDualStack,
-		NetworkResolver:        l4c.networkResolver,
-		EnableWeightedLB:       l4c.ctx.EnableWeightedL4ILB,
-		DisableIngressFirewall: l4c.ctx.DisableL4LBFirewall,
+		Service:                          svc,
+		Cloud:                            l4c.ctx.Cloud,
+		Namer:                            l4c.namer,
+		Recorder:                         l4c.ctx.Recorder(svc.Namespace),
+		DualStackEnabled:                 l4c.enableDualStack,
+		NetworkResolver:                  l4c.networkResolver,
+		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
+		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -263,13 +263,14 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 	// Use the same function for both create and updates. If controller crashes and restarts,
 	// all existing services will show up as Service Adds.
 	l4ilbParams := &loadbalancers.L4ILBParams{
-		Service:          service,
-		Cloud:            l4c.ctx.Cloud,
-		Namer:            l4c.namer,
-		Recorder:         l4c.ctx.Recorder(service.Namespace),
-		DualStackEnabled: l4c.enableDualStack,
-		NetworkResolver:  l4c.networkResolver,
-		EnableWeightedLB: l4c.ctx.EnableWeightedL4ILB,
+		Service:                service,
+		Cloud:                  l4c.ctx.Cloud,
+		Namer:                  l4c.namer,
+		Recorder:               l4c.ctx.Recorder(service.Namespace),
+		DualStackEnabled:       l4c.enableDualStack,
+		NetworkResolver:        l4c.networkResolver,
+		EnableWeightedLB:       l4c.ctx.EnableWeightedL4ILB,
+		DisableIngressFirewall: l4c.ctx.DisableL4LBFirewall,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -343,13 +344,14 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 	}()
 
 	l4ilbParams := &loadbalancers.L4ILBParams{
-		Service:          svc,
-		Cloud:            l4c.ctx.Cloud,
-		Namer:            l4c.namer,
-		Recorder:         l4c.ctx.Recorder(svc.Namespace),
-		DualStackEnabled: l4c.enableDualStack,
-		NetworkResolver:  l4c.networkResolver,
-		EnableWeightedLB: l4c.ctx.EnableWeightedL4ILB,
+		Service:                svc,
+		Cloud:                  l4c.ctx.Cloud,
+		Namer:                  l4c.namer,
+		Recorder:               l4c.ctx.Recorder(svc.Namespace),
+		DualStackEnabled:       l4c.enableDualStack,
+		NetworkResolver:        l4c.networkResolver,
+		EnableWeightedLB:       l4c.ctx.EnableWeightedL4ILB,
+		DisableIngressFirewall: l4c.ctx.DisableL4LBFirewall,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -515,6 +515,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 		StrongSessionAffinityEnabled: lc.enableStrongSessionAffinity,
 		NetworkResolver:              lc.networkResolver,
 		EnableWeightedLB:             lc.ctx.EnableWeightedL4NetLB,
+		DisableIngressFirewall:       lc.ctx.DisableL4LBFirewall,
 	}
 	l4netlb := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)
 
@@ -675,6 +676,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 		StrongSessionAffinityEnabled: lc.enableStrongSessionAffinity,
 		NetworkResolver:              lc.networkResolver,
 		EnableWeightedLB:             lc.ctx.EnableWeightedL4NetLB,
+		DisableIngressFirewall:       lc.ctx.DisableL4LBFirewall,
 	}
 	l4netLB := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer",

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -507,15 +507,15 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 	}()
 
 	l4NetLBParams := &loadbalancers.L4NetLBParams{
-		Service:                      service,
-		Cloud:                        lc.ctx.Cloud,
-		Namer:                        lc.namer,
-		Recorder:                     lc.ctx.Recorder(service.Namespace),
-		DualStackEnabled:             lc.enableDualStack,
-		StrongSessionAffinityEnabled: lc.enableStrongSessionAffinity,
-		NetworkResolver:              lc.networkResolver,
-		EnableWeightedLB:             lc.ctx.EnableWeightedL4NetLB,
-		DisableIngressFirewall:       lc.ctx.DisableL4LBFirewall,
+		Service:                          service,
+		Cloud:                            lc.ctx.Cloud,
+		Namer:                            lc.namer,
+		Recorder:                         lc.ctx.Recorder(service.Namespace),
+		DualStackEnabled:                 lc.enableDualStack,
+		StrongSessionAffinityEnabled:     lc.enableStrongSessionAffinity,
+		NetworkResolver:                  lc.networkResolver,
+		EnableWeightedLB:                 lc.ctx.EnableWeightedL4NetLB,
+		DisableNodesFirewallProvisioning: lc.ctx.DisableL4LBFirewall,
 	}
 	l4netlb := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)
 
@@ -668,15 +668,15 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 	}()
 
 	l4NetLBParams := &loadbalancers.L4NetLBParams{
-		Service:                      svc,
-		Cloud:                        lc.ctx.Cloud,
-		Namer:                        lc.namer,
-		Recorder:                     lc.ctx.Recorder(svc.Namespace),
-		DualStackEnabled:             lc.enableDualStack,
-		StrongSessionAffinityEnabled: lc.enableStrongSessionAffinity,
-		NetworkResolver:              lc.networkResolver,
-		EnableWeightedLB:             lc.ctx.EnableWeightedL4NetLB,
-		DisableIngressFirewall:       lc.ctx.DisableL4LBFirewall,
+		Service:                          svc,
+		Cloud:                            lc.ctx.Cloud,
+		Namer:                            lc.namer,
+		Recorder:                         lc.ctx.Recorder(svc.Namespace),
+		DualStackEnabled:                 lc.enableDualStack,
+		StrongSessionAffinityEnabled:     lc.enableStrongSessionAffinity,
+		NetworkResolver:                  lc.networkResolver,
+		EnableWeightedLB:                 lc.ctx.EnableWeightedL4NetLB,
+		DisableNodesFirewallProvisioning: lc.ctx.DisableL4LBFirewall,
 	}
 	l4netLB := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer",

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -612,7 +612,8 @@ func (l4 *L4) ensureIPv4Resources(result *L4ILBSyncResult, nodeNames []string, o
 
 func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, result *L4ILBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4.disableIngressFirewall == true {
+	if l4.disableIngressFirewall {
+		l4.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 ILB Service")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -614,7 +614,7 @@ func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, resu
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
 	if l4.disableNodesFirewallProvisioning {
 		l4.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 ILB Service to enable compatibility with firewall policies. " +
-			"Be sure the network administrator manually created a global firewall policy.")
+			"Be sure this cluster has a manually created global firewall policy in place.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -60,18 +60,18 @@ type L4 struct {
 	scope       meta.KeyType
 	namer       namer.L4ResourcesNamer
 	// recorder is used to generate k8s Events.
-	recorder               record.EventRecorder
-	Service                *corev1.Service
-	ServicePort            utils.ServicePort
-	NamespacedName         types.NamespacedName
-	forwardingRules        ForwardingRulesProvider
-	healthChecks           healthchecksl4.L4HealthChecks
-	enableDualStack        bool
-	network                network.NetworkInfo
-	networkResolver        network.Resolver
-	enableWeightedLB       bool
-	disableIngressFirewall bool
-	svcLogger              klog.Logger
+	recorder                         record.EventRecorder
+	Service                          *corev1.Service
+	ServicePort                      utils.ServicePort
+	NamespacedName                   types.NamespacedName
+	forwardingRules                  ForwardingRulesProvider
+	healthChecks                     healthchecksl4.L4HealthChecks
+	enableDualStack                  bool
+	network                          network.NetworkInfo
+	networkResolver                  network.Resolver
+	enableWeightedLB                 bool
+	disableNodesFirewallProvisioning bool
+	svcLogger                        klog.Logger
 }
 
 // L4ILBSyncResult contains information about the outcome of an L4 ILB sync. It stores the list of resource name annotations,
@@ -106,14 +106,14 @@ func NewL4ILBSyncResult(syncType string, startTime time.Time, svc *corev1.Servic
 }
 
 type L4ILBParams struct {
-	Service                *corev1.Service
-	Cloud                  *gce.Cloud
-	Namer                  namer.L4ResourcesNamer
-	Recorder               record.EventRecorder
-	DualStackEnabled       bool
-	NetworkResolver        network.Resolver
-	EnableWeightedLB       bool
-	DisableIngressFirewall bool
+	Service                          *corev1.Service
+	Cloud                            *gce.Cloud
+	Namer                            namer.L4ResourcesNamer
+	Recorder                         record.EventRecorder
+	DualStackEnabled                 bool
+	NetworkResolver                  network.Resolver
+	EnableWeightedLB                 bool
+	DisableNodesFirewallProvisioning bool
 }
 
 // NewL4Handler creates a new L4Handler for the given L4 service.
@@ -122,18 +122,18 @@ func NewL4Handler(params *L4ILBParams, logger klog.Logger) *L4 {
 
 	var scope meta.KeyType = meta.Regional
 	l4 := &L4{
-		cloud:                  params.Cloud,
-		scope:                  scope,
-		namer:                  params.Namer,
-		recorder:               params.Recorder,
-		Service:                params.Service,
-		healthChecks:           healthchecksl4.NewL4HealthChecks(params.Cloud, params.Recorder, logger),
-		forwardingRules:        forwardingrules.New(params.Cloud, meta.VersionGA, scope, logger),
-		enableDualStack:        params.DualStackEnabled,
-		networkResolver:        params.NetworkResolver,
-		enableWeightedLB:       params.EnableWeightedLB,
-		disableIngressFirewall: params.DisableIngressFirewall,
-		svcLogger:              logger,
+		cloud:                            params.Cloud,
+		scope:                            scope,
+		namer:                            params.Namer,
+		recorder:                         params.Recorder,
+		Service:                          params.Service,
+		healthChecks:                     healthchecksl4.NewL4HealthChecks(params.Cloud, params.Recorder, logger),
+		forwardingRules:                  forwardingrules.New(params.Cloud, meta.VersionGA, scope, logger),
+		enableDualStack:                  params.DualStackEnabled,
+		networkResolver:                  params.NetworkResolver,
+		enableWeightedLB:                 params.EnableWeightedLB,
+		disableNodesFirewallProvisioning: params.DisableNodesFirewallProvisioning,
+		svcLogger:                        logger,
 	}
 	l4.NamespacedName = types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace}
 	l4.backendPool = backends.NewPool(l4.cloud, l4.namer)
@@ -612,8 +612,9 @@ func (l4 *L4) ensureIPv4Resources(result *L4ILBSyncResult, nodeNames []string, o
 
 func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, result *L4ILBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4.disableIngressFirewall {
-		l4.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 ILB Service")
+	if l4.disableNodesFirewallProvisioning {
+		l4.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 ILB Service to enable compatibility with firewall policies. " +
+			"Be sure the network administrator manually created a global firewall policy.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -2281,10 +2281,10 @@ func TestDisableILBIngressFirewall(t *testing.T) {
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 
 	l4ilbParams := &L4ILBParams{
-		Service:                svc,
-		Cloud:                  fakeGCE,
-		Namer:                  namer,
-		DisableIngressFirewall: true,
+		Service:                          svc,
+		Cloud:                            fakeGCE,
+		Namer:                            namer,
+		DisableNodesFirewallProvisioning: true,
 	}
 	l4 := NewL4Handler(l4ilbParams, klog.TODO())
 	syncResult := &L4ILBSyncResult{

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -119,7 +119,8 @@ func (l4 *L4) getIPv6FRNameWithProtocol(protocol string) string {
 
 func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, result *L4ILBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4.disableIngressFirewall == true {
+	if l4.disableIngressFirewall {
+		l4.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 ILB Service")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -119,8 +119,9 @@ func (l4 *L4) getIPv6FRNameWithProtocol(protocol string) string {
 
 func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, result *L4ILBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4.disableIngressFirewall {
-		l4.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 ILB Service")
+	if l4.disableNodesFirewallProvisioning {
+		l4.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 ILB Service to enable compatibility with firewall policies. " +
+			"Be sure the network administrator manually created a global firewall policy.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -118,6 +118,10 @@ func (l4 *L4) getIPv6FRNameWithProtocol(protocol string) string {
 }
 
 func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, result *L4ILBSyncResult) {
+	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
+	if l4.disableIngressFirewall == true {
+		return
+	}
 	start := time.Now()
 
 	firewallName := l4.namer.L4IPv6Firewall(l4.Service.Namespace, l4.Service.Name)

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -121,7 +121,7 @@ func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, resu
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
 	if l4.disableNodesFirewallProvisioning {
 		l4.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 ILB Service to enable compatibility with firewall policies. " +
-			"Be sure the network administrator manually created a global firewall policy.")
+			"Be sure this cluster has a manually created global firewall policy in place.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -392,7 +392,8 @@ func (l4netlb *L4NetLB) ensureIPv4Resources(result *L4NetLBSyncResult, nodeNames
 
 func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, result *L4NetLBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4netlb.disableIngressFirewall == true {
+	if l4netlb.disableIngressFirewall {
+		l4netlb.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 NetLB Service")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -394,7 +394,7 @@ func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress st
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
 	if l4netlb.disableNodesFirewallProvisioning {
 		l4netlb.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 NetLB Service to enable compatibility with firewall policies. " +
-			"Be sure the network administrator manually created a global firewall policy.")
+			"Be sure this cluster has a manually created global firewall policy in place.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -67,12 +67,12 @@ type L4NetLB struct {
 	forwardingRules ForwardingRulesProvider
 	enableDualStack bool
 	// represents if `enable strong session affinity` flag was set
-	enableStrongSessionAffinity bool
-	networkInfo                 network.NetworkInfo
-	networkResolver             network.Resolver
-	enableWeightedLB            bool
-	disableIngressFirewall      bool
-	svcLogger                   klog.Logger
+	enableStrongSessionAffinity      bool
+	networkInfo                      network.NetworkInfo
+	networkResolver                  network.Resolver
+	enableWeightedLB                 bool
+	disableNodesFirewallProvisioning bool
+	svcLogger                        klog.Logger
 }
 
 // L4NetLBSyncResult contains information about the outcome of an L4 NetLB sync. It stores the list of resource name annotations,
@@ -109,36 +109,36 @@ func (r *L4NetLBSyncResult) SetMetricsForSuccessfulServiceSync() {
 }
 
 type L4NetLBParams struct {
-	Service                      *corev1.Service
-	Cloud                        *gce.Cloud
-	Namer                        namer.L4ResourcesNamer
-	Recorder                     record.EventRecorder
-	DualStackEnabled             bool
-	StrongSessionAffinityEnabled bool
-	NetworkResolver              network.Resolver
-	EnableWeightedLB             bool
-	DisableIngressFirewall       bool
+	Service                          *corev1.Service
+	Cloud                            *gce.Cloud
+	Namer                            namer.L4ResourcesNamer
+	Recorder                         record.EventRecorder
+	DualStackEnabled                 bool
+	StrongSessionAffinityEnabled     bool
+	NetworkResolver                  network.Resolver
+	EnableWeightedLB                 bool
+	DisableNodesFirewallProvisioning bool
 }
 
 // NewL4NetLB creates a new Handler for the given L4NetLB service.
 func NewL4NetLB(params *L4NetLBParams, logger klog.Logger) *L4NetLB {
 	logger = logger.WithName("L4NetLBHandler")
 	l4netlb := &L4NetLB{
-		cloud:                       params.Cloud,
-		scope:                       meta.Regional,
-		namer:                       params.Namer,
-		recorder:                    params.Recorder,
-		Service:                     params.Service,
-		NamespacedName:              types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace},
-		backendPool:                 backends.NewPoolWithConnectionTrackingPolicy(params.Cloud, params.Namer, params.StrongSessionAffinityEnabled),
-		healthChecks:                healthchecksl4.NewL4HealthChecks(params.Cloud, params.Recorder, logger),
-		forwardingRules:             forwardingrules.New(params.Cloud, meta.VersionGA, meta.Regional, logger),
-		enableDualStack:             params.DualStackEnabled,
-		enableStrongSessionAffinity: params.StrongSessionAffinityEnabled,
-		networkResolver:             params.NetworkResolver,
-		enableWeightedLB:            params.EnableWeightedLB,
-		disableIngressFirewall:      params.DisableIngressFirewall,
-		svcLogger:                   logger,
+		cloud:                            params.Cloud,
+		scope:                            meta.Regional,
+		namer:                            params.Namer,
+		recorder:                         params.Recorder,
+		Service:                          params.Service,
+		NamespacedName:                   types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace},
+		backendPool:                      backends.NewPoolWithConnectionTrackingPolicy(params.Cloud, params.Namer, params.StrongSessionAffinityEnabled),
+		healthChecks:                     healthchecksl4.NewL4HealthChecks(params.Cloud, params.Recorder, logger),
+		forwardingRules:                  forwardingrules.New(params.Cloud, meta.VersionGA, meta.Regional, logger),
+		enableDualStack:                  params.DualStackEnabled,
+		enableStrongSessionAffinity:      params.StrongSessionAffinityEnabled,
+		networkResolver:                  params.NetworkResolver,
+		enableWeightedLB:                 params.EnableWeightedLB,
+		disableNodesFirewallProvisioning: params.DisableNodesFirewallProvisioning,
+		svcLogger:                        logger,
 	}
 	return l4netlb
 }
@@ -392,8 +392,9 @@ func (l4netlb *L4NetLB) ensureIPv4Resources(result *L4NetLBSyncResult, nodeNames
 
 func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, result *L4NetLBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4netlb.disableIngressFirewall {
-		l4netlb.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 NetLB Service")
+	if l4netlb.disableNodesFirewallProvisioning {
+		l4netlb.svcLogger.Info("Skipped ensuring IPv4 nodes firewall for L4 NetLB Service to enable compatibility with firewall policies. " +
+			"Be sure the network administrator manually created a global firewall policy.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -1211,10 +1211,10 @@ func TestDisableNetLBIngressFirewall(t *testing.T) {
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 
 	l4netlbParams := &L4NetLBParams{
-		Service:                svc,
-		Cloud:                  fakeGCE,
-		Namer:                  namer,
-		DisableIngressFirewall: true,
+		Service:                          svc,
+		Cloud:                            fakeGCE,
+		Namer:                            namer,
+		DisableNodesFirewallProvisioning: true,
 	}
 	l4netlb := NewL4NetLB(l4netlbParams, klog.TODO())
 	syncResult := &L4NetLBSyncResult{

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -1200,6 +1200,49 @@ func TestWeightedNetLB(t *testing.T) {
 	}
 }
 
+func TestDisableNetLBIngressFirewall(t *testing.T) {
+	t.Parallel()
+	fakeGCE := getFakeGCECloud(gce.DefaultTestClusterValues())
+	nodeNames := []string{"test-node-1"}
+	// create a test VM so that target tags can be found
+	createVMInstanceWithTag(t, fakeGCE, "test-node-1", "test-node-1")
+
+	svc := test.NewL4NetLBRBSService(8080)
+	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
+
+	l4netlbParams := &L4NetLBParams{
+		Service:                svc,
+		Cloud:                  fakeGCE,
+		Namer:                  namer,
+		DisableIngressFirewall: true,
+	}
+	l4netlb := NewL4NetLB(l4netlbParams, klog.TODO())
+	syncResult := &L4NetLBSyncResult{
+		Annotations: make(map[string]string),
+	}
+
+	l4netlb.ensureIPv4NodesFirewall(nodeNames, "10.0.0.7", syncResult)
+	if syncResult.Error != nil {
+		t.Fatalf("ensureIPv4NodesFirewall() error %+v", syncResult)
+	}
+
+	ipv4FirewallName := l4netlb.namer.L4Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
+	err := verifyFirewallNotExists(l4netlb.cloud, ipv4FirewallName)
+	if err != nil {
+		t.Errorf("verifyFirewallNotExists(_, %s) for IPv4 NetLB firewall returned error %v, want nil", ipv4FirewallName, err)
+	}
+
+	l4netlb.ensureIPv6NodesFirewall("2001:db8::ff00:42:8329", nodeNames, syncResult)
+	if syncResult.Error != nil {
+		t.Fatalf("ensureIPv6NodesFirewall() error %+v", syncResult)
+	}
+	ipv6firewallName := l4netlb.namer.L4IPv6Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
+	err = verifyFirewallNotExists(l4netlb.cloud, ipv6firewallName)
+	if err != nil {
+		t.Errorf("verifyFirewallNotExists(_, %s) for IPv6 NetLB firewall returned error %v, want nil", ipv6firewallName, err)
+	}
+}
+
 func verifyNetLBCommonDualStackResourcesDeleted(l4netlb *L4NetLB) error {
 	backendServiceName := l4netlb.namer.L4Backend(l4netlb.Service.Namespace, l4netlb.Service.Name)
 

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -107,8 +107,9 @@ func (l4netlb *L4NetLB) ipv6FRName() string {
 
 func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, syncResult *L4NetLBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4netlb.disableIngressFirewall {
-		l4netlb.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 NetLB Service")
+	if l4netlb.disableNodesFirewallProvisioning {
+		l4netlb.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 NetLB Service to enable compatibility with firewall policies. " +
+			"Be sure the network administrator manually created a global firewall policy.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -106,6 +106,10 @@ func (l4netlb *L4NetLB) ipv6FRName() string {
 }
 
 func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, syncResult *L4NetLBSyncResult) {
+	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
+	if l4netlb.disableIngressFirewall == true {
+		return
+	}
 	start := time.Now()
 
 	firewallName := l4netlb.namer.L4IPv6Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -109,7 +109,7 @@ func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []st
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
 	if l4netlb.disableNodesFirewallProvisioning {
 		l4netlb.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 NetLB Service to enable compatibility with firewall policies. " +
-			"Be sure the network administrator manually created a global firewall policy.")
+			"Be sure this cluster has a manually created global firewall policy in place.")
 		return
 	}
 	start := time.Now()

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -107,7 +107,8 @@ func (l4netlb *L4NetLB) ipv6FRName() string {
 
 func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, syncResult *L4NetLBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
-	if l4netlb.disableIngressFirewall == true {
+	if l4netlb.disableIngressFirewall {
+		l4netlb.svcLogger.Info("Skipped ensuring IPv6 nodes firewall for L4 NetLB Service")
 		return
 	}
 	start := time.Now()


### PR DESCRIPTION
Added `disable-l4-lb-fw` flag to disable _only_ the ingress -> node firewalls for L4 ILB and NetLB to remove conflicts with firewall policies.

/assign @cezarygerard 
/assign @mmamczur 