### PR TITLE
instance group logger

### DIFF
--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -69,13 +69,13 @@ func TestLink(t *testing.T) {
 		BasePath:   utils.GetBasePath(fakeGCE),
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  1000,
-	}, klog.TODO())
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
 
 	// Mimic the instance group being created
-	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 
@@ -111,7 +111,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 		BasePath:   utils.GetBasePath(fakeGCE),
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  1000,
-	}, klog.TODO())
+	})
 	linker := newTestIGLinker(fakeGCE, fakeNodePool)
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
@@ -131,7 +131,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 		}
 
 		// Mimic the instance group being created
-		if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+		if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 			t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 		}
 

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -64,7 +64,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 		BasePath:   utils.GetBasePath(fakeGCE),
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  1000,
-	}, klog.TODO())
+	})
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaBackendServices.UpdateHook = mock.UpdateAlphaBackendServiceHook
@@ -87,7 +87,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	jig := newTestJig(fakeGCE)
 
 	sp := utils.ServicePort{NodePort: 80, BackendNamer: defaultNamer, Protocol: annotations.ProtocolHTTP}
-	_, err := jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	_, err := jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO())
 	if err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
@@ -115,7 +115,7 @@ func TestBackendInstanceGroupClobbering(t *testing.T) {
 	}
 
 	// Make sure repeated adds don't clobber the inserted instance group
-	_, err = jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	_, err = jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO())
 	if err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
@@ -160,7 +160,7 @@ func TestSyncChaosMonkey(t *testing.T) {
 
 	sp := utils.ServicePort{NodePort: 8080, Protocol: annotations.ProtocolHTTP, BackendNamer: defaultNamer}
 
-	_, err := jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	_, err := jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO())
 	if err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v, err %v", sp, err)
 	}
@@ -193,7 +193,7 @@ func TestSyncChaosMonkey(t *testing.T) {
 		return false, nil
 	}
 
-	_, err = jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort})
+	_, err = jig.fakeInstancePool.EnsureInstanceGroupsAndPorts(defaultNamer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO())
 	if err != nil {
 		t.Fatalf("Did not expect error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -64,7 +64,7 @@ func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer 
 		BasePath:   utils.GetBasePath(fakeGCE),
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  1000,
-	}, klog.TODO())
+	})
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 
@@ -83,7 +83,7 @@ func TestRegionalLink(t *testing.T) {
 	if err := linker.Link(sp, fakeGCE.ProjectID(), []string{usCentral1AZone}); err == nil {
 		t.Fatalf("Linking when instances does not exist should return error")
 	}
-	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 	if err := linker.Link(sp, fakeGCE.ProjectID(), []string{usCentral1AZone}); err == nil {
@@ -117,7 +117,7 @@ func TestRegionalUpdateLink(t *testing.T) {
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
 	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
-	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 	createBackendService(t, sp, fakeBackendPool)
@@ -153,7 +153,7 @@ func TestRegionalUpdateLinkWithNewBackends(t *testing.T) {
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
 	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
-	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 	createBackendService(t, sp, fakeBackendPool)
@@ -197,7 +197,7 @@ func TestRegionalUpdateLinkWithRemovedBackends(t *testing.T) {
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
 	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
-	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}); err != nil {
+	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
 	createBackendService(t, sp, fakeBackendPool)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -252,7 +252,7 @@ func NewControllerContext(
 		BasePath:   utils.GetBasePath(context.Cloud),
 		ZoneGetter: context.ZoneGetter,
 		MaxIGSize:  config.MaxIGSize,
-	}, logger)
+	})
 
 	return context
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -456,7 +456,7 @@ func (lbc *LoadBalancerController) SyncBackends(state interface{}, ingLogger klo
 func (lbc *LoadBalancerController) syncInstanceGroup(ing *v1.Ingress, ingSvcPorts []utils.ServicePort, ingLogger klog.Logger) error {
 	nodePorts := nodePorts(ingSvcPorts)
 	ingLogger.Info("Syncing Instance Group", "nodePorts", nodePorts)
-	igs, err := lbc.instancePool.EnsureInstanceGroupsAndPorts(lbc.ctx.ClusterNamer.InstanceGroup(), nodePorts)
+	igs, err := lbc.instancePool.EnsureInstanceGroupsAndPorts(lbc.ctx.ClusterNamer.InstanceGroup(), nodePorts, ingLogger)
 	if err != nil {
 		return err
 	}
@@ -466,7 +466,7 @@ func (lbc *LoadBalancerController) syncInstanceGroup(ing *v1.Ingress, ingSvcPort
 		return err
 	}
 	// Add/remove instances to the instance groups.
-	if err = lbc.instancePool.Sync(utils.GetNodeNames(nodes)); err != nil {
+	if err = lbc.instancePool.Sync(utils.GetNodeNames(nodes), ingLogger); err != nil {
 		return err
 	}
 
@@ -503,7 +503,7 @@ func (lbc *LoadBalancerController) GCBackends(toKeep []*v1.Ingress, ingLogger kl
 	if len(toKeep) == 0 {
 		igName := lbc.ctx.ClusterNamer.InstanceGroup()
 		ingLogger.Info("Deleting instance group", "instanceGroup", igName)
-		if err := lbc.instancePool.DeleteInstanceGroup(igName); err != err {
+		if err := lbc.instancePool.DeleteInstanceGroup(igName, ingLogger); err != err {
 			return err
 		}
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -93,7 +93,7 @@ func newLoadBalancerController() *LoadBalancerController {
 		BasePath:   utils.GetBasePath(fakeGCE),
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  1000,
-	}, klog.TODO())
+	})
 	lbc.l7Pool = loadbalancers.NewLoadBalancerPool(fakeGCE, namer, events.RecorderProducerMock{}, namer_util.NewFrontendNamerFactory(namer, "", klog.TODO()), klog.TODO())
 
 	lbc.hasSynced = func() bool { return true }
@@ -649,7 +649,7 @@ func TestMCIngressIG(t *testing.T) {
 	}
 
 	// Ensure that instance group exists.
-	instanceGroups, err := lbc.instancePool.List()
+	instanceGroups, err := lbc.instancePool.List(klog.TODO())
 	if err != nil {
 		t.Errorf("lbc.instancePool.List() = _, %v, want nil", err)
 	}
@@ -664,7 +664,7 @@ func TestMCIngressIG(t *testing.T) {
 	}
 
 	// Ensure that instance group still exists.
-	instanceGroups, err = lbc.instancePool.List()
+	instanceGroups, err = lbc.instancePool.List(klog.TODO())
 	if err != nil {
 		t.Errorf("lbc.instancePool.List() = _, %v, want nil", err)
 	}
@@ -679,7 +679,7 @@ func TestMCIngressIG(t *testing.T) {
 	}
 
 	// Ensure that instance group is cleaned up.
-	instanceGroups, err = lbc.instancePool.List()
+	instanceGroups, err = lbc.instancePool.List(klog.TODO())
 	if err != nil {
 		t.Errorf("lbc.instancePool.List() = _, %v, want nil", err)
 	}

--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -133,5 +133,5 @@ func (c *Controller) sync(key string) error {
 	if err != nil {
 		return err
 	}
-	return c.igManager.Sync(utils.GetNodeNames(nodes))
+	return c.igManager.Sync(utils.GetNodeNames(nodes), c.logger)
 }

--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
 )
 
 func TestNodeStatusChanged(t *testing.T) {
@@ -147,17 +148,17 @@ type IGManagerFake struct {
 	syncedNodes [][]string
 }
 
-func (igmf *IGManagerFake) Sync(nodeNames []string) error {
+func (igmf *IGManagerFake) Sync(nodeNames []string, logger klog.Logger) error {
 	igmf.syncedNodes = append(igmf.syncedNodes, nodeNames)
 	return nil
 }
 
-func (igmf *IGManagerFake) EnsureInstanceGroupsAndPorts(name string, ports []int64) ([]*compute.InstanceGroup, error) {
+func (igmf *IGManagerFake) EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) ([]*compute.InstanceGroup, error) {
 	igmf.syncedNodes = append(igmf.syncedNodes, []string{name})
 	return []*compute.InstanceGroup{}, nil
 }
 
-func (igmf *IGManagerFake) DeleteInstanceGroup(name string) error {
+func (igmf *IGManagerFake) DeleteInstanceGroup(name string, logger klog.Logger) error {
 	igmf.syncedNodes = append(igmf.syncedNodes, []string{name})
 	return nil
 }
@@ -167,6 +168,6 @@ func (igmf *IGManagerFake) Get(name, zone string) (*compute.InstanceGroup, error
 	return &ig, nil
 }
 
-func (igmf *IGManagerFake) List() ([]string, error) {
+func (igmf *IGManagerFake) List(logger klog.Logger) ([]string, error) {
 	return []string{}, nil
 }

--- a/pkg/instancegroups/interfaces.go
+++ b/pkg/instancegroups/interfaces.go
@@ -18,18 +18,19 @@ package instancegroups
 
 import (
 	compute "google.golang.org/api/compute/v1"
+	"k8s.io/klog/v2"
 )
 
 // Manager is an interface to sync kubernetes nodes to google cloud instance groups
 // through the Provider interface. It handles zones opaquely using the zoneLister.
 type Manager interface {
-	EnsureInstanceGroupsAndPorts(name string, ports []int64) ([]*compute.InstanceGroup, error)
-	DeleteInstanceGroup(name string) error
+	EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) ([]*compute.InstanceGroup, error)
+	DeleteInstanceGroup(name string, logger klog.Logger) error
 
 	Get(name, zone string) (*compute.InstanceGroup, error)
-	List() ([]string, error)
+	List(logger klog.Logger) ([]string, error)
 
-	Sync(nodeNames []string) error
+	Sync(nodeNames []string, logger klog.Logger) error
 }
 
 // Provider is an interface for managing gce instances groups, and the instances therein.

--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -55,7 +55,7 @@ func newNodePool(f Provider, maxIGSize int) Manager {
 		BasePath:   basePath,
 		ZoneGetter: fakeZoneGetter,
 		MaxIGSize:  maxIGSize,
-	}, klog.TODO())
+	})
 	return pool
 }
 
@@ -113,14 +113,14 @@ func TestNodePoolSync(t *testing.T) {
 
 		igName := defaultNamer.InstanceGroup()
 		ports := []int64{80}
-		_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+		_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports, klog.TODO())
 		if err != nil {
 			t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
 		}
 
 		// run sync with expected kubeNodes
 		apiCallsCountBeforeSync := len(fakeGCEInstanceGroups.calls)
-		err = pool.Sync(testCase.kubeNodes.List())
+		err = pool.Sync(testCase.kubeNodes.List(), klog.TODO())
 		if err != nil {
 			t.Fatalf("pool.Sync(%v) returned error %v, want nil", testCase.kubeNodes.List(), err)
 		}
@@ -155,7 +155,7 @@ func TestNodePoolSync(t *testing.T) {
 
 		// call sync one more time and check that it will be no-op and will not cause any api calls
 		apiCallsCountBeforeSync = len(fakeGCEInstanceGroups.calls)
-		err = pool.Sync(testCase.kubeNodes.List())
+		err = pool.Sync(testCase.kubeNodes.List(), klog.TODO())
 		if err != nil {
 			t.Fatalf("pool.Sync(%v) returned error %v, want nil", testCase.kubeNodes.List(), err)
 		}
@@ -181,17 +181,17 @@ func TestInstanceAlreadyMemberOfIG(t *testing.T) {
 
 	igName := defaultNamer.InstanceGroup()
 	ports := []int64{80}
-	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports, klog.TODO())
 	if err != nil {
 		t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
 	}
 
 	// run sync with 2 times, expect not error despite fakeInstanceGroups will return 'memberAlreadyExists'
-	err = pool.Sync(kubeNodes.List())
+	err = pool.Sync(kubeNodes.List(), klog.TODO())
 	if err != nil {
 		t.Fatalf("pool.Sync() returned error %v, want nil", err)
 	}
-	err = pool.Sync(kubeNodes.List())
+	err = pool.Sync(kubeNodes.List(), klog.TODO())
 	if err != nil {
 		t.Fatalf("pool.Sync() returned error %v, want nil", err)
 	}
@@ -267,7 +267,7 @@ func TestNodePoolSyncHugeCluster(t *testing.T) {
 			zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneC, tc.gceNodesZoneC.List()...)
 
 			ports := []int64{80}
-			_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+			_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports, klog.TODO())
 			if err != nil {
 				t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
 			}
@@ -275,7 +275,7 @@ func TestNodePoolSyncHugeCluster(t *testing.T) {
 			allKubeNodes = append(allKubeNodes, tc.kubeNodesZoneC.List()...)
 
 			// Execute manager's main instance group sync function
-			err = pool.Sync(allKubeNodes)
+			err = pool.Sync(allKubeNodes, klog.TODO())
 			if err != nil {
 				t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
 			}
@@ -296,7 +296,7 @@ func TestNodePoolSyncHugeCluster(t *testing.T) {
 			}
 
 			apiCallsCountBeforeSync := len(fakeGCEInstanceGroups.calls)
-			err = pool.Sync(allKubeNodes)
+			err = pool.Sync(allKubeNodes, klog.TODO())
 			if err != nil {
 				t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
 			}
@@ -322,13 +322,13 @@ func TestInstanceTruncatingOrder(t *testing.T) {
 	zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneA, gceNodesZoneA...)
 
 	ports := []int64{80}
-	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports, klog.TODO())
 	if err != nil {
 		t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
 	}
 
 	// Execute manager's main instance group sync function
-	err = pool.Sync(kubeNodesZoneA)
+	err = pool.Sync(kubeNodesZoneA, klog.TODO())
 	if err != nil {
 		t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
 	}
@@ -392,7 +392,7 @@ func TestSetNamedPorts(t *testing.T) {
 		// TODO: Add tests to remove named ports when we support that.
 	}
 	for _, testCase := range testCases {
-		igs, err := pool.EnsureInstanceGroupsAndPorts("ig", testCase.activePorts)
+		igs, err := pool.EnsureInstanceGroupsAndPorts("ig", testCase.activePorts, klog.TODO())
 		if err != nil {
 			t.Fatalf("unexpected error in setting ports %v to instance group: %s", testCase.activePorts, err)
 		}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -650,12 +650,12 @@ func (lc *L4NetLBController) ensureInstanceGroups(service *v1.Service, nodeNames
 	// L4 NetLB does not use node ports, so we provide empty slice
 	var nodePorts []int64
 	igName := lc.ctx.ClusterNamer.InstanceGroup()
-	_, err := lc.instancePool.EnsureInstanceGroupsAndPorts(igName, nodePorts)
+	_, err := lc.instancePool.EnsureInstanceGroupsAndPorts(igName, nodePorts, svcLogger)
 	if err != nil {
 		return fmt.Errorf("lc.instancePool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %w", igName, nodePorts, err)
 	}
 
-	return lc.instancePool.Sync(nodeNames)
+	return lc.instancePool.Sync(nodeNames, svcLogger)
 }
 
 // garbageCollectRBSNetLB cleans-up all gce resources related to service and removes NetLB finalizer
@@ -696,7 +696,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 
 	// Try to delete instance group, instancePool.DeleteInstanceGroup ignores errors if resource is in use or not found.
 	// TODO(cezarygerard) replace with multi-IG management
-	if err := lc.instancePool.DeleteInstanceGroup(lc.namer.InstanceGroup()); err != nil {
+	if err := lc.instancePool.DeleteInstanceGroup(lc.namer.InstanceGroup(), svcLogger); err != nil {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "DeleteInstanceGroupFailed",
 			"Error deleting delete Instance Group from L4 External LoadBalancer, err: %v", err)
 		result.Error = fmt.Errorf("Failed to delete Instance Group, err: %w", err)


### PR DESCRIPTION
**Instance Group Manager Logger Context Enhancement**

This pull request addresses a missing context issue within the Instance Group Manager logger. When the manager is called by 'client' structs, certain log fields lacked essential contextual information. 

To resolve this, the following changes were made:

* **Public function modification:** The public function of the Instance Group Manager now explicitly takes a logger as an argument.
* **Logger field removal:** The redundant logger field within the manager has been removed.

These adjustments ensure that logs generated when the manager interacts with 'client' structs contain comprehensive contextual details, facilitating improved troubleshooting and analysis. 
