### PR TITLE
[Cherry-pick #2663 to release-1.31] Use all zones when creating the shared IG for a s…

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -84,8 +84,8 @@ func NewManager(config *ManagerConfig) Manager {
 // all of which have the exact same named ports.
 func (m *manager) EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) (igs []*compute.InstanceGroup, err error) {
 	iglogger := logger.WithName("InstanceGroupsManager")
-	// Instance groups need to be created only in zones that have ready nodes.
-	zones, err := m.ZoneGetter.ListZones(zonegetter.CandidateNodesFilter, iglogger)
+	// Instance groups need to be created in all zones that nodes are in.
+	zones, err := m.ZoneGetter.ListZones(zonegetter.AllNodesFilter, iglogger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…ervice.

With this change, the code to ensure IGs will use AllNodesFilter to determine which zones to create IGs in. The goal is to avoid detaching groups which become temporarily unready, for example after master upgrade. This change should be fine since creating and using an IG that could be empty is ok from the LB perspective. On the other hand removing a temporarily unready group can cause 10 minutes of no traffic.

(cherry picked from commit 7ee231a5dc437d5e1b926fd0cf3919b926bf66f5)