### PR TITLE
MSC - Adjust endpoints_calculator.go L4 code to create endpoints in g…

### DIFF
--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -18,6 +18,7 @@ package syncers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/types"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
@@ -40,16 +42,20 @@ func TestBasicSubset(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node986"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "node25"}},
 	}
+	var nodesWithSubnet []*nodeWithSubnet
+	for _, node := range nodes {
+		nodesWithSubnet = append(nodesWithSubnet, newNodeWithSubnet(node, defaultTestSubnet))
+	}
 	count := 3
-	subset1 := pickSubsetsMinRemovals(nodes, "svc123", count, nil)
+	subset1 := pickSubsetsMinRemovals(nodesWithSubnet, "svc123", count, nil)
 	if len(subset1) < 3 {
 		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset1), subset1)
 	}
-	if !validateSubset(subset1, nodes) {
+	if !validateSubset(subset1, nodesWithSubnet) {
 		t.Errorf("Invalid subset list %v from %v", subset1, nodes)
 	}
-	subset2 := pickSubsetsMinRemovals(nodes, "svc345", count, nil)
-	subset3 := pickSubsetsMinRemovals(nodes, "svc56", count, nil)
+	subset2 := pickSubsetsMinRemovals(nodesWithSubnet, "svc345", count, nil)
+	subset3 := pickSubsetsMinRemovals(nodesWithSubnet, "svc56", count, nil)
 	t.Logf("Subset2 is %s", nodeNames(subset2))
 	t.Logf("Subset3 is %s", nodeNames(subset3))
 	if isIdentical(subset1, subset2) || isIdentical(subset3, subset2) || isIdentical(subset1, subset3) {
@@ -86,7 +92,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		description   string
-		nodesMap      map[string][]*v1.Node
+		nodesMap      map[string][]*nodeWithSubnet
 		svcKey        string
 		subsetLimit   int
 		expectedCount int
@@ -95,7 +101,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 	}{
 		{
 			description: "Total number of nodes > limit(250), some zones have only a couple of nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone3": makeNodes(7, 10),
@@ -107,7 +113,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes > limit(250), 3 zones, some zones have only a couple of nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone4": makeNodes(7, 250),
@@ -118,7 +124,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes > limit(250), all zones have 100 nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 100),
 				"zone2": makeNodes(100, 100),
 				"zone3": makeNodes(200, 100),
@@ -130,7 +136,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes > limit(250), 3 zones, all zones have 100 nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 100),
 				"zone2": makeNodes(100, 100),
 				"zone3": makeNodes(200, 100),
@@ -141,7 +147,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes < limit(250), some have only a couple of nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone3": makeNodes(7, 10),
@@ -154,7 +160,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes < limit(250), all have only a couple of nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone3": makeNodes(7, 3),
@@ -167,7 +173,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes > limit(25), some zones have only a couple of nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone3": makeNodes(7, 10),
@@ -179,7 +185,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 		},
 		{
 			description: "Total number of nodes > limit(25), one zone has no nodes.",
-			nodesMap: map[string][]*v1.Node{
+			nodesMap: map[string][]*nodeWithSubnet{
 				"zone1": makeNodes(1, 1),
 				"zone2": makeNodes(2, 5),
 				"zone3": nil,
@@ -190,27 +196,60 @@ func TestUnevenNodesInZones(t *testing.T) {
 			expectedCount: maxSubsetSizeDefault,
 			expectEmpty:   true,
 		},
+		{
+			description: "Nodes across subnets.",
+			nodesMap: map[string][]*nodeWithSubnet{
+				"zone1": makeNodesInSubnet(1, 1, "sub1"),
+				"zone2": makeNodes(2, 5),
+				"zone3": slices.Concat(makeNodes(7, 2), makeNodesInSubnet(9, 8, "sub2")),
+				"zone4": slices.Concat(makeNodes(17, 3), makeNodesInSubnet(20, 250, "sub1")),
+			},
+			svcKey:        "svc123",
+			subsetLimit:   maxSubsetSizeLocal,
+			expectedCount: maxSubsetSizeLocal,
+		},
+		{
+			description: "Over limit across subnets",
+			nodesMap: map[string][]*nodeWithSubnet{
+				"zone1": slices.Concat(makeNodes(1, 9), makeNodesInSubnet(10, 90, "subnetB")),
+				"zone2": makeNodesInSubnet(100, 100, "subnetB"),
+				"zone3": makeNodesInSubnet(200, 100, "subnetC"),
+				"zone4": slices.Concat(makeNodes(300, 1), makeNodesInSubnet(2, 99, "subnetB")),
+			},
+			svcKey:        "svc123",
+			subsetLimit:   maxSubsetSizeLocal,
+			expectedCount: maxSubsetSizeLocal,
+		},
 	}
+
 	for _, tc := range testCases {
-		subsetMap, err := getSubsetPerZone(tc.nodesMap, tc.subsetLimit, tc.svcKey, nil, klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL})
-		if err != nil {
-			t.Errorf("Failed to get subset for test '%s', err %v", tc.description, err)
-		}
-		if len(subsetMap) != len(tc.nodesMap) {
-			t.Errorf("Not all input zones were included in the subset.  subset map - %v, nodesMap %v, test '%s'",
-				subsetMap, tc.nodesMap, tc.description)
-		}
-		totalSubsetSize := 0
-		for zone, subset := range subsetMap {
-			if subset.Len() == 0 && !tc.expectEmpty {
-				t.Errorf("Got empty subset in zone %s for test '%s'", zone, tc.description)
+		t.Run(tc.description, func(t *testing.T) {
+
+			subsetMap, err := getSubsetPerZone(tc.nodesMap, tc.subsetLimit, tc.svcKey, nil, klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL})
+			if err != nil {
+				t.Errorf("Failed to get subset for test '%s', err %v", tc.description, err)
 			}
-			totalSubsetSize += subset.Len()
-		}
-		if totalSubsetSize != tc.expectedCount {
-			t.Errorf("Expected %d nodes in subset, Got %d for test '%s'", maxSubsetSizeLocal, totalSubsetSize,
-				tc.description)
-		}
+			zones := make(map[string]struct{})
+			for egi, _ := range subsetMap {
+				zones[egi.Zone] = struct{}{}
+			}
+			if len(zones) != len(tc.nodesMap) {
+				t.Errorf("Not all input zones were included in the subset.  subset map - %v, nodesMap %v, test '%s'",
+					subsetMap, tc.nodesMap, tc.description)
+			}
+			totalSubsetSize := 0
+			for zone, _ := range zones {
+				subset := getNetworkEndpointsForZone(zone, subsetMap)
+				if len(subset) == 0 && !tc.expectEmpty {
+					t.Errorf("Got empty subset in zone %s for test '%s'", zone, tc.description)
+				}
+				totalSubsetSize += len(subset)
+			}
+			if totalSubsetSize != tc.expectedCount {
+				t.Errorf("Expected %d nodes in subset, Got %d for test '%s'", maxSubsetSizeLocal, totalSubsetSize,
+					tc.description)
+			}
+		})
 	}
 }
 
@@ -218,7 +257,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		description   string
-		nodesMap      map[string][]*v1.Node
+		nodesMap      map[string][]*nodeWithSubnet
 		svcKey        string
 		expectedCount int
 		// expectEmpty indicates that some zones can have empty subsets
@@ -228,10 +267,10 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 	}{
 		{
 			description: "Default network, gets primary interface",
-			nodesMap: map[string][]*v1.Node{
-				"zone1": {makeNodeWithNetwork(t, "n1_1", map[string]string{"net1": "172.168.1.1"}), makeNodeWithNetwork(t, "n1_2", map[string]string{"net1": "172.168.1.2", "net2": "192.168.1.2"})},
-				"zone2": {makeNodeWithNetwork(t, "n2_1", map[string]string{"net1": "172.168.2.1"}), makeNodeWithNetwork(t, "n2_2", map[string]string{"net1": "172.168.2.2"})},
-				"zone3": {makeNodeWithNetwork(t, "n3_1", map[string]string{"net1": "172.168.3.1", "net2": "192.168.3.1"})},
+			nodesMap: map[string][]*nodeWithSubnet{
+				"zone1": {makeNodeWithNetwork(t, "n1_1", "zone1", map[string]string{"net1": "172.168.1.1"}), makeNodeWithNetwork(t, "n1_2", "zone1", map[string]string{"net1": "172.168.1.2", "net2": "192.168.1.2"})},
+				"zone2": {makeNodeWithNetwork(t, "n2_1", "zone2", map[string]string{"net1": "172.168.2.1"}), makeNodeWithNetwork(t, "n2_2", "zone2", map[string]string{"net1": "172.168.2.2"})},
+				"zone3": {makeNodeWithNetwork(t, "n3_1", "zone3", map[string]string{"net1": "172.168.3.1", "net2": "192.168.3.1"})},
 			},
 			svcKey: "svc123",
 			networkInfo: network.NetworkInfo{
@@ -246,10 +285,10 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 		},
 		{
 			description: "non-default network IPs",
-			nodesMap: map[string][]*v1.Node{
-				"zone1": {makeNodeWithNetwork(t, "n1_1", map[string]string{"net1": "172.168.1.1"}), makeNodeWithNetwork(t, "n1_2", map[string]string{"net2": "192.168.1.2", "net1": "172.168.1.2"})},
-				"zone2": {makeNodeWithNetwork(t, "n2_1", map[string]string{"net1": "172.168.2.1"}), makeNodeWithNetwork(t, "n2_2", map[string]string{"net1": "172.168.2.2"})},
-				"zone3": {makeNodeWithNetwork(t, "n3_1", map[string]string{"net1": "172.168.3.1", "net2": "192.168.3.1"})},
+			nodesMap: map[string][]*nodeWithSubnet{
+				"zone1": {makeNodeWithNetwork(t, "n1_1", "zone1", map[string]string{"net1": "172.168.1.1"}), makeNodeWithNetwork(t, "n1_2", "zone1", map[string]string{"net2": "192.168.1.2", "net1": "172.168.1.2"})},
+				"zone2": {makeNodeWithNetwork(t, "n2_1", "zone2", map[string]string{"net1": "172.168.2.1"}), makeNodeWithNetwork(t, "n2_2", "zone2", map[string]string{"net1": "172.168.2.2"})},
+				"zone3": {makeNodeWithNetwork(t, "n3_1", "zone3", map[string]string{"net1": "172.168.3.1", "net2": "192.168.3.1"})},
 			},
 			svcKey: "svc123",
 			networkInfo: network.NetworkInfo{
@@ -270,11 +309,11 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to get subset for test '%s', err %v", tc.description, err)
 			}
-			for zone, wantNodesAndIPs := range tc.expectedNodesMap {
+			for zoneAndSubnet, wantNodesAndIPs := range tc.expectedNodesMap {
 
 				for node, ip := range wantNodesAndIPs {
-					if (!subsetMap[zone].Has(types.NetworkEndpoint{Node: node, IP: ip})) {
-						t.Errorf("node %s in zone %s was supposed to have IP %s but got zone endpoints %+v", node, zone, ip, subsetMap[zone])
+					if (!subsetMap[zoneAndSubnet].Has(types.NetworkEndpoint{Node: node, IP: ip})) {
+						t.Errorf("node %s in zoneAndSubnet %s was supposed to have IP %s but got zoneAndSubnet endpoints %+v", node, zoneAndSubnet, ip, subsetMap[zoneAndSubnet])
 					}
 				}
 			}
@@ -282,10 +321,21 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 	}
 }
 
-func makeNodes(startIndex, count int) []*v1.Node {
-	nodes := []*v1.Node{}
+func makeNodes(startIndex, count int) []*nodeWithSubnet {
+	return makeNodesInSubnet(startIndex, count, defaultTestSubnet)
+}
+
+func makeNodesInSubnet(startIndex, count int, subnet string) []*nodeWithSubnet {
+	var nodes []*nodeWithSubnet
+
 	for i := startIndex; i < startIndex+count; i++ {
-		nodes = append(nodes, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node%d", i)}})
+		n := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("node%d", i),
+				Labels: map[string]string{utils.LabelNodeSubnet: subnet},
+			},
+		}
+		nodes = append(nodes, newNodeWithSubnet(n, subnet))
 	}
 	return nodes
 }
@@ -293,12 +343,20 @@ func makeNodes(startIndex, count int) []*v1.Node {
 // makeNodeWithNetwork creates a node with multi-networking annotations
 // networksAndIPs param should contain a map of network names to the IPs of the interface
 // of that network.
-func makeNodeWithNetwork(t *testing.T, name string, networksAndIPs map[string]string) *v1.Node {
+func makeNodeWithNetwork(t *testing.T, name string, zone string, networksAndIPs map[string]string) *nodeWithSubnet {
 	t.Helper()
+	var providerID string
+	if zone != "" {
+		providerID = fmt.Sprintf("gce://testProject/%s/%s", zone, name)
+	}
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: map[string]string{},
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: providerID,
+			PodCIDR:    "10.0.0.0/24",
 		},
 	}
 	var northInterfaces networkv1.NorthInterfacesAnnotation
@@ -316,7 +374,7 @@ func makeNodeWithNetwork(t *testing.T, name string, networksAndIPs map[string]st
 		}
 		node.ObjectMeta.Annotations[networkv1.NorthInterfacesAnnotationKey] = annotation
 	}
-	return node
+	return newNodeWithSubnet(node, defaultTestSubnet)
 }
 
 func TestNoRemovals(t *testing.T) {
@@ -330,7 +388,7 @@ func TestNoRemovals(t *testing.T) {
 	}
 	// nodeName abcd shows up 2nd in the sorted list for the given salt. So picking a subset of 5 will remove one of the
 	// existing nodes.
-	nodes = append(nodes, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node:abcd"}})
+	nodes = append(nodes, newNodeWithSubnet(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node:abcd"}}, defaultTestSubnet))
 	subset2 := pickSubsetsMinRemovals(nodes, "svc123", count, nil)
 	if len(subset2) < 5 {
 		t.Errorf("Expected %d subsets, got only %d - %v", count, len(subset2), subset2)
@@ -340,7 +398,7 @@ func TestNoRemovals(t *testing.T) {
 	}
 	existingEp := []types.NetworkEndpoint{}
 	for _, node := range subset1 {
-		existingEp = append(existingEp, types.NetworkEndpoint{Node: node.Name})
+		existingEp = append(existingEp, types.NetworkEndpoint{Node: node.node.Name})
 	}
 	subset3 := pickSubsetsMinRemovals(nodes, "svc123", count, existingEp)
 	if len(subset3) < 5 {
@@ -351,11 +409,11 @@ func TestNoRemovals(t *testing.T) {
 	}
 }
 
-func validateSubset(subset []*v1.Node, nodes []*v1.Node) bool {
+func validateSubset(subset []*nodeWithSubnet, nodes []*nodeWithSubnet) bool {
 	for _, val := range subset {
 		found := false
 		for _, node := range nodes {
-			if val == node {
+			if val.node == node.node {
 				found = true
 				break
 			}
@@ -367,15 +425,15 @@ func validateSubset(subset []*v1.Node, nodes []*v1.Node) bool {
 	return true
 }
 
-func nodeNames(subset []*v1.Node) string {
+func nodeNames(subset []*nodeWithSubnet) string {
 	names := []string{}
 	for _, n := range subset {
-		names = append(names, n.Name)
+		names = append(names, n.node.Name)
 	}
 	return strings.Join(names, " ")
 }
 
-func isIdentical(subset1, subset2 []*v1.Node) bool {
+func isIdentical(subset1, subset2 []*nodeWithSubnet) bool {
 	foundCount := 0
 	if len(subset1) != len(subset2) {
 		return false
@@ -383,7 +441,7 @@ func isIdentical(subset1, subset2 []*v1.Node) bool {
 	for _, node1 := range subset1 {
 		found := false
 		for _, node2 := range subset2 {
-			if node1 == node2 {
+			if node1.node == node2.node {
 				found = true
 				break
 			}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -71,7 +71,9 @@ const (
 	testUnreadyInstance1 = "unready-instance1"
 	testUnreadyInstance2 = "unready-instance2"
 
-	defaultTestSubnet = "default"
+	defaultTestSubnet    = "default"
+	secondaryTestSubnet1 = "secondary1"
+	secondaryTestSubnet2 = "secondary2"
 )
 
 func TestTransactionSyncNetworkEndpoints(t *testing.T) {


### PR DESCRIPTION
…roups per [zone, subnetwork] (or, more specifically, per EndpointGroupInfo).

The code does not prefer any subnetwork when determining subsets, so subsets will be mixed across subnetworks in a zone. Balancing focuses to spread nodes equally across zones but not across subnetworks.