### PR TITLE
Add backend_type label to l4_netlbs_count and the L4_netlb latency metrics

### DIFF
--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -94,7 +94,7 @@ func NewL4ILBSyncResult(syncType string, startTime time.Time, svc *corev1.Servic
 		StartTime:   startTime,
 		SyncType:    syncType,
 		// Internal Load Balancer doesn't support strong session affinity (passing `false` all along)
-		MetricsState: metrics.InitServiceMetricsState(svc, &startTime, isMultinetService, enabledStrongSessionAffinity, isWeightedLBPodsPerNode),
+		MetricsState: metrics.InitServiceMetricsState(svc, &startTime, isMultinetService, enabledStrongSessionAffinity, isWeightedLBPodsPerNode, metrics.L4BackendTypeNEG),
 	}
 	return result
 }

--- a/pkg/metrics/l4_metrics.go
+++ b/pkg/metrics/l4_metrics.go
@@ -31,6 +31,7 @@ const (
 	l4LabelMultinet              = "multinet"
 	l4LabelStrongSessionAffinity = "strong_session_affinity"
 	l4LabelWeightedLBPodsPerNode = "weighted_lb_pods_per_node"
+	l4LabelBackendType           = "backend_type"
 )
 
 var (
@@ -47,7 +48,7 @@ var (
 			Name: "l4_netlbs_count",
 			Help: "Metric containing the number of NetLBs that can be filtered by feature labels and status",
 		},
-		[]string{l4LabelStatus, l4LabelMultinet, l4LabelStrongSessionAffinity, l4LabelWeightedLBPodsPerNode},
+		[]string{l4LabelStatus, l4LabelMultinet, l4LabelStrongSessionAffinity, l4LabelWeightedLBPodsPerNode, l4LabelBackendType},
 	)
 )
 
@@ -56,7 +57,7 @@ func (im *ControllerMetrics) exportL4Metrics() {
 	im.exportL4NetLBsMetrics()
 }
 
-func InitServiceMetricsState(svc *corev1.Service, startTime *time.Time, isMultinetwork bool, enabledStrongSessionAffinity bool, isWeightedLBPodsPerNode bool) L4ServiceState {
+func InitServiceMetricsState(svc *corev1.Service, startTime *time.Time, isMultinetwork bool, enabledStrongSessionAffinity bool, isWeightedLBPodsPerNode bool, backendType L4BackendType) L4ServiceState {
 	state := L4ServiceState{
 		L4DualStackServiceLabels: L4DualStackServiceLabels{
 			IPFamilies: ipFamiliesToString(svc.Spec.IPFamilies),
@@ -65,6 +66,7 @@ func InitServiceMetricsState(svc *corev1.Service, startTime *time.Time, isMultin
 			Multinetwork:          isMultinetwork,
 			StrongSessionAffinity: enabledStrongSessionAffinity,
 			WeightedLBPodsPerNode: isWeightedLBPodsPerNode,
+			BackendType:           backendType,
 		},
 		// Always init status with error, and update with Success when service was provisioned
 		Status:             StatusError,
@@ -162,6 +164,7 @@ func (im *ControllerMetrics) exportL4NetLBsMetrics() {
 			l4LabelMultinet:              strconv.FormatBool(svcState.Multinetwork),
 			l4LabelStrongSessionAffinity: strconv.FormatBool(svcState.StrongSessionAffinity),
 			l4LabelWeightedLBPodsPerNode: strconv.FormatBool(svcState.WeightedLBPodsPerNode),
+			l4LabelBackendType:           string(svcState.BackendType),
 		}).Inc()
 	}
 	im.logger.V(3).Info("L4 NetLB usage metrics exported")

--- a/pkg/metrics/l4_metrics_test.go
+++ b/pkg/metrics/l4_metrics_test.go
@@ -109,52 +109,52 @@ func TestExportNetLBMetric(t *testing.T) {
 	notExceedingPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime + 5*time.Minute)
 
 	newMetrics.SetL4NetLBService("svc-success-multinet-1", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeNEG},
 		Status:                  StatusSuccess,
 	})
 	newMetrics.SetL4NetLBService("svc-success-all-labels", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: true, WeightedLBPodsPerNode: true},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: true, WeightedLBPodsPerNode: true, BackendType: L4BackendTypeNEG},
 		Status:                  StatusSuccess,
 	})
 	newMetrics.SetL4NetLBService("svc-success-multinet-2", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: true, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeNEG},
 		Status:                  StatusSuccess,
 	})
 	newMetrics.SetL4NetLBService("svc-success-ssa", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: true, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: true, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeNEG},
 		Status:                  StatusSuccess,
 	})
 	newMetrics.SetL4NetLBService("svc-success-weightedlb", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: true},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: true, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusSuccess,
 	})
 	newMetrics.SetL4NetLBService("svc-user-error-ssa", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: true, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: true, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusUserError,
 	})
 	newMetrics.SetL4NetLBService("svc-error", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusError,
 		FirstSyncErrorTime:      &notExceedingPersistentErrorThresholdTime,
 	})
 	newMetrics.SetL4NetLBService("svc-error", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusError,
 		FirstSyncErrorTime:      &notExceedingPersistentErrorThresholdTime,
 	})
 	newMetrics.SetL4NetLBService("svc-threshold-check", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusError,
 		FirstSyncErrorTime:      &pastPersistentErrorThresholdTime,
 	})
 	// check that updating later does not move FirstSyncErrorTime
 	newMetrics.SetL4NetLBService("svc-threshold-check", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		Status:                  StatusError,
 		FirstSyncErrorTime:      &notExceedingPersistentErrorThresholdTime,
 	})
 	newMetrics.SetL4NetLBService("svc-single-stack", L4ServiceState{
-		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false},
+		L4FeaturesServiceLabels: L4FeaturesServiceLabels{Multinetwork: false, StrongSessionAffinity: false, WeightedLBPodsPerNode: false, BackendType: L4BackendTypeInstanceGroup},
 		L4DualStackServiceLabels: L4DualStackServiceLabels{
 			IPFamilies:     "IPv4",
 			IPFamilyPolicy: "SingleStack",
@@ -165,19 +165,19 @@ func TestExportNetLBMetric(t *testing.T) {
 
 	newMetrics.exportL4NetLBsMetrics()
 
-	verifyL4NetLBMetric(t, 2, StatusSuccess, isMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 1, StatusSuccess, isMultinetwork, enabledStrongSessionAffinity, isWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 1, StatusSuccess, notMultinetwork, enabledStrongSessionAffinity, notWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 1, StatusSuccess, notMultinetwork, disabledStrongSessionAffinity, isWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 1, StatusUserError, notMultinetwork, enabledStrongSessionAffinity, notWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 2, StatusError, notMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode)
-	verifyL4NetLBMetric(t, 1, StatusPersistentError, notMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode)
+	verifyL4NetLBMetric(t, 2, StatusSuccess, isMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode, L4BackendTypeNEG)
+	verifyL4NetLBMetric(t, 1, StatusSuccess, isMultinetwork, enabledStrongSessionAffinity, isWeightedLBPodsPerNode, L4BackendTypeNEG)
+	verifyL4NetLBMetric(t, 1, StatusSuccess, notMultinetwork, enabledStrongSessionAffinity, notWeightedLBPodsPerNode, L4BackendTypeNEG)
+	verifyL4NetLBMetric(t, 1, StatusSuccess, notMultinetwork, disabledStrongSessionAffinity, isWeightedLBPodsPerNode, L4BackendTypeInstanceGroup)
+	verifyL4NetLBMetric(t, 1, StatusUserError, notMultinetwork, enabledStrongSessionAffinity, notWeightedLBPodsPerNode, L4BackendTypeInstanceGroup)
+	verifyL4NetLBMetric(t, 2, StatusError, notMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode, L4BackendTypeInstanceGroup)
+	verifyL4NetLBMetric(t, 1, StatusPersistentError, notMultinetwork, disabledStrongSessionAffinity, notWeightedLBPodsPerNode, L4BackendTypeInstanceGroup)
 }
 
-func verifyL4NetLBMetric(t *testing.T, expectedCount int, status L4ServiceStatus, multinet string, strongSessionAffinity string, weightedLBPodsPerNode string) {
-	countFloat := testutil.ToFloat64(l4NetLBCount.With(prometheus.Labels{l4LabelStatus: string(status), l4LabelMultinet: multinet, l4LabelStrongSessionAffinity: strongSessionAffinity, l4LabelWeightedLBPodsPerNode: weightedLBPodsPerNode}))
+func verifyL4NetLBMetric(t *testing.T, expectedCount int, status L4ServiceStatus, multinet string, strongSessionAffinity string, weightedLBPodsPerNode string, backendType L4BackendType) {
+	countFloat := testutil.ToFloat64(l4NetLBCount.With(prometheus.Labels{l4LabelStatus: string(status), l4LabelMultinet: multinet, l4LabelStrongSessionAffinity: strongSessionAffinity, l4LabelWeightedLBPodsPerNode: weightedLBPodsPerNode, l4LabelBackendType: string(backendType)}))
 	actualCount := int(math.Round(countFloat))
 	if expectedCount != actualCount {
-		t.Errorf("expected value %d but got %d", expectedCount, actualCount)
+		t.Errorf("expected value %d but got %d for status: %q, multinet: %q, ssa: %q, backendType: %q", expectedCount, actualCount, status, multinet, strongSessionAffinity, backendType)
 	}
 }

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -51,6 +51,11 @@ const StatusUserError = L4ServiceStatus("UserError")
 const StatusError = L4ServiceStatus("Error")
 const StatusPersistentError = L4ServiceStatus("PersistentError")
 
+type L4BackendType string
+
+const L4BackendTypeInstanceGroup = L4BackendType("IG")
+const L4BackendTypeNEG = L4BackendType("NEG")
+
 // L4DualStackServiceLabels defines ipFamilies, ipFamilyPolicy
 // of L4 DualStack service
 type L4DualStackServiceLabels struct {
@@ -68,6 +73,8 @@ type L4FeaturesServiceLabels struct {
 	StrongSessionAffinity bool
 	// WeightedLBPodsPerNode is true if weighted load balancing is enabled by pods per node
 	WeightedLBPodsPerNode bool
+	// BackendType is the type of the backend the LB uses (IGs or NEGs).
+	BackendType L4BackendType
 }
 
 // L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.


### PR DESCRIPTION
This extends the L4 NetLB metrics with `backend_type` field that will allow tracking the adoption and performance of NEG backed LBs vs IG ones.