### PR TITLE
Add "SHARED_LOADBALANCER_VIP" to internal addresses

### DIFF
--- a/pkg/address/manager_test.go
+++ b/pkg/address/manager_test.go
@@ -243,6 +243,36 @@ func TestAddressManagerIPv6(t *testing.T) {
 	}
 }
 
+func TestInternalSharedPurpose(t *testing.T) {
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	targetIP := ""
+
+	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
+	_, _, err = mgr.HoldAddress()
+	require.NoError(t, err)
+
+	addr, err := svc.GetRegionAddress(testLBName, vals.Region)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, addr.Purpose, address.PurposeShared)
+}
+
+func TestExternalSharedPurpose(t *testing.T) {
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	targetIP := ""
+
+	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, targetIP, cloud.SchemeExternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
+	_, _, err = mgr.HoldAddress()
+	require.NoError(t, err)
+
+	addr, err := svc.GetRegionAddress(testLBName, vals.Region)
+	require.NoError(t, err)
+
+	assert.Empty(t, addr.Purpose)
+}
+
 func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)


### PR DESCRIPTION
When creating multiple internal forwarding rules for one address we need to use the address with .Purpose = "SHARED_LOADBALANCER_VIP". Otherwise we will receive an `Error syncing load balancer: googleapi: Error 409: IP_IN_USE_BY_ANOTHER_RESOURCE - IP '10.164.0.18' is already being used by another resource` .

