### PR TITLE
[Cherrypick #2582 into release-1.28] Fix instance group sizes

### DIFF
--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -18,10 +18,12 @@ package instancegroups
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -29,13 +31,18 @@ import (
 )
 
 const (
-	defaultZone = "default-zone"
-	basePath    = "/basepath/projects/project-id/"
+	defaultTestZone = "default-zone"
+	testZoneA       = "dark-moon1-a"
+	testZoneB       = "dark-moon1-b"
+	testZoneC       = "dark-moon1-c"
+	basePath        = "/basepath/projects/project-id/"
+
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
 )
 
 var defaultNamer = namer.NewNamer("uid1", "fw1")
 
-func newNodePool(f *FakeInstanceGroups, zone string, maxIGSize int) Manager {
+func newNodePool(f Provider, maxIGSize int) Manager {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	fakeZoneGetter := zonegetter.NewZoneGetter(nodeInformer)
 
@@ -90,16 +97,16 @@ func TestNodePoolSync(t *testing.T) {
 		// create fake gce node pool with existing gceNodes
 		ig := &compute.InstanceGroup{Name: defaultNamer.InstanceGroup()}
 		zonesToIGs := map[string]IGsToInstances{
-			defaultZone: {
+			defaultTestZone: {
 				ig: testCase.gceNodes,
 			},
 		}
 		fakeGCEInstanceGroups := NewFakeInstanceGroups(zonesToIGs, maxIGSize)
 
-		pool := newNodePool(fakeGCEInstanceGroups, defaultZone, maxIGSize)
+		pool := newNodePool(fakeGCEInstanceGroups, maxIGSize)
 		for _, kubeNode := range testCase.kubeNodes.List() {
 			manager := pool.(*manager)
-			zonegetter.AddFakeNodes(manager.ZoneGetter, defaultZone, kubeNode)
+			zonegetter.AddFakeNodes(manager.ZoneGetter, defaultTestZone, kubeNode)
 		}
 
 		igName := defaultNamer.InstanceGroup()
@@ -122,9 +129,9 @@ func TestNodePoolSync(t *testing.T) {
 			t.Errorf("Should skip sync. apiCallsCountBeforeSync = %d, apiCallsCountAfterSync = %d", apiCallsCountBeforeSync, apiCallsCountAfterSync)
 		}
 
-		instancesList, err := fakeGCEInstanceGroups.ListInstancesInInstanceGroup(ig.Name, defaultZone, allInstances)
+		instancesList, err := fakeGCEInstanceGroups.ListInstancesInInstanceGroup(ig.Name, defaultTestZone, allInstances)
 		if err != nil {
-			t.Fatalf("fakeGCEInstanceGroups.ListInstancesInInstanceGroup(%s, %s, %s) returned error %v, want nil", ig.Name, defaultZone, allInstances, err)
+			t.Fatalf("fakeGCEInstanceGroups.ListInstancesInInstanceGroup(%s, %s, %s) returned error %v, want nil", ig.Name, defaultTestZone, allInstances, err)
 		}
 		instances, err := test.InstancesListToNameSet(instancesList)
 		if err != nil {
@@ -157,17 +164,204 @@ func TestNodePoolSync(t *testing.T) {
 	}
 }
 
+func TestInstanceAlreadyMemberOfIG(t *testing.T) {
+	maxIGSize := 1000
+	kubeNodes := sets.NewString("n1", "n2")
+
+	fakeInstanceGroups := new(fakeIGAlreadyExists)
+	fakeInstanceGroups.FakeInstanceGroups = NewFakeInstanceGroups(map[string]IGsToInstances{}, maxIGSize)
+
+	pool := newNodePool(fakeInstanceGroups, maxIGSize)
+	for _, kubeNode := range kubeNodes.List() {
+		manager := pool.(*manager)
+		zonegetter.AddFakeNodes(manager.ZoneGetter, defaultTestZone, kubeNode)
+	}
+
+	igName := defaultNamer.InstanceGroup()
+	ports := []int64{80}
+	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+	if err != nil {
+		t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
+	}
+
+	// run sync with 2 times, expect not error despite fakeInstanceGroups will return 'memberAlreadyExists'
+	err = pool.Sync(kubeNodes.List())
+	if err != nil {
+		t.Fatalf("pool.Sync() returned error %v, want nil", err)
+	}
+	err = pool.Sync(kubeNodes.List())
+	if err != nil {
+		t.Fatalf("pool.Sync() returned error %v, want nil", err)
+	}
+}
+
+type fakeIGAlreadyExists struct {
+	*FakeInstanceGroups
+}
+
+func (fakeIG *fakeIGAlreadyExists) AddInstancesToInstanceGroup(name, zone string, instanceRefs []*compute.InstanceReference) error {
+	return &googleapi.Error{
+		Code:    http.StatusBadRequest,
+		Message: fmt.Sprintf("Resource: %v is already a member of %v", instanceRefs, name),
+		Errors: []googleapi.ErrorItem{
+			{
+				Reason: "memberAlreadyExists",
+			},
+		},
+	}
+}
+
+func TestNodePoolSyncHugeCluster(t *testing.T) {
+	// for sake of easier debugging cap instance group size to 3
+	maxIGSize := 3
+
+	testCases := []struct {
+		description    string
+		gceNodesZoneA  sets.String
+		gceNodesZoneB  sets.String
+		gceNodesZoneC  sets.String
+		kubeNodesZoneA sets.String
+		kubeNodesZoneB sets.String
+		kubeNodesZoneC sets.String
+	}{
+		{
+			description:    "too many kube nodes in one 1 of 3 zone",
+			gceNodesZoneA:  getNodeSlice("nodes-zone-a", maxIGSize),
+			gceNodesZoneB:  getNodeSlice("nodes-zone-b", 2*maxIGSize),
+			gceNodesZoneC:  getNodeSlice("nodes-zone-c", maxIGSize),
+			kubeNodesZoneA: getNodeSlice("nodes-zone-a", maxIGSize),
+			kubeNodesZoneB: getNodeSlice("nodes-zone-b", 2*maxIGSize),
+			kubeNodesZoneC: getNodeSlice("nodes-zone-c", maxIGSize),
+		},
+		{
+			description:    "too many kube nodes in 2 of 3 zones",
+			gceNodesZoneA:  getNodeSlice("nodes-zone-a", maxIGSize),
+			gceNodesZoneB:  getNodeSlice("nodes-zone-b", 2*maxIGSize),
+			gceNodesZoneC:  getNodeSlice("nodes-zone-c", 2*maxIGSize),
+			kubeNodesZoneA: getNodeSlice("nodes-zone-a", maxIGSize),
+			kubeNodesZoneB: getNodeSlice("nodes-zone-b", 2*maxIGSize+1),
+			kubeNodesZoneC: getNodeSlice("nodes-zone-c", 2*maxIGSize+2),
+		},
+		{
+			description:    "too many kube nodes in 3 of 3 zones",
+			gceNodesZoneA:  getNodeSlice("nodes-zone-a", 2*maxIGSize),
+			gceNodesZoneB:  getNodeSlice("nodes-zone-b", 2*maxIGSize+1),
+			gceNodesZoneC:  getNodeSlice("nodes-zone-c", 2*maxIGSize+2),
+			kubeNodesZoneA: getNodeSlice("nodes-zone-a", 2*maxIGSize),
+			kubeNodesZoneB: getNodeSlice("nodes-zone-b", 2*maxIGSize),
+			kubeNodesZoneC: getNodeSlice("nodes-zone-c", 2*maxIGSize),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			igName := defaultNamer.InstanceGroup()
+			fakeGCEInstanceGroups := NewFakeInstanceGroups(map[string]IGsToInstances{}, maxIGSize)
+			pool := newNodePool(fakeGCEInstanceGroups, maxIGSize)
+			manager := pool.(*manager)
+			zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneA, tc.gceNodesZoneA.List()...)
+			zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneB, tc.gceNodesZoneB.List()...)
+			zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneC, tc.gceNodesZoneC.List()...)
+
+			ports := []int64{80}
+			_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+			if err != nil {
+				t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
+			}
+			allKubeNodes := append(tc.kubeNodesZoneA.List(), tc.kubeNodesZoneB.List()...)
+			allKubeNodes = append(allKubeNodes, tc.kubeNodesZoneC.List()...)
+
+			// Execute manager's main instance group sync function
+			err = pool.Sync(allKubeNodes)
+			if err != nil {
+				t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
+			}
+
+			// Check that instance group in each zone has only `maxIGSize` number of nodes
+			// including zones with 2*maxIGSize nodes
+			for _, zone := range []string{testZoneA, testZoneB, testZoneC} {
+				numberOfIGsInZone := len(fakeGCEInstanceGroups.zonesToIGsToInstances[zone])
+				if numberOfIGsInZone != 1 {
+					t.Errorf("Unexpected instance group added, got %v, want: 1", numberOfIGsInZone)
+				}
+				for _, igToInstances := range fakeGCEInstanceGroups.zonesToIGsToInstances[zone] {
+					t.Logf("number of nodes in instance group from zone: %v, got %v", zone, len(igToInstances))
+					if len(igToInstances) > maxIGSize {
+						t.Errorf("unexpected number of nodes in instance group from zone: %v, got %v, want: %v", zone, len(igToInstances), maxIGSize)
+					}
+				}
+			}
+
+			apiCallsCountBeforeSync := len(fakeGCEInstanceGroups.calls)
+			err = pool.Sync(allKubeNodes)
+			if err != nil {
+				t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
+			}
+			apiCallsCountAfterSync := len(fakeGCEInstanceGroups.calls)
+			if apiCallsCountBeforeSync != apiCallsCountAfterSync {
+				t.Errorf("Should skip sync if called second time with the same kubeNodes. apiCallsCountBeforeSync = %d, apiCallsCountAfterSync = %d", apiCallsCountBeforeSync, apiCallsCountAfterSync)
+			}
+		})
+	}
+}
+
+// TestInstanceTruncatingOrder verifies if nodes over maxIGSize are truncated from the last one (alphabetically)
+func TestInstanceTruncatingOrder(t *testing.T) {
+
+	maxIGSize := 3
+	gceNodesZoneA := []string{"d-node", "c-node", "b-node", "a-node"}
+	kubeNodesZoneA := []string{"d-node", "c-node", "b-node", "a-node"}
+
+	igName := defaultNamer.InstanceGroup()
+	fakeGCEInstanceGroups := NewFakeInstanceGroups(map[string]IGsToInstances{}, maxIGSize)
+	pool := newNodePool(fakeGCEInstanceGroups, maxIGSize)
+	manager := pool.(*manager)
+	zonegetter.AddFakeNodes(manager.ZoneGetter, testZoneA, gceNodesZoneA...)
+
+	ports := []int64{80}
+	_, err := pool.EnsureInstanceGroupsAndPorts(igName, ports)
+	if err != nil {
+		t.Fatalf("pool.EnsureInstanceGroupsAndPorts(%s, %v) returned error %v, want nil", igName, ports, err)
+	}
+
+	// Execute manager's main instance group sync function
+	err = pool.Sync(kubeNodesZoneA)
+	if err != nil {
+		t.Fatalf("pool.Sync(_) returned error %v, want nil", err)
+	}
+
+	numberOfIGsInZone := len(fakeGCEInstanceGroups.zonesToIGsToInstances[testZoneA])
+	if numberOfIGsInZone != 1 {
+		t.Errorf("Unexpected instance group added, got %v, want: 1", numberOfIGsInZone)
+	}
+	for _, instancesSet := range fakeGCEInstanceGroups.zonesToIGsToInstances[testZoneA] {
+		if instancesSet.Has("d-node") {
+			t.Errorf("Last nodes (alphabetically) should be truncated first.")
+		}
+
+	}
+}
+
+func getNodeSlice(prefix string, size int) sets.String {
+	nodes := make([]string, size)
+	for i := 0; i < size; i++ {
+		nodes[i] = fmt.Sprintf("%s-%d", prefix, i)
+	}
+	return sets.NewString(nodes...)
+}
+
 func TestSetNamedPorts(t *testing.T) {
 	maxIGSize := 1000
 	zonesToIGs := map[string]IGsToInstances{
-		defaultZone: {
+		defaultTestZone: {
 			&compute.InstanceGroup{Name: "ig"}: sets.NewString("ig"),
 		},
 	}
 	fakeIGs := NewFakeInstanceGroups(zonesToIGs, maxIGSize)
-	pool := newNodePool(fakeIGs, defaultZone, maxIGSize)
+	pool := newNodePool(fakeIGs, maxIGSize)
 	manager := pool.(*manager)
-	zonegetter.AddFakeNodes(manager.ZoneGetter, defaultZone, "test-node")
+	zonegetter.AddFakeNodes(manager.ZoneGetter, defaultTestZone, "test-node")
 
 	testCases := []struct {
 		activePorts   []int64
@@ -218,11 +412,11 @@ func TestSetNamedPorts(t *testing.T) {
 func TestGetInstanceReferences(t *testing.T) {
 	maxIGSize := 1000
 	zonesToIGs := map[string]IGsToInstances{
-		defaultZone: {
+		defaultTestZone: {
 			&compute.InstanceGroup{Name: "ig"}: sets.NewString("ig"),
 		},
 	}
-	pool := newNodePool(NewFakeInstanceGroups(zonesToIGs, maxIGSize), defaultZone, maxIGSize)
+	pool := newNodePool(NewFakeInstanceGroups(zonesToIGs, maxIGSize), maxIGSize)
 	instances := pool.(*manager)
 
 	nodeNames := []string{"node-1", "node-2", "node-3", "node-4.region.zone"}
@@ -230,10 +424,10 @@ func TestGetInstanceReferences(t *testing.T) {
 	expectedRefs := map[string]struct{}{}
 	for _, nodeName := range nodeNames {
 		name := strings.Split(nodeName, ".")[0]
-		expectedRefs[fmt.Sprintf("%szones/%s/instances/%s", basePath, defaultZone, name)] = struct{}{}
+		expectedRefs[fmt.Sprintf("%szones/%s/instances/%s", basePath, defaultTestZone, name)] = struct{}{}
 	}
 
-	refs := instances.getInstanceReferences(defaultZone, nodeNames)
+	refs := instances.getInstanceReferences(defaultTestZone, nodeNames)
 	for _, ref := range refs {
 		if _, ok := expectedRefs[ref.Instance]; !ok {
 			t.Errorf("found unexpected reference: %s, expected only %+v", ref.Instance, expectedRefs)

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -772,17 +772,23 @@ func TestProcessServiceCreationFailed(t *testing.T) {
 	for _, param := range []struct {
 		addMockFunc   func(*cloud.MockGCE)
 		expectedError string
-	}{{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.GetHook = test.GetErrorInstanceGroupHook },
-		expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error GetErrorInstanceGroupHook"},
-		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.ListHook = test.ListErrorHook },
-			expectedError: "ListErrorHook"},
-		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.InsertHook = test.InsertErrorHook },
-			expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error InsertErrorHook"},
-
-		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.AddInstancesHook = test.AddInstancesErrorHook },
-			expectedError: "AddInstances: [AddInstancesErrorHook]"},
-		{addMockFunc: func(c *cloud.MockGCE) { c.MockInstanceGroups.ListInstancesHook = test.ListInstancesWithErrorHook },
-			expectedError: "ListInstancesWithErrorHook"},
+	}{
+		{
+			addMockFunc:   func(c *cloud.MockGCE) { c.MockInstanceGroups.GetHook = test.GetErrorInstanceGroupHook },
+			expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error GetErrorInstanceGroupHook",
+		},
+		{
+			addMockFunc:   func(c *cloud.MockGCE) { c.MockInstanceGroups.InsertHook = test.InsertErrorHook },
+			expectedError: "lc.instancePool.EnsureInstanceGroupsAndPorts(k8s-ig--aaaaa, []) returned error InsertErrorHook",
+		},
+		{
+			addMockFunc:   func(c *cloud.MockGCE) { c.MockInstanceGroups.AddInstancesHook = test.AddInstancesErrorHook },
+			expectedError: "AddInstancesErrorHook",
+		},
+		{
+			addMockFunc:   func(c *cloud.MockGCE) { c.MockInstanceGroups.ListInstancesHook = test.ListInstancesWithErrorHook },
+			expectedError: "ListInstancesWithErrorHook",
+		},
 	} {
 		lc := newL4NetLBServiceController()
 		param.addMockFunc((lc.ctx.Cloud.Compute().(*cloud.MockGCE)))
@@ -791,7 +797,7 @@ func TestProcessServiceCreationFailed(t *testing.T) {
 		key, _ := common.KeyFunc(svc)
 		err := lc.sync(key)
 		if err == nil || err.Error() != param.expectedError {
-			t.Errorf("Error mismatch '%v' != '%v'", err, param.expectedError)
+			t.Errorf("Error mismatch got:'%v' want: '%v'", err, param.expectedError)
 		}
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -198,6 +198,14 @@ func IsInUsedByError(err error) bool {
 	return strings.Contains(apiErr.Message, "being used by")
 }
 
+func IsMemberAlreadyExistsError(err error) bool {
+	apiErr, ok := err.(*googleapi.Error)
+	if !ok || apiErr.Code != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(apiErr.Error(), "memberAlreadyExists")
+}
+
 // IsNetworkTierMismatchGCEError checks if error is a GCE network tier mismatch for external IP
 func IsNetworkTierMismatchGCEError(err error) bool {
 	return networkTierErrorRegexp.MatchString(err.Error())


### PR DESCRIPTION
there is an error in truncating to 1000 nodes before iterating over zones when adding/removing instances from instance group.

The instance group management logic should be following:

- For each zone add up to #m.maxIGSize number of nodes to the instance group
- If there is more then truncate last nodes (in alphabetical order)
- the logic should be consistent with cloud-provider-gcp's Legacy L4 ILB Controller: https://github.com/kubernetes/cloud-provider-gcp/blob/fca628cb3bf9267def0abb509eaae87d2d4040f3/providers/gce/gce_loadbalancer_internal.go#L606C1-L675C1
- the  production value for m.maxIGSize should be set to 1000 as is in the cloud-provider-gcp.