### PR TITLE
Firewall Allowed for NetLB mixed protocol

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -264,6 +264,7 @@ func main() {
 		DisableL4LBFirewall:           flags.F.DisableL4LBFirewall,
 		EnableL4NetLBNEGs:             flags.F.EnableL4NetLBNEG,
 		EnableL4NetLBNEGsDefault:      flags.F.EnableL4NetLBNEGDefault,
+		EnableL4MixedProtocol:         flags.F.EnableL4MixedProtocol,
 	}
 	ctx := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	go app.RunHTTPServer(ctx.HealthCheck, rootLogger)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -147,6 +147,7 @@ type ControllerContextConfig struct {
 	DisableL4LBFirewall           bool
 	EnableL4NetLBNEGs             bool
 	EnableL4NetLBNEGsDefault      bool
+	EnableL4MixedProtocol         bool
 }
 
 // NewControllerContext returns a new shared set of informers.
@@ -164,7 +165,8 @@ func NewControllerContext(
 	clusterNamer *namer.Namer,
 	kubeSystemUID types.UID,
 	config ControllerContextConfig,
-	logger klog.Logger) *ControllerContext {
+	logger klog.Logger,
+) *ControllerContext {
 	logger = logger.WithName("ControllerContext")
 
 	podInformer := informerv1.NewPodInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())

--- a/pkg/firewalls/allowed.go
+++ b/pkg/firewalls/allowed.go
@@ -1,0 +1,26 @@
+package firewalls
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+)
+
+// AllowedForService creates a slice of *compute.FirewallAllowed rules
+// for given Kubernetes Serivice port definitions.
+func AllowedForService(svcPorts []api_v1.ServicePort) []*compute.FirewallAllowed {
+	var allowed []*compute.FirewallAllowed
+	if udpPorts := forwardingrules.GetPorts(svcPorts, api_v1.ProtocolUDP); len(udpPorts) > 0 {
+		allowed = append(allowed, &compute.FirewallAllowed{
+			IPProtocol: "udp",
+			Ports:      udpPorts,
+		})
+	}
+	if tcpPorts := forwardingrules.GetPorts(svcPorts, api_v1.ProtocolTCP); len(tcpPorts) > 0 {
+		allowed = append(allowed, &compute.FirewallAllowed{
+			IPProtocol: "tcp",
+			Ports:      tcpPorts,
+		})
+	}
+	return allowed
+}

--- a/pkg/firewalls/allowed_test.go
+++ b/pkg/firewalls/allowed_test.go
@@ -1,0 +1,105 @@
+package firewalls
+
+import (
+	"testing"
+
+	compute "google.golang.org/api/compute/v1"
+	api_v1 "k8s.io/api/core/v1"
+)
+
+func TestAllowedForService(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		svcPorts []api_v1.ServicePort
+		want     []*compute.FirewallAllowed
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc: "udp only",
+			svcPorts: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     1080,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     8080,
+				},
+			},
+			want: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "udp",
+					Ports:      []string{"1080", "8080"},
+				},
+			},
+		},
+		{
+			desc: "tcp only",
+			svcPorts: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     1080,
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     443,
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     8080,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     8080,
+				},
+			},
+			want: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "udp",
+					Ports:      []string{"1080", "8080"},
+				},
+				{
+					IPProtocol: "tcp",
+					Ports:      []string{"80", "443", "8080"},
+				},
+			},
+		},
+		{
+			desc: "mixed protocol",
+			svcPorts: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     443,
+				},
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     8080,
+				},
+			},
+			want: []*compute.FirewallAllowed{
+				{
+					IPProtocol: "tcp",
+					Ports:      []string{"80", "443", "8080"},
+				},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := AllowedForService(tC.svcPorts)
+			if eq, err := equalAllowRules(got, tC.want); !eq || err != nil {
+				t.Errorf("AllowedForService(_) = %v, want %v", got, tC.want)
+			}
+		})
+	}
+}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -90,7 +90,8 @@ type L4NetLBController struct {
 func NewL4NetLBController(
 	ctx *context.ControllerContext,
 	stopCh <-chan struct{},
-	logger klog.Logger) *L4NetLBController {
+	logger klog.Logger,
+) *L4NetLBController {
 	logger = logger.WithName("L4NetLBController")
 	if ctx.NumL4NetLBWorkers <= 0 {
 		logger.Info("External L4 worker count has not been set, setting to 1")
@@ -448,6 +449,7 @@ func (lc *L4NetLBController) shutdown() {
 	lc.logger.Info("Shutting down l4NetLBController")
 	lc.svcQueue.Shutdown()
 }
+
 func (lc *L4NetLBController) syncWrapper(key string) (err error) {
 	syncTrackingId := rand.Int31()
 	svcLogger := lc.logger.WithValues("serviceKey", key, "syncId", syncTrackingId)
@@ -730,6 +732,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 		StrongSessionAffinityEnabled:     lc.enableStrongSessionAffinity,
 		NetworkResolver:                  lc.networkResolver,
 		EnableWeightedLB:                 lc.ctx.EnableWeightedL4NetLB,
+		EnableMixedProtocol:              lc.ctx.EnableL4MixedProtocol,
 		DisableNodesFirewallProvisioning: lc.ctx.DisableL4LBFirewall,
 	}
 	l4netLB := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)


### PR DESCRIPTION
When specifying multi protocol service NetLB Controller needs to update firewall rules to allow traffic to flow on both TCP and UDP ports. This PR introduces `firewalls.AllowedForService` which adds that functionality, and invokes the function if the EnableL4MixedProtocol flag is enabled.