### PR TITLE
Add protocol aware GetPorts function

### DIFF
--- a/pkg/forwardingrules/ports.go
+++ b/pkg/forwardingrules/ports.go
@@ -1,0 +1,31 @@
+package forwardingrules
+
+import (
+	"fmt"
+
+	api_v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// Protocol field is optional.
+	// When it is empty the default is TCP
+	defaultProtocol = api_v1.ProtocolTCP
+)
+
+// GetPorts returns slice of ports for the specified protocol.
+func GetPorts(svcPorts []api_v1.ServicePort, protocol api_v1.Protocol) []string {
+	ports := []string{}
+
+	for _, p := range svcPorts {
+		proto := p.Protocol
+		if proto == "" {
+			proto = defaultProtocol
+		}
+
+		if proto == protocol {
+			ports = append(ports, fmt.Sprint(p.Port))
+		}
+	}
+
+	return ports
+}

--- a/pkg/forwardingrules/ports_test.go
+++ b/pkg/forwardingrules/ports_test.go
@@ -1,0 +1,76 @@
+package forwardingrules_test
+
+import (
+	"fmt"
+	"testing"
+
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+)
+
+func TestGetPorts(t *testing.T) {
+	mixedPorts := []api_v1.ServicePort{
+		{
+			Protocol:   api_v1.ProtocolTCP,
+			Port:       1001,
+			TargetPort: intstr.FromInt(1010),
+		},
+		{
+			Protocol:   api_v1.ProtocolUDP,
+			Port:       1001,
+			TargetPort: intstr.FromString("namedport"),
+		},
+		{
+			Protocol: api_v1.ProtocolTCP,
+			Port:     8080,
+		},
+	}
+
+	defaultProtocolPort := []api_v1.ServicePort{
+		{
+			Name: "default2tcp",
+			Port: 1001,
+		},
+	}
+
+	testCases := []struct {
+		desc         string
+		servicePorts []api_v1.ServicePort
+		protocol     api_v1.Protocol
+		want         []string
+	}{
+		{
+			desc:         "empty",
+			servicePorts: []api_v1.ServicePort{},
+			protocol:     api_v1.ProtocolTCP,
+			want:         []string{},
+		},
+		{
+			desc:         "udp",
+			servicePorts: mixedPorts,
+			protocol:     api_v1.ProtocolUDP,
+			want:         []string{"1001"},
+		},
+		{
+			desc:         "tcp",
+			servicePorts: mixedPorts,
+			protocol:     api_v1.ProtocolTCP,
+			want:         []string{"1001", "8080"},
+		},
+		{
+			desc:         "tcp default",
+			servicePorts: defaultProtocolPort,
+			protocol:     api_v1.ProtocolTCP,
+			want:         []string{"1001"},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := forwardingrules.GetPorts(tC.servicePorts, tC.protocol)
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tC.want) {
+				t.Errorf("GetPorts(_, _) = %v, want %v", got, tC.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Mixed protocol feature cannot rely on existing utils.GetPorts as it returns all ports in the spec, ignoring protocol. 

Part of the https://github.com/kubernetes/ingress-gce/pull/2734