### PR TITLE
Add initial cache sync check

### DIFF
--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -457,7 +457,7 @@ func TestProcessUpdateClusterIPToILBService(t *testing.T) {
 func TestProcessMultipleServices(t *testing.T) {
 	backoff := retry.DefaultRetry
 	// Increase the duration since updates take longer on prow.
-	backoff.Duration = 1 * time.Second
+	backoff.Duration = 3 * time.Second
 	for _, onlyLocal := range []bool{true, false} {
 		t.Run(fmt.Sprintf("L4 with LocalMode=%v", onlyLocal), func(t *testing.T) {
 			l4c := newServiceController(t, newFakeGCE())
@@ -515,7 +515,9 @@ func TestProcessServiceWithDelayedNEGAdd(t *testing.T) {
 	addILBService(l4c, newSvc)
 	l4c.svcQueue.Enqueue(newSvc)
 
-	if err := retry.OnError(retry.DefaultRetry, func(error) bool { return true }, func() error {
+	backoff := retry.DefaultRetry
+	backoff.Duration = 3 * time.Second
+	if err := retry.OnError(backoff, func(error) bool { return true }, func() error {
 		if numRequeues := l4c.svcQueue.NumRequeues(newSvc); numRequeues == 0 {
 			return fmt.Errorf("Failed to requeue service with delayed NEG addition.")
 		}
@@ -531,9 +533,6 @@ func TestProcessServiceWithDelayedNEGAdd(t *testing.T) {
 	addNEG(l4c, newSvc)
 
 	var svcErr error
-	backoff := retry.DefaultRetry
-	// Increase the duration since the requeue time for failed events increases exponentially.
-	backoff.Duration = 10 * time.Second
 	if err := retry.OnError(backoff, func(error) bool { return true }, func() error {
 		if newSvc, svcErr = l4c.client.CoreV1().Services(newSvc.Namespace).Get(context2.TODO(), newSvc.Name, v1.GetOptions{}); svcErr != nil {
 			return fmt.Errorf("Failed to lookup service %s, err: %v", newSvc.Name, svcErr)
@@ -854,7 +853,9 @@ func newServiceController(t *testing.T, fakeGCE *gce.Cloud) *L4Controller {
 	for _, n := range nodes {
 		ctx.NodeInformer.GetIndexer().Add(n)
 	}
-	return NewILBController(ctx, stopCh, klog.TODO())
+	l4c := NewILBController(ctx, stopCh, klog.TODO())
+	l4c.hasSynced = func() bool { return true }
+	return l4c
 }
 
 func newFakeGCE() *gce.Cloud {

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -298,7 +298,9 @@ func newL4NetLBServiceController() *L4NetLBController {
 	for _, n := range nodes {
 		ctx.NodeInformer.GetIndexer().Add(n)
 	}
-	return NewL4NetLBController(ctx, stopCh, klog.TODO())
+	lc := NewL4NetLBController(ctx, stopCh, klog.TODO())
+	lc.hasSynced = func() bool { return true }
+	return lc
 }
 
 func validateNetLBSvcStatus(svc *v1.Service, t *testing.T) {
@@ -350,7 +352,7 @@ func validateAnnotationsDeleted(svc *v1.Service) error {
 
 func TestProcessMultipleNetLBServices(t *testing.T) {
 	backoff := retry.DefaultRetry
-	backoff.Duration = 1 * time.Second
+	backoff.Duration = 3 * time.Second
 	for _, onlyLocal := range []bool{true, false} {
 		t.Run(fmt.Sprintf("L4 with LocalMode=%v", onlyLocal), func(t *testing.T) {
 			lc := newL4NetLBServiceController()


### PR DESCRIPTION
## Wait for cache sync before L4NetLBController and L4Controller run

This pull request introduces a delay mechanism to ensure cache synchronization before the L4NetLBController and L4Controller commence operation. This is accomplished by incorporating a 10-minute wait period with 5-second polling intervals, ensuring that all required informers have been duly updated.

## Testing:

* **Unit Tests:** Existing unit tests should continue to pass without modifications.
