### PR TITLE
Allow externalTrafficPolicy: Cluster on multinetworking services

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -128,11 +128,6 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 		return DefaultNetwork(nr.cloudProvider), nil
 	}
 
-	// TODO: remove this check once DPv2 supports externalTrafficPolicy=Cluster services.
-	if service.Spec.ExternalTrafficPolicy != apiv1.ServiceExternalTrafficPolicyLocal {
-		return nil, utils.NewUserError(fmt.Errorf("multinetwork services with externalTrafficPolicy='%s' are not supported, only externalTrafficPolicy=Local services are supported", service.Spec.ExternalTrafficPolicy))
-	}
-
 	obj, exists, err := nr.networkLister.GetByKey(networkName)
 	if err != nil {
 		return nil, err

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -195,35 +195,6 @@ func TestServiceNetwork(t *testing.T) {
 			service:            serviceWithSecondaryNet,
 			wantErr:            "network.Spec.Type=Device is not supported for multinetwork LoadBalancer services, the only supported network type is L3",
 		},
-		{
-			desc:               "service with externalTrafficPolicy=Cluster",
-			network:            testNetwork("secondary-network", "secondary-network-params"),
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service: &apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "testService"},
-				Spec: apiv1.ServiceSpec{
-					Selector: map[string]string{
-						networkSelector: "secondary-network",
-					},
-					ExternalTrafficPolicy: apiv1.ServiceExternalTrafficPolicyCluster,
-				},
-			},
-			wantErr: "multinetwork services with externalTrafficPolicy='Cluster' are not supported, only externalTrafficPolicy=Local services are supported",
-		},
-		{
-			desc:               "service with externalTrafficPolicy default",
-			network:            testNetwork("secondary-network", "secondary-network-params"),
-			gkeNetworkParamSet: testGKENetworkParamSet("secondary-network-params", "secondary-vpc", "secondary-subnet"),
-			service: &apiv1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "testService"},
-				Spec: apiv1.ServiceSpec{
-					Selector: map[string]string{
-						networkSelector: "secondary-network",
-					},
-				},
-			},
-			wantErr: "multinetwork services with externalTrafficPolicy='' are not supported, only externalTrafficPolicy=Local services are supported",
-		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Removes the constraint that previously restricted externalTrafficPolicy to only `Local` on multinetworking services