### PR TITLE
Use Premium Network Tier for RXLB

### DIFF
--- a/pkg/loadbalancers/addresses.go
+++ b/pkg/loadbalancers/addresses.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
@@ -82,15 +81,10 @@ func (l7 *L7) checkStaticIP() (err error) {
 
 func (l7 *L7) newStaticAddress(name string) *composite.Address {
 	isInternal := utils.IsGCEL7ILBIngress(&l7.ingress)
-	isRegionalExternal := utils.IsGCEL7XLBRegionalIngress(&l7.ingress)
 	address := &composite.Address{Name: name, Address: l7.fw.IPAddress, Version: meta.VersionGA}
 	if isInternal {
 		// Used for L7 ILB
 		address.AddressType = "INTERNAL"
-	} else if isRegionalExternal {
-		// GCP requires L7 Regional External Addresses to use Standard Network Tier,
-		// (the same as regional external forwarding rules).
-		address.NetworkTier = cloud.NetworkTierStandard.ToGCEValue()
 	}
 
 	return address

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -290,8 +290,6 @@ func (t *Translator) ToCompositeForwardingRule(env *Env, protocol namer.NamerPro
 		}
 	} else if t.IsL7XLBRegional {
 		fr.LoadBalancingScheme = "EXTERNAL_MANAGED"
-		// Regional External LB only supports Standard Network Tier.
-		fr.NetworkTier = cloud.NetworkTierStandard.ToGCEValue()
 		fr.Network = env.Network
 	}
 

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -16,9 +16,10 @@ package translator
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"reflect"
 	"testing"
+
+	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
@@ -429,7 +430,6 @@ func TestToForwardingRule(t *testing.T) {
 				Description:         description,
 				Version:             version,
 				LoadBalancingScheme: "EXTERNAL_MANAGED",
-				NetworkTier:         "STANDARD",
 			},
 		},
 		{
@@ -446,7 +446,6 @@ func TestToForwardingRule(t *testing.T) {
 				Description:         description,
 				Version:             version,
 				LoadBalancingScheme: "EXTERNAL_MANAGED",
-				NetworkTier:         "STANDARD",
 			},
 		},
 		{


### PR DESCRIPTION
- Apparently Premium tier became available for RXLB https://cloud.google.com/network-tiers/docs/overview#resources
- Verified with locally running controller, and it indeed works