### PR TITLE
Create additional NEGs based on subnets in Node Topology CR.

### DIFF
--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	defaultTestZone      = "zone-a"
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 )
 
 func newTestIGLinker(fakeGCE *gce.Cloud, fakeInstancePool instancegroups.Manager) *instanceGroupLinker {

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -59,7 +59,7 @@ func TestLink(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
@@ -101,7 +101,7 @@ func TestLinkWithCreationModeError(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -53,7 +53,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeInstancePool := instancegroups.NewManager(&instancegroups.ManagerConfig{

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -53,7 +53,7 @@ func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer 
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, usCentral1AZone, "test-instance1")
 	zonegetter.AddFakeNodes(fakeZoneGetter, "us-central1-c", "test-instance2")
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -248,7 +248,7 @@ func NewControllerContext(
 		logger,
 	)
 	// The subnet specified in gce.conf is considered as the default subnet.
-	context.ZoneGetter = zonegetter.NewZoneGetter(context.NodeInformer, context.Cloud.SubnetworkURL())
+	context.ZoneGetter = zonegetter.NewZoneGetter(context.NodeInformer, context.NodeTopologyInformer, context.Cloud.SubnetworkURL())
 	context.InstancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      context.Cloud,
 		Namer:      context.ClusterNamer,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -328,10 +328,6 @@ func (ctx *ControllerContext) HasSynced() bool {
 		funcs = append(funcs, ctx.FirewallInformer.HasSynced)
 	}
 
-	if ctx.NodeTopologyInformer != nil {
-		funcs = append(funcs, ctx.NodeTopologyInformer.HasSynced)
-	}
-
 	for _, f := range funcs {
 		if !f() {
 			return false

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -58,7 +58,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 )
 
-const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 
 var (
 	nodePortCounter = 30000

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -73,7 +73,7 @@ func newLoadBalancerController() *LoadBalancerController {
 	svcNegClient := svcnegclient.NewSimpleClientset()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, fakeZone, "test-node")
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockGlobalForwardingRules.InsertHook = loadbalancers.InsertGlobalForwardingRuleHook

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -71,7 +71,9 @@ func newLoadBalancerController() *LoadBalancerController {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	svcNegClient := svcnegclient.NewSimpleClientset()
-	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	vals := gce.DefaultTestClusterValues()
+	vals.SubnetworkURL = defaultTestSubnetURL
+	fakeGCE := gce.NewFakeGCECloud(vals)
 	nodeInformer := zonegetter.FakeNodeInformer()
 	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.AddFakeNodes(fakeZoneGetter, fakeZone, "test-node")

--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 	config.HasSynced = func() bool {
 		return true
 	}
-	config.ZoneGetter = zonegetter.NewFakeZoneGetter(informer, defaultTestSubnetURL, false)
+	config.ZoneGetter = zonegetter.NewFakeZoneGetter(informer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	controller := NewController(config, logr.Logger{})
 

--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -18,12 +18,13 @@ package instancegroups
 
 import (
 	"fmt"
-	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/ingress-gce/pkg/utils"
 	"net/http"
 	"strings"
 	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/utils"
 
 	"google.golang.org/api/googleapi"
 	"k8s.io/klog/v2"
@@ -49,7 +50,7 @@ var defaultNamer = namer.NewNamer("uid1", "fw1", klog.TODO())
 
 func newNodePool(f Provider, maxIGSize int) Manager {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	pool := NewManager(&ManagerConfig{
 		Cloud:      f,

--- a/pkg/instancegroups/manager_test.go
+++ b/pkg/instancegroups/manager_test.go
@@ -43,7 +43,7 @@ const (
 	testZoneC       = "dark-moon1-c"
 	basePath        = "/basepath/projects/project-id/"
 
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 )
 
 var defaultNamer = namer.NewNamer("uid1", "fw1", klog.TODO())

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 )
 
 const (
@@ -852,6 +853,7 @@ func newServiceController(t *testing.T, fakeGCE *gce.Cloud) *L4Controller {
 		NumL4Workers: 5,
 	}
 	ctx := context.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx.ZoneGetter = zonegetter.NewFakeZoneGetter(ctx.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	// Add some nodes so that NEG linker kicks in during ILB creation.
 	nodes, err := test.CreateAndInsertNodes(ctx.Cloud, []string{"instance-1"}, vals.ZoneName)
 	if err != nil {

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -75,7 +75,7 @@ const (
 	shortSessionAffinityIdleTimeout = int32(20)     // 20 sec could be used for regular Session Affinity
 	longSessionAffinityIdleTimeout  = int32(2 * 60) // 2 min or 120 sec for Strong Session Affinity
 
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 )
 
 var (

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -49,7 +49,7 @@ import (
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/endpointslices"
-	namer2 "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
@@ -68,7 +68,7 @@ type Controller struct {
 	gcPeriod        time.Duration
 	recorder        record.EventRecorder
 	namer           negtypes.NetworkEndpointGroupNamer
-	l4Namer         namer2.L4ResourcesNamer
+	l4Namer         namer.L4ResourcesNamer
 	zoneGetter      *zonegetter.ZoneGetter
 	networkResolver network.Resolver
 
@@ -135,7 +135,7 @@ func NewController(
 	gkeNetworkParamSetInformer cache.SharedIndexInformer,
 	nodeTopologyInformer cache.SharedIndexInformer,
 	hasSynced func() bool,
-	l4Namer namer2.L4ResourcesNamer,
+	l4Namer namer.L4ResourcesNamer,
 	defaultBackendService utils.ServicePort,
 	cloud negtypes.NetworkEndpointGroupCloud,
 	zoneGetter *zonegetter.ZoneGetter,
@@ -182,6 +182,7 @@ func NewController(
 	syncerMetrics := syncMetrics.NewNegMetricsCollector(flags.F.NegMetricsExportInterval, logger)
 	manager := newSyncerManager(
 		namer,
+		l4Namer,
 		recorder,
 		cloud,
 		zoneGetter,

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -2115,6 +2115,7 @@ func newTestNode(name string, unschedulable bool) *apiv1.Node {
 			Name: name,
 		},
 		Spec: apiv1.NodeSpec{
+			PodCIDR:       "10.100.1.0/24",
 			Unschedulable: unschedulable,
 		},
 	}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -124,7 +124,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 	}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	return NewController(
 		kubeClient,
@@ -1756,7 +1756,7 @@ func validateServiceAnnotationWithPortInfoMap(t *testing.T, svc *apiv1.Service, 
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode()), klog.TODO())
 	if !sets.NewString(expectZones...).Equal(sets.NewString(zones...)) {
 		t.Errorf("Unexpected zones listed by the predicate function, got %v, want %v", zones, expectZones)
@@ -1837,7 +1837,7 @@ func validateServiceStateAnnotationExceptNames(t *testing.T, svc *apiv1.Service,
 	}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	// This routine is called from tests verifying L7 NEGs.
 	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L7Mode), klog.TODO())
 

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -46,6 +46,7 @@ import (
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
@@ -64,6 +65,7 @@ func (k serviceKey) Key() string {
 // syncerManager contains all the active syncer goroutines and manage their lifecycle.
 type syncerManager struct {
 	namer      negtypes.NetworkEndpointGroupNamer
+	l4Namer    namer.L4ResourcesNamer
 	recorder   record.EventRecorder
 	cloud      negtypes.NetworkEndpointGroupCloud
 	zoneGetter *zonegetter.ZoneGetter
@@ -118,6 +120,7 @@ type syncerManager struct {
 }
 
 func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
+	l4Namer namer.L4ResourcesNamer,
 	recorder record.EventRecorder,
 	cloud negtypes.NetworkEndpointGroupCloud,
 	zoneGetter *zonegetter.ZoneGetter,
@@ -140,6 +143,7 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 
 	return &syncerManager{
 		namer:               namer,
+		l4Namer:             l4Namer,
 		recorder:            recorder,
 		cloud:               cloud,
 		zoneGetter:          zoneGetter,
@@ -228,6 +232,11 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				&portInfo.NetworkInfo,
 				portInfo.L4LBType,
 			)
+			nonDefaultSubnetNEGNamer := manager.namer
+			if syncerKey.NegType == negtypes.VmIpEndpointType {
+				nonDefaultSubnetNEGNamer = manager.l4Namer
+			}
+
 			syncer = negsyncer.NewTransactionSyncer(
 				syncerKey,
 				manager.recorder,
@@ -243,12 +252,12 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				string(manager.kubeSystemUID),
 				manager.svcNegClient,
 				manager.syncerMetrics,
-				!manager.namer.IsNEG(portInfo.NegName),
+				syncerKey.NegType == negtypes.VmIpPortEndpointType && !manager.namer.IsNEG(portInfo.NegName),
 				manager.logger,
 				manager.lpConfig,
 				manager.enableDualStackNEG,
 				portInfo.NetworkInfo,
-				manager.namer,
+				nonDefaultSubnetNEGNamer,
 			)
 			manager.syncerMap[syncerKey] = syncer
 		}

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -248,6 +248,7 @@ func (manager *syncerManager) EnsureSyncers(namespace, name string, newPorts neg
 				manager.lpConfig,
 				manager.enableDualStackNEG,
 				portInfo.NetworkInfo,
+				manager.namer,
 			)
 			manager.syncerMap[syncerKey] = syncer
 		}

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -92,6 +92,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	manager := newSyncerManager(
 		testContext.NegNamer,
+		testContext.L4Namer,
 		record.NewFakeRecorder(100),
 		negtypes.NewAdapter(testContext.Cloud),
 		zoneGetter,

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -82,7 +82,7 @@ const (
 	negName1    = "neg1"
 
 	defaultTestSubnet    = "default"
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 )
 
 func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce.Cloud, *negtypes.TestContext) {

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -89,7 +89,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	manager := newSyncerManager(
 		testContext.NegNamer,
 		record.NewFakeRecorder(100),

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 
 	defaultTestSubnet    = "default"
 	nonDefaultTestSubnet = "non-default"

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -59,7 +59,7 @@ func (f *fakeLookUp) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool 
 }
 
 func newTestReadinessReflector(testContext *negtypes.TestContext, enableMultiSubnetCluster bool) *readinessReflector {
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, enableMultiSubnetCluster)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, enableMultiSubnetCluster)
 	reflector := NewReadinessReflector(
 		testContext.KubeClient,
 		testContext.KubeClient,

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -42,8 +42,9 @@ import (
 // The L7 implementation is tested in TestToZoneNetworkEndpointMapUtil.
 func TestLocalGetEndpointSet(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zonegetter.SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default", SubnetworkURL: defaultTestSubnetURL}
 	prevFlag := flags.F.EnableMultiSubnetCluster
 	defer func() { flags.F.EnableMultiSubnetCluster = prevFlag }()
@@ -196,8 +197,9 @@ func nodeInterfacesAnnotation(t *testing.T, network, ip string) string {
 // TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4EndpointsCalculator.
 func TestClusterGetEndpointSet(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zonegetter.SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default", SubnetworkURL: defaultTestSubnetURL}
 	prevFlag := flags.F.EnableMultiSubnetCluster
 	defer func() { flags.F.EnableMultiSubnetCluster = prevFlag }()
@@ -397,10 +399,10 @@ func TestValidateEndpoints(t *testing.T) {
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	serviceLister := testContext.ServiceInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, true)
-	zoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics())
 
-	zoneGetterMSC := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, true)
+	zoneGetterMSC := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
 	L7EndpointsCalculatorMSC := NewL7EndpointsCalculator(zoneGetterMSC, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics())
 	L7EndpointsCalculatorMSC.enableMultiSubnetCluster = true
 	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL}, negtypes.L4InternalLB)

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -130,6 +130,8 @@ type transactionSyncer struct {
 	// networkInfo contains the network information to use in GCP resources (VPC URL, Subnetwork URL).
 	// and the k8s network name (can be used in endpoints calculation).
 	networkInfo network.NetworkInfo
+
+	namer negtypes.NetworkEndpointGroupNamer
 }
 
 func NewTransactionSyncer(
@@ -152,6 +154,7 @@ func NewTransactionSyncer(
 	lpConfig labels.PodLabelPropagationConfig,
 	enableDualStackNEG bool,
 	networkInfo network.NetworkInfo,
+	namer negtypes.NetworkEndpointGroupNamer,
 ) negtypes.NegSyncer {
 
 	logger := log.WithName("Syncer").WithValues("service", klog.KRef(negSyncerKey.Namespace, negSyncerKey.Name), "negName", negSyncerKey.NegName)
@@ -182,6 +185,7 @@ func NewTransactionSyncer(
 		enableDualStackNEG:        enableDualStackNEG,
 		podLabelPropagationConfig: lpConfig,
 		networkInfo:               networkInfo,
+		namer:                     namer,
 	}
 	// Syncer implements life cycle logic
 	syncer := newSyncer(negSyncerKey, serviceLister, recorder, ts, logger)

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/googleapi"
 	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -425,7 +426,6 @@ func (s *transactionSyncer) resetErrorState() {
 
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
-	var err error
 	// NEGs should be created in zones with candidate nodes only.
 	zones, err := s.zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(s.EpCalculatorMode), s.logger)
 	if err != nil {
@@ -436,38 +436,78 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	var negObjRefs []negv1beta1.NegObjectReference
 	updateNEGStatus := true
 	negsByLocation := make(map[string]int)
-	for _, zone := range zones {
-		var negObj negv1beta1.NegObjectReference
-		negObj, err = ensureNetworkEndpointGroup(
-			s.Namespace,
-			s.Name,
-			s.NegSyncerKey.NegName,
-			zone,
-			s.NegSyncerKey.String(),
-			s.kubeSystemUID,
-			fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
-			s.NegSyncerKey.NegType,
-			s.cloud,
-			s.serviceLister,
-			s.recorder,
-			s.NegSyncerKey.GetAPIVersion(),
-			s.customName,
-			s.networkInfo,
-			s.logger,
-		)
-		if err != nil {
-			errList = append(errList, err)
-			// Do not modify NEG Status if there is conflict within the same cluster
-			// and namespace because the CR is owned by a different syncer.
-			if errors.Is(err, utils.ErrNEGUsedByAnotherSyncer) {
-				updateNEGStatus = false
-				break
+
+	// Get default subnet from syncer's networkInfo.
+	defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
+	if err != nil {
+		s.logger.Error(err, "Errored getting default subnet from NetworkInfo")
+		return err
+	}
+
+	// List all existing subnets from the cluster.
+	subnetConfigs, err := s.zoneGetter.ListSubnets(s.logger)
+	if err != nil {
+		s.logger.Error(err, "Failed to list subnets from zoneGetter")
+		return err
+	}
+
+	for _, subnetConfig := range subnetConfigs {
+		negName := s.NegSyncerKey.NegName
+		networkInfo := s.networkInfo
+
+		if subnetConfig.Name != defaultSubnet {
+			// Determine the NEG name for the non-default subnet NEGs.
+			negName, err = s.getNonDefaultSubnetName(subnetConfig.Name)
+			if err != nil {
+				s.logger.Error(err, "Unable to get the name of the additional NEG based on the subnet name", "subnetName", subnetConfig.Name)
+				errList = append(errList, err)
+				continue
 			}
+
+			// Determine the networkInfo for the non-default subnet NEGs.
+			resourceID, err := cloud.ParseResourceURL(subnetConfig.SubnetPath)
+			if err != nil {
+				s.logger.Error(err, "Failed to parse subnet path", "subnetPath", subnetConfig.SubnetPath)
+				errList = append(errList, err)
+				continue
+			}
+			// Add compute and version GA prefix.
+			networkInfo.SubnetworkURL = cloud.SelfLink(meta.VersionGA, resourceID.ProjectID, resourceID.Resource, resourceID.Key)
 		}
 
-		if s.svcNegClient != nil && err == nil {
-			negObjRefs = append(negObjRefs, negObj)
-			negsByLocation[zone]++
+		for _, zone := range zones {
+			var negObj negv1beta1.NegObjectReference
+			negObj, err = ensureNetworkEndpointGroup(
+				s.Namespace,
+				s.Name,
+				negName,
+				zone,
+				s.NegSyncerKey.String(),
+				s.kubeSystemUID,
+				fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
+				s.NegSyncerKey.NegType,
+				s.cloud,
+				s.serviceLister,
+				s.recorder,
+				s.NegSyncerKey.GetAPIVersion(),
+				s.customName,
+				networkInfo,
+				s.logger,
+			)
+			if err != nil {
+				errList = append(errList, err)
+				// Do not modify NEG Status if there is conflict within the same cluster
+				// and namespace because the CR is owned by a different syncer.
+				if errors.Is(err, utils.ErrNEGUsedByAnotherSyncer) {
+					updateNEGStatus = false
+					break
+				}
+			}
+
+			if s.svcNegClient != nil && err == nil {
+				negObjRefs = append(negObjRefs, negObj)
+				negsByLocation[zone]++
+			}
 		}
 	}
 
@@ -885,6 +925,21 @@ func (s *transactionSyncer) computeEPSStaleness(endpointSlices []*discovery.Endp
 		metrics.PublishNegEPSStalenessMetrics(epsStaleness)
 		s.logger.V(3).Info("Endpoint slice syncs", "Namespace", endpointSlice.Namespace, "Name", endpointSlice.Name, "staleness", epsStaleness)
 	}
+}
+
+// getNonDefaultSubnetName returns the name of the NEG based on the subnet name.
+func (s *transactionSyncer) getNonDefaultSubnetName(subnet string) (string, error) {
+	negNamer := s.namer
+	if s.customName {
+		negName, err := negNamer.NonDefaultSubnetCustomNEG(s.NegSyncerKey.NegName, subnet)
+		if err != nil {
+			return "", err
+		}
+		return negName, nil
+	}
+
+	negName := negNamer.NonDefaultSubnetNEG(s.NegSyncerKey.Namespace, s.NegSyncerKey.Name, subnet, s.NegSyncerKey.PortTuple.Port)
+	return negName, nil
 }
 
 // computeDegradedModeCorrectness computes degraded mode correctness metrics based on the difference between degraded mode and normal calculation

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1732,7 +1732,7 @@ func TestIsZoneChange(t *testing.T) {
 func TestUnknownNodes(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
 	testSubnetwork := defaultTestSubnetURL
 	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
@@ -1828,7 +1828,7 @@ func TestUnknownNodes(t *testing.T) {
 func TestEnableDegradedMode(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	vals := gce.DefaultTestClusterValues()
 	vals.SubnetworkURL = defaultTestSubnetURL
 	fakeGCE := gce.NewFakeGCECloud(vals)
@@ -2457,7 +2457,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 	reflector := &readiness.NoopReflector{}
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	negsyncer := NewTransactionSyncer(svcPort,
 		record.NewFakeRecorder(100),

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -2479,6 +2479,7 @@ func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negTyp
 		labels.PodLabelPropagationConfig{},
 		testContext.EnableDualStackNEG,
 		network.NetworkInfo{NetworkURL: fakeGCE.NetworkURL(), SubnetworkURL: fakeGCE.SubnetworkURL()},
+		testContext.NegNamer,
 	)
 	transactionSyncer := negsyncer.(*syncer).core.(*transactionSyncer)
 	indexers := map[string]cache.IndexFunc{

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
@@ -72,6 +73,7 @@ const (
 	testUnreadyInstance2 = "unready-instance2"
 
 	defaultTestSubnet    = "default"
+	additionalTestSubnet = "additional-subnet"
 	secondaryTestSubnet1 = "secondary1"
 	secondaryTestSubnet2 = "secondary2"
 )
@@ -1227,7 +1229,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 						Description:         tc.negDesc,
 					}, zone, klog.TODO())
 				}
-				expectedNegRefs, err = negObjectReferences(fakeCloud, negv1beta1.ActiveState, expectZones)
+				expectedNegRefs, err = negObjectReferences(fakeCloud, negv1beta1.ActiveState, expectZones, syncer.NegSyncerKey.NegName)
 				if err != nil {
 					t.Errorf("Failed to get negObjRef from NEG CR: %v", err)
 				}
@@ -1262,7 +1264,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 				t.Errorf("Failed to get NEG from neg client: %s", err)
 			}
 			if !tc.expectErr {
-				expectedNegRefs, err = negObjectReferences(fakeCloud, negv1beta1.ActiveState, expectZones)
+				expectedNegRefs, err = negObjectReferences(fakeCloud, negv1beta1.ActiveState, expectZones, syncer.NegSyncerKey.NegName)
 				if err != nil {
 					t.Errorf("Failed to get negObjRef from NEG CR: %v", err)
 				}
@@ -1337,6 +1339,198 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone3, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone4, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 
+	}
+}
+
+func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
+	zones := []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3}
+	testNetworkURL := cloud.SelfLink(meta.VersionGA, "mock-project", "networks", meta.GlobalKey(defaultTestSubnet))
+	testSubnetworkURL := cloud.SelfLink(meta.VersionGA, "mock-project", "subnetworks", meta.RegionalKey(defaultTestSubnet, "test-region"))
+	testNegType := negtypes.VmIpPortEndpointType
+	additionalTestSubnetworkURL := cloud.SelfLink(meta.VersionGA, "mock-project", "subnetworks", meta.RegionalKey(additionalTestSubnet, "test-region"))
+
+	nodeTopologyCrWithDefaultSubnetOnly := nodetopologyv1.NodeTopology{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodeTopology",
+			APIVersion: "networking.gke.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Status: nodetopologyv1.NodeTopologyStatus{
+			Subnets: []nodetopologyv1.SubnetConfig{
+				{Name: defaultTestSubnet, SubnetPath: fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", defaultTestSubnet)},
+			},
+		},
+	}
+	nodeTopologyCrWithAdditionalSubnets := nodeTopologyCrWithDefaultSubnetOnly
+	nodeTopologyCrWithAdditionalSubnets.Status.Subnets = append(nodeTopologyCrWithAdditionalSubnets.Status.Subnets,
+		nodetopologyv1.SubnetConfig{
+			Name:       additionalTestSubnet,
+			SubnetPath: fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", additionalTestSubnet),
+		},
+	)
+
+	currNodeTopologyCRName := flags.F.NodeTopologyCRName
+	prevFlag := flags.F.EnableMultiSubnetClusterPhase1
+	defer func() {
+		flags.F.NodeTopologyCRName = currNodeTopologyCRName
+		flags.F.EnableMultiSubnetClusterPhase1 = prevFlag
+	}()
+	flags.F.NodeTopologyCRName = "default"
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+
+	negDesc := utils.NegDescription{
+		ClusterUID:  kubeSystemUID,
+		Namespace:   testServiceNamespace,
+		ServiceName: testServiceName,
+		Port:        "80",
+	}.String()
+	testCases := []struct {
+		desc           string
+		customNEGName  string
+		nodeTopologyCr *nodetopologyv1.NodeTopology
+		negDesc        string
+		expectError    bool
+		// expectNeedToUpdate indicates whether there is any conflicting NEG description.
+		// When there is conflict, we do not update NEG Object Ref.
+		expectNeedToUpdate bool
+	}{
+		{
+			desc:               "NodeTopology CR doesn't exist",
+			expectError:        true,
+			negDesc:            negDesc,
+			expectNeedToUpdate: false,
+		},
+		{
+			desc:               "NodeTopology CR only contains default subnet",
+			nodeTopologyCr:     &nodeTopologyCrWithDefaultSubnetOnly,
+			negDesc:            negDesc,
+			expectNeedToUpdate: true,
+		},
+		{
+			desc:               "NodeTopology CR contains additional subnets, auto-generated NEG name",
+			nodeTopologyCr:     &nodeTopologyCrWithAdditionalSubnets,
+			negDesc:            negDesc,
+			expectNeedToUpdate: true,
+		},
+		{
+			desc:               "NodeTopology CR contains additional subnets, custom NEG name not exceeding character limit",
+			customNEGName:      "custom-neg",
+			nodeTopologyCr:     &nodeTopologyCrWithAdditionalSubnets,
+			negDesc:            negDesc,
+			expectError:        false,
+			expectNeedToUpdate: true,
+		},
+		{
+			desc:               "NodeTopology CR contains additional subnets, custom NEG name exceeding character limit",
+			customNEGName:      "012345678901234567890123456789012345678901234567890123456", // 57 characters
+			nodeTopologyCr:     &nodeTopologyCrWithAdditionalSubnets,
+			negDesc:            negDesc,
+			expectError:        true,
+			expectNeedToUpdate: true,
+		},
+		{
+			desc:           "NodeTopology CR contains additional subnets, conflicting NEG description",
+			nodeTopologyCr: &nodeTopologyCrWithAdditionalSubnets,
+			negDesc: utils.NegDescription{
+				ClusterUID:  kubeSystemUID,
+				Namespace:   testServiceNamespace,
+				ServiceName: testServiceName,
+				Port:        "81", // Expected port to be 80
+			}.String(),
+			expectError:        true,
+			expectNeedToUpdate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetworkURL, testNetworkURL)
+
+			_, syncer := newTestTransactionSyncer(fakeCloud, testNegType, tc.customNEGName != "")
+			if tc.customNEGName != "" {
+				syncer.NegSyncerKey.NegName = tc.customNEGName
+			}
+			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+
+			negName := syncer.NegSyncerKey.NegName
+
+			for _, zone := range zones {
+				err := fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
+					Version:             syncer.NegSyncerKey.GetAPIVersion(),
+					Name:                negName,
+					NetworkEndpointType: string(syncer.NegSyncerKey.NegType),
+					Network:             fakeCloud.NetworkURL(),
+					Subnetwork:          fakeCloud.SubnetworkURL(),
+					Description:         tc.negDesc,
+				}, zone, klog.TODO())
+				if err != nil {
+					t.Fatalf("Failed to create NEG: %v", err)
+				}
+			}
+
+			negClient := syncer.svcNegClient
+			negRefByZone, err := negObjectReferences(fakeCloud, negv1beta1.ActiveState, sets.NewString(zones...), syncer.NegSyncerKey.NegName)
+			if err != nil {
+				t.Errorf("Failed to get negObjRef from NEG CR: %v", err)
+			}
+			var refs []negv1beta1.NegObjectReference
+			for _, neg := range negRefByZone {
+				refs = append(refs, neg)
+			}
+			origCR := createNegCR(negName, v1.Now(), true, true, refs)
+			initialNegCr, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create test NEG CR: %s", err)
+			}
+			syncer.svcNegLister.Add(initialNegCr)
+
+			if tc.nodeTopologyCr != nil {
+				if err := zonegetter.AddNodeTopologyCR(syncer.zoneGetter, tc.nodeTopologyCr); err != nil {
+					t.Fatalf("Failed to create Node Topology CR: %v", err)
+				}
+			}
+
+			err = syncer.ensureNetworkEndpointGroups()
+
+			if tc.expectError && err == nil {
+				t.Errorf("Got no errors after ensureNetworkEndpointGroupsFromNodeTopology(), expected errors")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Got errors %v after ensureNetworkEndpointGroupsFromNodeTopology(), expected no errors", err)
+			}
+
+			syncedNegCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), negName, v1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get NEG from neg client: %s", err)
+			}
+			if tc.expectNeedToUpdate {
+				if reflect.DeepEqual(initialNegCr.Status, syncedNegCR.Status) {
+					t.Errorf("Detected no updates on NEG CR status after ensureNetworkEndpointGroups(), expected updates:\nNEG CR Status: %v", syncedNegCR.Status)
+				}
+
+				for _, neg := range syncedNegCR.Status.NetworkEndpointGroups {
+					expectedNegSubnetUrl := testSubnetworkURL
+					// If this NEG is not in the default subnets
+					resourceID, err := cloud.ParseResourceURL(neg.SelfLink)
+					if err != nil {
+						t.Fatalf("Failed to parse NEG SelfLink %q: %v", neg.SelfLink, err)
+					}
+					if resourceID.Key.Name != negName {
+						expectedNegSubnetUrl = additionalTestSubnetworkURL
+					}
+					if neg.SubnetURL != expectedNegSubnetUrl {
+						t.Errorf("For neg %q, got subnet URL = %q, expected %q", neg.SelfLink, neg.SubnetURL, expectedNegSubnetUrl)
+					}
+				}
+
+			} else {
+				if !reflect.DeepEqual(initialNegCr.Status, syncedNegCR.Status) {
+					t.Errorf("Detected updates on NEG CR status after ensureNetworkEndpointGroups(), expected no updates:\nbefore %+v,\n after %+v", initialNegCr.Status, syncedNegCR.Status)
+				}
+			}
+		})
 	}
 }
 
@@ -1656,7 +1850,7 @@ func TestIsZoneChange(t *testing.T) {
 					Subnetwork:          fakeCloud.SubnetworkURL(),
 				}, zone, klog.TODO())
 			}
-			negRefMap, err := negObjectReferences(fakeCloud, negv1beta1.ActiveState, sets.NewString(origZones...))
+			negRefMap, err := negObjectReferences(fakeCloud, negv1beta1.ActiveState, sets.NewString(origZones...), syncer.NegSyncerKey.NegName)
 			if err != nil {
 				t.Errorf("Failed to get negObjRef from NEG CR: %v", err)
 			}
@@ -2430,6 +2624,73 @@ func TestCollectLabelStats(t *testing.T) {
 	}
 }
 
+func TestGetNonDefaultSubnetName(t *testing.T) {
+	t.Parallel()
+	vals := gce.DefaultTestClusterValues()
+	vals.SubnetworkURL = defaultTestSubnetURL
+	fakeGCE := gce.NewFakeGCECloud(vals)
+	negtypes.MockNetworkEndpointAPIs(fakeGCE)
+	fakeCloud := negtypes.NewAdapter(fakeGCE)
+	testNegTypes := []negtypes.NetworkEndpointType{
+		negtypes.VmIpEndpointType,
+		negtypes.VmIpPortEndpointType,
+	}
+
+	testCases := []struct {
+		desc              string
+		customNEGName     string
+		expectedL4NegName string
+		expectedL7NegName string
+		expectError       bool
+	}{
+		{
+			desc:              "auto-generated NEG name",
+			expectedL4NegName: "k8s1-clusteri-test-ns-test-name-0-cc51aa-8a665f6c",
+			expectedL7NegName: "k8s1-clusteri-test-ns-test-name-80-cc51aa-137ee03a",
+			expectError:       false,
+		},
+		{
+			desc:              "custom NEG name not exceeding character limit",
+			customNEGName:     "custom-neg",
+			expectedL4NegName: "custom-neg-cc51aa",
+			expectedL7NegName: "custom-neg-cc51aa",
+			expectError:       false,
+		},
+		{
+			desc:          " custom NEG name exceeding character limit",
+			customNEGName: "012345678901234567890123456789012345678901234567890123456", // 57 characters
+			expectError:   true,
+		},
+	}
+
+	for _, testNegType := range testNegTypes {
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				_, syncer := newTestTransactionSyncer(fakeCloud, testNegType, tc.customNEGName != "")
+				if tc.customNEGName != "" {
+					syncer.NegSyncerKey.NegName = tc.customNEGName
+				}
+				got, err := syncer.getNonDefaultSubnetName(additionalTestSubnet)
+				t.Logf("NEG name: %q, custom Name: %v", syncer.NegSyncerKey.NegName, syncer.customName)
+				if err == nil && tc.expectError {
+					t.Errorf("For NEG type %q, got err == nil, expected err != nil", testNegType)
+				}
+				if err != nil && !tc.expectError {
+					t.Errorf("For NEG type %q, got err = %v, expected err == nil", testNegType, err)
+				}
+				if !tc.expectError {
+					if testNegType == negtypes.VmIpEndpointType && got != tc.expectedL4NegName {
+						t.Errorf("For NEG type %q, got NEG name %q, expected %q", testNegType, got, tc.expectedL4NegName)
+					}
+					if testNegType == negtypes.VmIpPortEndpointType && got != tc.expectedL7NegName {
+						t.Errorf("For NEG type %q, got NEG name %q, expected %q", testNegType, got, tc.expectedL7NegName)
+					}
+				}
+			})
+		}
+	}
+}
+
 func newTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, negType negtypes.NetworkEndpointType, customName bool) (negtypes.NegSyncer, *transactionSyncer) {
 	testContext := negtypes.NewTestContext()
 	svcPort := negtypes.NegSyncerKey{
@@ -2619,10 +2880,10 @@ func waitForTransactions(syncer *transactionSyncer) error {
 }
 
 // negObjectReferences returns objectReferences for NEG CRs from NEG Objects
-func negObjectReferences(cloud negtypes.NetworkEndpointGroupCloud, state negv1beta1.NegState, zones sets.String) (map[string]negv1beta1.NegObjectReference, error) {
+func negObjectReferences(cloud negtypes.NetworkEndpointGroupCloud, state negv1beta1.NegState, zones sets.String, negName string) (map[string]negv1beta1.NegObjectReference, error) {
 	negObjs := make(map[string]negv1beta1.NegObjectReference)
 	for zone := range zones {
-		neg, err := cloud.GetNetworkEndpointGroup(testNegName, zone, meta.VersionGA, klog.TODO())
+		neg, err := cloud.GetNetworkEndpointGroup(negName, zone, meta.VersionGA, klog.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -2752,14 +3013,14 @@ func checkNegCR(t *testing.T, negCR *negv1beta1.ServiceNetworkEndpointGroup, pre
 	expectedNegRefs := make(map[string]negv1beta1.NegObjectReference)
 
 	if expectPopulatedNegRefs {
-		ret, err := negObjectReferences(cloud, negv1beta1.ActiveState, activeZones)
+		ret, err := negObjectReferences(cloud, negv1beta1.ActiveState, activeZones, negCR.Name)
 		if err != nil {
 			t.Fatalf("Failed to get negObjRef: %v", err)
 		}
 		for k, v := range ret {
 			expectedNegRefs[k] = v
 		}
-		ret, err = negObjectReferences(cloud, negv1beta1.InactiveState, inactiveZones)
+		ret, err = negObjectReferences(cloud, negv1beta1.InactiveState, inactiveZones, negCR.Name)
 		if err != nil {
 			t.Fatalf("Failed to get negObjRef: %v", err)
 		}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 
 func TestEncodeDecodeEndpoint(t *testing.T) {
 	ip := "10.0.0.10"

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -495,7 +495,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
 	testEndpointSlice := getDefaultEndpointSlices()
 	addPodsToLister(podLister, testEndpointSlice)
@@ -749,7 +749,7 @@ func TestIpsForPod(t *testing.T) {
 func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	negCloud := negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	negName := "test-neg-name"
 	irrelevantNegName := "irrelevant"
@@ -1572,7 +1572,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
 	addPodsToLister(podLister, getDefaultEndpointSlices())
@@ -1802,7 +1802,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, false)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, false)
 
 	// Add the pod that corresponds to empty zone instance.
 	podLister.Add(&v1.Pod{
@@ -2438,7 +2438,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, true)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, defaultTestSubnetURL, true)
+	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, true)
 
 	// Add defaultSubnetLabelPod that corresponds to defaultSubnetLabelInstance.
 	podLister.Add(&v1.Pod{

--- a/pkg/neg/types/fakes.go
+++ b/pkg/neg/types/fakes.go
@@ -201,7 +201,7 @@ func (f *FakeNetworkEndpointGroupCloud) SubnetworkURL() string {
 }
 
 func (f *FakeNetworkEndpointGroupCloud) NetworkProjectID() string {
-	return "test-network-project-id"
+	return "mock-project"
 }
 
 func (f *FakeNetworkEndpointGroupCloud) Region() string {

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -43,6 +43,7 @@ type NetworkEndpointGroupCloud interface {
 // NetworkEndpointGroupNamer is an interface for generating network endpoint group name.
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
+	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
 	IsNEG(name string) bool
 }
 

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
 )
 
@@ -43,9 +44,8 @@ type NetworkEndpointGroupCloud interface {
 // NetworkEndpointGroupNamer is an interface for generating network endpoint group name.
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
-	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
-	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)
 	IsNEG(name string) bool
+	namer.NonDefaultSubnetNEGNamer
 }
 
 // NegSyncer is an interface to interact with syncer

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -44,6 +44,7 @@ type NetworkEndpointGroupCloud interface {
 type NetworkEndpointGroupNamer interface {
 	NEG(namespace, name string, port int32) string
 	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
+	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)
 	IsNEG(name string) bool
 }
 

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -69,6 +69,8 @@ const (
 	// L4LBTypes are used to mark what type of LB the calculator is determinig endpoints for.
 	L4InternalLB = L4LBType("INTERNAL")
 	L4ExternalLB = L4LBType("EXTERNAL")
+
+	MaxDefaultSubnetNegNameLength = 56
 )
 
 // SvcPortTuple is the tuple representing one service port

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -760,7 +760,7 @@ func TestNodePredicateForEndpointCalculatorMode(t *testing.T) {
 			predicate := NodeFilterForEndpointCalculatorMode(tc.epCalculatorMode)
 			nodeInformer := zonegetter.FakeNodeInformer()
 			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-			zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+			zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 			zones, err := zoneGetter.ListZones(predicate, klog.TODO())
 			if err != nil {
 				t.Errorf("Failed listing zones with predicate, err - %v", err)

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -43,6 +43,10 @@ func (*negNamer) IsNEG(name string) bool {
 	return false
 }
 
+func (*negNamer) NonDefaultSubnetNEG(namespace, name, subnetName string, svcPort int32) string {
+	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, svcPort, subnetName)
+}
+
 func TestPortInfoMapMerge(t *testing.T) {
 	namer := &negNamer{}
 	namespace := "namespace"

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/default"
+const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
 
 type negNamer struct{}
 
@@ -45,6 +45,10 @@ func (*negNamer) IsNEG(name string) bool {
 
 func (*negNamer) NonDefaultSubnetNEG(namespace, name, subnetName string, svcPort int32) string {
 	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, svcPort, subnetName)
+}
+
+func (*negNamer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {
+	return fmt.Sprintf("%v-%v", customNEGName, subnetName), nil
 }
 
 func TestPortInfoMapMerge(t *testing.T) {

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -57,6 +57,9 @@ type BackendNamer interface {
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
+	// NonDefaultSubnetNEG returns the gce neg name for NEGs created in non-default
+	// subnet.
+	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
 	// RXLBBackendName returns the Regional External Ingress backend name,
 	// based on the service namespace, name and target port.
 	RXLBBackendName(namespace, name string, port int32) string

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -63,6 +63,9 @@ type BackendNamer interface {
 	// RXLBBackendName returns the Regional External Ingress backend name,
 	// based on the service namespace, name and target port.
 	RXLBBackendName(namespace, name string, port int32) string
+	// NonDefaultSubnetCustomNEG returns the gce neg name for custom NEGs created
+	// in non-default subnets.
+	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)
 	// L4Backend returns the name for L4 LB backend resources, based on the service namespace and name.
 	// It supports ILB with subsetting enabled (VM_IP_NEGs) and NetLB with RBS enabled.
 	// The second output parameter indicates if the namer is supported.

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -52,20 +52,16 @@ type IngressFrontendNamerFactory interface {
 // BackendNamer is an interface to name GCE backend resources. It wraps backend
 // naming policy of namer.Namer.
 type BackendNamer interface {
+	NonDefaultSubnetNEGNamer
+
 	// IGBackend constructs the name for a backend service targeting instance groups.
 	IGBackend(nodePort int64) string
 	// NEG returns the gce neg name based on the service namespace, name
 	// and target port.
 	NEG(namespace, name string, Port int32) string
-	// NonDefaultSubnetNEG returns the gce neg name for NEGs created in non-default
-	// subnet.
-	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
 	// RXLBBackendName returns the Regional External Ingress backend name,
 	// based on the service namespace, name and target port.
 	RXLBBackendName(namespace, name string, port int32) string
-	// NonDefaultSubnetCustomNEG returns the gce neg name for custom NEGs created
-	// in non-default subnets.
-	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)
 	// L4Backend returns the name for L4 LB backend resources, based on the service namespace and name.
 	// It supports ILB with subsetting enabled (VM_IP_NEGs) and NetLB with RBS enabled.
 	// The second output parameter indicates if the namer is supported.
@@ -77,6 +73,15 @@ type BackendNamer interface {
 	// NameBelongsToCluster checks if a given backend resource name is tagged with
 	// this cluster's UID.
 	NameBelongsToCluster(resourceName string) bool
+}
+
+type NonDefaultSubnetNEGNamer interface {
+	// NonDefaultSubnetNEG returns the gce neg name for NEGs created in non-default
+	// subnet.
+	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
+	// NonDefaultSubnetCustomNEG returns the gce neg name for custom NEGs created
+	// in non-default subnets.
+	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)
 }
 
 // V1FrontendNamer wraps frontend naming policy helper functions of namer.Namer.

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -1,6 +1,7 @@
 package namer
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/ingress-gce/pkg/utils/common"
@@ -61,7 +62,7 @@ func (namer *L4Namer) L4Backend(namespace, name string) string {
 	}, "-")
 }
 
-// L4NonDefaultSubnetNEG returns the gce NEG name for L4 NEGs in non default
+// NonDefaultSubnetNEG returns the gce NEG name for L4 NEGs in non default
 // subnet based on the service namespace, name, and subnet name.
 // Naming convention:
 //
@@ -69,7 +70,7 @@ func (namer *L4Namer) L4Backend(namespace, name string) string {
 //
 // subnetHash length = 6, suffix length = 8, and the remainings are trimmed evenly.
 // Output name is at most 63 characters.
-func (namer *L4Namer) L4NonDefaultSubnetNEG(namespace, name, subnetName string) string {
+func (namer *L4Namer) NonDefaultSubnetNEG(namespace, name, subnetName string, _ int32) string {
 	return strings.Join([]string{
 		namer.v2Prefix,
 		namer.v2ClusterUID,
@@ -77,6 +78,13 @@ func (namer *L4Namer) L4NonDefaultSubnetNEG(namespace, name, subnetName string) 
 		subnetHash(subnetName),
 		namer.getClusterSuffix(namespace, name),
 	}, "-")
+}
+
+// NonDefaultSubnetCustomNEG returns the gce neg name in the non-default subnet
+// when the NEG name is a custom one.
+// Custom Name NEG for L4 NEG is not allowed.
+func (n *L4Namer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {
+	return "", fmt.Errorf("Custom NEG is not allowed for L4")
 }
 
 // L4Firewall returns the gce Firewall name based on the service namespace and name

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -118,7 +118,7 @@ func TestL4Namer(t *testing.T) {
 		frName := newNamer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		ipv6FrName := newNamer.L4IPv6ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto))
 		negName := newNamer.L4Backend(tc.namespace, tc.name)
-		nonDefaultNegName := newNamer.L4NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName)
+		nonDefaultNegName := newNamer.NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName, 0) // Port is not used for L4 NEG
 		fwName := newNamer.L4Firewall(tc.namespace, tc.name)
 		ipv6FWName := newNamer.L4IPv6Firewall(tc.namespace, tc.name)
 		hcName := newNamer.L4HealthCheck(tc.namespace, tc.name, tc.sharedHC)

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -490,7 +490,6 @@ func (n *Namer) RXLBBackendName(namespace, name string, port int32) string {
 
 // NonDefaultSubnetCustomNEG returns the gce neg name in the non-default subnet
 // when the NEG name is a custom one.
-// It will be shared between L4 and L7 NEGs.
 func (n *Namer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {
 	if len(customNEGName) > MaxDefaultSubnetNegNameLength {
 		return "", ErrCustomNEGNameTooLong

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -85,7 +85,11 @@ const (
 
 	// Length of the subnet hash for non default subnet NEGs.
 	subnetHashLength = 6
+
+	MaxDefaultSubnetNegNameLength = 56
 )
+
+var ErrCustomNEGNameTooLong = fmt.Errorf("custom NEG name exceeds %v characters limit", MaxDefaultSubnetNegNameLength)
 
 // NamerProtocol is an enum for the different protocols given as
 // parameters to Namer.
@@ -482,6 +486,16 @@ func (n *Namer) RXLBBackendName(namespace, name string, port int32) string {
 	truncName := truncFields[1]
 	truncPort := truncFields[2]
 	return fmt.Sprintf("%s-e-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, negSuffix(n.shortUID(), namespace, name, portStr, ""))
+}
+
+// NonDefaultSubnetCustomNEG returns the gce neg name in the non-default subnet
+// when the NEG name is a custom one.
+// It will be shared between L4 and L7 NEGs.
+func (n *Namer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {
+	if len(customNEGName) > MaxDefaultSubnetNegNameLength {
+		return "", ErrCustomNEGNameTooLong
+	}
+	return fmt.Sprintf("%s-%s", customNEGName, subnetHash(subnetName)), nil
 }
 
 // IsNEG returns true if the name is a NEG owned by this cluster.

--- a/pkg/utils/zonegetter/fake.go
+++ b/pkg/utils/zonegetter/fake.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	nodetopologyfake "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned/fake"
+	informernodetopology "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/informers/externalversions/nodetopology/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,6 +42,10 @@ const (
 
 func FakeNodeInformer() cache.SharedIndexInformer {
 	return informerv1.NewNodeInformer(fake.NewSimpleClientset(), 1*time.Second, utils.NewNamespaceIndexer())
+}
+
+func FakeNodeTopologyInformer() cache.SharedIndexInformer {
+	return informernodetopology.NewNodeTopologyInformer(nodetopologyfake.NewSimpleClientset(), 1*time.Second, utils.NewNamespaceIndexer())
 }
 
 // DeleteFakeNodesInZone deletes all nodes in a zone.

--- a/pkg/utils/zonegetter/fake.go
+++ b/pkg/utils/zonegetter/fake.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	nodetopologyfake "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned/fake"
 	informernodetopology "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/informers/externalversions/nodetopology/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -592,4 +593,13 @@ func PopulateFakeNodeInformer(nodeInformer cache.SharedIndexInformer, addMSCNode
 			fmt.Printf("Failed to add node non-default-subnet-instance: %v\n", err)
 		}
 	}
+}
+
+// AddNodeTopologyCR adds fake node topology CR to the ZoneGetter.
+func AddNodeTopologyCR(zoneGetter *ZoneGetter, nodeTopologyCR *nodetopologyv1.NodeTopology) error {
+	return zoneGetter.nodeTopologyInformer.GetIndexer().Add(nodeTopologyCR)
+}
+
+func SetNodeTopologyHasSynced(zoneGetter *ZoneGetter, f func() bool) {
+	zoneGetter.nodeTopologyHasSynced = f
 }

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/flags"
@@ -73,10 +75,15 @@ type ZoneGetter struct {
 	singleStoredZone string
 
 	// Whether zoneGetter should only list default subnet nodes.
+	// onlyIncludeDefaultSubnetNodes is a static value that only depends on the phase/flags.
 	onlyIncludeDefaultSubnetNodes bool
 
 	// The subnetURL of the cluster's default subnet.
 	defaultSubnetURL string
+
+	// nodeTopologyHasSynced is a function that is evaluated every time to
+	// check if we can trust nodeTopology Informer.
+	nodeTopologyHasSynced func() bool
 }
 
 // ZoneAndSubnetForNode returns the zone and subnet for a given node by looking up providerID.
@@ -110,7 +117,11 @@ func (z *ZoneGetter) ZoneAndSubnetForNode(name string, logger klog.Logger) (stri
 		nodeLogger.Error(err, "Failed to get subnet from node's LabelNodeSubnet")
 		return "", "", err
 	}
-	if z.onlyIncludeDefaultSubnetNodes {
+
+	nodeTopologySynced := z.nodeTopologyHasSynced()
+	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
+		logger.Info("Falling back to only using default subnet when getting subnet for node", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+
 		defaultSubnet, err := utils.KeyName(z.defaultSubnetURL)
 		if err != nil {
 			nodeLogger.Error(err, "Failed to extract default subnet information from URL", "defaultSubnetURL", z.defaultSubnetURL)
@@ -178,6 +189,42 @@ func (z *ZoneGetter) ListZones(filter Filter, logger klog.Logger) ([]string, err
 	return zones.List(), nil
 }
 
+// ListSubnets returns the lists of subnets in the cluster based on the
+// NodeTopology CR.
+// If the CR does not exist or it is not ready, ListSubnets will return only the
+// default subnet.
+func (z *ZoneGetter) ListSubnets(logger klog.Logger) ([]nodetopologyv1.SubnetConfig, error) {
+	nodeTopologyCRName := flags.F.NodeTopologyCRName
+	nodeTopologySynced := z.nodeTopologyHasSynced()
+	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
+		logger.Info("Falling back to only using default subnet when listing subnets", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+
+		// Parse from https://compute.googleapis.com/v1/projects/... to projects/... format.
+		resourceID, err := cloud.ParseResourceURL(z.defaultSubnetURL)
+		if err != nil {
+			logger.Error(err, "Failed to parse defaultSubnetURL", "defaultSubnetURL", z.defaultSubnetURL)
+			return nil, err
+		}
+		defaultSubnetName := resourceID.Key.Name
+		defaultSubnetPath := cloud.RelativeResourceName(resourceID.ProjectID, resourceID.Resource, resourceID.Key)
+		return []nodetopologyv1.SubnetConfig{{Name: defaultSubnetName, SubnetPath: defaultSubnetPath}}, nil
+	}
+
+	n, exists, err := z.nodeTopologyInformer.GetIndexer().GetByKey(nodeTopologyCRName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting node topology CR %s from cache: %w", nodeTopologyCRName, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("node topology CR %s is not in store", nodeTopologyCRName)
+	}
+
+	nodeTopologyCR, ok := n.(*nodetopologyv1.NodeTopology)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast %v to node topology type", n)
+	}
+	return nodeTopologyCR.Status.Subnets, nil
+}
+
 // IsNodeSelectedByFilter checks if the node matches the node filter mode.
 func (z *ZoneGetter) IsNodeSelectedByFilter(node *api_v1.Node, filter Filter, filterLogger klog.Logger) bool {
 	nodeAndFilterLogger := filterLogger.WithValues("nodeName", node.Name)
@@ -195,7 +242,10 @@ func (z *ZoneGetter) IsNodeSelectedByFilter(node *api_v1.Node, filter Filter, fi
 
 // allNodesPredicate selects all nodes.
 func (z *ZoneGetter) allNodesPredicate(node *api_v1.Node, nodeLogger klog.Logger) bool {
-	if z.onlyIncludeDefaultSubnetNodes {
+	nodeTopologySynced := z.nodeTopologyHasSynced()
+	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
+		nodeLogger.Info("Falling back to only using default subnet when listing all nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+
 		isInDefaultSubnet, err := isNodeInDefaultSubnet(node, z.defaultSubnetURL, nodeLogger)
 		if err != nil {
 			nodeLogger.Error(err, "Failed to verify if the node is in default subnet")
@@ -223,7 +273,10 @@ func (z *ZoneGetter) candidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes(
 }
 
 func (z *ZoneGetter) nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes, excludeUpgradingNodes bool, nodeAndFilterLogger klog.Logger) bool {
-	if z.onlyIncludeDefaultSubnetNodes {
+	nodeTopologySynced := z.nodeTopologyHasSynced()
+	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
+		nodeAndFilterLogger.Info("Falling back to only using default subnet when listing nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+
 		isInDefaultSubnet, err := isNodeInDefaultSubnet(node, z.defaultSubnetURL, nodeAndFilterLogger)
 		if err != nil {
 			nodeAndFilterLogger.Error(err, "Failed to verify if the node is in default subnet")
@@ -364,6 +417,9 @@ func NewZoneGetter(nodeInformer, nodeTopologyInformer cache.SharedIndexInformer,
 		nodeTopologyInformer:          nodeTopologyInformer,
 		onlyIncludeDefaultSubnetNodes: flags.F.EnableMultiSubnetCluster && !flags.F.EnableMultiSubnetClusterPhase1,
 		defaultSubnetURL:              defaultSubnetURL,
+		nodeTopologyHasSynced: func() bool {
+			return nodeTopologyInformer != nil && nodeTopologyInformer.HasSynced()
+		},
 	}
 }
 
@@ -375,5 +431,8 @@ func NewFakeZoneGetter(nodeInformer, nodeTopologyInformer cache.SharedIndexInfor
 		nodeTopologyInformer:          nodeTopologyInformer,
 		onlyIncludeDefaultSubnetNodes: onlyIncludeDefaultSubnetNodes,
 		defaultSubnetURL:              defaultSubnetURL,
+		nodeTopologyHasSynced: func() bool {
+			return nodeTopologyInformer != nil && nodeTopologyInformer.HasSynced()
+		},
 	}
 }

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -62,7 +62,8 @@ var providerIDRE = regexp.MustCompile(`^` + "gce" + `://([^/]+)/([^/]+)/([^/]+)$
 
 // ZoneGetter manages lookups for GCE instances to zones.
 type ZoneGetter struct {
-	nodeLister cache.Indexer
+	nodeLister           cache.Indexer
+	nodeTopologyInformer cache.SharedIndexInformer
 	// Mode indicates if the ZoneGetter is in GCP or Non-GCP mode
 	// GCP mode ZoneGetter fetches zones from k8s node resource objects.
 	// Non-GCP mode ZoneGetter always return its one single stored zone
@@ -356,20 +357,22 @@ func NewNonGCPZoneGetter(zone string) *ZoneGetter {
 }
 
 // NewZoneGetter initialize a ZoneGetter in GCP mode.
-func NewZoneGetter(nodeInformer cache.SharedIndexInformer, defaultSubnetURL string) *ZoneGetter {
+func NewZoneGetter(nodeInformer, nodeTopologyInformer cache.SharedIndexInformer, defaultSubnetURL string) *ZoneGetter {
 	return &ZoneGetter{
 		mode:                          GCP,
 		nodeLister:                    nodeInformer.GetIndexer(),
+		nodeTopologyInformer:          nodeTopologyInformer,
 		onlyIncludeDefaultSubnetNodes: flags.F.EnableMultiSubnetCluster && !flags.F.EnableMultiSubnetClusterPhase1,
 		defaultSubnetURL:              defaultSubnetURL,
 	}
 }
 
 // NewFakeZoneGetter initialize a fake ZoneGetter in GCP mode to use in test.
-func NewFakeZoneGetter(nodeInformer cache.SharedIndexInformer, defaultSubnetURL string, onlyIncludeDefaultSubnetNodes bool) *ZoneGetter {
+func NewFakeZoneGetter(nodeInformer, nodeTopologyInformer cache.SharedIndexInformer, defaultSubnetURL string, onlyIncludeDefaultSubnetNodes bool) *ZoneGetter {
 	return &ZoneGetter{
 		mode:                          GCP,
 		nodeLister:                    nodeInformer.GetIndexer(),
+		nodeTopologyInformer:          nodeTopologyInformer,
 		onlyIncludeDefaultSubnetNodes: onlyIncludeDefaultSubnetNodes,
 		defaultSubnetURL:              defaultSubnetURL,
 	}

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -36,7 +36,7 @@ func TestListZones(t *testing.T) {
 
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	testCases := []struct {
 		desc      string
 		filter    Filter
@@ -82,7 +82,7 @@ func TestListZonesMultipleSubnets(t *testing.T) {
 
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, true)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, true)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
 
 	testCases := []struct {
 		desc      string
@@ -126,7 +126,7 @@ func TestListNodes(t *testing.T) {
 
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	testCases := []struct {
 		desc      string
@@ -167,7 +167,7 @@ func TestListNodesMultipleSubnets(t *testing.T) {
 
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, true)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, true)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
 
 	testCases := []struct {
 		desc      string
@@ -203,7 +203,7 @@ func TestListNodesMultipleSubnets(t *testing.T) {
 func TestZoneAndSubnetForNode(t *testing.T) {
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, false)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 
 	testCases := []struct {
 		desc           string
@@ -284,7 +284,7 @@ func TestZoneForNodeMultipleSubnets(t *testing.T) {
 
 	nodeInformer := FakeNodeInformer()
 	PopulateFakeNodeInformer(nodeInformer, true)
-	zoneGetter := NewFakeZoneGetter(nodeInformer, defaultTestSubnetURL, true)
+	zoneGetter := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
 
 	testCases := []struct {
 		desc       string
@@ -488,7 +488,7 @@ func TestNonGCPZoneGetter(t *testing.T) {
 
 func TestIsNodeSelectedByFilter(t *testing.T) {
 	fakeNodeInformer := FakeNodeInformer()
-	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, defaultTestSubnetURL, true)
+	zoneGetter := NewFakeZoneGetter(fakeNodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
 
 	testCases := []struct {
 		node                    apiv1.Node


### PR DESCRIPTION
* Query Node Topology CR for the current set of NEGs in the cluster.
* When ensureNetworkEndpointGroups(), ensure NEGs are properly provisioned in the non-default subnets as well.