### PR TITLE
Use all zones when creating the shared IG for an RBS service.

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -84,8 +84,8 @@ func NewManager(config *ManagerConfig) Manager {
 // all of which have the exact same named ports.
 func (m *manager) EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) (igs []*compute.InstanceGroup, err error) {
 	iglogger := logger.WithName("InstanceGroupsManager")
-	// Instance groups need to be created only in zones that have ready nodes.
-	zones, err := m.ZoneGetter.ListZones(zonegetter.CandidateNodesFilter, iglogger)
+	// Instance groups need to be created in all zones that nodes are in.
+	zones, err := m.ZoneGetter.ListZones(zonegetter.AllNodesFilter, iglogger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -629,11 +629,6 @@ func (lc *L4NetLBController) ensureBackendLinking(service *v1.Service, linkType 
 		svcLogger.V(2).Info("Finished linking backends to backend service for k8s service", "timeTaken", time.Since(start))
 	}()
 
-	zones, err := lc.zoneGetter.ListZones(zonegetter.CandidateNodesFilter, svcLogger)
-	if err != nil {
-		return err
-	}
-
 	namespacedName := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
 	portId := utils.ServicePortID{Service: namespacedName}
 	servicePort := utils.ServicePort{
@@ -644,6 +639,11 @@ func (lc *L4NetLBController) ensureBackendLinking(service *v1.Service, linkType 
 	// NEG backends should only be used for multinetwork services on the non default network.
 	if linkType == negLink {
 		svcLogger.V(2).Info("Linking backend service with NEGs for service")
+		// Only negs in zones with ready nodes will be attached to the service
+		zones, err := lc.zoneGetter.ListZones(zonegetter.CandidateNodesFilter, svcLogger)
+		if err != nil {
+			return err
+		}
 		servicePort.VMIPNEGEnabled = true
 		var groupKeys []backends.GroupKey
 		for _, zone := range zones {
@@ -652,6 +652,13 @@ func (lc *L4NetLBController) ensureBackendLinking(service *v1.Service, linkType 
 		return lc.negLinker.Link(servicePort, groupKeys)
 	} else if linkType == instanceGroupLink {
 		svcLogger.V(2).Info("Linking backend service with Instance Groups for service (uses default network)")
+		// The BackendService should be linked with zones of all nodes that's why AllNodesFilter is used.
+		// This is to prevent zones with unready nodes to be removed from the load balancer.
+		// The unready nodes will not be added to the group by the IG syncer but removing a group can cause 10 min outage if done because of a temporarily unready node.
+		zones, err := lc.zoneGetter.ListZones(zonegetter.AllNodesFilter, svcLogger)
+		if err != nil {
+			return err
+		}
 		return lc.igLinker.Link(servicePort, lc.ctx.Cloud.ProjectID(), zones)
 	} else {
 		return fmt.Errorf("cannot link backend service - invalid backend link type %d", linkType)


### PR DESCRIPTION
With this change, the code to ensure IGs will use AllNodesFilter to determine which zones to create IGs in. The goal is to avoid detaching groups which become temporarily unready, for example after master upgrade. This change should be fine since creating and using an IG that could be empty is ok from the LB perspective. On the other hand removing a temporarily unready group can cause 10 minutes of no traffic.