### PR TITLE
Add backends.GetProtocol func for mixed protocol

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -264,6 +264,7 @@ func main() {
 		DisableL4LBFirewall:           flags.F.DisableL4LBFirewall,
 		EnableL4NetLBNEGs:             flags.F.EnableL4NetLBNEG,
 		EnableL4NetLBNEGsDefault:      flags.F.EnableL4NetLBNEGDefault,
+		EnableL4MixedProtocol:         flags.F.EnableL4MixedProtocol,
 	}
 	ctx := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	go app.RunHTTPServer(ctx.HealthCheck, rootLogger)

--- a/pkg/backends/protocol.go
+++ b/pkg/backends/protocol.go
@@ -1,0 +1,44 @@
+package backends
+
+import (
+	api_v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// ProtocolL3 is the value used for Protocol when creating L3 Backend Service
+	ProtocolL3 = "UNSPECIFIED"
+	// ProtocolTCP is the value used for Protocol when creating TCP Backend Service
+	ProtocolTCP = "TCP"
+	// ProtocolUDP is the value used for Protocol when creating UDP Backend Service
+	ProtocolUDP = "UDP"
+)
+
+// GetProtocol returns the protocol for the BackendService based on Kubernetes Service port definitions.
+//
+// See https://cloud.google.com/load-balancing/docs/internal#forwarding-rule-protocols
+func GetProtocol(svcPorts []api_v1.ServicePort) string {
+	protocolSet := make(map[api_v1.Protocol]struct{})
+	for _, port := range svcPorts {
+		protocol := port.Protocol
+		if protocol == "" {
+			// Protocol is optional, defaults to TCP
+			protocol = api_v1.ProtocolTCP
+		}
+		protocolSet[protocol] = struct{}{}
+	}
+
+	_, okTCP := protocolSet[api_v1.ProtocolTCP]
+	_, okUDP := protocolSet[api_v1.ProtocolUDP]
+
+	switch {
+	case okTCP && okUDP:
+		// L3 Backend service is created with UNSPECIFIED protocol.
+		return ProtocolL3
+	case okUDP:
+		return ProtocolUDP
+	case okTCP:
+		return ProtocolTCP
+	default:
+		return ProtocolTCP
+	}
+}

--- a/pkg/backends/protocol_test.go
+++ b/pkg/backends/protocol_test.go
@@ -1,0 +1,75 @@
+package backends_test
+
+import (
+	"testing"
+
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/backends"
+)
+
+func TestGetProtocol(t *testing.T) {
+	tcpPort := api_v1.ServicePort{
+		Protocol: api_v1.ProtocolTCP,
+	}
+	udpPort := api_v1.ServicePort{
+		Protocol: api_v1.ProtocolUDP,
+	}
+	emptyPort := api_v1.ServicePort{}
+
+	testCases := []struct {
+		ports []api_v1.ServicePort
+		want  string
+		desc  string
+	}{
+		{
+			desc:  "no ports",
+			ports: []api_v1.ServicePort{},
+			want:  backends.ProtocolTCP,
+		},
+		{
+			desc:  "udp single",
+			ports: []api_v1.ServicePort{udpPort},
+			want:  backends.ProtocolUDP,
+		},
+		{
+			desc:  "udp multiple",
+			ports: []api_v1.ServicePort{udpPort, udpPort},
+			want:  backends.ProtocolUDP,
+		},
+		{
+			desc:  "tcp single",
+			ports: []api_v1.ServicePort{tcpPort},
+			want:  backends.ProtocolTCP,
+		},
+		{
+			desc:  "tcp multiple",
+			ports: []api_v1.ServicePort{tcpPort, tcpPort},
+			want:  backends.ProtocolTCP,
+		},
+		{
+			desc:  "tcp default",
+			ports: []api_v1.ServicePort{emptyPort},
+			want:  backends.ProtocolTCP,
+		},
+		{
+			desc:  "mixed, udp first",
+			ports: []api_v1.ServicePort{udpPort, tcpPort},
+			want:  backends.ProtocolL3,
+		},
+		{
+			desc:  "mixed, tcp first",
+			ports: []api_v1.ServicePort{tcpPort, udpPort},
+			want:  backends.ProtocolL3,
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := backends.GetProtocol(tC.ports)
+
+			if got != tC.want {
+				t.Errorf("GetProtocol(_) = %v, want %v", got, tC.want)
+			}
+		})
+	}
+}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -147,6 +147,7 @@ type ControllerContextConfig struct {
 	DisableL4LBFirewall           bool
 	EnableL4NetLBNEGs             bool
 	EnableL4NetLBNEGsDefault      bool
+	EnableL4MixedProtocol         bool
 }
 
 // NewControllerContext returns a new shared set of informers.
@@ -164,7 +165,8 @@ func NewControllerContext(
 	clusterNamer *namer.Namer,
 	kubeSystemUID types.UID,
 	config ControllerContextConfig,
-	logger klog.Logger) *ControllerContext {
+	logger klog.Logger,
+) *ControllerContext {
 	logger = logger.WithName("ControllerContext")
 
 	podInformer := informerv1.NewPodInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -288,6 +288,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
+		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -369,6 +370,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
+		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)


### PR DESCRIPTION
Similar to https://github.com/kubernetes/ingress-gce/pull/2733, but this one only looks at the service definitions, for single protocol it won't change anything, so for example TCP will still have TCP backend, but when both TCP and UDP services are used it will use L3 backend service.

