### PR TITLE
Firewall Rules - multi protocol support

### DIFF
--- a/pkg/firewalls/equal.go
+++ b/pkg/firewalls/equal.go
@@ -1,0 +1,84 @@
+package firewalls
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// Equal compares two Firewalls and returns true if they are the same in context of LoadBalancers.
+//
+// It will always compare Allow rules, DestinationRanges, SourceRanges and TargetTags.
+// If skipDescription is set to false it will also compare contents of Description.
+func Equal(a, b *compute.Firewall, skipDescription bool) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case (a == nil && b != nil) || (a != nil && b == nil):
+		return false
+	case !equalAllowRules(a.Allowed, b.Allowed):
+		return false
+	case !utils.EqualStringSets(a.DestinationRanges, b.DestinationRanges):
+		return false
+	case !utils.EqualStringSets(a.SourceRanges, b.SourceRanges):
+		return false
+	case !utils.EqualStringSets(a.TargetTags, b.TargetTags):
+		return false
+	case !skipDescription && a.Description != b.Description:
+		return false
+	default:
+		return true
+	}
+}
+
+// EqualAllowRules compares the FirewallAllowed arrays and returns whether they are equal.
+//
+// Arrays are equal when they expose the same set of ports for each protocol.
+func equalAllowRules(a, b []*compute.FirewallAllowed) bool {
+	am := portsAllowedPerProtocol(a)
+	bm := portsAllowedPerProtocol(b)
+
+	return reflect.DeepEqual(am, bm)
+}
+
+// We list all the ports, since FirewallAllowed allows to specify ranges using strings like 10-13, and this should be equal to 10,11,12,13
+func portsAllowedPerProtocol(a []*compute.FirewallAllowed) map[string]map[int]struct{} {
+	portsOpenForProtocol := make(map[string]map[int]struct{})
+	for _, rule := range a {
+		protocol := strings.ToLower(rule.IPProtocol)
+		if _, ok := portsOpenForProtocol[protocol]; !ok {
+			portsOpenForProtocol[protocol] = make(map[int]struct{})
+		}
+
+		for _, portStr := range rule.Ports {
+			start, end := parsePort(portStr)
+			for i := start; i <= end; i++ {
+				portsOpenForProtocol[protocol][i] = struct{}{}
+			}
+		}
+	}
+	return portsOpenForProtocol
+}
+
+// parsePort returns [start, end] range (inclusive)
+// handles:
+// * single port like "12"
+// * ports range like "12-15"
+func parsePort(p string) (start, end int) {
+	if p == "" {
+		return 0, -1
+	}
+
+	splits := strings.Split(p, "-")
+	if len(splits) == 1 {
+		num, _ := strconv.Atoi(splits[0])
+		return num, num
+	}
+
+	start, _ = strconv.Atoi(splits[0])
+	end, _ = strconv.Atoi(splits[1])
+	return
+}

--- a/pkg/firewalls/equal.go
+++ b/pkg/firewalls/equal.go
@@ -1,6 +1,7 @@
 package firewalls
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -13,39 +14,50 @@ import (
 //
 // It will always compare Allow rules, DestinationRanges, SourceRanges and TargetTags.
 // If skipDescription is set to false it will also compare contents of Description.
-func Equal(a, b *compute.Firewall, skipDescription bool) bool {
+//
+// Returns error when there is a port definition that isn't an int or range (int-int)
+func Equal(a, b *compute.Firewall, skipDescription bool) (bool, error) {
 	switch {
 	case a == nil && b == nil:
-		return true
+		return true, nil
 	case (a == nil && b != nil) || (a != nil && b == nil):
-		return false
-	case !equalAllowRules(a.Allowed, b.Allowed):
-		return false
+		return false, nil
 	case !utils.EqualStringSets(a.DestinationRanges, b.DestinationRanges):
-		return false
+		return false, nil
 	case !utils.EqualStringSets(a.SourceRanges, b.SourceRanges):
-		return false
+		return false, nil
 	case !utils.EqualStringSets(a.TargetTags, b.TargetTags):
-		return false
+		return false, nil
 	case !skipDescription && a.Description != b.Description:
-		return false
+		return false, nil
 	default:
-		return true
+		return equalAllowRules(a.Allowed, b.Allowed)
 	}
 }
 
 // EqualAllowRules compares the FirewallAllowed arrays and returns whether they are equal.
 //
 // Arrays are equal when they expose the same set of ports for each protocol.
-func equalAllowRules(a, b []*compute.FirewallAllowed) bool {
-	am := portsAllowedPerProtocol(a)
-	bm := portsAllowedPerProtocol(b)
+//
+// Returns error when there is a port definition that isn't an int or range (int-int)
+func equalAllowRules(a, b []*compute.FirewallAllowed) (bool, error) {
+	am, err := portsAllowedPerProtocol(a)
+	if err != nil {
+		return false, err
+	}
 
-	return reflect.DeepEqual(am, bm)
+	bm, err := portsAllowedPerProtocol(b)
+	if err != nil {
+		return false, err
+	}
+
+	return reflect.DeepEqual(am, bm), nil
 }
 
 // We list all the ports, since FirewallAllowed allows to specify ranges using strings like 10-13, and this should be equal to 10,11,12,13
-func portsAllowedPerProtocol(a []*compute.FirewallAllowed) map[string]map[int]struct{} {
+//
+// Returns error when there is a port definition that isn't an int or range (int-int)
+func portsAllowedPerProtocol(a []*compute.FirewallAllowed) (map[string]map[int]struct{}, error) {
 	portsOpenForProtocol := make(map[string]map[int]struct{})
 	for _, rule := range a {
 		protocol := strings.ToLower(rule.IPProtocol)
@@ -54,31 +66,46 @@ func portsAllowedPerProtocol(a []*compute.FirewallAllowed) map[string]map[int]st
 		}
 
 		for _, portStr := range rule.Ports {
-			start, end := parsePort(portStr)
+			start, end, err := parsePort(portStr)
+			if err != nil {
+				return nil, err
+			}
 			for i := start; i <= end; i++ {
 				portsOpenForProtocol[protocol][i] = struct{}{}
 			}
 		}
 	}
-	return portsOpenForProtocol
+	return portsOpenForProtocol, nil
 }
 
 // parsePort returns [start, end] range (inclusive)
 // handles:
 // * single port like "12"
 // * ports range like "12-15"
-func parsePort(p string) (start, end int) {
+func parsePort(p string) (start, end int, err error) {
 	if p == "" {
-		return 0, -1
+		return 0, -1, fmt.Errorf("failed to parse a port: empty string")
 	}
 
 	splits := strings.Split(p, "-")
 	if len(splits) == 1 {
-		num, _ := strconv.Atoi(splits[0])
-		return num, num
+		num, err := strconv.Atoi(splits[0])
+		if err != nil {
+			return 0, -1, fmt.Errorf("failed to parse a port `%s`: %w", splits[0], err)
+		}
+		return num, num, nil
 	}
 
-	start, _ = strconv.Atoi(splits[0])
-	end, _ = strconv.Atoi(splits[1])
-	return
+	if len(splits) != 2 {
+		return 0, -1, fmt.Errorf("failed to parse a port `%s`: invalid format", p)
+	}
+
+	if start, err = strconv.Atoi(splits[0]); err != nil {
+		return 0, -1, fmt.Errorf("failed to parse a port `%s`: %w", splits[0], err)
+	}
+	if end, err = strconv.Atoi(splits[1]); err != nil {
+		return 0, -1, fmt.Errorf("failed to parse a port `%s`: %w", splits[0], err)
+	}
+
+	return start, end, nil
 }

--- a/pkg/firewalls/equal_test.go
+++ b/pkg/firewalls/equal_test.go
@@ -1,0 +1,275 @@
+package firewalls_test
+
+import (
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+	"k8s.io/ingress-gce/pkg/firewalls"
+)
+
+func TestEqual(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		a               *compute.Firewall
+		b               *compute.Firewall
+		skipDescription bool
+		want            bool
+	}{
+		{
+			desc: "same, complete example",
+			a: &compute.Firewall{
+				Description: "example fw rule",
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+				SourceRanges: []string{
+					"10.1.2.8/29",
+					"10.1.3.8/29",
+				},
+				DestinationRanges: []string{
+					"10.1.2.16/29",
+					"10.1.3.16/29",
+				},
+				TargetTags: []string{"k8s-test"},
+			},
+			b: &compute.Firewall{
+				Description: "example fw rule",
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+				SourceRanges: []string{
+					"10.1.2.8/29",
+					"10.1.3.8/29",
+				},
+				DestinationRanges: []string{
+					"10.1.2.16/29",
+					"10.1.3.16/29",
+				},
+				TargetTags: []string{"k8s-test"},
+			},
+			want: true,
+		},
+		{
+			desc: "nil, nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			desc: "b nil",
+			a:    &compute.Firewall{},
+			b:    nil,
+			want: false,
+		},
+		{
+			desc: "a nil",
+			a:    nil,
+			b:    &compute.Firewall{},
+			want: false,
+		},
+		{
+			desc: "same rules, multi protocol",
+			a: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "345"},
+					},
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			b: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "345"},
+					},
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "same rules, tcp protocol",
+			a: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			b: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "same rules, udp protocol",
+			a: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			b: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123", "321"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "same rules, port ranges",
+			a: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123-125", "321"},
+					},
+				},
+			},
+			b: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"123", "124", "125", "321-321"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "mixed case protocol",
+			a: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "udp",
+						Ports:      []string{"1234"},
+					},
+				},
+			},
+			b: &compute.Firewall{
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "UDP",
+						Ports:      []string{"1234"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			desc: "different source ranges",
+			a: &compute.Firewall{
+				SourceRanges: []string{
+					"11.1.2.8/29",
+				},
+			},
+			b: &compute.Firewall{
+				SourceRanges: []string{
+					"10.1.2.8/29",
+				},
+			},
+			want: false,
+		},
+		{
+			desc: "different source ranges, list",
+			a: &compute.Firewall{
+				SourceRanges: []string{
+					"10.1.2.8/29",
+					"10.1.2.9/29",
+				},
+			},
+			b: &compute.Firewall{
+				SourceRanges: []string{
+					"10.1.2.8/29",
+					"10.1.2.10/29",
+				},
+			},
+			want: false,
+		},
+		{
+			desc: "different destination ranges",
+			a: &compute.Firewall{
+				DestinationRanges: []string{
+					"10.1.2.16/29",
+				},
+			},
+			b: &compute.Firewall{
+				DestinationRanges: []string{
+					"11.1.2.16/29",
+				},
+			},
+			want: false,
+		},
+		{
+			desc: "different destination ranges, list",
+			a: &compute.Firewall{
+				DestinationRanges: []string{
+					"10.1.2.17/29",
+					"10.1.2.16/29",
+				},
+			},
+			b: &compute.Firewall{
+				DestinationRanges: []string{
+					"11.1.2.17/29",
+					"10.1.2.16/29",
+				},
+			},
+			want: false,
+		},
+		{
+			desc: "different descriptions, skipDescription=true",
+			a: &compute.Firewall{
+				Description: "fw rule v0",
+			},
+			b: &compute.Firewall{
+				Description: "fw rule v1",
+			},
+			skipDescription: true,
+			want:            true,
+		},
+		{
+			desc: "different descriptions, skipDescriptions=false",
+			a: &compute.Firewall{
+				Description: "fw rule v0",
+			},
+			b: &compute.Firewall{
+				Description: "fw rule v1",
+			},
+			skipDescription: false,
+			want:            false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := firewalls.Equal(tC.a, tC.b, tC.skipDescription)
+			if got != tC.want {
+				t.Errorf("firewalls.Equal(%v, %v, %v) = %v, want %v", tC.a, tC.b, tC.skipDescription, got, tC.want)
+			}
+		})
+	}
+}

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -81,8 +81,8 @@ func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParam
 	}
 
 	// Don't compare the "description" field for shared firewall rules
-	if Equal(expectedFw, existingFw, sharedRule) {
-		return utils.ResourceResync, nil
+	if eq, err := Equal(expectedFw, existingFw, sharedRule); eq || err != nil {
+		return utils.ResourceResync, err
 	}
 
 	fwLogger.V(2).Info("EnsureL4FirewallRule: patching L4 firewall")

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -17,8 +17,6 @@ limitations under the License.
 package firewalls
 
 import (
-	"strings"
-
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
@@ -36,9 +34,8 @@ type FirewallParams struct {
 	IP                string
 	SourceRanges      []string
 	DestinationRanges []string
-	PortRanges        []string
 	NodeNames         []string
-	Protocol          string
+	Allowed           []*compute.FirewallAllowed
 	L4Type            utils.L4LBType
 	Network           network.NetworkInfo
 }
@@ -59,18 +56,14 @@ func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParam
 	if err != nil {
 		fwLogger.Info("EnsureL4FirewallRule: failed to generate description for L4 rule", "err", err)
 	}
+
 	expectedFw := &compute.Firewall{
 		Name:         params.Name,
 		Description:  fwDesc,
 		Network:      params.Network.NetworkURL,
 		SourceRanges: params.SourceRanges,
 		TargetTags:   nodeTags,
-		Allowed: []*compute.FirewallAllowed{
-			{
-				IPProtocol: strings.ToLower(params.Protocol),
-				Ports:      params.PortRanges,
-			},
-		},
+		Allowed:      params.Allowed,
 	}
 	if flags.F.EnablePinhole {
 		expectedFw.DestinationRanges = params.DestinationRanges
@@ -88,7 +81,7 @@ func EnsureL4FirewallRule(cloud *gce.Cloud, nsName string, params *FirewallParam
 	}
 
 	// Don't compare the "description" field for shared firewall rules
-	if firewallRuleEqual(expectedFw, existingFw, sharedRule) {
+	if Equal(expectedFw, existingFw, sharedRule) {
 		return utils.ResourceResync, nil
 	}
 
@@ -113,39 +106,6 @@ func EnsureL4FirewallRuleDeleted(cloud *gce.Cloud, fwName string, fwLogger klog.
 		return err
 	}
 	return nil
-}
-
-func firewallRuleEqual(a, b *compute.Firewall, skipDescription bool) bool {
-	if len(a.Allowed) != len(b.Allowed) {
-		return false
-	}
-	for i := range a.Allowed {
-		if !allowRulesEqual(a.Allowed[i], b.Allowed[i]) {
-			return false
-		}
-	}
-
-	if !utils.EqualStringSets(a.DestinationRanges, b.DestinationRanges) {
-		return false
-	}
-
-	if !utils.EqualStringSets(a.SourceRanges, b.SourceRanges) {
-		return false
-	}
-
-	if !utils.EqualStringSets(a.TargetTags, b.TargetTags) {
-		return false
-	}
-
-	if !skipDescription && a.Description != b.Description {
-		return false
-	}
-	return true
-}
-
-func allowRulesEqual(a *compute.FirewallAllowed, b *compute.FirewallAllowed) bool {
-	return a.IPProtocol == b.IPProtocol &&
-		utils.EqualStringSets(a.Ports, b.Ports)
 }
 
 func ensureFirewall(svc *v1.Service, shared bool, params *FirewallParams, cloud *gce.Cloud, recorder record.EventRecorder, fwLogger klog.Logger) (utils.ResourceSyncStatus, error) {

--- a/pkg/firewalls/firewalls_l4_test.go
+++ b/pkg/firewalls/firewalls_l4_test.go
@@ -41,11 +41,15 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				DestinationRanges: []string{
 					"10.1.2.16/29",
 				},
-				PortRanges: []string{"8080"},
-				NodeNames:  []string{"k8s-test-node"},
-				Protocol:   "TCP",
-				L4Type:     utils.ILB,
-				Network:    network.NetworkInfo{IsDefault: true},
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"8080"},
+					},
+				},
+				NodeNames: []string{"k8s-test-node"},
+				L4Type:    utils.ILB,
+				Network:   network.NetworkInfo{IsDefault: true},
 			},
 			shared: false,
 			want: &compute.Firewall{
@@ -77,11 +81,15 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				DestinationRanges: []string{
 					"10.1.2.16/29",
 				},
-				PortRanges: []string{"8080"},
-				NodeNames:  []string{"k8s-test-node"},
-				Protocol:   "TCP",
-				L4Type:     utils.ILB,
-				Network:    network.NetworkInfo{IsDefault: true},
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"8080"},
+					},
+				},
+				NodeNames: []string{"k8s-test-node"},
+				L4Type:    utils.ILB,
+				Network:   network.NetworkInfo{IsDefault: true},
 			},
 			shared: false,
 			existingRule: &compute.Firewall{
@@ -125,10 +133,14 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				SourceRanges: []string{
 					"10.1.2.8/29",
 				},
-				PortRanges: []string{"8080"},
-				NodeNames:  []string{"k8s-test-node"},
-				Protocol:   "TCP",
-				L4Type:     utils.ILB,
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "TCP",
+						Ports:      []string{"8080"},
+					},
+				},
+				NodeNames: []string{"k8s-test-node"},
+				L4Type:    utils.ILB,
 				Network: network.NetworkInfo{
 					IsDefault:  false,
 					NetworkURL: "https://www.googleapis.com/compute/v1/projects/test-poject/global/networks/test-vpc",

--- a/pkg/firewalls/firewalls_l4_test.go
+++ b/pkg/firewalls/firewalls_l4_test.go
@@ -62,7 +62,7 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				Description: firewallDescription,
 				Allowed: []*compute.FirewallAllowed{
 					{
-						IPProtocol: "tcp",
+						IPProtocol: "TCP",
 						Ports:      []string{"8080"},
 					},
 				},
@@ -102,7 +102,7 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				Description: firewallDescription,
 				Allowed: []*compute.FirewallAllowed{
 					{
-						IPProtocol: "tcp",
+						IPProtocol: "TCP",
 						Ports:      []string{"8080"},
 					},
 				},
@@ -117,7 +117,7 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				Description: firewallDescription,
 				Allowed: []*compute.FirewallAllowed{
 					{
-						IPProtocol: "tcp",
+						IPProtocol: "TCP",
 						Ports:      []string{"8080"},
 					},
 				},
@@ -157,7 +157,7 @@ func TestEnsureL4FirewallRule(t *testing.T) {
 				Description: firewallDescription,
 				Allowed: []*compute.FirewallAllowed{
 					{
-						IPProtocol: "tcp",
+						IPProtocol: "TCP",
 						Ports:      []string{"8080"},
 					},
 				},

--- a/pkg/healthchecksl4/healthchecksl4_test.go
+++ b/pkg/healthchecksl4/healthchecksl4_test.go
@@ -387,7 +387,6 @@ func TestCompareHealthChecks(t *testing.T) {
 
 // Checks that newL4HealthCheck() returns correct CheckInterval and UnhealthyThreshold
 func TestSharedHealthChecks(t *testing.T) {
-
 	t.Parallel()
 	testCases := []struct {
 		desc                   string
@@ -561,7 +560,7 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 		TargetTags:   []string{"k8s-test"},
 		Allowed: []*compute.FirewallAllowed{
 			{
-				IPProtocol: "tcp",
+				IPProtocol: "TCP",
 				Ports:      []string{"1234"},
 			},
 		},
@@ -574,7 +573,7 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 		TargetTags:   []string{"k8s-test"},
 		Allowed: []*compute.FirewallAllowed{
 			{
-				IPProtocol: "tcp",
+				IPProtocol: "TCP",
 				Ports:      []string{"1234"},
 			},
 		},

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -48,9 +49,7 @@ const (
 		"you need access to this feature please contact Google Cloud support team"
 )
 
-var (
-	noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-)
+var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
 
 // Many of the functions in this file are re-implemented from gce_loadbalancer_internal.go
 // L4 handles the resource creation/deletion/update for a given L4 ILB service.
@@ -132,8 +131,10 @@ func NewL4Handler(params *L4ILBParams, logger klog.Logger) *L4 {
 	}
 	l4.NamespacedName = types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace}
 	l4.backendPool = backends.NewPool(l4.cloud, l4.namer)
-	l4.ServicePort = utils.ServicePort{ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
-		VMIPNEGEnabled: true}
+	l4.ServicePort = utils.ServicePort{
+		ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
+		VMIPNEGEnabled: true,
+	}
 	return l4
 }
 
@@ -149,8 +150,10 @@ func (l4 *L4) getILBOptions() gce.ILBOptions {
 		return gce.ILBOptions{}
 	}
 
-	return gce.ILBOptions{AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
-		SubnetName: annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet()}
+	return gce.ILBOptions{
+		AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
+		SubnetName:        annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet(),
+	}
 }
 
 // EnsureInternalLoadBalancerDeleted performs a cleanup of all GCE resources for the given loadbalancer service.
@@ -646,10 +649,14 @@ func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, resu
 	}
 	// Add firewall rule for ILB traffic to nodes
 	nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:        portRanges,
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: string(protocol),
+				Ports:      portRanges,
+			},
+		},
 		SourceRanges:      ipv4SourceRanges,
 		DestinationRanges: []string{ipAddress},
-		Protocol:          string(protocol),
 		Name:              firewallName,
 		NodeNames:         nodeNames,
 		L4Type:            utils.ILB,

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -986,7 +986,7 @@ func TestEnsureInternalLoadBalancerErrors(t *testing.T) {
 			l4 := NewL4Handler(l4ilbParams, klog.TODO())
 			l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ilbParams.Recorder)
 
-			//lbName :=l4.namer.L4Backend(params.service.Namespace, params.service.Name)
+			// lbName :=l4.namer.L4Backend(params.service.Namespace, params.service.Name)
 			frName := l4.GetFRName()
 			key, err := composite.CreateKey(l4.cloud, frName, meta.Regional)
 			if err != nil {
@@ -1883,7 +1883,7 @@ func TestEnsureIPv4Firewall4Nodes(t *testing.T) {
 	}
 	expectedAllowed := &compute.FirewallAllowed{
 		Ports:      []string{"8080"},
-		IPProtocol: "tcp",
+		IPProtocol: "TCP",
 	}
 	allowed := firewall.Allowed[0]
 	if diff := cmp.Diff(expectedAllowed, allowed); diff != "" {
@@ -1937,7 +1937,7 @@ func TestEnsureIPv6Firewall4Nodes(t *testing.T) {
 	}
 	expectedAllowed := &compute.FirewallAllowed{
 		Ports:      []string{"8080"},
-		IPProtocol: "tcp",
+		IPProtocol: "TCP",
 	}
 	allowed := firewall.Allowed[0]
 	if diff := cmp.Diff(expectedAllowed, allowed); diff != "" {
@@ -2312,7 +2312,6 @@ func TestWeightedILB(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestDisableILBIngressFirewall(t *testing.T) {

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1355,10 +1355,14 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 		Name:              fwName,
 		SourceRanges:      []string{"10.0.0.0/20"},
 		DestinationRanges: []string{"20.0.0.0/20"},
-		PortRanges:        utils.GetPortRanges(tc.Input),
-		NodeNames:         nodeNames,
-		Protocol:          string(v1.ProtocolTCP),
-		IP:                "1.2.3.4",
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: string(v1.ProtocolTCP),
+				Ports:      utils.GetPortRanges(tc.Input),
+			},
+		},
+		NodeNames: nodeNames,
+		IP:        "1.2.3.4",
 	}
 	_, err = firewalls.EnsureL4FirewallRule(l4.cloud, utils.ServiceKeyFunc(svc.Namespace, svc.Name), &fwrParams /*sharedRule = */, false, klog.TODO())
 	if err != nil {

--- a/pkg/loadbalancers/l4ipv6.go
+++ b/pkg/loadbalancers/l4ipv6.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
@@ -147,10 +148,14 @@ func (l4 *L4) ensureIPv6NodesFirewall(ipAddress string, nodeNames []string, resu
 	}
 
 	ipv6nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:        portRanges,
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: string(protocol),
+				Ports:      portRanges,
+			},
+		},
 		SourceRanges:      ipv6SourceRanges,
 		DestinationRanges: []string{ipAddress},
-		Protocol:          string(protocol),
 		Name:              firewallName,
 		NodeNames:         nodeNames,
 		L4Type:            utils.ILB,

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	compute "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -434,10 +435,14 @@ func (l4netlb *L4NetLB) ensureIPv4NodesFirewall(nodeNames []string, ipAddress st
 
 	// Add firewall rule for L4 External LoadBalancer traffic to nodes
 	nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:        portRanges,
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: string(protocol),
+				Ports:      portRanges,
+			},
+		},
 		SourceRanges:      sourceRanges,
 		DestinationRanges: []string{ipAddress},
-		Protocol:          string(protocol),
 		Name:              firewallName,
 		IP:                l4netlb.Service.Spec.LoadBalancerIP,
 		NodeNames:         nodeNames,

--- a/pkg/loadbalancers/l4netlbipv6.go
+++ b/pkg/loadbalancers/l4netlbipv6.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	compute "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/firewalls"
@@ -134,10 +135,14 @@ func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipAddress string, nodeNames []st
 	}
 
 	ipv6nodesFWRParams := firewalls.FirewallParams{
-		PortRanges:        portRanges,
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: string(protocol),
+				Ports:      portRanges,
+			},
+		},
 		SourceRanges:      ipv6SourceRanges,
 		DestinationRanges: []string{ipAddress},
-		Protocol:          string(protocol),
 		Name:              firewallName,
 		NodeNames:         nodeNames,
 		L4Type:            utils.XLB,


### PR DESCRIPTION
Changes the L4 Firewall to allow for the future multi protocol LB feature.

`compute.Firewall` struct allows to pass multiple allow rules of `compute.FirewallAllowed` type. Previously we only used one allow rule per service, but that will change with a multi protocol support feature where we will need to pass one rule for TCP and one for UDP.

There might be issues with casing, as the protocol is either UPPERCASE or lowercase. I want to make sure this doesn't trigger unnecessary updates to GCP, hopefully E2E tests will catch that.