### PR TITLE
IPv6 NetLB - disallow using on standard tier network

### DIFF
--- a/pkg/loadbalancers/forwarding_rules_ipv6.go
+++ b/pkg/loadbalancers/forwarding_rules_ipv6.go
@@ -169,6 +169,12 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	netTier, isFromAnnotation := utils.GetNetworkTier(l4netlb.Service)
 	frLogger.V(2).Info("network tier for service", "networkTier", netTier, "isFromAnnotation", isFromAnnotation)
 
+	// IPv6 address is not supported for External Regional Network Load Balancing with Standard network tier.
+	if netTier == cloud.NetworkTierStandard {
+		resourceErr := "IPv6 External Load Balancer"
+		return nil, utils.ResourceResync, utils.NewUnsupportedNetworkTierErr(resourceErr, string(cloud.NetworkTierStandard))
+	}
+
 	// Only for IPv6, address reservation is not supported on Standard Tier
 	if !l4netlb.cloud.IsLegacyNetwork() && netTier == cloud.NetworkTierPremium {
 		nm := types.NamespacedName{Namespace: l4netlb.Service.Namespace, Name: l4netlb.Service.Name}.String()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,6 +110,20 @@ func NewNetworkTierErr(resourceInErr, desired, received string) *NetworkTierErro
 	return &NetworkTierError{resource: resourceInErr, desiredNT: desired, receivedNT: received}
 }
 
+type UnsupportedNetworkTierError struct {
+	resource      string
+	unsupportedNT string
+}
+
+// Error function prints out Network Tier error.
+func (e *UnsupportedNetworkTierError) Error() string {
+	return fmt.Sprintf("Network tier %s is not supported for %s", e.unsupportedNT, e.resource)
+}
+
+func NewUnsupportedNetworkTierErr(resourceInErr, networkTier string) *UnsupportedNetworkTierError {
+	return &UnsupportedNetworkTierError{resource: resourceInErr, unsupportedNT: networkTier}
+}
+
 // IPConfigurationError is a struct to define error caused by User misconfiguration the Load Balancer IP.
 type IPConfigurationError struct {
 	ip     string
@@ -217,6 +231,12 @@ func IsNetworkTierError(err error) bool {
 	return errors.As(err, &netTierError)
 }
 
+// IsUnsupportedNetworkTierError checks if wrapped error is an Unsupported Network Tier error
+func IsUnsupportedNetworkTierError(err error) bool {
+	var netTierError *UnsupportedNetworkTierError
+	return errors.As(err, &netTierError)
+}
+
 // IsIPConfigurationError checks if wrapped error is an IP configuration error.
 func IsIPConfigurationError(err error) bool {
 	var ipConfigError *IPConfigurationError
@@ -244,6 +264,7 @@ func IsUserError(err error) bool {
 		IsIPConfigurationError(err) ||
 		IsInvalidLoadBalancerSourceRangesSpecError(err) ||
 		IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
+		IsUnsupportedNetworkTierError(err) ||
 		errors.As(err, &userError)
 }
 


### PR DESCRIPTION
BUG FIX:

NetLB does not support IPv6 on standard tier network.
Whenever this config was used the real setup was silently using premium tier.