### PR TITLE
ILB - if wrong subnet specified mark as user error

### DIFF
--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -677,11 +677,15 @@ func (l4 *L4) getServiceSubnetworkURL(options gce.ILBOptions) (string, error) {
 }
 
 func (l4 *L4) getSubnetworkURLByName(subnetName string) (string, error) {
-	subnetKey, err := l4.CreateKey(subnetName)
+	subnetwork, err := l4.cloud.GetSubnetwork(l4.cloud.Region(), subnetName)
 	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return "", utils.NewInvalidSubnetConfigurationError(l4.cloud.ProjectID(), subnetName)
+		}
 		return "", err
 	}
-	return cloud.SelfLink(meta.VersionGA, l4.cloud.NetworkProjectID(), "subnetworks", subnetKey), nil
+
+	return subnetwork.SelfLink, nil
 }
 
 func (l4 *L4) hasAnnotation(annotationKey string) bool {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -138,6 +138,20 @@ func NewIPConfigurationError(ip, reason string) *IPConfigurationError {
 	return &IPConfigurationError{ip: ip, reason: reason}
 }
 
+// InvalidSubnetConfigurationError is a struct to define error caused by User misconfiguration of Load Balancer's subnet.
+type InvalidSubnetConfigurationError struct {
+	projectName string
+	subnetName  string
+}
+
+func (e *InvalidSubnetConfigurationError) Error() string {
+	return fmt.Sprintf("Subnetwork \"%s\" can't be found for project %s", e.subnetName, e.projectName)
+}
+
+func NewInvalidSubnetConfigurationError(projectName, subnetName string) *InvalidSubnetConfigurationError {
+	return &InvalidSubnetConfigurationError{projectName: projectName, subnetName: subnetName}
+}
+
 // L4LBType indicates if L4 LoadBalancer is Internal or External
 type L4LBType int
 
@@ -243,6 +257,12 @@ func IsIPConfigurationError(err error) bool {
 	return errors.As(err, &ipConfigError)
 }
 
+// IsInvalidSubnetConfigurationError checks if wrapped error is an Invalid Subnet Configuration error.
+func IsInvalidSubnetConfigurationError(err error) bool {
+	var invalidSubnetConfigError *InvalidSubnetConfigurationError
+	return errors.As(err, &invalidSubnetConfigError)
+}
+
 // IsInvalidLoadBalancerSourceRangesSpecError checks if wrapped error is an InvalidLoadBalancerSourceRangesSpecError error.
 func IsInvalidLoadBalancerSourceRangesSpecError(err error) bool {
 	var invalidLoadBalancerSourceRangesSpecError *InvalidLoadBalancerSourceRangesSpecError
@@ -262,6 +282,7 @@ func IsUserError(err error) bool {
 	var userError *UserError
 	return IsNetworkTierError(err) ||
 		IsIPConfigurationError(err) ||
+		IsInvalidSubnetConfigurationError(err) ||
 		IsInvalidLoadBalancerSourceRangesSpecError(err) ||
 		IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
 		IsUnsupportedNetworkTierError(err) ||


### PR DESCRIPTION
If non-existent subnetwork for internal load balancer specified using `networking.gke.io/internal-load-balancer-subnet` annotation mark resulting error as user one