### PR TITLE
Fix debu log in instance group manager

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -337,7 +337,7 @@ func (m *manager) Sync(nodes []string) (err error) {
 		addNodes := kubeNodes.Difference(gceNodes).List()
 
 		m.logger.V(2).Info("Removing nodes", "removeNodes", events.TruncatedStringList(removeNodes))
-		m.logger.V(2).Info("Adding nodes", "addNodes", events.TruncatedStringList(removeNodes))
+		m.logger.V(2).Info("Adding nodes", "addNodes", events.TruncatedStringList(addNodes))
 
 		start := time.Now()
 		if len(removeNodes) != 0 {


### PR DESCRIPTION
The "Adding nodes %s" log was using removed nodes slice