### PR TITLE
Remove unnecessary interfaces in pkg/backends

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -217,7 +217,8 @@ func (p *Pool) Delete(name string, version meta.Version, scope meta.KeyType, beL
 	return nil
 }
 
-// Get the health of a BackendService given its name.
+// Health checks the health of a BackendService given its name.
+// Returns ("HEALTHY", nil) if healthy, otherwise ("Unknown", err)
 func (p *Pool) Health(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) (string, error) {
 	be, err := p.Get(name, version, scope, beLogger)
 	if err != nil {
@@ -288,8 +289,8 @@ func (p *Pool) List(key *meta.Key, version meta.Version, beLogger klog.Logger) (
 	return clusterBackends, nil
 }
 
-// AddSignedUrlKey adds a SignedUrlKey to a BackendService
-func (p *Pool) AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, urlKeyLogger klog.Logger) error {
+// AddSignedURLKey adds a SignedUrlKey to a BackendService
+func (p *Pool) AddSignedURLKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, urlKeyLogger klog.Logger) error {
 	urlKeyLogger.Info("Adding SignedUrlKey")
 
 	scope, err := composite.ScopeFromSelfLink(be.SelfLink)
@@ -307,8 +308,8 @@ func (p *Pool) AddSignedUrlKey(be *composite.BackendService, signedurlkey *compo
 	return nil
 }
 
-// DeleteSignedUrlKey deletes a SignedUrlKey from BackendService
-func (p *Pool) DeleteSignedUrlKey(be *composite.BackendService, keyName string, urlKeyLogger klog.Logger) error {
+// DeleteSignedURLKey deletes a SignedUrlKey from BackendService
+func (p *Pool) DeleteSignedURLKey(be *composite.BackendService, keyName string, urlKeyLogger klog.Logger) error {
 	urlKeyLogger.Info("Deleting SignedUrlKey")
 
 	scope, err := composite.ScopeFromSelfLink(be.SelfLink)

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -49,21 +49,18 @@ const (
 	LocalityLBPolicyMaglev LocalityLBPolicyType = "MAGLEV"
 )
 
-// Backends handles CRUD operations for backends.
-type Backends struct {
+// Pool handles CRUD operations on a pool of GCE Backend Services.
+type Pool struct {
 	cloud                       *gce.Cloud
 	namer                       namer.BackendNamer
 	useConnectionTrackingPolicy bool
 }
 
-// Backends is a Pool.
-var _ Pool = (*Backends)(nil)
-
 // NewPool returns a new backend pool.
 // - cloud: implements BackendServices
 // - namer: produces names for backends.
-func NewPool(cloud *gce.Cloud, namer namer.BackendNamer) *Backends {
-	return &Backends{
+func NewPool(cloud *gce.Cloud, namer namer.BackendNamer) *Pool {
+	return &Pool{
 		cloud: cloud,
 		namer: namer,
 	}
@@ -74,8 +71,8 @@ func NewPool(cloud *gce.Cloud, namer namer.BackendNamer) *Backends {
 // - cloud: implements BackendServices
 // - namer: produces names for backends.
 // - useConnectionTrackingPolicy: specifies the need in Connection Tracking Policy configuration
-func NewPoolWithConnectionTrackingPolicy(cloud *gce.Cloud, namer namer.BackendNamer, useConnectionTrackingPolicy bool) *Backends {
-	return &Backends{
+func NewPoolWithConnectionTrackingPolicy(cloud *gce.Cloud, namer namer.BackendNamer, useConnectionTrackingPolicy bool) *Pool {
+	return &Pool{
 		cloud:                       cloud,
 		namer:                       namer,
 		useConnectionTrackingPolicy: useConnectionTrackingPolicy,
@@ -107,11 +104,11 @@ func ensureDescription(be *composite.BackendService, sp *utils.ServicePort) (nee
 	return true
 }
 
-// Create implements Pool.
-func (b *Backends) Create(sp utils.ServicePort, hcLink string, beLogger klog.Logger) (*composite.BackendService, error) {
+// Create a composite BackendService and returns it.
+func (p *Pool) Create(sp utils.ServicePort, hcLink string, beLogger klog.Logger) (*composite.BackendService, error) {
 	name := sp.BackendName()
 	namedPort := &compute.NamedPort{
-		Name: b.namer.NamedPort(sp.NodePort),
+		Name: p.namer.NamedPort(sp.NodePort),
 		Port: sp.NodePort,
 	}
 
@@ -140,22 +137,22 @@ func (b *Backends) Create(sp utils.ServicePort, hcLink string, beLogger klog.Log
 
 	ensureDescription(be, &sp)
 	scope := features.ScopeFromServicePort(&sp)
-	key, err := composite.CreateKey(b.cloud, name, scope)
+	key, err := composite.CreateKey(p.cloud, name, scope)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := composite.CreateBackendService(b.cloud, key, be, beLogger); err != nil {
+	if err := composite.CreateBackendService(p.cloud, key, be, beLogger); err != nil {
 		return nil, err
 	}
 	// Note: We need to perform a GCE call to re-fetch the object we just created
 	// so that the "Fingerprint" field is filled in. This is needed to update the
 	// object without error.
-	return b.Get(name, version, scope, beLogger)
+	return p.Get(name, version, scope, beLogger)
 }
 
-// Update implements Pool.
-func (b *Backends) Update(be *composite.BackendService, beLogger klog.Logger) error {
+// Update a BackendService given the composite type.
+func (p *Pool) Update(be *composite.BackendService, beLogger klog.Logger) error {
 	// Ensure the backend service has the proper version before updating.
 	be.Version = features.VersionFromDescription(be.Description)
 	scope, err := composite.ScopeFromSelfLink(be.SelfLink)
@@ -163,23 +160,23 @@ func (b *Backends) Update(be *composite.BackendService, beLogger klog.Logger) er
 		return err
 	}
 
-	key, err := composite.CreateKey(b.cloud, be.Name, scope)
+	key, err := composite.CreateKey(p.cloud, be.Name, scope)
 	if err != nil {
 		return err
 	}
-	if err := composite.UpdateBackendService(b.cloud, key, be, beLogger); err != nil {
+	if err := composite.UpdateBackendService(p.cloud, key, be, beLogger); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Get implements Pool.
-func (b *Backends) Get(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) (*composite.BackendService, error) {
-	key, err := composite.CreateKey(b.cloud, name, scope)
+// Get a composite BackendService given a required version.
+func (p *Pool) Get(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) (*composite.BackendService, error) {
+	key, err := composite.CreateKey(p.cloud, name, scope)
 	if err != nil {
 		return nil, err
 	}
-	be, err := composite.GetBackendService(b.cloud, key, version, beLogger)
+	be, err := composite.GetBackendService(p.cloud, key, version, beLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +186,7 @@ func (b *Backends) Get(name string, version meta.Version, scope meta.KeyType, be
 	versionRequired := features.VersionFromDescription(be.Description)
 
 	if features.IsLowerVersion(versionRequired, version) {
-		be, err = composite.GetBackendService(b.cloud, key, versionRequired, beLogger)
+		be, err = composite.GetBackendService(p.cloud, key, versionRequired, beLogger)
 		if err != nil {
 			return nil, err
 		}
@@ -197,16 +194,16 @@ func (b *Backends) Get(name string, version meta.Version, scope meta.KeyType, be
 	return be, nil
 }
 
-// Delete implements Pool.
-func (b *Backends) Delete(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) error {
+// Delete a BackendService given its name.
+func (p *Pool) Delete(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) error {
 	beLogger.Info("Deleting backend service")
 
-	key, err := composite.CreateKey(b.cloud, name, scope)
+	key, err := composite.CreateKey(p.cloud, name, scope)
 	if err != nil {
 		return err
 	}
 	beLogger = beLogger.WithValues("backendKey", key)
-	err = composite.DeleteBackendService(b.cloud, key, version, beLogger)
+	err = composite.DeleteBackendService(p.cloud, key, version, beLogger)
 	if err != nil {
 		if utils.IsHTTPErrorCode(err, http.StatusNotFound) || utils.IsInUsedByError(err) {
 			// key also contains region information.
@@ -220,9 +217,9 @@ func (b *Backends) Delete(name string, version meta.Version, scope meta.KeyType,
 	return nil
 }
 
-// Health implements Pool.
-func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) (string, error) {
-	be, err := b.Get(name, version, scope, beLogger)
+// Get the health of a BackendService given its name.
+func (p *Pool) Health(name string, version meta.Version, scope meta.KeyType, beLogger klog.Logger) (string, error) {
+	be, err := p.Get(name, version, scope, beLogger)
 	if err != nil {
 		return "Unknown", fmt.Errorf("error getting backend service %s: %w", name, err)
 	}
@@ -237,9 +234,9 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType,
 		var hs *compute.BackendServiceGroupHealth
 		switch scope {
 		case meta.Global:
-			hs, err = b.cloud.GetGlobalBackendServiceHealth(name, backend.Group)
+			hs, err = p.cloud.GetGlobalBackendServiceHealth(name, backend.Group)
 		case meta.Regional:
-			hs, err = b.cloud.GetRegionalBackendServiceHealth(name, b.cloud.Region(), backend.Group)
+			hs, err = p.cloud.GetRegionalBackendServiceHealth(name, p.cloud.Region(), backend.Group)
 		default:
 			return "Unknown", fmt.Errorf("invalid scope for Health(): %s", scope)
 		}
@@ -263,14 +260,14 @@ func (b *Backends) Health(name string, version meta.Version, scope meta.KeyType,
 	return ret, nil
 }
 
-// List lists all backends managed by this controller.
-func (b *Backends) List(key *meta.Key, version meta.Version, beLogger klog.Logger) ([]*composite.BackendService, error) {
+// List BackendService names that are managed by this pool.
+func (p *Pool) List(key *meta.Key, version meta.Version, beLogger klog.Logger) ([]*composite.BackendService, error) {
 	// TODO: for consistency with the rest of this sub-package this method
 	// should return a list of backend ports.
 	var backends []*composite.BackendService
 	var err error
 
-	backends, err = composite.ListBackendServices(b.cloud, key, version, beLogger)
+	backends, err = composite.ListBackendServices(p.cloud, key, version, beLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +275,7 @@ func (b *Backends) List(key *meta.Key, version meta.Version, beLogger klog.Logge
 	var clusterBackends []*composite.BackendService
 
 	for _, bs := range backends {
-		if b.namer.NameBelongsToCluster(bs.Name) {
+		if p.namer.NameBelongsToCluster(bs.Name) {
 			scope, err := composite.ScopeFromSelfLink(bs.SelfLink)
 			if err != nil {
 				return nil, err
@@ -292,7 +289,7 @@ func (b *Backends) List(key *meta.Key, version meta.Version, beLogger klog.Logge
 }
 
 // AddSignedUrlKey adds a SignedUrlKey to a BackendService
-func (b *Backends) AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, urlKeyLogger klog.Logger) error {
+func (p *Pool) AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, urlKeyLogger klog.Logger) error {
 	urlKeyLogger.Info("Adding SignedUrlKey")
 
 	scope, err := composite.ScopeFromSelfLink(be.SelfLink)
@@ -300,18 +297,18 @@ func (b *Backends) AddSignedUrlKey(be *composite.BackendService, signedurlkey *c
 		return err
 	}
 
-	key, err := composite.CreateKey(b.cloud, be.Name, scope)
+	key, err := composite.CreateKey(p.cloud, be.Name, scope)
 	if err != nil {
 		return err
 	}
-	if err := composite.AddSignedUrlKey(b.cloud, key, be, signedurlkey, urlKeyLogger); err != nil {
+	if err := composite.AddSignedUrlKey(p.cloud, key, be, signedurlkey, urlKeyLogger); err != nil {
 		return err
 	}
 	return nil
 }
 
 // DeleteSignedUrlKey deletes a SignedUrlKey from BackendService
-func (b *Backends) DeleteSignedUrlKey(be *composite.BackendService, keyName string, urlKeyLogger klog.Logger) error {
+func (p *Pool) DeleteSignedUrlKey(be *composite.BackendService, keyName string, urlKeyLogger klog.Logger) error {
 	urlKeyLogger.Info("Deleting SignedUrlKey")
 
 	scope, err := composite.ScopeFromSelfLink(be.SelfLink)
@@ -319,18 +316,18 @@ func (b *Backends) DeleteSignedUrlKey(be *composite.BackendService, keyName stri
 		return err
 	}
 
-	key, err := composite.CreateKey(b.cloud, be.Name, scope)
+	key, err := composite.CreateKey(p.cloud, be.Name, scope)
 	if err != nil {
 		return err
 	}
-	if err := composite.DeleteSignedUrlKey(b.cloud, key, be, keyName, urlKeyLogger); err != nil {
+	if err := composite.DeleteSignedUrlKey(p.cloud, key, be, keyName, urlKeyLogger); err != nil {
 		return err
 	}
 	return nil
 }
 
 // EnsureL4BackendService creates or updates the backend service with the given name.
-func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogger klog.Logger) (*composite.BackendService, utils.ResourceSyncStatus, error) {
+func (p *Pool) EnsureL4BackendService(params L4BackendServiceParams, beLogger klog.Logger) (*composite.BackendService, utils.ResourceSyncStatus, error) {
 	start := time.Now()
 	beLogger = beLogger.WithValues("L4BackendServiceParams", params)
 	beLogger.V(2).Info("EnsureL4BackendService started")
@@ -340,11 +337,11 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 
 	beLogger.V(2).Info("EnsureL4BackendService: checking existing backend service")
 
-	key, err := composite.CreateKey(b.cloud, params.Name, meta.Regional)
+	key, err := composite.CreateKey(p.cloud, params.Name, meta.Regional)
 	if err != nil {
 		return nil, utils.ResourceResync, err
 	}
-	currentBS, err := composite.GetBackendService(b.cloud, key, meta.VersionGA, beLogger)
+	currentBS, err := composite.GetBackendService(p.cloud, key, meta.VersionGA, beLogger)
 	if err != nil && !utils.IsNotFoundError(err) {
 		return nil, utils.ResourceResync, err
 	}
@@ -364,7 +361,7 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 	}
 
 	// We need this configuration only for Strong Session Affinity feature
-	if b.useConnectionTrackingPolicy {
+	if p.useConnectionTrackingPolicy {
 		beLogger.V(2).Info(fmt.Sprintf("EnsureL4BackendService: using connection tracking policy: %+v", params.ConnectionTrackingPolicy))
 		expectedBS.ConnectionTrackingPolicy = params.ConnectionTrackingPolicy
 	}
@@ -382,7 +379,7 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 	// Create backend service if none was found
 	if currentBS == nil {
 		beLogger.V(2).Info("EnsureL4BackendService: creating backend service")
-		err := composite.CreateBackendService(b.cloud, key, expectedBS, beLogger)
+		err := composite.CreateBackendService(p.cloud, key, expectedBS, beLogger)
 		if err != nil {
 			return nil, utils.ResourceResync, err
 		}
@@ -390,7 +387,7 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 		// We need to perform a GCE call to re-fetch the object we just created
 		// so that the "Fingerprint" field is filled in. This is needed to update the
 		// object without error. The lookup is also needed to populate the selfLink.
-		createdBS, err := composite.GetBackendService(b.cloud, key, meta.VersionGA, beLogger)
+		createdBS, err := composite.GetBackendService(p.cloud, key, meta.VersionGA, beLogger)
 		return createdBS, utils.ResourceUpdate, err
 	} else {
 		// TODO(FelipeYepez) remove this check once LocalityLBPolicyMaglev does not require allow lisiting
@@ -402,7 +399,7 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 		}
 	}
 
-	if backendSvcEqual(expectedBS, currentBS, b.useConnectionTrackingPolicy) {
+	if backendSvcEqual(expectedBS, currentBS, p.useConnectionTrackingPolicy) {
 		beLogger.V(2).Info("EnsureL4BackendService: backend service did not change, skipping update")
 		return currentBS, utils.ResourceResync, nil
 	}
@@ -415,12 +412,12 @@ func (b *Backends) EnsureL4BackendService(params L4BackendServiceParams, beLogge
 	expectedBS.Fingerprint = currentBS.Fingerprint
 	// Copy backends to avoid detaching them during update. This could be replaced with a patch call in the future.
 	expectedBS.Backends = currentBS.Backends
-	if err := composite.UpdateBackendService(b.cloud, key, expectedBS, beLogger); err != nil {
+	if err := composite.UpdateBackendService(p.cloud, key, expectedBS, beLogger); err != nil {
 		return nil, utils.ResourceUpdate, err
 	}
 	beLogger.V(2).Info("EnsureL4BackendService: updated backend service successfully")
 
-	updatedBS, err := composite.GetBackendService(b.cloud, key, meta.VersionGA, beLogger)
+	updatedBS, err := composite.GetBackendService(p.cloud, key, meta.VersionGA, beLogger)
 	return updatedBS, utils.ResourceUpdate, err
 }
 

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -64,7 +64,7 @@ const maxRPS = 1
 // instanceGroupLinker handles linking backends to InstanceGroup's.
 type instanceGroupLinker struct {
 	instancePool instancegroups.Manager
-	backendPool  Pool
+	backendPool  *Pool
 
 	logger klog.Logger
 }
@@ -72,7 +72,7 @@ type instanceGroupLinker struct {
 // instanceGroupLinker is a Linker
 var _ Linker = (*instanceGroupLinker)(nil)
 
-func NewInstanceGroupLinker(instancePool instancegroups.Manager, backendPool Pool, logger klog.Logger) Linker {
+func NewInstanceGroupLinker(instancePool instancegroups.Manager, backendPool *Pool, logger klog.Logger) Linker {
 	return &instanceGroupLinker{
 		instancePool: instancePool,
 		backendPool:  backendPool,

--- a/pkg/backends/ig_linker.go
+++ b/pkg/backends/ig_linker.go
@@ -72,6 +72,7 @@ type instanceGroupLinker struct {
 // instanceGroupLinker is a Linker
 var _ Linker = (*instanceGroupLinker)(nil)
 
+// NewInstanceGroupLinker creates a new instance of Linker
 func NewInstanceGroupLinker(instancePool instancegroups.Manager, backendPool *Pool, logger klog.Logger) Linker {
 	return &instanceGroupLinker{
 		instancePool: instancePool,

--- a/pkg/backends/integration_test.go
+++ b/pkg/backends/integration_test.go
@@ -40,7 +40,7 @@ import (
 type Jig struct {
 	fakeInstancePool instancegroups.Manager
 	linker           Linker
-	syncer           Syncer
+	syncer           *Syncer
 }
 
 func newTestJig(fakeGCE *gce.Cloud) *Jig {
@@ -76,7 +76,7 @@ func newTestJig(fakeGCE *gce.Cloud) *Jig {
 	return &Jig{
 		fakeInstancePool: fakeInstancePool,
 		linker:           NewInstanceGroupLinker(fakeInstancePool, fakeBackendPool, klog.TODO()),
-		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, fakeGCE),
+		syncer:           NewBackendSyncer(fakeBackendPool, fakeHealthChecks, fakeGCE, NewFakeProbeProvider(nil)),
 	}
 }
 

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -31,27 +31,6 @@ type GroupKey struct {
 	Name string
 }
 
-// Pool is an interface to perform CRUD operations on a pool of GCE
-// Backend Services.
-type Pool interface {
-	// Get a composite BackendService given a required version.
-	Get(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (*composite.BackendService, error)
-	// Create a composite BackendService and returns it.
-	Create(sp utils.ServicePort, hcLink string, logger klog.Logger) (*composite.BackendService, error)
-	// Update a BackendService given the composite type.
-	Update(be *composite.BackendService, logger klog.Logger) error
-	// Delete a BackendService given its name.
-	Delete(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) error
-	// Get the health of a BackendService given its name.
-	Health(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (string, error)
-	// Get a list of BackendService names that are managed by this pool.
-	List(key *meta.Key, version meta.Version, logger klog.Logger) ([]*composite.BackendService, error)
-	// Add a SignedUrlKey to a BackendService
-	AddSignedUrlKey(be *composite.BackendService, signedurlkey *composite.SignedUrlKey, logger klog.Logger) error
-	// Deletes a SignedUrlKey from BackendService
-	DeleteSignedUrlKey(be *composite.BackendService, keyName string, logger klog.Logger) error
-}
-
 // Syncer is an interface to sync Kubernetes services to GCE BackendServices.
 type Syncer interface {
 	// Init an implementation of ProbeProvider.

--- a/pkg/backends/interfaces.go
+++ b/pkg/backends/interfaces.go
@@ -31,21 +31,6 @@ type GroupKey struct {
 	Name string
 }
 
-// Syncer is an interface to sync Kubernetes services to GCE BackendServices.
-type Syncer interface {
-	// Init an implementation of ProbeProvider.
-	Init(p ProbeProvider)
-	// Sync a BackendService. Implementations should only create the BackendService
-	// but not its groups.
-	Sync(svcPorts []utils.ServicePort, logger klog.Logger) error
-	// GC garbage collects unused BackendService's
-	GC(svcPorts []utils.ServicePort, logger klog.Logger) error
-	// Status returns the status of a BackendService given its name.
-	Status(name string, version meta.Version, scope meta.KeyType, logger klog.Logger) (string, error)
-	// Shutdown cleans up all BackendService's previously synced.
-	Shutdown() error
-}
-
 // Linker is an interface to link backends with their associated groups.
 type Linker interface {
 	// Link a BackendService to its groups.

--- a/pkg/backends/neg_linker.go
+++ b/pkg/backends/neg_linker.go
@@ -32,7 +32,7 @@ import (
 
 // negLinker handles linking backends to NEG's.
 type negLinker struct {
-	backendPool                    Pool
+	backendPool                    *Pool
 	negGetter                      NEGGetter
 	cloud                          *gce.Cloud
 	svcNegLister                   cache.Indexer
@@ -45,7 +45,7 @@ type negLinker struct {
 var _ Linker = (*negLinker)(nil)
 
 func NewNEGLinker(
-	backendPool Pool,
+	backendPool *Pool,
 	negGetter NEGGetter,
 	cloud *gce.Cloud,
 	svcNegLister cache.Indexer,

--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -32,6 +32,7 @@ type RegionalInstanceGroupLinker struct {
 	logger klog.Logger
 }
 
+// NewRegionalInstanceGroupLinker creates an instance of RegionalInstanceGroupLinker
 func NewRegionalInstanceGroupLinker(instancePool instancegroups.Manager, backendPool *Pool, logger klog.Logger) *RegionalInstanceGroupLinker {
 	return &RegionalInstanceGroupLinker{
 		instancePool: instancePool,

--- a/pkg/backends/regional_ig_linker.go
+++ b/pkg/backends/regional_ig_linker.go
@@ -27,12 +27,12 @@ import (
 // RegionalInstanceGroupLinker handles linking backends to InstanceGroups.
 type RegionalInstanceGroupLinker struct {
 	instancePool instancegroups.Manager
-	backendPool  Pool
+	backendPool  *Pool
 
 	logger klog.Logger
 }
 
-func NewRegionalInstanceGroupLinker(instancePool instancegroups.Manager, backendPool Pool, logger klog.Logger) *RegionalInstanceGroupLinker {
+func NewRegionalInstanceGroupLinker(instancePool instancegroups.Manager, backendPool *Pool, logger klog.Logger) *RegionalInstanceGroupLinker {
 	return &RegionalInstanceGroupLinker{
 		instancePool: instancePool,
 		backendPool:  backendPool,

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -49,7 +49,7 @@ func linkerTestClusterValues() gce.TestClusterValues {
 	}
 }
 
-func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Backends, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
+func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Pool, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 
 	nodeInformer := zonegetter.FakeNodeInformer()
@@ -233,7 +233,7 @@ func TestRegionalUpdateLinkWithRemovedBackends(t *testing.T) {
 	}
 }
 
-func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Backends) {
+func createBackendService(t *testing.T, sp utils.ServicePort, backendPool *Pool) {
 	t.Helper()
 	backendParams := L4BackendServiceParams{
 		Name:                     sp.BackendName(),

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -126,7 +126,7 @@ func (s *Syncer) ensureBackendService(sp utils.ServicePort, ingLogger klog.Logge
 		}
 	}
 
-	if err := s.ensureBackendSignedUrlKeys(sp, be, beLogger); err != nil {
+	if err := s.ensureBackendSignedURLKeys(sp, be, beLogger); err != nil {
 		return err
 	}
 
@@ -143,7 +143,7 @@ func (s *Syncer) ensureBackendService(sp utils.ServicePort, ingLogger klog.Logge
 	return nil
 }
 
-func (s *Syncer) ensureBackendSignedUrlKeys(sp utils.ServicePort, be *composite.BackendService, beLogger klog.Logger) error {
+func (s *Syncer) ensureBackendSignedURLKeys(sp utils.ServicePort, be *composite.BackendService, beLogger klog.Logger) error {
 	existingKeyNames := map[string]bool{}
 	if be.CdnPolicy != nil && be.CdnPolicy.SignedUrlKeyNames != nil {
 		for _, key := range be.CdnPolicy.SignedUrlKeyNames {
@@ -170,7 +170,7 @@ func (s *Syncer) ensureBackendSignedUrlKeys(sp utils.ServicePort, be *composite.
 		urlKeyLogger := beLogger.WithValues("SignedUrlKey", keyName)
 		if !found {
 			urlKeyLogger.Info("Removing SignedUrlKey")
-			if err := s.backendPool.DeleteSignedUrlKey(be, keyName, urlKeyLogger); err != nil {
+			if err := s.backendPool.DeleteSignedURLKey(be, keyName, urlKeyLogger); err != nil {
 				return err
 			}
 		}
@@ -179,7 +179,7 @@ func (s *Syncer) ensureBackendSignedUrlKeys(sp utils.ServicePort, be *composite.
 	for _, key := range newSignedUrlKeys {
 		urlKeyLogger := beLogger.WithValues("SignedUrlKey", key.KeyName)
 		urlKeyLogger.Info("Adding SignedUrlKey")
-		if err := s.backendPool.AddSignedUrlKey(be, key, urlKeyLogger); err != nil {
+		if err := s.backendPool.AddSignedURLKey(be, key, urlKeyLogger); err != nil {
 			return err
 		}
 	}

--- a/pkg/backends/syncer.go
+++ b/pkg/backends/syncer.go
@@ -31,7 +31,7 @@ import (
 
 // backendSyncer manages the lifecycle of backends.
 type backendSyncer struct {
-	backendPool   Pool
+	backendPool   *Pool
 	healthChecker healthchecks.HealthChecker
 	prober        ProbeProvider
 	cloud         *gce.Cloud
@@ -41,9 +41,10 @@ type backendSyncer struct {
 var _ Syncer = (*backendSyncer)(nil)
 
 func NewBackendSyncer(
-	backendPool Pool,
+	backendPool *Pool,
 	healthChecker healthchecks.HealthChecker,
-	cloud *gce.Cloud) Syncer {
+	cloud *gce.Cloud,
+) Syncer {
 	return &backendSyncer{
 		backendPool:   backendPool,
 		healthChecker: healthChecker,
@@ -148,7 +149,6 @@ func (s *backendSyncer) ensureBackendService(sp utils.ServicePort, ingLogger klo
 }
 
 func (s *backendSyncer) ensureBackendSignedUrlKeys(sp utils.ServicePort, be *composite.BackendService, beLogger klog.Logger) error {
-
 	existingKeyNames := map[string]bool{}
 	if be.CdnPolicy != nil && be.CdnPolicy.SignedUrlKeyNames != nil {
 		for _, key := range be.CdnPolicy.SignedUrlKeyNames {

--- a/pkg/backends/syncer_test.go
+++ b/pkg/backends/syncer_test.go
@@ -61,7 +61,7 @@ func newPortset(ports []utils.ServicePort) *portset {
 
 func (p *portset) existingPorts() []utils.ServicePort {
 	var result []utils.ServicePort
-	for sp, _ := range p.existing {
+	for sp := range p.existing {
 		result = append(result, sp)
 	}
 	return result
@@ -94,7 +94,7 @@ func (p *portset) del(ports []utils.ServicePort) error {
 // check() iterates through all and checks that the ports in 'existing' exist in gce, and that those
 // that are not in 'existing' do not exist
 func (p *portset) check(fakeGCE *gce.Cloud) error {
-	for sp, _ := range p.all {
+	for sp := range p.all {
 		_, found := p.existing[sp]
 		beName := sp.BackendName()
 		key, err := composite.CreateKey(fakeGCE, beName, features.ScopeFromServicePort(&sp))
@@ -138,19 +138,18 @@ var (
 	}
 )
 
-func newTestSyncer(fakeGCE *gce.Cloud) *backendSyncer {
+func newTestSyncer(fakeGCE *gce.Cloud) *Syncer {
 	fakeHealthChecks := healthchecks.NewHealthChecker(fakeGCE, "/", defaultBackendSvc, healthchecks.NewFakeRecorderGetter(0), healthchecks.NewFakeServiceGetter(), healthchecks.HealthcheckFlags{})
 
 	fakeBackendPool := NewPool(fakeGCE, defaultNamer)
 
-	syncer := &backendSyncer{
+	probes := map[utils.ServicePort]*api_v1.Probe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS, BackendNamer: defaultNamer}: existingProbe}
+	syncer := &Syncer{
 		backendPool:   fakeBackendPool,
 		healthChecker: fakeHealthChecks,
 		cloud:         fakeGCE,
+		prober:        NewFakeProbeProvider(probes),
 	}
-
-	probes := map[utils.ServicePort]*api_v1.Probe{{NodePort: 443, Protocol: annotations.ProtocolHTTPS, BackendNamer: defaultNamer}: existingProbe}
-	syncer.Init(NewFakeProbeProvider(probes))
 
 	// Add standard hooks for mocking update calls. Each test can set a different update hook if it chooses to.
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockAlphaBackendServices.UpdateHook = mock.UpdateAlphaBackendServiceHook
@@ -470,7 +469,7 @@ func TestSyncQuota(t *testing.T) {
 			quota := len(tc.newPorts)
 
 			// Add hooks to simulate quota changes & errors.
-			insertFunc := func(ctx context.Context, key *meta.Key, beName string) (bool, error) {
+			insertFunc := func(_ context.Context, _ *meta.Key, beName string) (bool, error) {
 				if bsCreated+1 > quota {
 					return true, &googleapi.Error{Code: http.StatusForbidden, Body: beName}
 				}
@@ -599,7 +598,6 @@ func TestEnsureBackendServiceProtocol(t *testing.T) {
 						if needsProtocolUpdate {
 							t.Fatalf("Expected ensureProtocol for the same port to return false, got %v", needsProtocolUpdate)
 						}
-
 					} else {
 						if !needsProtocolUpdate {
 							t.Fatalf("Expected ensureProtocol for updating to a new port to return true, got %v", needsProtocolUpdate)
@@ -643,7 +641,6 @@ func TestEnsureBackendServiceDescription(t *testing.T) {
 						if needsDescriptionUpdate {
 							t.Fatalf("Expected ensureDescription for the same port to return false, got %v", needsDescriptionUpdate)
 						}
-
 					} else {
 						if !needsDescriptionUpdate {
 							t.Fatalf("Expected ensureDescription for updating to a new port to return true, got %v", needsDescriptionUpdate)

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -68,7 +68,7 @@ type L4Controller struct {
 	zoneGetter *zonegetter.ZoneGetter
 	// needed for linking the NEG with the backend service for each ILB service.
 	NegLinker   backends.Linker
-	backendPool *backends.Backends
+	backendPool *backends.Pool
 	namer       namer.L4ResourcesNamer
 	// enqueueTracker tracks the latest time an update was enqueued
 	enqueueTracker utils.TimeTracker

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -70,7 +70,7 @@ type L4NetLBController struct {
 	// syncTracker tracks the latest time an enqueued service was synced
 	syncTracker utils.TimeTracker
 
-	backendPool                 *backends.Backends
+	backendPool                 *backends.Pool
 	instancePool                instancegroups.Manager
 	igLinker                    *backends.RegionalInstanceGroupLinker
 	negLinker                   backends.Linker
@@ -90,7 +90,8 @@ type L4NetLBController struct {
 func NewL4NetLBController(
 	ctx *context.ControllerContext,
 	stopCh <-chan struct{},
-	logger klog.Logger) *L4NetLBController {
+	logger klog.Logger,
+) *L4NetLBController {
 	logger = logger.WithName("L4NetLBController")
 	if ctx.NumL4NetLBWorkers <= 0 {
 		logger.Info("External L4 worker count has not been set, setting to 1")
@@ -448,6 +449,7 @@ func (lc *L4NetLBController) shutdown() {
 	lc.logger.Info("Shutting down l4NetLBController")
 	lc.svcQueue.Shutdown()
 }
+
 func (lc *L4NetLBController) syncWrapper(key string) (err error) {
 	syncTrackingId := rand.Int31()
 	svcLogger := lc.logger.WithValues("serviceKey", key, "syncId", syncTrackingId)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -48,15 +48,13 @@ const (
 		"you need access to this feature please contact Google Cloud support team"
 )
 
-var (
-	noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-)
+var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
 
 // Many of the functions in this file are re-implemented from gce_loadbalancer_internal.go
 // L4 handles the resource creation/deletion/update for a given L4 ILB service.
 type L4 struct {
 	cloud       *gce.Cloud
-	backendPool *backends.Backends
+	backendPool *backends.Pool
 	scope       meta.KeyType
 	namer       namer.L4ResourcesNamer
 	// recorder is used to generate k8s Events.
@@ -132,8 +130,10 @@ func NewL4Handler(params *L4ILBParams, logger klog.Logger) *L4 {
 	}
 	l4.NamespacedName = types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace}
 	l4.backendPool = backends.NewPool(l4.cloud, l4.namer)
-	l4.ServicePort = utils.ServicePort{ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
-		VMIPNEGEnabled: true}
+	l4.ServicePort = utils.ServicePort{
+		ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
+		VMIPNEGEnabled: true,
+	}
 	return l4
 }
 
@@ -149,8 +149,10 @@ func (l4 *L4) getILBOptions() gce.ILBOptions {
 		return gce.ILBOptions{}
 	}
 
-	return gce.ILBOptions{AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
-		SubnetName: annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet()}
+	return gce.ILBOptions{
+		AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
+		SubnetName:        annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet(),
+	}
 }
 
 // EnsureInternalLoadBalancerDeleted performs a cleanup of all GCE resources for the given loadbalancer service.

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -56,7 +56,7 @@ const (
 // L4NetLB handles the resource creation/deletion/update for a given L4 External LoadBalancer service.
 type L4NetLB struct {
 	cloud       *gce.Cloud
-	backendPool *backends.Backends
+	backendPool *backends.Pool
 	scope       meta.KeyType
 	namer       namer.L4ResourcesNamer
 	// recorder is used to generate k8s Events.

--- a/pkg/loadbalancers/l7.go
+++ b/pkg/loadbalancers/l7.go
@@ -41,9 +41,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var (
-	errAllProtocolsDisabled = errors.New("invalid configuration: both HTTP and HTTPS are disabled (kubernetes.io/ingress.allow-http is false and there is no valid TLS configuration); your Ingress will not be able to serve any traffic")
-)
+var errAllProtocolsDisabled = errors.New("invalid configuration: both HTTP and HTTPS are disabled (kubernetes.io/ingress.allow-http is false and there is no valid TLS configuration); your Ingress will not be able to serve any traffic")
 
 // L7RuntimeInfo is info passed to this module from the controller runtime.
 type L7RuntimeInfo struct {
@@ -463,7 +461,7 @@ func (l7 *L7) getFrontendAnnotations(existing map[string]string) map[string]stri
 }
 
 // GetLBAnnotations returns the annotations of an l7. This includes it's current status.
-func GetLBAnnotations(l7 *L7, existing map[string]string, backendSyncer backends.Syncer, ingLogger klog.Logger) (map[string]string, error) {
+func GetLBAnnotations(l7 *L7, existing map[string]string, backendSyncer *backends.Syncer, ingLogger klog.Logger) (map[string]string, error) {
 	backends, err := getBackendNames(l7.um)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As per [Go Wiki](https://go.dev/wiki/CodeReviewComments#interfaces) interfaces should generally belong in the package that uses values of the interface type, not the package that implements these values. In this case there is no real added value of using interfaces instead of concrete types. We can safely remove them and get rid of boilerplate.