### PR TITLE
fix: GCE_VM_IP NEGs should be synced on each Node change.

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -110,7 +110,6 @@ type syncerManager struct {
 
 	// zone maps keep track of the last set of zones the neg controller has seen
 	// for their respective NEG types. zone maps are protected by the mu mutex.
-	vmIpZoneMap     map[string]struct{}
 	vmIpPortZoneMap map[string]struct{}
 
 	// lpConfig configures the pod label to be propagated to NEG endpoints.
@@ -135,8 +134,7 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 	lpConfig podlabels.PodLabelPropagationConfig,
 	logger klog.Logger) *syncerManager {
 
-	var vmIpZoneMap, vmIpPortZoneMap map[string]struct{}
-	updateZoneMap(&vmIpZoneMap, negtypes.NodeFilterForNetworkEndpointType(negtypes.VmIpEndpointType), zoneGetter, logger)
+	var vmIpPortZoneMap map[string]struct{}
 	updateZoneMap(&vmIpPortZoneMap, negtypes.NodeFilterForNetworkEndpointType(negtypes.VmIpPortEndpointType), zoneGetter, logger)
 
 	return &syncerManager{
@@ -158,7 +156,6 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 		enableDualStackNEG:  enableDualStackNEG,
 		numGCWorkers:        numGCWorkers,
 		logger:              logger,
-		vmIpZoneMap:         vmIpZoneMap,
 		vmIpPortZoneMap:     vmIpPortZoneMap,
 		lpConfig:            lpConfig,
 	}
@@ -318,7 +315,6 @@ func (manager *syncerManager) SyncNodes() {
 	defer manager.mu.Unlock()
 
 	// When a zone change occurs (new zone is added or deleted), a sync should be triggered
-	isVmIpZoneChange := updateZoneMap(&manager.vmIpZoneMap, negtypes.NodeFilterForNetworkEndpointType(negtypes.VmIpEndpointType), manager.zoneGetter, manager.logger)
 	isVmIpPortZoneChange := updateZoneMap(&manager.vmIpPortZoneMap, negtypes.NodeFilterForNetworkEndpointType(negtypes.VmIpPortEndpointType), manager.zoneGetter, manager.logger)
 
 	for key, syncer := range manager.syncerMap {
@@ -329,9 +325,7 @@ func (manager *syncerManager) SyncNodes() {
 		switch key.NegType {
 
 		case negtypes.VmIpEndpointType:
-			if isVmIpZoneChange {
-				syncer.Sync()
-			}
+			syncer.Sync()
 
 		case negtypes.VmIpPortEndpointType, negtypes.NonGCPPrivateEndpointType:
 			if isVmIpPortZoneChange {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1443,6 +1443,11 @@ func TestSyncNodesConditions(t *testing.T) {
 			negType:    negtypes.VmIpPortEndpointType,
 		},
 		{
+			desc:       "vm ip neg, should always sync on any node change",
+			expectSync: true,
+			negType:    negtypes.VmIpEndpointType,
+		},
+		{
 			desc:       "vm ip neg, zones added",
 			expectSync: true,
 			negType:    negtypes.VmIpEndpointType,
@@ -1458,7 +1463,7 @@ func TestSyncNodesConditions(t *testing.T) {
 		},
 		{
 			desc:       "vm ip neg, zones are the same",
-			expectSync: false,
+			expectSync: true,
 			negType:    negtypes.VmIpEndpointType,
 		},
 		{


### PR DESCRIPTION
This reverts the behaviour to what existed prior to https://github.com/kubernetes/ingress-gce/pull/1754.

This is also logical, since for GCE_VM_IP NEGs, the endpoints are the nodes themselves. So similar to the behavior for GCE_VM_IP_PORT negs which get synced on EndpointSlice changes, it makes sense to sync GCE_VM_IP NEGs on Node changes.

/assign @swetharepakula 
/assign @mmamczur 