### PR TITLE
L4 Weighted Load Balancing sync latency and error count metrics

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -595,7 +595,8 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 		svcLogger.V(2).Info("Internal L4 Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsLegacyState)
 		l4c.ctx.ControllerMetrics.SetL4ILBServiceForLegacyMetric(namespacedName, result.MetricsLegacyState)
 		l4c.ctx.ControllerMetrics.SetL4ILBService(namespacedName, result.MetricsState)
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync)
+		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB)
 		if l4c.enableDualStack {
 			svcLogger.V(2).Info("Internal L4 DualStack Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsState)
 			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, isResync)
@@ -611,7 +612,8 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 			l4c.ctx.ControllerMetrics.DeleteL4ILBServiceForLegacyMetric(namespacedName)
 			l4c.ctx.ControllerMetrics.DeleteL4ILBService(namespacedName)
 		}
-		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false)
+		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
+		l4metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false, isWeightedLB)
 		if l4c.enableDualStack {
 			l4metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, false)
 		}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -796,9 +796,7 @@ func (lc *L4NetLBController) publishSyncMetrics(result *loadbalancers.L4NetLBSyn
 		l4metrics.PublishL4NetLBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, isResync)
 	}
 	l4metrics.PublishL4SyncDetails(l4NetLBControllerName, result.Error == nil, isResync, result.GCEResourceUpdate.WereAnyResourcesModified())
-	if result.Error == nil {
-		l4metrics.PublishL4NetLBSyncSuccess(result.SyncType, result.StartTime, isResync)
-		return
-	}
-	l4metrics.PublishL4NetLBSyncError(result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync)
+
+	isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
+	l4metrics.PublishNetLBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB)
 }

--- a/pkg/l4lb/metrics/metrics.go
+++ b/pkg/l4lb/metrics/metrics.go
@@ -42,21 +42,24 @@ const (
 	l4LBRemovedFinalizerMetricName                 = "l4_removed_finalizer_count"
 	l4LBControllerPanicsMetricName                 = "l4_controllers_panics_count"
 	L4netlbSyncDetailsMetricName                   = "l4_netlb_sync_details_count"
+	l4WeightedLBPodsPerNodeMetricName              = "l4_weighted_lb_pods_per_node"
 )
 
 var (
-	l4LBSyncLatencyMetricsLabels = []string{
+	l4LBSyncLatencyCommonMetricLabels = []string{
 		"sync_result",     // result of the sync
 		"sync_type",       // whether this is a new service, update or delete
 		"periodic_resync", // whether the sync was periodic resync or a update caused by a resource change
 	}
-	l4LBDualStackSyncLatencyMetricsLabels = append(l4LBSyncLatencyMetricsLabels, "ip_families")
+	l4LBSyncLatencyMetricsLabels          = append(l4LBSyncLatencyCommonMetricLabels, l4WeightedLBPodsPerNodeMetricName)
+	l4LBDualStackSyncLatencyMetricsLabels = append(l4LBSyncLatencyCommonMetricLabels, "ip_families")
 	l4LBSyncErrorMetricLabels             = []string{
 		"sync_type",    // whether this is a new service, update or delete
 		"gce_resource", // The GCE resource whose update caused the error
 		// max number of values for error_type = 18 k8s error reasons + 60 http status errors.
 		// In production, we will see much fewer number, since many of the error codes are not applicable.
-		"error_type", // what type of error it was
+		"error_type",                      // what type of error it was
+		l4WeightedLBPodsPerNodeMetricName, // whether the service uses weighted load balancing by pods-per-node
 	}
 	l4ILBSyncLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -64,7 +67,7 @@ var (
 			Help: "Latency of an L4 ILB Sync",
 			// custom buckets - [0.9375s, 1.875s, 3.75s, 7.5s, 30s, 60s, 120s, 240s(4min), 480s(8min), 960s(16m), 3840s(64min), 7680s(128m) +Inf]
 			// using funny starter bucket, 0.9375s will only add buckets to existing metric, this is a safe operation in most time series db
-			Buckets: prometheus.ExponentialBuckets(0.9375, 2, 12),
+			Buckets: prometheus.ExponentialBuckets(0.9375, 2, 15),
 		},
 		l4LBSyncLatencyMetricsLabels,
 	)
@@ -83,7 +86,7 @@ var (
 			Help:    "Latency of an L4 ILB Multinet Sync",
 			Buckets: prometheus.ExponentialBuckets(0.5, 2, 15),
 		},
-		l4LBSyncLatencyMetricsLabels,
+		l4LBSyncLatencyCommonMetricLabels,
 	)
 	l4NetLBMultiNetSyncLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -91,7 +94,7 @@ var (
 			Help:    "Latency of an L4 NetLB Multinet Sync",
 			Buckets: prometheus.ExponentialBuckets(0.5, 2, 15),
 		},
-		l4LBSyncLatencyMetricsLabels,
+		l4LBSyncLatencyCommonMetricLabels,
 	)
 	l4ILBSyncErrorCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -108,7 +111,7 @@ var (
 			Help: "Latency of an L4 NetLB Sync",
 			// custom buckets - [0.9375s, 1.875s, 3.75s, 7.5s, 30s, 60s, 120s, 240s(4min), 480s(8min), 960s(16m), 3840s(64min), 7680s(128m) +Inf]
 			// using funny starter bucket, 0.9375s will only add buckets to existing metric, this is a safe operation in most time series db
-			Buckets: prometheus.ExponentialBuckets(0.9375, 2, 12),
+			Buckets: prometheus.ExponentialBuckets(0.9375, 2, 15),
 		},
 		l4LBSyncLatencyMetricsLabels,
 	)
@@ -193,7 +196,7 @@ func init() {
 	prometheus.MustRegister(l4NetLBDualStackSyncLatency)
 	klog.V(3).Infof("Registering L4 ILB MultiNet controller metrics %v", l4ILBMultiNetSyncLatency)
 	prometheus.MustRegister(l4ILBMultiNetSyncLatency)
-	klog.V(3).Infof("Registering L4 NetLB MultiNet controller metrics %v", l4ILBMultiNetSyncLatency)
+	klog.V(3).Infof("Registering L4 NetLB MultiNet controller metrics %v", l4NetLBMultiNetSyncLatency)
 	prometheus.MustRegister(l4NetLBMultiNetSyncLatency)
 	klog.V(3).Infof("Registering L4 healthcheck failures count metric: %v", l4FailedHealthCheckCount)
 	prometheus.MustRegister(l4FailedHealthCheckCount)
@@ -210,20 +213,20 @@ func init() {
 }
 
 // PublishILBSyncMetrics exports metrics related to the L4 ILB sync.
-func PublishILBSyncMetrics(success bool, syncType, gceResource, errType string, startTime time.Time, isResync bool) {
-	publishL4ILBSyncLatency(success, syncType, startTime, isResync)
+func PublishILBSyncMetrics(success bool, syncType, gceResource, errType string, startTime time.Time, isResync bool, isWeightedLB bool) {
+	publishL4ILBSyncLatency(success, syncType, startTime, isResync, isWeightedLB)
 	if !success {
-		publishL4ILBSyncErrorCount(syncType, gceResource, errType)
+		publishL4ILBSyncErrorCount(syncType, gceResource, errType, isWeightedLB)
 	}
 }
 
 // publishL4ILBSyncLatency exports the given sync latency datapoint.
-func publishL4ILBSyncLatency(success bool, syncType string, startTime time.Time, isResync bool) {
+func publishL4ILBSyncLatency(success bool, syncType string, startTime time.Time, isResync bool, isWeightedLB bool) {
 	status := statusSuccess
 	if !success {
 		status = statusError
 	}
-	l4ILBSyncLatency.WithLabelValues(status, syncType, strconv.FormatBool(isResync)).Observe(time.Since(startTime).Seconds())
+	l4ILBSyncLatency.WithLabelValues(status, syncType, strconv.FormatBool(isResync), strconv.FormatBool(isWeightedLB)).Observe(time.Since(startTime).Seconds())
 }
 
 // PublishL4ILBDualStackSyncLatency exports the given sync latency datapoint.
@@ -244,6 +247,14 @@ func PublishL4ILBMultiNetSyncLatency(success bool, syncType string, startTime ti
 	l4ILBMultiNetSyncLatency.WithLabelValues(status, syncType, strconv.FormatBool(isResync)).Observe(time.Since(startTime).Seconds())
 }
 
+// PublishNetLBSyncMetrics exports metrics related to the L4 NetLB sync.
+func PublishNetLBSyncMetrics(success bool, syncType, gceResource, errType string, startTime time.Time, isResync bool, isWeightedLB bool) {
+	publishL4NetLBSync(success, syncType, startTime, isResync, isWeightedLB)
+	if !success {
+		publishL4NetLBSyncErrorCount(syncType, gceResource, errType, isWeightedLB)
+	}
+}
+
 // PublishL4NetLBMultiNetSyncLatency exports the given sync latency datapoint.
 func PublishL4NetLBMultiNetSyncLatency(success bool, syncType string, startTime time.Time, isResync bool) {
 	status := statusSuccess
@@ -254,13 +265,17 @@ func PublishL4NetLBMultiNetSyncLatency(success bool, syncType string, startTime 
 }
 
 // publishL4ILBSyncLatency exports the given sync latency datapoint.
-func publishL4ILBSyncErrorCount(syncType, gceResource, errorType string) {
-	l4ILBSyncErrorCount.WithLabelValues(syncType, gceResource, errorType).Inc()
+func publishL4ILBSyncErrorCount(syncType, gceResource, errorType string, isWeightedLB bool) {
+	l4ILBSyncErrorCount.WithLabelValues(syncType, gceResource, errorType, strconv.FormatBool(isWeightedLB)).Inc()
 }
 
-// PublishL4NetLBSyncSuccess exports latency metrics for L4 NetLB service after successful sync.
-func PublishL4NetLBSyncSuccess(syncType string, startTime time.Time, isResync bool) {
-	l4NetLBSyncLatency.WithLabelValues(statusSuccess, syncType, strconv.FormatBool(isResync)).Observe(time.Since(startTime).Seconds())
+// publishL4NetLBSync exports latency metrics for L4 NetLB service after sync.
+func publishL4NetLBSync(success bool, syncType string, startTime time.Time, isResync bool, isWeightedLB bool) {
+	status := statusSuccess
+	if !success {
+		status = statusError
+	}
+	l4NetLBSyncLatency.WithLabelValues(status, syncType, strconv.FormatBool(isResync), strconv.FormatBool(isWeightedLB)).Observe(time.Since(startTime).Seconds())
 }
 
 // PublishL4NetLBDualStackSyncLatency exports the given sync latency datapoint.
@@ -272,10 +287,9 @@ func PublishL4NetLBDualStackSyncLatency(success bool, syncType, ipFamilies strin
 	l4NetLBDualStackSyncLatency.WithLabelValues(status, syncType, strconv.FormatBool(isResync), ipFamilies).Observe(time.Since(startTime).Seconds())
 }
 
-// PublishL4NetLBSyncError exports latency and error count metrics for L4 NetLB after error sync.
-func PublishL4NetLBSyncError(syncType, gceResource, errType string, startTime time.Time, isResync bool) {
-	l4NetLBSyncLatency.WithLabelValues(statusError, syncType, strconv.FormatBool(isResync)).Observe(time.Since(startTime).Seconds())
-	l4NetLBSyncErrorCount.WithLabelValues(syncType, gceResource, errType).Inc()
+// publishL4NetLBSyncErrorCount exports error count metrics for L4 NetLB after error sync.
+func publishL4NetLBSyncErrorCount(syncType, gceResource, errType string, isWeightedLB bool) {
+	l4NetLBSyncErrorCount.WithLabelValues(syncType, gceResource, errType, strconv.FormatBool(isWeightedLB)).Inc()
 }
 
 func PublishL4RemovedILBLegacyFinalizer() {


### PR DESCRIPTION
If Weighted Load Balancing is enabled on a service by pods-per-node annotation, export its sync latency metrics for both ILB and NetLB. Include label for weighted load balancing in error count metric