### PR TITLE
Fix small typo in `hack/run-local-glbc.sh`

### DIFF
--- a/hack/run-local-glbc.sh
+++ b/hack/run-local-glbc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Run glbc. First run `run-local.sh` to set things up.
+# Run glbc. First run `setup-local.sh` to set things up.
 #
 # Files touched: /tmp/kubectl-proxy.log /tmp/glbc.log
 


### PR DESCRIPTION
File `run-local.sh` does not exist. It should be set to `setup-local.sh` as docs suggest.

See: [docs/contrib/dev-setup.md](https://github.com/kubernetes/ingress-gce/blob/master/docs/contrib/dev-setup.md)