### PR TITLE
ILB mixed protocol backend

### DIFF
--- a/pkg/backends/protocol.go
+++ b/pkg/backends/protocol.go
@@ -1,0 +1,63 @@
+package backends
+
+import (
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/composite"
+)
+
+const (
+	L3Protocol = "UNSPECIFIED"
+)
+
+// GetProtocol returns the protocol for the BackendService based on Kubernetes Service port definitions
+// and existing backend service.
+//
+// If the service exists and service protocols match existingBS return that protocol.
+// Otherwise prefer L3.
+//
+// See https://cloud.google.com/load-balancing/docs/internal#forwarding-rule-protocols
+func GetProtocol(svcPorts []api_v1.ServicePort, existingBS *composite.BackendService) string {
+	if doesntExist := existingBS == nil; doesntExist {
+		return L3Protocol
+	}
+
+	if alreadyL3 := existingBS.Protocol == L3Protocol; alreadyL3 {
+		return L3Protocol
+	}
+
+	if len(svcPorts) == 0 {
+		return existingBS.Protocol
+	}
+
+	requiredProtocol := protocolRequiredForService(svcPorts)
+	needsChangeCausingTrafficInterruption := existingBS.Protocol != requiredProtocol
+
+	if needsChangeCausingTrafficInterruption {
+		return L3Protocol
+	}
+
+	// service exists, we don't want to create traffic interruption
+	return requiredProtocol
+}
+
+func protocolRequiredForService(svcPorts []api_v1.ServicePort) string {
+	protocolSet := make(map[api_v1.Protocol]struct{})
+	for _, port := range svcPorts {
+		protocolSet[port.Protocol] = struct{}{}
+	}
+
+	_, okTCP := protocolSet[api_v1.ProtocolTCP]
+	_, okUDP := protocolSet[api_v1.ProtocolUDP]
+
+	switch {
+	case okTCP && okUDP:
+		// L3 Backend service is created with UNSPECIFIED protocol.
+		return L3Protocol
+	case okUDP:
+		return string(api_v1.ProtocolUDP)
+	case okTCP:
+		return string(api_v1.ProtocolTCP)
+	default:
+		return L3Protocol
+	}
+}

--- a/pkg/backends/protocol_test.go
+++ b/pkg/backends/protocol_test.go
@@ -1,0 +1,207 @@
+package backends_test
+
+import (
+	"testing"
+
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/backends"
+	"k8s.io/ingress-gce/pkg/composite"
+)
+
+func TestGetProtocol(t *testing.T) {
+	tcpPort := api_v1.ServicePort{
+		Name:     "TCP Port",
+		Protocol: api_v1.ProtocolTCP,
+	}
+	udpPort := api_v1.ServicePort{
+		Name:     "UDP Port",
+		Protocol: api_v1.ProtocolUDP,
+	}
+	l3BackendService := &composite.BackendService{
+		Protocol: backends.L3Protocol,
+	}
+	tcpBackendService := &composite.BackendService{
+		Protocol: "TCP",
+	}
+	udpBackendService := &composite.BackendService{
+		Protocol: "UDP",
+	}
+
+	testCases := []struct {
+		ports            []api_v1.ServicePort
+		bs               *composite.BackendService
+		expectedProtocol string
+		desc             string
+	}{
+		{
+			ports:            []api_v1.ServicePort{},
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, no ports",
+		},
+		{
+			ports:            nil,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, no ports",
+		},
+		{
+			ports:            nil,
+			bs:               tcpBackendService,
+			expectedProtocol: string(api_v1.ProtocolTCP),
+			desc:             "TCP Backend, no ports",
+		},
+		{
+			ports:            nil,
+			bs:               udpBackendService,
+			expectedProtocol: string(api_v1.ProtocolUDP),
+			desc:             "UDP Backend, no ports",
+		},
+		{
+			ports:            nil,
+			bs:               l3BackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "L3 Backend, no ports",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+			},
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, UDP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+			},
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, TCP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+				tcpPort,
+			},
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, Mixed protocols, first UDP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+				udpPort,
+			},
+			expectedProtocol: backends.L3Protocol,
+			desc:             "No Backend, Mixed protocols, first TCP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+			},
+			bs:               udpBackendService,
+			expectedProtocol: string(api_v1.ProtocolUDP),
+			desc:             "UDP Backend, UDP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+			},
+			bs:               udpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "UDP Backend, TCP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+				tcpPort,
+			},
+			bs:               udpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "UDP Backend, Mixed protocols, first UDP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+				udpPort,
+			},
+			bs:               udpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "UDP Backend, Mixed protocols, first TCP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+			},
+			bs:               tcpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "TCP Backend, UDP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+			},
+			bs:               tcpBackendService,
+			expectedProtocol: string(api_v1.ProtocolTCP),
+			desc:             "TCP Backend, TCP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+				tcpPort,
+			},
+			bs:               tcpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "TCP Backend, Mixed protocols, first UDP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+				udpPort,
+			},
+			bs:               tcpBackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "TCP Backend, Mixed protocols, first TCP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+			},
+			bs:               l3BackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "L3 Backend, UDP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+			},
+			bs:               l3BackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "L3 Backend, TCP protocol only",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				udpPort,
+				tcpPort,
+			},
+			bs:               l3BackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "L3 Backend, Mixed protocols, first UDP",
+		},
+		{
+			ports: []api_v1.ServicePort{
+				tcpPort,
+				udpPort,
+			},
+			bs:               l3BackendService,
+			expectedProtocol: backends.L3Protocol,
+			desc:             "L3 Backend, Mixed protocols, first TCP",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			protocol := backends.GetProtocol(tc.ports, tc.bs)
+
+			if protocol != tc.expectedProtocol {
+				t.Errorf("GetProtocol = %v, want %v", protocol, tc.expectedProtocol)
+			}
+		})
+	}
+}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -147,6 +147,7 @@ type ControllerContextConfig struct {
 	DisableL4LBFirewall           bool
 	EnableL4NetLBNEGs             bool
 	EnableL4NetLBNEGsDefault      bool
+	EnableL4MixedProtocol         bool
 }
 
 // NewControllerContext returns a new shared set of informers.
@@ -164,7 +165,8 @@ func NewControllerContext(
 	clusterNamer *namer.Namer,
 	kubeSystemUID types.UID,
 	config ControllerContextConfig,
-	logger klog.Logger) *ControllerContext {
+	logger klog.Logger,
+) *ControllerContext {
 	logger = logger.WithName("ControllerContext")
 
 	podInformer := informerv1.NewPodInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -288,6 +288,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
+		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -369,6 +370,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
+		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -49,9 +49,7 @@ const (
 		"you need access to this feature please contact Google Cloud support team"
 )
 
-var (
-	noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
-)
+var noConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy = nil
 
 // Many of the functions in this file are re-implemented from gce_loadbalancer_internal.go
 // L4 handles the resource creation/deletion/update for a given L4 ILB service.
@@ -71,6 +69,7 @@ type L4 struct {
 	network                          network.NetworkInfo
 	networkResolver                  network.Resolver
 	enableWeightedLB                 bool
+	enableMixedProtocol              bool
 	disableNodesFirewallProvisioning bool
 	svcLogger                        klog.Logger
 }
@@ -110,6 +109,7 @@ type L4ILBParams struct {
 	NetworkResolver                  network.Resolver
 	EnableWeightedLB                 bool
 	DisableNodesFirewallProvisioning bool
+	EnableMixedProtocol              bool
 }
 
 // NewL4Handler creates a new L4Handler for the given L4 service.
@@ -128,13 +128,16 @@ func NewL4Handler(params *L4ILBParams, logger klog.Logger) *L4 {
 		enableDualStack:                  params.DualStackEnabled,
 		networkResolver:                  params.NetworkResolver,
 		enableWeightedLB:                 params.EnableWeightedLB,
+		enableMixedProtocol:              params.EnableMixedProtocol,
 		disableNodesFirewallProvisioning: params.DisableNodesFirewallProvisioning,
 		svcLogger:                        logger,
 	}
 	l4.NamespacedName = types.NamespacedName{Name: params.Service.Name, Namespace: params.Service.Namespace}
 	l4.backendPool = backends.NewPool(l4.cloud, l4.namer)
-	l4.ServicePort = utils.ServicePort{ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
-		VMIPNEGEnabled: true}
+	l4.ServicePort = utils.ServicePort{
+		ID: utils.ServicePortID{Service: l4.NamespacedName}, BackendNamer: l4.namer,
+		VMIPNEGEnabled: true,
+	}
 	return l4
 }
 
@@ -150,8 +153,10 @@ func (l4 *L4) getILBOptions() gce.ILBOptions {
 		return gce.ILBOptions{}
 	}
 
-	return gce.ILBOptions{AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
-		SubnetName: annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet()}
+	return gce.ILBOptions{
+		AllowGlobalAccess: gce.GetLoadBalancerAnnotationAllowGlobalAccess(l4.Service),
+		SubnetName:        annotations.FromService(l4.Service).GetInternalLoadBalancerAnnotationSubnet(),
+	}
 }
 
 // EnsureInternalLoadBalancerDeleted performs a cleanup of all GCE resources for the given loadbalancer service.
@@ -462,12 +467,15 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 
 	servicePorts := l4.Service.Spec.Ports
-	protocol := utils.GetProtocol(servicePorts)
+	backendProtocol := string(utils.GetProtocol(servicePorts))
+	if l4.enableMixedProtocol {
+		backendProtocol = backends.GetProtocol(servicePorts, existingBS)
+	}
 
 	// if Service protocol changed, we must delete forwarding rule before changing backend service,
 	// otherwise, on updating backend service, google cloud api will return error
-	if existingBS != nil && existingBS.Protocol != string(protocol) {
-		l4.svcLogger.Info("Protocol changed for service", "existingProtocol", existingBS.Protocol, "newProtocol", string(protocol))
+	if existingBS != nil && existingBS.Protocol != backendProtocol {
+		l4.svcLogger.Info("Protocol changed for service", "existingProtocol", existingBS.Protocol, "newProtocol", backendProtocol)
 		if existingIPv4FR != nil {
 			// Delete ipv4 forwarding rule if it exists
 			err = l4.forwardingRules.Delete(existingIPv4FR.Name)
@@ -491,7 +499,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	backendParams := backends.L4BackendServiceParams{
 		Name:                     bsName,
 		HealthCheckLink:          hcLink,
-		Protocol:                 string(protocol),
+		Protocol:                 backendProtocol,
 		SessionAffinity:          string(l4.Service.Spec.SessionAffinity),
 		Scheme:                   string(cloud.SchemeInternal),
 		NamespacedName:           l4.NamespacedName,


### PR DESCRIPTION
This PR allows the controller to create and migrate to L3 controllers. `backends.GetProtocol` will default to L3 protocol unless, there is already an existing service and ports that match the backend. For example if we have a running TCP backend and only services defined in the spec are TCP, it won't change protocol. However if we try to change from TCP to UDP, or mixed we will get L3. Once we are in L3 I don't think there is any reason to go out of it. `pkg/backends/protocol_test.go` contains an exhaustive list of scenarios and expected behavior.

~~In draft until the L4 Mixed Protocol feature flag is merged.~~

Alternative that does not take into account existing services can be found here: https://github.com/kubernetes/ingress-gce/pull/2739