### PR TITLE
Moving from string(zone) to endpointGroupInfo when mapping NEGs, and populate subnet values for nodes in zoneGetter and NEG syncers.

### DIFF
--- a/pkg/instancegroups/manager.go
+++ b/pkg/instancegroups/manager.go
@@ -240,7 +240,7 @@ func (m *manager) List(logger klog.Logger) ([]string, error) {
 func (m *manager) splitNodesByZone(names []string, logger klog.Logger) map[string][]string {
 	nodesByZone := map[string][]string{}
 	for _, name := range names {
-		zone, err := m.ZoneGetter.ZoneForNode(name, logger)
+		zone, _, err := m.ZoneGetter.ZoneAndSubnetForNode(name, logger)
 		if err != nil {
 			logger.Error(err, "Failed to get zones for instance node, skipping", "name", name)
 			continue

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -81,6 +81,7 @@ const (
 	labelValue2 = "v2"
 	negName1    = "neg1"
 
+	defaultTestSubnet    = "default"
 	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
 )
 

--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -294,7 +294,7 @@ func (sm *SyncerMetrics) computeEndpointStateMetrics() (negtypes.StateCountMap, 
 
 // CollectDualStackMigrationMetrics will be used by dualstack.Migrator to export
 // metrics.
-func (sm *SyncerMetrics) CollectDualStackMigrationMetrics(key negtypes.NegSyncerKey, committedEndpoints map[string]negtypes.NetworkEndpointSet, migrationCount int) {
+func (sm *SyncerMetrics) CollectDualStackMigrationMetrics(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, migrationCount int) {
 	sm.updateMigrationStartAndEndTime(key, migrationCount)
 	sm.updateEndpointsCountPerType(key, committedEndpoints, migrationCount)
 }
@@ -337,7 +337,7 @@ func (sm *SyncerMetrics) updateMigrationStartAndEndTime(key negtypes.NegSyncerKe
 	sm.dualStackMigrationStartTime[key] = sm.clock.Now()
 }
 
-func (sm *SyncerMetrics) updateEndpointsCountPerType(key negtypes.NegSyncerKey, committedEndpoints map[string]negtypes.NetworkEndpointSet, migrationCount int) {
+func (sm *SyncerMetrics) updateEndpointsCountPerType(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, migrationCount int) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 

--- a/pkg/neg/metrics/metricscollector/metrics_collector_test.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector_test.go
@@ -118,13 +118,13 @@ func TestUpdateMigrationStartAndEndTime(t *testing.T) {
 
 func TestUpdateEndpointsCountPerType(t *testing.T) {
 	syncerKey := syncerKey(1)
-	inputCommittedEndpoints := map[string]types.NetworkEndpointSet{
-		"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+	inputCommittedEndpoints := map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet{
+		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "ipv4only-1"}, {IP: "ipv4only-2"}, {IP: "ipv4only-3"},
 			{IPv6: "ipv6only-1"},
 			{IP: "dualStack-1a", IPv6: "dualStack-1b"}, {IP: "dualStack-2a", IPv6: "dualStack-2b"},
 		}...),
-		"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+		{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "ipv4only-4"},
 			{IP: "dualStack-3a", IPv6: "dualStack-3b"},
 		}...),

--- a/pkg/neg/syncers/dualstack/migrator_test.go
+++ b/pkg/neg/syncers/dualstack/migrator_test.go
@@ -19,11 +19,11 @@ func TestFilter(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		migrator            *Migrator
-		addEndpoints        map[string]types.NetworkEndpointSet
-		removeEndpoints     map[string]types.NetworkEndpointSet
-		committedEndpoints  map[string]types.NetworkEndpointSet
-		wantAddEndpoints    map[string]types.NetworkEndpointSet
-		wantRemoveEndpoints map[string]types.NetworkEndpointSet
+		addEndpoints        map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		removeEndpoints     map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		committedEndpoints  map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantAddEndpoints    map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantRemoveEndpoints map[types.EndpointGroupInfo]types.NetworkEndpointSet
 		wantMigrationZone   bool
 	}{
 		{
@@ -33,30 +33,30 @@ func TestFilter(t *testing.T) {
 				m.Pause()
 				return m
 			}(),
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					// Migration-endpoints were filtered out but no new migration
 					// detachment was started.
 					{IP: "c", IPv6: "C"},
@@ -66,30 +66,30 @@ func TestFilter(t *testing.T) {
 		{
 			desc:     "unpaused migrator should filter migration endpoints AND also start detachment",
 			migrator: newMigratorForTest(t, true),
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // Migration detachment started.
 					{IP: "c", IPv6: "C"},
 				}...),
@@ -99,31 +99,31 @@ func TestFilter(t *testing.T) {
 		{
 			desc:     "migrator should do nothing if enableDualStack is false",
 			migrator: newMigratorForTest(t, false),
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
@@ -138,7 +138,7 @@ func TestFilter(t *testing.T) {
 			gotCommittedEndpoints := cloneZoneNetworkEndpointsMap(tc.committedEndpoints)
 			gotMigrationZone := tc.migrator.Filter(gotAddEndpoints, gotRemoveEndpoints, gotCommittedEndpoints)
 
-			if tc.wantMigrationZone && gotMigrationZone == "" {
+			if tc.wantMigrationZone && gotMigrationZone.Zone == "" && gotMigrationZone.Subnet == "" {
 				t.Errorf("Filter() returned empty migrationZone; want non empty migrationZone")
 			}
 
@@ -271,7 +271,7 @@ func TestFilter_FunctionalTest(t *testing.T) {
 	// filteredRemoveEndpoints.
 	//
 	// If shouldAttach is false, no attachments will be done.
-	doNEGAttachDetach := func(addEndpoints, removeEndpoints, committedEndpoints, filteredAddEndpoints, filteredRemoveEndpoints map[string]types.NetworkEndpointSet, shouldAttach bool) {
+	doNEGAttachDetach := func(addEndpoints, removeEndpoints, committedEndpoints, filteredAddEndpoints, filteredRemoveEndpoints map[types.EndpointGroupInfo]types.NetworkEndpointSet, shouldAttach bool) {
 		// Endpoints are detachment by deleting them from the removeEndpoints set.
 		for zone, endpointSet := range filteredRemoveEndpoints {
 			removeEndpoints[zone].Delete(endpointSet.List()...)
@@ -293,11 +293,11 @@ func TestFilter_FunctionalTest(t *testing.T) {
 			// Step 1: Generate endpoints to be used as input.
 			/////////////////////////////////////////////////////////////////////////
 
-			addEndpoints := make(map[string]types.NetworkEndpointSet)       // Contains dual-stack endpoints which are to be added to the NEG.
-			removeEndpoints := make(map[string]types.NetworkEndpointSet)    // Contains single-stack endpoints which are to be removed from the NEG.
-			committedEndpoints := make(map[string]types.NetworkEndpointSet) // Initially empty.
+			addEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)       // Contains dual-stack endpoints which are to be added to the NEG.
+			removeEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)    // Contains single-stack endpoints which are to be removed from the NEG.
+			committedEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet) // Initially empty.
 			for i := 0; i < tc.initialNEGEndpointsCount; i++ {
-				zone := fmt.Sprintf("zone-%v", i%tc.zonesCount)
+				zone := types.EndpointGroupInfo{Zone: fmt.Sprintf("zone-%v", i%tc.zonesCount)}
 				ipv4 := fmt.Sprintf("ipv4-%v", 2*i+1)
 				ipv6 := fmt.Sprintf("ipv6-%v", 2*i+2)
 				if addEndpoints[zone] == nil {
@@ -323,7 +323,7 @@ func TestFilter_FunctionalTest(t *testing.T) {
 
 				doNEGAttachDetach(addEndpoints, removeEndpoints, committedEndpoints, filteredAddEndpoints, filteredRemoveEndpoints, tc.attachSucceeds)
 				fakeClock := tc.migrator.clock.(*clocktesting.FakeClock)
-				if migrationZone != "" {
+				if migrationZone.Zone != "" || migrationZone.Subnet != "" {
 					// Update the time of the last successful detach.
 					tc.migrator.previousDetach = fakeClock.Now()
 				}
@@ -350,16 +350,16 @@ func TestFilter_FunctionalTest(t *testing.T) {
 }
 
 func TestPause(t *testing.T) {
-	addEndpoints := map[string]types.NetworkEndpointSet{
-		"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+	addEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a", IPv6: "A"}, // migrating
 			{IP: "b"},
 			{IP: "c", IPv6: "C"},
 			{IP: "d"}, // migrating
 		}...),
 	}
-	removeEndpoints := map[string]types.NetworkEndpointSet{
-		"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+	removeEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a"}, // migrating
 			{IP: "e", IPv6: "E"},
 			{IP: "d", IPv6: "D"}, // migrating
@@ -372,12 +372,12 @@ func TestPause(t *testing.T) {
 	// starting migration-detachments.
 	clonedAddEndpoints := cloneZoneNetworkEndpointsMap(addEndpoints)
 	clonedRemoveEndpoints := cloneZoneNetworkEndpointsMap(removeEndpoints)
-	migrator.Filter(clonedAddEndpoints, clonedRemoveEndpoints, map[string]types.NetworkEndpointSet{})
+	migrator.Filter(clonedAddEndpoints, clonedRemoveEndpoints, map[types.EndpointGroupInfo]types.NetworkEndpointSet{})
 	possibleMigrationDetachments := []types.NetworkEndpoint{
 		{IP: "a"},            // migrating
 		{IP: "d", IPv6: "D"}, // migrating
 	}
-	if !clonedRemoveEndpoints["zone1"].HasAny(possibleMigrationDetachments...) {
+	if !clonedRemoveEndpoints[types.EndpointGroupInfo{Zone: "zone1"}].HasAny(possibleMigrationDetachments...) {
 		t.Fatalf("Precondition to verify the behaviour of Pause() not satisfied; Filter() should start migration-detachments; got removeEndpoints=%+v; want non-empty union with %+v", clonedRemoveEndpoints, possibleMigrationDetachments)
 	}
 
@@ -391,9 +391,9 @@ func TestPause(t *testing.T) {
 
 	// The effect of Pause() is observed by verifying that Filter() does not start
 	// any migration-detachments when paused.
-	migrator.Filter(addEndpoints, removeEndpoints, map[string]types.NetworkEndpointSet{})
-	wantRemoveEndpoints := map[string]types.NetworkEndpointSet{
-		"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+	migrator.Filter(addEndpoints, removeEndpoints, map[types.EndpointGroupInfo]types.NetworkEndpointSet{})
+	wantRemoveEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+		types.EndpointGroupInfo{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			// Since we don't expect any migration-detachments, this set should be
 			// missing all migration endpoints.
 			{IP: "e", IPv6: "E"},
@@ -523,24 +523,24 @@ func TestContinue_NoInputError_ShouldChangeTimeSincePreviousDetach(t *testing.T)
 func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 	testCases := []struct {
 		desc                        string
-		addEndpoints                map[string]types.NetworkEndpointSet
-		removeEndpoints             map[string]types.NetworkEndpointSet
-		committedEndpoints          map[string]types.NetworkEndpointSet
-		migrationEndpoints          map[string]types.NetworkEndpointSet
+		addEndpoints                map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		removeEndpoints             map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		committedEndpoints          map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		migrationEndpoints          map[types.EndpointGroupInfo]types.NetworkEndpointSet
 		migrator                    *Migrator
 		wantCurrentlyMigratingCount int
 	}{
 		{
 			desc:            "less than or equal to 10 (committed + migration) endpoints should only detach 1 at a time",
-			addEndpoints:    map[string]types.NetworkEndpointSet{},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 				}...),
 			},
@@ -549,15 +549,15 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 		},
 		{
 			desc:            "more than 10 (committed + migration) endpoints can detach more than 1 at a time",
-			addEndpoints:    map[string]types.NetworkEndpointSet{},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 					{IP: "11"},
 				}...),
@@ -570,19 +570,19 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// migration was NOT too long ago, then we will not start any new
 			// detachments since we wait for the pending attaches to complete
 			desc: "many endpoints are waiting to be attached AND previous migration was quite recent",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -598,19 +598,19 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// migration was too long ago BUT we are in error state, then we will not
 			// start any new detachments since we wait to get out of error state.
 			desc: "many endpoints are waiting to be attached AND previous migration was too long ago BUT in error state",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -627,19 +627,19 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// want to keep waiting indefinitely for the next detach and we proceed
 			// with the detachments.
 			desc: "many endpoints are waiting to be attached BUT previous migration was too long ago AND not in error state",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -648,22 +648,22 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 		},
 		{
 			desc: "no detachments started since nothing to migrate",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "2"},
 				}...),
 			},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "3"}, {IP: "4"}, {IP: "5"}, {IP: "6"},
 				}...),
 			},
-			migrationEndpoints:          map[string]types.NetworkEndpointSet{},
+			migrationEndpoints:          map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			migrator:                    newMigratorForTest(t, true),
 			wantCurrentlyMigratingCount: 0,
 		},
@@ -672,21 +672,21 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// more than the number of endpoints in any single zone, we should not
 			// include endpoints from multiple zones.
 			desc:            "endpoints from multiple zones should not be detached at once",
-			addEndpoints:    map[string]types.NetworkEndpointSet{},
-			removeEndpoints: map[string]types.NetworkEndpointSet{},
-			committedEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"},
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "5"}, {IP: "6"}, {IP: "7"}, {IP: "8"},
 				}...),
 			},
-			migrationEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "9"}, {IP: "10"},
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "11"}, {IP: "12"},
 				}...),
 			},
@@ -704,8 +704,8 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 
 			migrationZone := tc.migrator.calculateMigrationEndpointsToDetach(tc.addEndpoints, tc.removeEndpoints, tc.committedEndpoints, tc.migrationEndpoints)
 
-			if tc.wantCurrentlyMigratingCount > 0 && migrationZone == "" {
-				t.Fatalf("calculateMigrationEndpointsToDetach(...) returned empty zone which means no migration detachment was started; want %v endpoints to undergo detachment", tc.wantCurrentlyMigratingCount)
+			if tc.wantCurrentlyMigratingCount > 0 && (migrationZone.Zone == "" && migrationZone.Subnet == "") {
+				t.Fatalf("calculateMigrationEndpointsToDetach(...) returned empty zone and subnet which means no migration detachment was started; want %v endpoints to undergo detachment", tc.wantCurrentlyMigratingCount)
 			}
 
 			// Ensure that we didn't modify the addEndpoints and committedEndpoints.
@@ -744,84 +744,84 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 	testCases := []struct {
 		name                              string
-		addEndpoints                      map[string]types.NetworkEndpointSet
-		removeEndpoints                   map[string]types.NetworkEndpointSet
-		wantMigrationEndpointsInAddSet    map[string]types.NetworkEndpointSet
-		wantMigrationEndpointsInRemoveSet map[string]types.NetworkEndpointSet
+		addEndpoints                      map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		removeEndpoints                   map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantMigrationEndpointsInAddSet    map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantMigrationEndpointsInRemoveSet map[types.EndpointGroupInfo]types.NetworkEndpointSet
 	}{
 		{
 			name: "detect multiple migrating endpoints",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 					{IP: "c", IPv6: "C"},
 					{IP: "d"}, // migrating
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "e", IPv6: "E"}, // migrating
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "f", IPv6: "F"},
 					{IP: "d", IPv6: "D"}, // migrating
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "E"}, // migrating
 				}...),
 			},
-			wantMigrationEndpointsInAddSet: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantMigrationEndpointsInAddSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "d"},
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "e", IPv6: "E"},
 				}...),
 			},
-			wantMigrationEndpointsInRemoveSet: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"},
 					{IP: "d", IPv6: "D"},
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "E"},
 				}...),
 			},
 		},
 		{
 			name: "partial IP change without stack change is not considered migrating",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "B"},
 				}...),
 			},
-			wantMigrationEndpointsInAddSet:    map[string]types.NetworkEndpointSet{},
-			wantMigrationEndpointsInRemoveSet: map[string]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInAddSet:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 		},
 		{
 			name: "difference in port or node is not considered migrating",
-			addEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A", Port: "80"},
 					{IP: "b", Node: "node2"},
 				}...),
 			},
-			removeEndpoints: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "81"},
 					{IP: "b", IPv6: "B", Node: "node1"},
 				}...),
 			},
-			wantMigrationEndpointsInAddSet:    map[string]types.NetworkEndpointSet{},
-			wantMigrationEndpointsInRemoveSet: map[string]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInAddSet:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 		},
 	}
 
@@ -841,133 +841,133 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 
 func TestMoveEndpoint(t *testing.T) {
 	testCases := []struct {
-		name        string
-		endpoint    types.NetworkEndpoint
-		inputSource map[string]types.NetworkEndpointSet
-		inputDest   map[string]types.NetworkEndpointSet
-		wantSource  map[string]types.NetworkEndpointSet
-		wantDest    map[string]types.NetworkEndpointSet
-		zone        string
-		wantSuccess bool
+		name              string
+		endpoint          types.NetworkEndpoint
+		inputSource       map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		inputDest         map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantSource        map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		wantDest          map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		endpointGroupInfo types.EndpointGroupInfo
+		wantSuccess       bool
 	}{
 		{
 			name:     "completely valid input, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			inputDest: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			wantDest: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			zone:        "zone1",
-			wantSuccess: true,
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1"},
+			wantSuccess:       true,
 		},
 		{
 			name:     "zone does not exist in source",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			inputDest: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			wantDest: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			zone: "zone3",
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
 		},
 		{
 			name:     "zone does not exist in destination, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			inputDest: map[string]types.NetworkEndpointSet{
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			wantDest: map[string]types.NetworkEndpointSet{
-				"zone1": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
-				"zone2": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			zone:        "zone1",
-			wantSuccess: true,
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1"},
+			wantSuccess:       true,
 		},
 		{
 			name:     "source is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputDest: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantDest: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			zone: "zone3",
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
 		},
 		{
 			name:     "destination is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[string]types.NetworkEndpointSet{
-				"zone3": types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			zone: "zone3",
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSuccess := moveEndpoint(tc.endpoint, tc.inputSource, tc.inputDest, tc.zone)
+			gotSuccess := moveEndpoint(tc.endpoint, tc.inputSource, tc.inputDest, tc.endpointGroupInfo)
 
 			if gotSuccess != tc.wantSuccess {
 				t.Errorf("moveEndpoint(%v, ...) = %v, want = %v", tc.endpoint, gotSuccess, tc.wantSuccess)
@@ -982,10 +982,10 @@ func TestMoveEndpoint(t *testing.T) {
 	}
 }
 
-func cloneZoneNetworkEndpointsMap(m map[string]types.NetworkEndpointSet) map[string]types.NetworkEndpointSet {
-	clone := make(map[string]types.NetworkEndpointSet)
-	for zone, endpointSet := range m {
-		clone[zone] = types.NewNetworkEndpointSet(endpointSet.List()...)
+func cloneZoneNetworkEndpointsMap(m map[types.EndpointGroupInfo]types.NetworkEndpointSet) map[types.EndpointGroupInfo]types.NetworkEndpointSet {
+	clone := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)
+	for endpointGroupInfo, endpointSet := range m {
+		clone[endpointGroupInfo] = types.NewNetworkEndpointSet(endpointSet.List()...)
 	}
 	return clone
 }

--- a/pkg/neg/syncers/dualstack/migrator_test.go
+++ b/pkg/neg/syncers/dualstack/migrator_test.go
@@ -15,6 +15,8 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
+const defaultTestSubnet = "default"
+
 func TestFilter(t *testing.T) {
 	testCases := []struct {
 		desc                string
@@ -34,29 +36,29 @@ func TestFilter(t *testing.T) {
 				return m
 			}(),
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
 			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
 			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					// Migration-endpoints were filtered out but no new migration
 					// detachment was started.
 					{IP: "c", IPv6: "C"},
@@ -67,29 +69,29 @@ func TestFilter(t *testing.T) {
 			desc:     "unpaused migrator should filter migration endpoints AND also start detachment",
 			migrator: newMigratorForTest(t, true),
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
 			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
 			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // Migration detachment started.
 					{IP: "c", IPv6: "C"},
 				}...),
@@ -100,30 +102,30 @@ func TestFilter(t *testing.T) {
 			desc:     "migrator should do nothing if enableDualStack is false",
 			migrator: newMigratorForTest(t, false),
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
 			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
 			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
@@ -297,16 +299,16 @@ func TestFilter_FunctionalTest(t *testing.T) {
 			removeEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)    // Contains single-stack endpoints which are to be removed from the NEG.
 			committedEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet) // Initially empty.
 			for i := 0; i < tc.initialNEGEndpointsCount; i++ {
-				zone := types.EndpointGroupInfo{Zone: fmt.Sprintf("zone-%v", i%tc.zonesCount)}
+				epGroupInfo := types.EndpointGroupInfo{Zone: fmt.Sprintf("zone-%v", i%tc.zonesCount), Subnet: defaultTestSubnet}
 				ipv4 := fmt.Sprintf("ipv4-%v", 2*i+1)
 				ipv6 := fmt.Sprintf("ipv6-%v", 2*i+2)
-				if addEndpoints[zone] == nil {
-					addEndpoints[zone] = types.NewNetworkEndpointSet()
-					removeEndpoints[zone] = types.NewNetworkEndpointSet()
-					committedEndpoints[zone] = types.NewNetworkEndpointSet()
+				if addEndpoints[epGroupInfo] == nil {
+					addEndpoints[epGroupInfo] = types.NewNetworkEndpointSet()
+					removeEndpoints[epGroupInfo] = types.NewNetworkEndpointSet()
+					committedEndpoints[epGroupInfo] = types.NewNetworkEndpointSet()
 				}
-				addEndpoints[zone].Insert(types.NetworkEndpoint{IP: ipv4, IPv6: ipv6})
-				removeEndpoints[zone].Insert(types.NetworkEndpoint{IP: ipv4})
+				addEndpoints[epGroupInfo].Insert(types.NetworkEndpoint{IP: ipv4, IPv6: ipv6})
+				removeEndpoints[epGroupInfo].Insert(types.NetworkEndpoint{IP: ipv4})
 			}
 
 			tc.migrator.errorStateChecker.(*fakeErrorStateChecker).errorState = tc.errorState
@@ -351,7 +353,7 @@ func TestFilter_FunctionalTest(t *testing.T) {
 
 func TestPause(t *testing.T) {
 	addEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+		{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a", IPv6: "A"}, // migrating
 			{IP: "b"},
 			{IP: "c", IPv6: "C"},
@@ -359,7 +361,7 @@ func TestPause(t *testing.T) {
 		}...),
 	}
 	removeEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+		{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a"}, // migrating
 			{IP: "e", IPv6: "E"},
 			{IP: "d", IPv6: "D"}, // migrating
@@ -377,7 +379,7 @@ func TestPause(t *testing.T) {
 		{IP: "a"},            // migrating
 		{IP: "d", IPv6: "D"}, // migrating
 	}
-	if !clonedRemoveEndpoints[types.EndpointGroupInfo{Zone: "zone1"}].HasAny(possibleMigrationDetachments...) {
+	if !clonedRemoveEndpoints[types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet}].HasAny(possibleMigrationDetachments...) {
 		t.Fatalf("Precondition to verify the behaviour of Pause() not satisfied; Filter() should start migration-detachments; got removeEndpoints=%+v; want non-empty union with %+v", clonedRemoveEndpoints, possibleMigrationDetachments)
 	}
 
@@ -393,7 +395,7 @@ func TestPause(t *testing.T) {
 	// any migration-detachments when paused.
 	migrator.Filter(addEndpoints, removeEndpoints, map[types.EndpointGroupInfo]types.NetworkEndpointSet{})
 	wantRemoveEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-		types.EndpointGroupInfo{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+		types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			// Since we don't expect any migration-detachments, this set should be
 			// missing all migration endpoints.
 			{IP: "e", IPv6: "E"},
@@ -535,12 +537,12 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 				}...),
 			},
@@ -552,12 +554,12 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 					{IP: "11"},
 				}...),
@@ -571,18 +573,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// detachments since we wait for the pending attaches to complete
 			desc: "many endpoints are waiting to be attached AND previous migration was quite recent",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -599,18 +601,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// start any new detachments since we wait to get out of error state.
 			desc: "many endpoints are waiting to be attached AND previous migration was too long ago BUT in error state",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -628,18 +630,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// with the detachments.
 			desc: "many endpoints are waiting to be attached BUT previous migration was too long ago AND not in error state",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
 			},
@@ -649,17 +651,17 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 		{
 			desc: "no detachments started since nothing to migrate",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "2"},
 				}...),
 			},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "3"}, {IP: "4"}, {IP: "5"}, {IP: "6"},
 				}...),
 			},
@@ -675,18 +677,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
 			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"},
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "5"}, {IP: "6"}, {IP: "7"}, {IP: "8"},
 				}...),
 			},
 			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "9"}, {IP: "10"},
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "11"}, {IP: "12"},
 				}...),
 			},
@@ -752,41 +754,41 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 		{
 			name: "detect multiple migrating endpoints",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 					{IP: "c", IPv6: "C"},
 					{IP: "d"}, // migrating
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "e", IPv6: "E"}, // migrating
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "f", IPv6: "F"},
 					{IP: "d", IPv6: "D"}, // migrating
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "E"}, // migrating
 				}...),
 			},
 			wantMigrationEndpointsInAddSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "d"},
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "e", IPv6: "E"},
 				}...),
 			},
 			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"},
 					{IP: "d", IPv6: "D"},
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "E"},
 				}...),
 			},
@@ -794,12 +796,12 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 		{
 			name: "partial IP change without stack change is not considered migrating",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "B"},
 				}...),
 			},
@@ -809,13 +811,13 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 		{
 			name: "difference in port or node is not considered migrating",
 			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A", Port: "80"},
 					{IP: "b", Node: "node2"},
 				}...),
 			},
 			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "81"},
 					{IP: "b", IPv6: "B", Node: "node1"},
 				}...),
@@ -854,114 +856,114 @@ func TestMoveEndpoint(t *testing.T) {
 			name:     "completely valid input, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
 			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
 			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
 			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1"},
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet},
 			wantSuccess:       true,
 		},
 		{
 			name:     "zone does not exist in source",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
 			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
 			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
 			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 		{
 			name:     "zone does not exist in destination, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
 			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
 			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
 			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
-				{Zone: "zone2"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1"},
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet},
 			wantSuccess:       true,
 		},
 		{
 			name:     "source is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
 			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 		{
 			name:     "destination is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
 			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
 			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-				{Zone: "zone3"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3"},
+			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 	}
 

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -49,7 +49,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		endpointsData       []negtypes.EndpointsData
-		wantEndpointSets    map[string]negtypes.NetworkEndpointSet
+		wantEndpointSets    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
 		nodeLabelsMap       map[string]map[string]string
 		nodeAnnotationsMap  map[string]map[string]string
@@ -61,9 +61,9 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -73,9 +73,9 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, all nodes unready",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -95,9 +95,9 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			},
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 2 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes. 2 out of those 4 are non-candidates.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			network:             defaultNetwork,
@@ -123,11 +123,11 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			//networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 3 out of 6 nodes are picked because only 3 have multi-nic annotation with a matching network name
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1},
 					negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}),
 			},
 		},
@@ -178,7 +178,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		endpointsData       []negtypes.EndpointsData
-		wantEndpointSets    map[string]negtypes.NetworkEndpointSet
+		wantEndpointSets    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
 		nodeLabelsMap       map[string]map[string]string
 		nodeAnnotationsMap  map[string]map[string]string
@@ -190,11 +190,11 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
-				negtypes.TestZone3: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
+				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -204,11 +204,11 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, all nodes unready",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
-				negtypes.TestZone3: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
+				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -221,11 +221,11 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, some nodes marked as non-candidates",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all valid candidate nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
-				negtypes.TestZone3: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
+				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -242,11 +242,11 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
 			// Even when there are no service endpoints, nodes are selected at random.
 			endpointsData: []negtypes.EndpointsData{},
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
-				negtypes.TestZone3: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
+				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.7", Node: testUnreadyInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.8", Node: testUnreadyInstance2}),
 			},
 			networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
@@ -255,9 +255,9 @@ func TestClusterGetEndpointSet(t *testing.T) {
 		{
 			desc:          "multinetwork endpoints, only for nodes connected to the specified network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
-			wantEndpointSets: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
+			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
 			},
 			network: network.NetworkInfo{IsDefault: false, K8sNetwork: "other"},
 			nodeAnnotationsMap: map[string]map[string]string{
@@ -401,7 +401,7 @@ func TestValidateEndpoints(t *testing.T) {
 		ec                 negtypes.NetworkEndpointsCalculator
 		ecMSC              negtypes.NetworkEndpointsCalculator
 		testEndpointSlices []*discovery.EndpointSlice
-		currentMap         map[string]negtypes.NetworkEndpointSet
+		currentMap         map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		// Use mutation to inject error into that we cannot trigger currently.
 		mutation func([]negtypes.EndpointsData, negtypes.EndpointPodMap) ([]negtypes.EndpointsData, negtypes.EndpointPodMap)
 		expect   error
@@ -634,7 +634,7 @@ func TestValidateEndpoints(t *testing.T) {
 		desc               string
 		ecMSC              negtypes.NetworkEndpointsCalculator
 		testEndpointSlices []*discovery.EndpointSlice
-		currentMap         map[string]negtypes.NetworkEndpointSet
+		currentMap         map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		// Use mutation to inject error into that we cannot trigger currently.
 		mutation             func([]negtypes.EndpointsData, negtypes.EndpointPodMap) ([]negtypes.EndpointsData, negtypes.EndpointPodMap)
 		expectCalculationErr error

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -163,8 +163,8 @@ func sortZones(nodesPerZone map[string][]*v1.Node) []ZoneInfo {
 //	Since the number of nodes will keep increasing in successive zones due to the sorting, even if fewer nodes were
 //	present in some zones, more nodes will be picked from other nodes, taking the total subset size to the given limit
 //	whenever possible.
-func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, totalLimit int, svcID string, currentMap map[string]negtypes.NetworkEndpointSet, logger klog.Logger, networkInfo *network.NetworkInfo) (map[string]negtypes.NetworkEndpointSet, error) {
-	result := make(map[string]negtypes.NetworkEndpointSet)
+func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, totalLimit int, svcID string, currentMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, logger klog.Logger, networkInfo *network.NetworkInfo) (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, error) {
+	result := make(map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet)
 	var currentList []negtypes.NetworkEndpoint
 
 	subsetSize := 0
@@ -177,9 +177,9 @@ func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, totalLimit int, svcID 
 		// split the limit across the leftover zones.
 		subsetSize = totalLimit / zonesRemaining
 		logger.Info("Picking subset for a zone", "subsetSize", subsetSize, "zone", zone, "svcID", svcID)
-		result[zone.Name] = negtypes.NewNetworkEndpointSet()
+		result[negtypes.EndpointGroupInfo{Zone: zone.Name}] = negtypes.NewNetworkEndpointSet()
 		if currentMap != nil {
-			if zset, ok := currentMap[zone.Name]; ok && zset != nil {
+			if zset, ok := currentMap[negtypes.EndpointGroupInfo{Zone: zone.Name}]; ok && zset != nil {
 				currentList = zset.List()
 			} else {
 				currentList = nil
@@ -193,7 +193,7 @@ func getSubsetPerZone(nodesPerZone map[string][]*v1.Node, totalLimit int, svcID 
 			} else {
 				ip = utils.GetNodePrimaryIP(node, logger)
 			}
-			result[zone.Name].Insert(negtypes.NetworkEndpoint{Node: node.Name, IP: ip})
+			result[negtypes.EndpointGroupInfo{Zone: zone.Name}].Insert(negtypes.NetworkEndpoint{Node: node.Name, IP: ip})
 		}
 		totalLimit -= len(subset)
 		zonesRemaining--

--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -23,6 +23,7 @@ import (
 
 	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
 	"k8s.io/ingress-gce/pkg/neg/types"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/klog/v2"
 
@@ -223,7 +224,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 		// expectEmpty indicates that some zones can have empty subsets
 		expectEmpty      bool
 		networkInfo      network.NetworkInfo
-		expectedNodesMap map[string]map[string]string
+		expectedNodesMap map[negtypes.EndpointGroupInfo]map[string]string
 	}{
 		{
 			description: "Default network, gets primary interface",
@@ -234,10 +235,10 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 			},
 			svcKey: "svc123",
 			// empty IPs since test can't get the primary IP
-			expectedNodesMap: map[string]map[string]string{
-				"zone1": {"n1_1": "", "n1_2": ""},
-				"zone2": {"n2_1": "", "n2_2": ""},
-				"zone3": {"n3_1": ""},
+			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
+				{Zone: "zone1"}: {"n1_1": "", "n1_2": ""},
+				{Zone: "zone2"}: {"n2_1": "", "n2_2": ""},
+				{Zone: "zone3"}: {"n3_1": ""},
 			},
 		},
 		{
@@ -252,10 +253,10 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				IsDefault:  false,
 				K8sNetwork: "net1",
 			},
-			expectedNodesMap: map[string]map[string]string{
-				"zone1": {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
-				"zone2": {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
-				"zone3": {"n3_1": "172.168.3.1"},
+			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
+				{Zone: "zone1"}: {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
+				{Zone: "zone2"}: {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
+				{Zone: "zone3"}: {"n3_1": "172.168.3.1"},
 			},
 		},
 	}

--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -192,7 +192,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		subsetMap, err := getSubsetPerZone(tc.nodesMap, tc.subsetLimit, tc.svcKey, nil, klog.TODO(), &network.NetworkInfo{})
+		subsetMap, err := getSubsetPerZone(tc.nodesMap, tc.subsetLimit, tc.svcKey, nil, klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL})
 		if err != nil {
 			t.Errorf("Failed to get subset for test '%s', err %v", tc.description, err)
 		}
@@ -234,11 +234,14 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				"zone3": {makeNodeWithNetwork(t, "n3_1", map[string]string{"net1": "172.168.3.1", "net2": "192.168.3.1"})},
 			},
 			svcKey: "svc123",
+			networkInfo: network.NetworkInfo{
+				SubnetworkURL: defaultTestSubnetURL,
+			},
 			// empty IPs since test can't get the primary IP
 			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
-				{Zone: "zone1"}: {"n1_1": "", "n1_2": ""},
-				{Zone: "zone2"}: {"n2_1": "", "n2_2": ""},
-				{Zone: "zone3"}: {"n3_1": ""},
+				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "", "n1_2": ""},
+				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "", "n2_2": ""},
+				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": ""},
 			},
 		},
 		{
@@ -250,13 +253,14 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 			},
 			svcKey: "svc123",
 			networkInfo: network.NetworkInfo{
-				IsDefault:  false,
-				K8sNetwork: "net1",
+				IsDefault:     false,
+				K8sNetwork:    "net1",
+				SubnetworkURL: defaultTestSubnetURL,
 			},
 			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
-				{Zone: "zone1"}: {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
-				{Zone: "zone2"}: {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
-				{Zone: "zone3"}: {"n3_1": "172.168.3.1"},
+				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
+				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
+				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": "172.168.3.1"},
 			},
 		},
 	}

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -270,7 +270,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	mergeTransactionIntoZoneEndpointMap(currentMap, s.transactions, s.logger)
 	s.logStats(currentMap, "after in-progress operations have completed, NEG endpoints")
 
-	var targetMap map[string]negtypes.NetworkEndpointSet
+	var targetMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 	var endpointPodMap negtypes.EndpointPodMap
 	slices, err := s.endpointSliceLister.ByIndex(endpointslices.EndpointSlicesByServiceIndex, endpointslices.FormatEndpointSlicesServiceKey(s.Namespace, s.Name))
 	if err != nil {
@@ -286,7 +286,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	endpointsData := negtypes.EndpointsDataFromEndpointSlices(endpointSlices)
 	targetMap, endpointPodMap, err = s.getEndpointsCalculation(endpointsData, currentMap)
 
-	var degradedTargetMap, notInDegraded, onlyInDegraded map[string]negtypes.NetworkEndpointSet
+	var degradedTargetMap, notInDegraded, onlyInDegraded map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 	var degradedPodMap negtypes.EndpointPodMap
 	var degradedModeErr error
 	if s.enableDegradedModeMetrics || s.enableDegradedMode {
@@ -378,8 +378,8 @@ func (s *transactionSyncer) syncInternalImpl() error {
 
 func (s *transactionSyncer) getEndpointsCalculation(
 	endpointsData []negtypes.EndpointsData,
-	currentMap map[string]negtypes.NetworkEndpointSet,
-) (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, error) {
+	currentMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet,
+) (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap, error) {
 	targetMap, endpointPodMap, endpointsExcludedInCalculation, err := s.endpointsCalculator.CalculateEndpoints(endpointsData, currentMap)
 	if err != nil {
 		return nil, nil, err
@@ -470,12 +470,13 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 }
 
 // syncNetworkEndpoints spins off go routines to execute NEG operations
-func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints map[string]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap, migrationZone string) error {
-	syncFunc := func(endpointMap map[string]negtypes.NetworkEndpointSet, operation transactionOp) error {
-		for zone, endpointSet := range endpointMap {
-			zone := zone
+func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap, migrationZone negtypes.EndpointGroupInfo) error {
+	syncFunc := func(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, operation transactionOp) error {
+		for endpointGroupInfo, endpointSet := range endpointMap {
+			zone := endpointGroupInfo.Zone
+			subnet := endpointGroupInfo.Subnet
 			if endpointSet.Len() == 0 {
-				s.logger.V(2).Info("0 endpoints in the endpoint list. Skipping operation", "operation", attachOp, "negSyncerKey", s.NegSyncerKey.String(), "zone", zone)
+				s.logger.V(2).Info("0 endpoints in the endpoint list. Skipping operation", "operation", attachOp, "negSyncerKey", s.NegSyncerKey.String(), "zone", zone, "subnet", subnet)
 				continue
 			}
 
@@ -487,6 +488,7 @@ func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints m
 			transEntry := transactionEntry{
 				Operation: operation,
 				Zone:      zone,
+				Subnet:    subnet,
 			}
 
 			// Insert networkEndpoint into transaction table
@@ -498,12 +500,12 @@ func (s *transactionSyncer) syncNetworkEndpoints(addEndpoints, removeEndpoints m
 				go s.attachNetworkEndpoints(zone, batch)
 			}
 			if operation == detachOp {
-				if zone == migrationZone {
+				if zone == migrationZone.Zone && subnet == migrationZone.Subnet {
 					// Prevent any further migration-detachments from starting while one
 					// is already in progress.
 					s.dsMigrator.Pause()
 				}
-				go s.detachNetworkEndpoints(zone, batch, zone == migrationZone)
+				go s.detachNetworkEndpoints(zone, batch, zone == migrationZone.Zone && subnet == migrationZone.Subnet)
 			}
 		}
 		return nil
@@ -667,8 +669,8 @@ func (s *transactionSyncer) needCommit() bool {
 }
 
 // commitPods groups the endpoints by zone and signals the readiness reflector to poll pods of the NEG
-func (s *transactionSyncer) commitPods(endpointMap map[string]negtypes.NetworkEndpointSet, endpointPodMap negtypes.EndpointPodMap) {
-	for zone, endpointSet := range endpointMap {
+func (s *transactionSyncer) commitPods(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, endpointPodMap negtypes.EndpointPodMap) {
+	for endpointGroupInfo, endpointSet := range endpointMap {
 		zoneEndpointMap := negtypes.EndpointPodMap{}
 		for _, endpoint := range endpointSet.List() {
 			podName, ok := endpointPodMap[endpoint]
@@ -678,7 +680,9 @@ func (s *transactionSyncer) commitPods(endpointMap map[string]negtypes.NetworkEn
 			}
 			zoneEndpointMap[endpoint] = podName
 		}
-		s.reflector.CommitPods(s.NegSyncerKey, s.NegSyncerKey.NegName, zone, zoneEndpointMap)
+		// TODO(sawsa307): Make sure commitPods is called for non-default subnet NEGs.
+		// Only zone is needed because NEGs from non-default subnet have different names.
+		s.reflector.CommitPods(s.NegSyncerKey, s.NegSyncerKey.NegName, endpointGroupInfo.Zone, zoneEndpointMap)
 	}
 }
 
@@ -715,7 +719,7 @@ func (s *transactionSyncer) isZoneChange() bool {
 }
 
 // filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table
-func filterEndpointByTransaction(endpointMap map[string]negtypes.NetworkEndpointSet, table networkEndpointTransactionTable, logger klog.Logger) {
+func filterEndpointByTransaction(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, table networkEndpointTransactionTable, logger klog.Logger) {
 	for _, endpointSet := range endpointMap {
 		for _, endpoint := range endpointSet.List() {
 			if entry, ok := table.Get(endpoint); ok {
@@ -728,7 +732,7 @@ func filterEndpointByTransaction(endpointMap map[string]negtypes.NetworkEndpoint
 
 // mergeTransactionIntoZoneEndpointMap merges the ongoing transaction into the endpointMap.
 // This converts the existing endpointMap to the state when all transactions completed
-func mergeTransactionIntoZoneEndpointMap(endpointMap map[string]negtypes.NetworkEndpointSet, transactions networkEndpointTransactionTable, logger klog.Logger) {
+func mergeTransactionIntoZoneEndpointMap(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, transactions networkEndpointTransactionTable, logger klog.Logger) {
 	for _, endpointKey := range transactions.Keys() {
 		entry, ok := transactions.Get(endpointKey)
 		// If called in syncInternal, as the transaction table
@@ -736,36 +740,37 @@ func mergeTransactionIntoZoneEndpointMap(endpointMap map[string]negtypes.Network
 			logger.V(2).Info("Transaction entry of key was not found.", "endpointKey", endpointKey)
 			continue
 		}
+		key := negtypes.EndpointGroupInfo{Zone: entry.Zone, Subnet: entry.Subnet}
 		// Add endpoints in attach transaction
 		if entry.Operation == attachOp {
-			if _, ok := endpointMap[entry.Zone]; !ok {
-				endpointMap[entry.Zone] = negtypes.NewNetworkEndpointSet()
+			if _, ok := endpointMap[key]; !ok {
+				endpointMap[key] = negtypes.NewNetworkEndpointSet()
 			}
-			endpointMap[entry.Zone].Insert(endpointKey)
+			endpointMap[key].Insert(endpointKey)
 		}
 		// Remove endpoints in detach transaction
 		if entry.Operation == detachOp {
-			if _, ok := endpointMap[entry.Zone]; !ok {
+			if _, ok := endpointMap[key]; !ok {
 				continue
 			}
-			endpointMap[entry.Zone].Delete(endpointKey)
+			endpointMap[key].Delete(endpointKey)
 		}
 	}
 	return
 }
 
 // logStats logs aggregated stats of the input endpointMap
-func (s *transactionSyncer) logStats(endpointMap map[string]negtypes.NetworkEndpointSet, desc string) {
+func (s *transactionSyncer) logStats(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, desc string) {
 	var stats []interface{}
 	stats = append(stats, "description", desc)
-	for zone, endpointSet := range endpointMap {
-		stats = append(stats, zone, fmt.Sprintf("%d endpoints", endpointSet.Len()))
+	for endpointGroupInfo, endpointSet := range endpointMap {
+		stats = append(stats, endpointGroupInfo.Zone, endpointGroupInfo.Subnet, fmt.Sprintf("%d endpoints", endpointSet.Len()))
 	}
 	s.logger.V(3).Info("Stats for NEG", stats...)
 }
 
 // logEndpoints logs individual endpoint in the input endpointMap
-func (s *transactionSyncer) logEndpoints(endpointMap map[string]negtypes.NetworkEndpointSet, desc string) {
+func (s *transactionSyncer) logEndpoints(endpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, desc string) {
 	s.logger.V(3).Info("Endpoints for NEG", "description", desc, "endpointMap", endpointMap)
 }
 
@@ -869,7 +874,7 @@ func (s *transactionSyncer) computeEPSStaleness(endpointSlices []*discovery.Endp
 }
 
 // computeDegradedModeCorrectness computes degraded mode correctness metrics based on the difference between degraded mode and normal calculation
-func computeDegradedModeCorrectness(notInDegraded, onlyInDegraded map[string]negtypes.NetworkEndpointSet, negType string, logger klog.Logger) {
+func computeDegradedModeCorrectness(notInDegraded, onlyInDegraded map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negType string, logger klog.Logger) {
 	logger.Info("Exporting degraded mode correctness metrics", "notInDegraded", notInDegraded, "onlyInDegraded", onlyInDegraded)
 	notInDegradedEndpoints := 0
 	for _, val := range notInDegraded {
@@ -1013,7 +1018,7 @@ func findCondition(conditions []negv1beta1.Condition, conditionType string) (neg
 }
 
 // getEndpointPodLabelMap goes through all the endpoints to be attached and fetches the labels from the endpoint pods.
-func getEndpointPodLabelMap(endpoints map[string]negtypes.NetworkEndpointSet, endpointPodMap negtypes.EndpointPodMap, podLister cache.Store, lpConfig labels.PodLabelPropagationConfig, recorder record.EventRecorder, logger klog.Logger) labels.EndpointPodLabelMap {
+func getEndpointPodLabelMap(endpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, endpointPodMap negtypes.EndpointPodMap, podLister cache.Store, lpConfig labels.PodLabelPropagationConfig, recorder record.EventRecorder, logger klog.Logger) labels.EndpointPodLabelMap {
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	for _, endpointSet := range endpoints {
 		for endpoint := range endpointSet {
@@ -1044,7 +1049,7 @@ func getEndpointPodLabelMap(endpoints map[string]negtypes.NetworkEndpointSet, en
 
 // publishAnnotationSizeMetrics goes through all the endpoints to be attached
 // and publish annotation size metrics.
-func publishAnnotationSizeMetrics(endpoints map[string]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap) {
+func publishAnnotationSizeMetrics(endpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap) {
 	for _, endpointSet := range endpoints {
 		for endpoint := range endpointSet {
 			labelMap := endpointPodLabelMap[endpoint]
@@ -1054,7 +1059,7 @@ func publishAnnotationSizeMetrics(endpoints map[string]negtypes.NetworkEndpointS
 }
 
 // collectLabelStats calculate the number of endpoints and the number of endpoints with annotations.
-func collectLabelStats(currentPodLabelMap, addPodLabelMap labels.EndpointPodLabelMap, targetEndpointMap map[string]negtypes.NetworkEndpointSet) metricscollector.LabelPropagationStats {
+func collectLabelStats(currentPodLabelMap, addPodLabelMap labels.EndpointPodLabelMap, targetEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet) metricscollector.LabelPropagationStats {
 	labelPropagationStats := metricscollector.LabelPropagationStats{}
 	for _, endpointSet := range targetEndpointMap {
 		for endpoint := range endpointSet {

--- a/pkg/neg/syncers/transaction_table.go
+++ b/pkg/neg/syncers/transaction_table.go
@@ -17,8 +17,9 @@ limitations under the License.
 package syncers
 
 import (
-	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"sync"
+
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 )
 
 type networkEndpointTransactionTable interface {
@@ -51,6 +52,8 @@ type transactionEntry struct {
 	Operation transactionOp
 	// Zone represents the zone of the transaction
 	Zone string
+	// Subnet represents the subnet of the NEG corresponds to this transaction
+	Subnet string
 }
 
 // transactionTable records ongoing NEG API operation per endpoint

--- a/pkg/neg/syncers/transaction_table_test.go
+++ b/pkg/neg/syncers/transaction_table_test.go
@@ -50,6 +50,7 @@ func TestTransactionTable(t *testing.T) {
 		entry := transactionEntry{
 			attachOp,
 			fmt.Sprintf("%s%d", zonePrefix, i),
+			"",
 		}
 		table.Put(key, entry)
 		testKeyMap[key] = entry
@@ -63,6 +64,7 @@ func TestTransactionTable(t *testing.T) {
 		newEntry := transactionEntry{
 			detachOp,
 			fmt.Sprintf("%s%d", zonePrefix, i),
+			"",
 		}
 		table.Put(key, newEntry)
 		testKeyMap[key] = newEntry

--- a/pkg/neg/syncers/transaction_table_test.go
+++ b/pkg/neg/syncers/transaction_table_test.go
@@ -50,7 +50,7 @@ func TestTransactionTable(t *testing.T) {
 		entry := transactionEntry{
 			attachOp,
 			fmt.Sprintf("%s%d", zonePrefix, i),
-			"",
+			defaultTestSubnet,
 		}
 		table.Put(key, entry)
 		testKeyMap[key] = entry
@@ -64,7 +64,7 @@ func TestTransactionTable(t *testing.T) {
 		newEntry := transactionEntry{
 			detachOp,
 			fmt.Sprintf("%s%d", zonePrefix, i),
-			"",
+			defaultTestSubnet,
 		}
 		table.Put(key, newEntry)
 		testKeyMap[key] = newEntry

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -128,84 +128,84 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 
 		testCases := []struct {
 			desc            string
-			addEndpoints    map[string]negtypes.NetworkEndpointSet
-			removeEndpoints map[string]negtypes.NetworkEndpointSet
-			expectEndpoints map[string]negtypes.NetworkEndpointSet
+			addEndpoints    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+			removeEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+			expectEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		}{
 			{
 				"empty input",
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			},
 			{
 				"add some endpoints",
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"remove some endpoints",
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"add duplicate endpoints",
-				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				"add and remove endpoints",
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
 			},
 			{
 				"add more endpoints",
-				map[string]negtypes.NetworkEndpointSet{
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 			},
 			{
 				"add and remove endpoints in both zones",
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
+				map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 		}
@@ -214,7 +214,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 			// TODO(gauravkghildiyal): When the DualStack Migrator is fully
 			// implemented, check if we need to cover scenarios where `migrationZone`
 			// is not empty.
-			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, "")
+			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, negtypes.EndpointGroupInfo{})
 			if err != nil {
 				t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -223,8 +223,8 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 			}
 
-			for zone, endpoints := range tc.expectEndpoints {
-				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+			for endpointGroupInfo, endpoints := range tc.expectEndpoints {
+				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, endpointGroupInfo.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 				if err != nil {
 					t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 				}
@@ -239,7 +239,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				}
 
 				if !endpoints.Equal(endpointSet) {
-					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
+					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, endpointGroupInfo.Zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
 				}
 			}
 		}
@@ -270,7 +270,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		desc                    string
 		labelPropagationEnabled bool
 		negType                 negtypes.NetworkEndpointType
-		addEndpoints            map[string]negtypes.NetworkEndpointSet
+		addEndpoints            map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		endpointPodLabelMap     labels.EndpointPodLabelMap
 		expectedNEAnnotation    labels.PodLabelMap
 	}{
@@ -278,7 +278,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"empty input",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			labels.EndpointPodLabelMap{},
 			nil,
 		},
@@ -286,9 +286,9 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L4 endpoints with label map populated",
 			true,
 			negtypes.VmIpEndpointType,
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
 			},
 			generateEndpointPodLabelMap(
 				map[string]negtypes.NetworkEndpointSet{
@@ -306,9 +306,9 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L4 endpoints with empty label map",
 			true,
 			negtypes.VmIpEndpointType,
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
 			},
 			generateEndpointPodLabelMap(
 				map[string]negtypes.NetworkEndpointSet{
@@ -323,9 +323,9 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints label map populated",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
 			generateEndpointPodLabelMap(
 				map[string]negtypes.NetworkEndpointSet{
@@ -346,9 +346,9 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints with empty label map",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
 			generateEndpointPodLabelMap(
 				map[string]negtypes.NetworkEndpointSet{
@@ -363,9 +363,9 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints label map populated, but EnableNEGLabelPropagation flag disabled",
 			false,
 			negtypes.VmIpPortEndpointType,
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
 			generateEndpointPodLabelMap(
 				map[string]negtypes.NetworkEndpointSet{
@@ -390,7 +390,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
-		err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, map[string]negtypes.NetworkEndpointSet{}, tc.endpointPodLabelMap, "")
+		err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}, tc.endpointPodLabelMap, negtypes.EndpointGroupInfo{})
 		if err != nil {
 			t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 		}
@@ -398,8 +398,8 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 		}
 
-		for zone := range tc.addEndpoints {
-			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		for endpointGroupInfo := range tc.addEndpoints {
+			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, endpointGroupInfo.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 			if err != nil {
 				t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -595,31 +595,31 @@ func TestCommitTransaction(t *testing.T) {
 func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[string]negtypes.NetworkEndpointSet
+		endpointMap       map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		table             func() networkEndpointTransactionTable
-		expectEndpointMap map[string]negtypes.NetworkEndpointSet
+		expectEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 	}{
 		{
 			"empty map and transactions",
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty transactions",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"empty map",
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -639,16 +639,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add existing endpoints",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
@@ -669,16 +669,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
@@ -699,16 +699,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
 			},
 		},
 		{
 			"remove existing endpoints",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
@@ -719,16 +719,16 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints and remove existing endpoints",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
@@ -744,9 +744,9 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 	}
@@ -762,19 +762,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 func TestFilterEndpointByTransaction(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[string]negtypes.NetworkEndpointSet
+		endpointMap       map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		table             func() networkEndpointTransactionTable
-		expectEndpointMap map[string]negtypes.NetworkEndpointSet
+		expectEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 	}{
 		{
 			"both empty",
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty map",
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -789,30 +789,30 @@ func TestFilterEndpointByTransaction(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[string]negtypes.NetworkEndpointSet{},
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty transaction",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"empty transaction",
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
-				testZone2: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
+			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 	}
@@ -835,21 +835,21 @@ func TestCommitPods(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc         string
-		input        func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
+		input        func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
 		expectOutput func() map[string]negtypes.EndpointPodMap
 	}{
 		{
 			desc: "empty input",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
 				return nil, nil
 			},
 			expectOutput: func() map[string]negtypes.EndpointPodMap { return map[string]negtypes.EndpointPodMap{} },
 		},
 		{
 			desc: "10 endpoints from 1 instance in 1 zone",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				return map[string]negtypes.NetworkEndpointSet{testZone1: endpointSet}, endpointMap
+				return map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{{Zone: testZone1}: endpointSet}, endpointMap
 			},
 			expectOutput: func() map[string]negtypes.EndpointPodMap {
 				_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -858,23 +858,23 @@ func TestCommitPods(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instances in 2 zone",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet(),
-					testZone2: negtypes.NewNetworkEndpointSet(),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet(),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet(),
 				}
 				retMap := negtypes.EndpointPodMap{}
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
 			},
@@ -896,30 +896,30 @@ func TestCommitPods(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instances in 2 zone, but half of the endpoints does not have corresponding pod mapping",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet(),
-					testZone2: negtypes.NewNetworkEndpointSet(),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet(),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet(),
 				}
 				retMap := negtypes.EndpointPodMap{}
 
 				endpointSet, _ := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 5, testInstance4, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
@@ -942,30 +942,30 @@ func TestCommitPods(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instances in 2 zone, and more endpoints are in pod mapping",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet(),
-					testZone2: negtypes.NewNetworkEndpointSet(),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet(),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet(),
 				}
 				retMap := negtypes.EndpointPodMap{}
 
 				endpointSet, _ := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 15, testInstance1, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 15, testInstance2, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 15, testInstance3, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 
 				endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 15, testInstance4, "8080")
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
@@ -988,22 +988,22 @@ func TestCommitPods(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instances in 2 zone, but some nodes do not have endpoint pod mapping",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet(),
-					testZone2: negtypes.NewNetworkEndpointSet(),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet(),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet(),
 				}
 				retMap := negtypes.EndpointPodMap{}
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[testZone1] = retSet[testZone1].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone1}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1}].Union(endpointSet)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[testZone2] = retSet[testZone2].Union(endpointSet)
+				retSet[negtypes.EndpointGroupInfo{Zone: testZone2}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2}].Union(endpointSet)
 				return retSet, retMap
 			},
 			expectOutput: func() map[string]negtypes.EndpointPodMap {
@@ -1732,20 +1732,20 @@ func TestUnknownNodes(t *testing.T) {
 
 	testEndpointSlices := getDefaultEndpointSlices()
 	testEndpointSlices[0].Endpoints[0].NodeName = utilpointer.StringPtr("unknown-node")
-	testEndpointMap := map[string]*composite.NetworkEndpoint{
-		negtypes.TestZone1: &composite.NetworkEndpoint{
+	testEndpointMap := map[negtypes.EndpointGroupInfo]*composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone1}: &composite.NetworkEndpoint{
 			Instance:  negtypes.TestInstance1,
 			IpAddress: testIP1,
 			Port:      testPort,
 		},
 
-		negtypes.TestZone2: &composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone2}: &composite.NetworkEndpoint{
 			Instance:  negtypes.TestInstance3,
 			IpAddress: testIP2,
 			Port:      testPort,
 		},
 
-		negtypes.TestZone4: &composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone4}: &composite.NetworkEndpoint{
 			Instance:  negtypes.TestUpgradeInstance1,
 			IpAddress: testIP3,
 			Port:      testPort,
@@ -1754,10 +1754,10 @@ func TestUnknownNodes(t *testing.T) {
 
 	// Create initial NetworkEndpointGroups in cloud
 	var objRefs []negv1beta1.NegObjectReference
-	for zone, endpoint := range testEndpointMap {
-		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, zone, klog.TODO())
-		fakeCloud.AttachNetworkEndpoints(testNegName, zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
-		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, zone, meta.VersionGA, klog.TODO())
+	for endpointGroupInfo, endpoint := range testEndpointMap {
+		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, endpointGroupInfo.Zone, klog.TODO())
+		fakeCloud.AttachNetworkEndpoints(testNegName, endpointGroupInfo.Zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
+		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, endpointGroupInfo.Zone, meta.VersionGA, klog.TODO())
 		if err != nil {
 			t.Fatalf("failed to get neg from fake cloud: %s", err)
 		}
@@ -1795,14 +1795,14 @@ func TestUnknownNodes(t *testing.T) {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
 
-	expectedEndpoints := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	expectedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))},
 		),
-		negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: testIP2, Node: negtypes.TestInstance3, Port: strconv.Itoa(int(testPort))},
 		),
-		negtypes.TestZone4: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: testIP3, Node: negtypes.TestUpgradeInstance1, Port: strconv.Itoa(int(testPort))},
 		),
 	}
@@ -1864,39 +1864,39 @@ func TestEnableDegradedMode(t *testing.T) {
 		},
 	}
 
-	initialEndpoints := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	initialEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 		),
-		negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.2||instance3||80"),
 		),
-		negtypes.TestZone4: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.2.1||upgrade-instance1||80"),
 		),
 	}
 
-	updateSucceedEndpoints := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	updateSucceedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80")),
-		negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
-		negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+		{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 	}
 
-	updateFailedEndpoints := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	updateFailedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80")),
-		negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
-		negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+		{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
+		{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 	}
 
 	testCases := []struct {
@@ -1904,7 +1904,7 @@ func TestEnableDegradedMode(t *testing.T) {
 		modify               func(ts *transactionSyncer)
 		negName              string // to distinguish endpoints in differnt NEGs
 		testEndpointSlices   []*discovery.EndpointSlice
-		expectedEndpoints    map[string]negtypes.NetworkEndpointSet
+		expectedEndpoints    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedInErrorState bool
 		expectErr            error
 	}{
@@ -2245,13 +2245,13 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc   string
-		input  func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
+		input  func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
 		expect func() labels.EndpointPodLabelMap
 	}{
 		{
 			desc: "empty inputs",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				return map[string]negtypes.NetworkEndpointSet{}, negtypes.EndpointPodMap{}
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				return map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}, negtypes.EndpointPodMap{}
 			},
 			expect: func() labels.EndpointPodLabelMap {
 				return labels.EndpointPodLabelMap{}
@@ -2259,10 +2259,10 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 		},
 		{
 			desc: "Add endpoints in diferent zones",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(endpointSet2),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(endpointSet2),
 				}
 				retMap := negtypes.EndpointPodMap{}
 				retMap = unionEndpointMap(retMap, endpointPodMap1)
@@ -2282,10 +2282,10 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 		},
 		{
 			desc: "Add endpoints in diferent zones with pod not found",
-			input: func() (map[string]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[string]negtypes.NetworkEndpointSet{
-					testZone1: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
-					testZone2: negtypes.NewNetworkEndpointSet().Union(endpointSet2).Union(endpointSet3),
+			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
+					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(endpointSet2).Union(endpointSet3),
 				}
 				retMap := negtypes.EndpointPodMap{}
 				retMap = unionEndpointMap(retMap, endpointPodMap1)
@@ -2331,14 +2331,14 @@ func TestCollectLabelStats(t *testing.T) {
 		desc              string
 		curLabelMap       labels.EndpointPodLabelMap
 		addLabelMap       labels.EndpointPodLabelMap
-		targetEndpointMap map[string]negtypes.NetworkEndpointSet
+		targetEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expect            metricscollector.LabelPropagationStats
 	}{
 		{
 			desc:              "Empty inputs",
 			curLabelMap:       labels.EndpointPodLabelMap{},
 			addLabelMap:       labels.EndpointPodLabelMap{},
-			targetEndpointMap: map[string]negtypes.NetworkEndpointSet{},
+			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			expect: metricscollector.LabelPropagationStats{
 				EndpointsWithAnnotation: 0,
 				NumberOfEndpoints:       0,
@@ -2352,8 +2352,8 @@ func TestCollectLabelStats(t *testing.T) {
 				},
 			},
 			addLabelMap: labels.EndpointPodLabelMap{},
-			targetEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet(
+			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
@@ -2375,12 +2375,12 @@ func TestCollectLabelStats(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			targetEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				testZone1: negtypes.NewNetworkEndpointSet(
+			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				testZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
@@ -2398,8 +2398,8 @@ func TestCollectLabelStats(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			targetEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				testZone2: negtypes.NewNetworkEndpointSet(
+			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: testZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -518,14 +518,14 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 			desc:     "default service port name",
 			portName: "",
 			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.2", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.3", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.4", Node: "instance1", Port: "80"},
 					{IP: "10.100.2.1", Node: "instance2", Port: "80"},
 				}...),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.3.1", Node: "instance3", Port: "80"},
 				}...),
 			},
@@ -543,10 +543,10 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 			desc:     "explicitly named service port",
 			portName: testNamedPort,
 			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.4.1", Node: "instance4", Port: "81"},
 					{IP: "10.100.3.2", Node: "instance3", Port: "8081"},
 					{IP: "10.100.4.2", Node: "instance4", Port: "8081"},
@@ -568,10 +568,10 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 			desc:     "dual stack enabled with explicitly named service ports",
 			portName: testNamedPort,
 			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.4.1", Node: "instance4", Port: "81"},
 					{IP: "10.100.3.2", IPv6: "a:b::1", Node: "instance3", Port: "8081"},
 					{IP: "10.100.4.2", IPv6: "a:b::2", Node: "instance4", Port: "8081"},
@@ -594,14 +594,14 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 			desc:     "non GCP network endpoints",
 			portName: "",
 			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Port: "80"},
 					{IP: "10.100.1.2", Port: "80"},
 					{IP: "10.100.1.3", Port: "80"},
 					{IP: "10.100.1.4", Port: "80"},
 					{IP: "10.100.2.1", Port: "80"},
 				}...),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.3.1", Port: "80"},
 				}...),
 			},
@@ -804,9 +804,9 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{},
 			expectErr:           false,
@@ -826,9 +826,9 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(endpoint1),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(endpoint1),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -852,12 +852,12 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -892,15 +892,15 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -935,15 +935,15 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -978,15 +978,15 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -1025,18 +1025,18 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 			mode: negtypes.L4LocalMode,
 			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
 				// NEGs in zone1, zone2 and zone4 are created from previous test case.
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint5,
 				),
-				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -1072,7 +1072,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc.mutate(negCloud)
 		// tc.mode of "" will result in the default node predicate being selected, which is ok for this test.
-		endpointSets, annotationMap, err := retrieveExistingZoneNetworkEndpointMap(negName, zoneGetter, negCloud, meta.VersionGA, tc.mode, false, klog.TODO())
+		endpointSets, annotationMap, err := retrieveExistingZoneNetworkEndpointMap(negName, zoneGetter, negCloud, meta.VersionGA, tc.mode, false, defaultTestSubnet, klog.TODO())
 
 		if tc.expectErr {
 			if err == nil {
@@ -1657,13 +1657,13 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80")),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
@@ -1681,9 +1681,9 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testNamedPort,
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81")),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"),
 					networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"),
 					networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"),
@@ -1705,13 +1705,13 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.2.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.3||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.4||||80")),
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
@@ -1758,7 +1758,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			},
 			portName: testEmptyNamedPort,
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.10.0.1||instance1||80"),
 				),
 			},
@@ -1785,8 +1785,6 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 // and toZoneNetworkEndpointMapDegradedMode return the correct endpoints and
 // correct type of error with the supplied invalid endpoint information.
 func TestValidateEndpointFields(t *testing.T) {
-	t.Parallel()
-
 	emptyNamedPort := ""
 	emptyNodeName := ""
 	port80 := int32(80)
@@ -1844,7 +1842,7 @@ func TestValidateEndpointFields(t *testing.T) {
 
 	// endpointMap and podMap contain all correct endpoints.
 	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
@@ -1863,7 +1861,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	// In degraded mode, we should exclude the invalid endpoint for non-coverable cases(pod invalid or empty zone).
 	// We always inject to first endpoint, so the result only contain the second endpoint.
 	endpointMapExcluded := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
 	}
@@ -2254,7 +2252,7 @@ func TestValidateEndpointFields(t *testing.T) {
 				},
 			},
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.2.2", Node: instance2, Port: "80"},
@@ -2364,7 +2362,7 @@ func TestValidateEndpointFields(t *testing.T) {
 				},
 			},
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.4", IPv6: "a:b::4", Node: instance4, Port: "80"},
@@ -2378,7 +2376,7 @@ func TestValidateEndpointFields(t *testing.T) {
 			expectErr:        nil,
 			expectErrorState: false,
 			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
 				),
@@ -2545,7 +2543,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 	})
 
 	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
@@ -2613,11 +2611,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 				},
 			},
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				{Zone: negtypes.TestZone5}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone5, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.1.1", Node: defaultSubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2629,11 +2627,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			expectErr:        nil,
 			expectErrorState: false,
 			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				{Zone: negtypes.TestZone5}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone5, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.1.1", Node: defaultSubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2691,11 +2689,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 				},
 			},
 			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				{Zone: negtypes.TestZone6}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone6, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.2.1", Node: emptySubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2707,11 +2705,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			expectErr:        nil,
 			expectErrorState: false,
 			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				{Zone: negtypes.TestZone6}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone6, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.2.1", Node: emptySubnetLabelInstance, Port: "80"},
 				),
 			},

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -188,109 +188,109 @@ func TestNetworkEndpointCalculateDifference(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		targetSet  map[string]negtypes.NetworkEndpointSet
-		currentSet map[string]negtypes.NetworkEndpointSet
-		addSet     map[string]negtypes.NetworkEndpointSet
-		removeSet  map[string]negtypes.NetworkEndpointSet
+		targetSet  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		currentSet map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		addSet     map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		removeSet  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 	}{
 		// unchanged
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			addSet:    map[string]negtypes.NetworkEndpointSet{},
-			removeSet: map[string]negtypes.NetworkEndpointSet{},
+			addSet:    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		// unchanged
 		{
-			targetSet:  map[string]negtypes.NetworkEndpointSet{},
-			currentSet: map[string]negtypes.NetworkEndpointSet{},
-			addSet:     map[string]negtypes.NetworkEndpointSet{},
-			removeSet:  map[string]negtypes.NetworkEndpointSet{},
+			targetSet:  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			addSet:     map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet:  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		// add in one zone
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[string]negtypes.NetworkEndpointSet{},
-			addSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			removeSet: map[string]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		// add in 2 zones
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			currentSet: map[string]negtypes.NetworkEndpointSet{},
-			addSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			removeSet: map[string]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 		},
 		// remove in one zone
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{},
-			currentSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			addSet: map[string]negtypes.NetworkEndpointSet{},
-			removeSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
 		},
 		// remove in 2 zones
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{},
-			currentSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			addSet: map[string]negtypes.NetworkEndpointSet{},
-			removeSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
 		},
 		// add and delete in one zone
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
 			},
-			addSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
 			},
-			removeSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
 			},
 		},
 		// add and delete in 2 zones
 		{
-			targetSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
 			},
-			addSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
 			},
-			removeSet: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
 			},
 		},
 	}
@@ -502,7 +502,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc                       string
 		portName                   string
-		wantZoneNetworkEndpointMap map[string]negtypes.NetworkEndpointSet
+		wantZoneNetworkEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		wantNetworkEndpointPodMap  negtypes.EndpointPodMap
 		networkEndpointType        negtypes.NetworkEndpointType
 		enableDualStackNEG         bool
@@ -510,22 +510,22 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:                       "target port does not exist",
 			portName:                   "non-exists",
-			wantZoneNetworkEndpointMap: map[string]negtypes.NetworkEndpointSet{},
+			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			wantNetworkEndpointPodMap:  negtypes.EndpointPodMap{},
 			networkEndpointType:        negtypes.VmIpPortEndpointType,
 		},
 		{
 			desc:     "default service port name",
 			portName: "",
-			wantZoneNetworkEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.2", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.3", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.4", Node: "instance1", Port: "80"},
 					{IP: "10.100.2.1", Node: "instance2", Port: "80"},
 				}...),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.3.1", Node: "instance3", Port: "80"},
 				}...),
 			},
@@ -542,11 +542,11 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "explicitly named service port",
 			portName: testNamedPort,
-			wantZoneNetworkEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.4.1", Node: "instance4", Port: "81"},
 					{IP: "10.100.3.2", Node: "instance3", Port: "8081"},
 					{IP: "10.100.4.2", Node: "instance4", Port: "8081"},
@@ -567,11 +567,11 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "dual stack enabled with explicitly named service ports",
 			portName: testNamedPort,
-			wantZoneNetworkEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.4.1", Node: "instance4", Port: "81"},
 					{IP: "10.100.3.2", IPv6: "a:b::1", Node: "instance3", Port: "8081"},
 					{IP: "10.100.4.2", IPv6: "a:b::2", Node: "instance4", Port: "8081"},
@@ -593,15 +593,15 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "non GCP network endpoints",
 			portName: "",
-			wantZoneNetworkEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Port: "80"},
 					{IP: "10.100.1.2", Port: "80"},
 					{IP: "10.100.1.3", Port: "80"},
 					{IP: "10.100.1.4", Port: "80"},
 					{IP: "10.100.2.1", Port: "80"},
 				}...),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.3.1", Port: "80"},
 				}...),
 			},
@@ -774,7 +774,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 		desc                string
 		mutate              func(cloud negtypes.NetworkEndpointGroupCloud)
 		mode                negtypes.EndpointsCalculatorMode
-		expect              map[string]negtypes.NetworkEndpointSet
+		expect              map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectAnnotationMap labels.EndpointPodLabelMap
 		expectErr           bool
 	}{
@@ -803,10 +803,10 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone2, klog.TODO())
 				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{},
 			expectErr:           false,
@@ -825,10 +825,10 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				}, meta.VersionGA, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(endpoint1),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(endpoint1),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -851,13 +851,13 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				}, meta.VersionGA, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -891,16 +891,16 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				}, meta.VersionGA, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(),
 			},
 			expectAnnotationMap: labels.EndpointPodLabelMap{
 				endpoint1: labels.PodLabelMap{
@@ -934,16 +934,16 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				}, meta.VersionGA, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -977,16 +977,16 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 					},
 				}, meta.VersionGA, klog.TODO())
 			},
-			expect: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -1023,20 +1023,20 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 			},
 			// set mode to L4 since this scenario applies more to VM_IP NEGs.
 			mode: negtypes.L4LocalMode,
-			expect: map[string]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
 				// NEGs in zone1, zone2 and zone4 are created from previous test case.
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
 				),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,
 				),
-				negtypes.TestZone3: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone3}: negtypes.NewNetworkEndpointSet(
 					endpoint5,
 				),
-				negtypes.TestZone4: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone4}: negtypes.NewNetworkEndpointSet(
 					endpoint6,
 					endpoint7,
 				),
@@ -1640,7 +1640,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 		desc                string
 		testEndpointSlices  []*discovery.EndpointSlice
 		portName            string
-		expectedEndpointMap map[string]negtypes.NetworkEndpointSet
+		expectedEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedPodMap      negtypes.EndpointPodMap
 		networkEndpointType negtypes.NetworkEndpointType
 	}{
@@ -1648,7 +1648,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:                "non exist target port",
 			testEndpointSlices:  getDefaultEndpointSlices(),
 			portName:            testNonExistPort,
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{},
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
 			expectedPodMap:      negtypes.EndpointPodMap{},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1656,14 +1656,14 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "empty named port",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.2.1||instance2||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.3||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.4||instance1||80")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||instance3||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
@@ -1680,10 +1680,10 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "named target port",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testNamedPort,
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.4.1||instance4||81"),
 					networkEndpointFromEncodedEndpoint("10.100.3.2||instance3||8081"),
 					networkEndpointFromEncodedEndpoint("10.100.4.2||instance4||8081"),
@@ -1704,14 +1704,14 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "Non-GCP network endpoints",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.2.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.3||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.4||||80")),
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.3.1||||80")),
 			},
 			expectedPodMap: negtypes.EndpointPodMap{
@@ -1757,8 +1757,8 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 				},
 			},
 			portName: testEmptyNamedPort,
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.10.0.1||instance1||80"),
 				),
 			},
@@ -1843,8 +1843,8 @@ func TestValidateEndpointFields(t *testing.T) {
 	})
 
 	// endpointMap and podMap contain all correct endpoints.
-	endpointMap := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
@@ -1862,8 +1862,8 @@ func TestValidateEndpointFields(t *testing.T) {
 	//
 	// In degraded mode, we should exclude the invalid endpoint for non-coverable cases(pod invalid or empty zone).
 	// We always inject to first endpoint, so the result only contain the second endpoint.
-	endpointMapExcluded := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	endpointMapExcluded := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
 	}
@@ -1874,11 +1874,11 @@ func TestValidateEndpointFields(t *testing.T) {
 	testCases := []struct {
 		desc                            string
 		testEndpointSlices              []*discovery.EndpointSlice
-		expectedEndpointMap             map[string]negtypes.NetworkEndpointSet
+		expectedEndpointMap             map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedPodMap                  negtypes.EndpointPodMap
 		expectErr                       error
 		expectErrorState                bool
-		expectedEndpointMapDegradedMode map[string]negtypes.NetworkEndpointSet
+		expectedEndpointMapDegradedMode map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedPodMapDegradedMode      negtypes.EndpointPodMap
 	}{
 		{
@@ -2253,8 +2253,8 @@ func TestValidateEndpointFields(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.2.2", Node: instance2, Port: "80"},
@@ -2363,8 +2363,8 @@ func TestValidateEndpointFields(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.4", IPv6: "a:b::4", Node: instance4, Port: "80"},
@@ -2377,8 +2377,8 @@ func TestValidateEndpointFields(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone2: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
 				),
@@ -2544,8 +2544,8 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 		},
 	})
 
-	endpointMap := map[string]negtypes.NetworkEndpointSet{
-		negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
@@ -2558,11 +2558,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 	testCases := []struct {
 		desc                            string
 		testEndpointSlices              []*discovery.EndpointSlice
-		expectedEndpointMap             map[string]negtypes.NetworkEndpointSet
+		expectedEndpointMap             map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedPodMap                  negtypes.EndpointPodMap
 		expectErr                       error
 		expectErrorState                bool
-		expectedEndpointMapDegradedMode map[string]negtypes.NetworkEndpointSet
+		expectedEndpointMapDegradedMode map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
 		expectedPodMapDegradedMode      negtypes.EndpointPodMap
 	}{
 		{
@@ -2612,12 +2612,12 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				negtypes.TestZone5: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone5}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.1.1", Node: defaultSubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2628,12 +2628,12 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				negtypes.TestZone5: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone5}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.1.1", Node: defaultSubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2690,12 +2690,12 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				negtypes.TestZone6: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone6}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.2.1", Node: emptySubnetLabelInstance, Port: "80"},
 				),
 			},
@@ -2706,12 +2706,12 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[string]negtypes.NetworkEndpointSet{
-				negtypes.TestZone1: negtypes.NewNetworkEndpointSet(
+			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 				),
-				negtypes.TestZone6: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone6}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.101.2.1", Node: emptySubnetLabelInstance, Port: "80"},
 				),
 			},

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -81,11 +81,13 @@ type NegSyncerManager interface {
 }
 
 type NetworkEndpointsCalculator interface {
-	// CalculateEndpoints computes the NEG endpoints based on service endpoints and the current NEG state and returns a
-	// map of zone name to network endpoint set
-	CalculateEndpoints(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, int, error)
+	// CalculateEndpoints computes the NEG endpoints based on service endpoints
+	// and the current NEG state and returns a map of EndpointGroupInfo to
+	// network endpoint set. EndpointGroupInfo contains the zone and subnet of
+	// this NEG.
+	CalculateEndpoints(eds []EndpointsData, currentMap map[EndpointGroupInfo]NetworkEndpointSet) (map[EndpointGroupInfo]NetworkEndpointSet, EndpointPodMap, int, error)
 	// CalculateEndpointsDegradedMode computes the NEG endpoints using degraded mode calculation
-	CalculateEndpointsDegradedMode(eds []EndpointsData, currentMap map[string]NetworkEndpointSet) (map[string]NetworkEndpointSet, EndpointPodMap, error)
+	CalculateEndpointsDegradedMode(eds []EndpointsData, currentMap map[EndpointGroupInfo]NetworkEndpointSet) (map[EndpointGroupInfo]NetworkEndpointSet, EndpointPodMap, error)
 	// Mode indicates the mode that the EndpointsCalculator is operating in.
 	Mode() EndpointsCalculatorMode
 	// ValidateEndpoints validates the NEG endpoint information is correct

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -412,3 +412,8 @@ func NegInfoFromNegRef(negRef negv1beta1.NegObjectReference) (NegInfo, error) {
 	}
 	return NegInfo{Name: resourceID.Key.Name, Zone: resourceID.Key.Zone}, nil
 }
+
+type EndpointGroupInfo struct {
+	Zone   string
+	Subnet string
+}


### PR DESCRIPTION
* Use endpointGroupInfo instead of string(zone) when mapping NEGs since now endpoints shall be partitioned based on the zone and the subnet they are in.
* Nodes in non-default subnets will be filtered when enableMultiSubnetCluster=true and enableMultiSubnetClusterPhase1=false. When enableMultiSubnetClusterPhase1=true, we will include endpoints
  and nodes from non-default subnets.