### PR TITLE
Undesired operation detection for L4 ILB

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -606,6 +606,7 @@ func (l4c *L4Controller) publishMetrics(result *loadbalancers.L4ILBSyncResult, n
 		if result.MetricsState.Multinetwork {
 			l4metrics.PublishL4ILBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, isResync)
 		}
+		l4metrics.PublishL4SyncDetails(l4ILBControllerName, result.Error == nil, isResync, result.ResourceUpdates.WereAnyResourcesModified())
 
 	case loadbalancers.SyncTypeDelete:
 		// if service is successfully deleted, remove it from cache

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -480,6 +480,12 @@ func (l4c *L4Controller) sync(key string, svcLogger klog.Logger) error {
 			// result will be nil if the service was ignored(due to presence of service controller finalizer).
 			return nil
 		}
+		svcLogger.V(3).Info("Resources modified in the sync", "modifiedResources", result.ResourceUpdates.String(), "wasResync", isResync)
+		if isResync {
+			if result.ResourceUpdates.WereAnyResourcesModified() {
+				svcLogger.V(3).Error(nil, "Resources were modified but this was not expected for a resync.", "modifiedResources", result.ResourceUpdates.String())
+			}
+		}
 		l4c.publishMetrics(result, namespacedName, isResync, svcLogger)
 		l4c.serviceVersions.SetProcessed(key, svc.ResourceVersion, result.Error == nil, isResync, svcLogger)
 		return skipUserError(result.Error, svcLogger)

--- a/pkg/l4lb/metrics/metrics.go
+++ b/pkg/l4lb/metrics/metrics.go
@@ -42,7 +42,7 @@ const (
 	l4LastSyncTimeName                             = "l4_last_sync_time"
 	l4LBRemovedFinalizerMetricName                 = "l4_removed_finalizer_count"
 	l4LBControllerPanicsMetricName                 = "l4_controllers_panics_count"
-	L4netlbSyncDetailsMetricName                   = "l4_netlb_sync_details_count"
+	L4SyncDetailsMetricName                        = "l4_sync_details_count"
 	l4WeightedLBPodsPerNodeMetricName              = "l4_weighted_lb_pods_per_node"
 )
 
@@ -183,8 +183,8 @@ var (
 
 	l4LBSyncDetails = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: L4netlbSyncDetailsMetricName,
-			Help: "Details of updates done during a resync",
+			Name: L4SyncDetailsMetricName,
+			Help: "Details of updates done during L4 LB ensure operations",
 		},
 		[]string{"controller_name", "success", "predicted_periodic_resync", "was_update"},
 	)

--- a/pkg/loadbalancers/forwarding_rules_ipv6_test.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6_test.go
@@ -17,10 +17,25 @@ limitations under the License.
 package loadbalancers
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/compute/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
 )
 
 func TestIPv6ForwardingRulesEqual(t *testing.T) {
@@ -179,4 +194,183 @@ func TestIPv6ForwardingRulesEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestL4EnsureIPv6ForwardingRuleUpdate(t *testing.T) {
+	serviceNamespace := "testNs"
+	serviceName := "testSvc"
+	l4namer := namer.NewL4Namer("test", namer.NewNamer("testCluster", "testFirewall", klog.TODO()))
+
+	bsLink := "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1"
+	networkURL := "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc"
+	subnetworkURL := "https://www.googleapis.com/compute/v1/projects/test-poject/regions/us-central1/subnetworks/default-subnet"
+
+	testCases := []struct {
+		desc         string
+		svc          *corev1.Service
+		namedAddress *compute.Address
+		existingRule *composite.ForwardingRule
+		wantRule     *composite.ForwardingRule
+		wantUpdate   utils.ResourceSyncStatus
+		wantErrMsg   string
+	}{
+		{
+			desc: "create",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: nil,
+			wantRule: &composite.ForwardingRule{
+				Ports:               []string{"8080"},
+				IPProtocol:          "TCP",
+				IpVersion:           IPVersionIPv6,
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         ipV6ForwardingRuleDescription(t, serviceNamespace, serviceName),
+			},
+			wantUpdate: utils.ResourceUpdate,
+		},
+		{
+			desc: "no update",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: &composite.ForwardingRule{
+				Ports:               []string{"8080"},
+				IPProtocol:          "TCP",
+				IpVersion:           IPVersionIPv6,
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         ipV6ForwardingRuleDescription(t, serviceNamespace, serviceName),
+			},
+			wantRule: &composite.ForwardingRule{
+				Ports:               []string{"8080"},
+				IPProtocol:          "TCP",
+				IpVersion:           IPVersionIPv6,
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         ipV6ForwardingRuleDescription(t, serviceNamespace, serviceName),
+			},
+			wantUpdate: utils.ResourceResync,
+		},
+		{
+			desc: "update ports",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: types.UID("1")},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     8080,
+							Protocol: corev1.ProtocolTCP,
+						},
+						{
+							Port:     8082,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+					Type: "LoadBalancer",
+				},
+			},
+			existingRule: &composite.ForwardingRule{
+				Ports:               []string{"8080"},
+				IPProtocol:          "TCP",
+				IpVersion:           IPVersionIPv6,
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         ipV6ForwardingRuleDescription(t, serviceNamespace, serviceName),
+			},
+			wantRule: &composite.ForwardingRule{
+				Ports:               []string{"8080", "8082"},
+				IPProtocol:          "TCP",
+				IpVersion:           IPVersionIPv6,
+				LoadBalancingScheme: string(cloud.SchemeInternal),
+				NetworkTier:         cloud.NetworkTierDefault.ToGCEValue(),
+				Version:             meta.VersionGA,
+				BackendService:      bsLink,
+				Description:         ipV6ForwardingRuleDescription(t, serviceNamespace, serviceName),
+			},
+			wantUpdate: utils.ResourceUpdate,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			l4 := &L4{
+				cloud:           fakeGCE,
+				forwardingRules: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
+				namer:           l4namer,
+				Service:         tc.svc,
+				network: network.NetworkInfo{
+					IsDefault:     true,
+					NetworkURL:    networkURL,
+					SubnetworkURL: subnetworkURL,
+				},
+				recorder: &record.FakeRecorder{},
+			}
+			tc.wantRule.Name = l4.getIPv6FRName()
+			if tc.existingRule != nil {
+				tc.existingRule.Name = l4.getIPv6FRName()
+			}
+			if tc.namedAddress != nil {
+				fakeGCE.ReserveRegionAddress(tc.namedAddress, fakeGCE.Region())
+			}
+			fr, updated, err := l4.ensureIPv6ForwardingRule(bsLink, gce.ILBOptions{}, tc.existingRule, "")
+
+			if err != nil && tc.wantErrMsg == "" {
+				t.Errorf("ensureIPv4ForwardingRule() err=%v", err)
+			}
+			if tc.wantErrMsg != "" {
+				if err == nil {
+					t.Errorf("ensureIPv4ForwardingRule() wanted error with msg=%q but got none", tc.wantErrMsg)
+				} else if !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("ensureIPv4ForwardingRule() wanted error with msg=%q but got err=%v", tc.wantErrMsg, err)
+				}
+				return
+			}
+			if updated != tc.wantUpdate {
+				t.Errorf("ensureIPv4ForwardingRule() wanted updated=%v but got=%v", tc.wantUpdate, updated)
+			}
+
+			if diff := cmp.Diff(tc.wantRule, fr, cmpopts.IgnoreFields(composite.ForwardingRule{}, "SelfLink", "Region", "Scope")); diff != "" {
+				t.Errorf("ensureIPv4ForwardingRule() diff -want +got\n%v\n", diff)
+			}
+		})
+	}
+}
+
+func ipV6ForwardingRuleDescription(t *testing.T, namespace, name string) string {
+	t.Helper()
+	description, err := (&utils.L4LBResourceDescription{ServiceName: utils.ServiceKeyFunc(namespace, name)}).Marshal()
+	if err != nil {
+		t.Errorf("failed to create forwarding rule description for service %s/%s", namespace, name)
+	}
+	return description
+
 }

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -34,7 +34,8 @@ import (
 // - IPv6 Firewall
 // it also adds IPv6 address to LB status
 func (l4 *L4) ensureIPv6Resources(syncResult *L4ILBSyncResult, nodeNames []string, options gce.ILBOptions, bsLink string, existingIPv6FwdRule *composite.ForwardingRule, ipv6AddressToUse string) {
-	ipv6fr, err := l4.ensureIPv6ForwardingRule(bsLink, options, existingIPv6FwdRule, ipv6AddressToUse)
+	ipv6fr, fwdRuleSyncStatus, err := l4.ensureIPv6ForwardingRule(bsLink, options, existingIPv6FwdRule, ipv6AddressToUse)
+	syncResult.ResourceUpdates.SetForwardingRule(fwdRuleSyncStatus)
 	if err != nil {
 		l4.svcLogger.Error(err, "ensureIPv6Resources: Failed to ensure ipv6 forwarding rule")
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
@@ -156,7 +157,8 @@ func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, resu
 		Network:           l4.network,
 	}
 
-	_, err = firewalls.EnsureL4LBFirewallForNodes(l4.Service, &ipv6nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
+	fwSyncStatus, err := firewalls.EnsureL4LBFirewallForNodes(l4.Service, &ipv6nodesFWRParams, l4.cloud, l4.recorder, fwLogger)
+	result.ResourceUpdates.SetFirewallForNodes(fwSyncStatus)
 	if err != nil {
 		result.GCEResourceInError = annotations.FirewallRuleIPv6Resource
 		result.Error = err

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -41,7 +41,7 @@ const (
 // it also adds IPv6 address to LB status
 func (l4netlb *L4NetLB) ensureIPv6Resources(syncResult *L4NetLBSyncResult, nodeNames []string, bsLink string) {
 	ipv6fr, wasUpdate, err := l4netlb.ensureIPv6ForwardingRule(bsLink)
-	syncResult.GCEResourceUpdate.forwardingRuleUpdate = wasUpdate
+	syncResult.GCEResourceUpdate.SetForwardingRule(wasUpdate)
 	if err != nil {
 		l4netlb.svcLogger.Error(err, "ensureIPv6Resources: Failed to create ipv6 forwarding rule")
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
@@ -145,7 +145,7 @@ func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []st
 	}
 
 	wasUpdate, err := firewalls.EnsureL4LBFirewallForNodes(l4netlb.Service, &ipv6nodesFWRParams, l4netlb.cloud, l4netlb.recorder, fwLogger)
-	syncResult.GCEResourceUpdate.firewallForNodesUpdate = wasUpdate
+	syncResult.GCEResourceUpdate.SetFirewallForNodes(wasUpdate)
 	if err != nil {
 		fwLogger.Error(err, "Failed to ensure ipv6 nodes firewall for L4 NetLB")
 		syncResult.GCEResourceInError = annotations.FirewallRuleIPv6Resource

--- a/pkg/loadbalancers/resourceupdate.go
+++ b/pkg/loadbalancers/resourceupdate.go
@@ -1,0 +1,95 @@
+package loadbalancers
+
+import (
+	"strings"
+
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// ResourceUpdates tracks the updates to the GCE resources that were done during ensuring the LB.
+// Ensuring of a resource follows this pattern:
+// - get the existing resource
+// - compare it with the expected state
+// - if the resource is already in the expected state - do nothing
+// - if the resource differs perform an update
+// This struct will track if nothing was done (resync) or if an update was performed.
+// It usually should be added to the SyncResult struct of L4 controllers and updated
+// with sync results of GCE resources ensure operations.
+// It is part of the effort to add more transparency to what the controller
+// is doing and also to detect situations where resources are unexpectedly updated.
+type ResourceUpdates struct {
+	backendServiceUpdate   utils.ResourceSyncStatus
+	forwardingRuleUpdate   utils.ResourceSyncStatus
+	healthCheckUpdate      utils.ResourceSyncStatus
+	firewallForNodesUpdate utils.ResourceSyncStatus
+	firewallForHCUpdate    utils.ResourceSyncStatus
+}
+
+// WereAnyResourcesModified returns true if any of the LB resources were updated.
+func (ru *ResourceUpdates) WereAnyResourcesModified() bool {
+	return ru.forwardingRuleUpdate == utils.ResourceUpdate ||
+		ru.backendServiceUpdate == utils.ResourceUpdate ||
+		ru.healthCheckUpdate == utils.ResourceUpdate ||
+		ru.firewallForNodesUpdate == utils.ResourceUpdate ||
+		ru.firewallForHCUpdate == utils.ResourceUpdate
+}
+
+func (ru *ResourceUpdates) String() string {
+	if ru.WereAnyResourcesModified() {
+		var modifiedResources []string
+		if ru.forwardingRuleUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "forwarding rule")
+		}
+		if ru.backendServiceUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "backend service")
+		}
+		if ru.healthCheckUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "health check")
+		}
+		if ru.firewallForNodesUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "nodes firewall")
+		}
+		if ru.firewallForHCUpdate == utils.ResourceUpdate {
+			modifiedResources = append(modifiedResources, "health check firewall")
+		}
+		return strings.Join(modifiedResources, ",")
+	}
+	return "-"
+}
+
+func (ru *ResourceUpdates) set(field *utils.ResourceSyncStatus, new utils.ResourceSyncStatus) {
+	if *field == utils.ResourceUpdate {
+		return
+	}
+	*field = new
+}
+
+// SetBackendService sets the status of the Backend Service update.
+// When this function is invoked multiple times with at least one UPDATE status then the result will be UPDATE.
+func (ru *ResourceUpdates) SetBackendService(status utils.ResourceSyncStatus) {
+	ru.set(&ru.backendServiceUpdate, status)
+}
+
+// SetForwardingRule sets the status of the Forwarding Rule update.
+// When this function is invoked multiple times with at least one UPDATE status then the result will be UPDATE.
+func (ru *ResourceUpdates) SetForwardingRule(status utils.ResourceSyncStatus) {
+	ru.set(&ru.forwardingRuleUpdate, status)
+}
+
+// SetHealthCheck sets the status of the Health Check update.
+// When this function is invoked multiple times with at least one UPDATE status then the result will be UPDATE.
+func (ru *ResourceUpdates) SetHealthCheck(status utils.ResourceSyncStatus) {
+	ru.set(&ru.healthCheckUpdate, status)
+}
+
+// SetFirewallForNodes sets the status of the Firewall for nodes update.
+// When this function is invoked multiple times with at least one UPDATE status then the result will be UPDATE.
+func (ru *ResourceUpdates) SetFirewallForNodes(status utils.ResourceSyncStatus) {
+	ru.set(&ru.firewallForNodesUpdate, status)
+}
+
+// SetFirewallForHealthCheck sets the status of the Firewall for Health Check update.
+// When this function is invoked multiple times with at least one UPDATE status then the result will be UPDATE.
+func (ru *ResourceUpdates) SetFirewallForHealthCheck(status utils.ResourceSyncStatus) {
+	ru.set(&ru.firewallForHCUpdate, status)
+}


### PR DESCRIPTION
Code to detect a situation when a service processing is a resync but causes GCE resource updates.
This is a follow up to #2616, the same change but for ILB.

The changes include some missing test coverage for areas that were touched by these changes.
Also some previously written code for NetLB part is moved around or slightly modified. The metric is renamed but it is safe since it was not read anywhere.

Note to reviewers unfamiliar with the idea:
When the controller ensures a LB service it could be because of 2 reasons:
- user changed the service spec - we expect some update in GCE to be done
- periodic resync - changes to GCE resources are not expected in most cases

With this change the ILB controller will track if it modified any GCE resources. Then later we compare this with the type of sync (real update or just resync) and exports this data as a metric.

The intent is to potentially use it for an alerting mechanism or just as an aid in debugging.