### PR TITLE
Add L3 forwarding rules annotations and fix transitions

### DIFF
--- a/pkg/annotations/service.go
+++ b/pkg/annotations/service.go
@@ -86,12 +86,18 @@ const (
 	// UDPForwardingRuleKey is the annotation key used by l4 controller to record
 	// GCP UDP forwarding rule name.
 	UDPForwardingRuleKey = ServiceStatusPrefix + "/udp-" + ForwardingRuleResource
+	// L3ForwardingRuleKey is the annotation key used by l4 controller to record
+	// GCP L3_DEFAULT forwarding rule name.
+	L3ForwardingRuleKey = ServiceStatusPrefix + "/l3-" + ForwardingRuleResource
 	// TCPForwardingRuleIPv6Key is the annotation key used by l4 controller to record
 	// GCP IPv6 TCP forwarding rule name.
 	TCPForwardingRuleIPv6Key = TCPForwardingRuleKey + IPv6Suffix
 	// UDPForwardingRuleIPv6Key is the annotation key used by l4 controller to record
 	// GCP IPv6 UDP forwarding rule name.
 	UDPForwardingRuleIPv6Key = UDPForwardingRuleKey + IPv6Suffix
+	// L3ForwardingRuleIPv6Key is the annotation key used by l4 controller to record
+	// GCP IPv6 L3_DEFAULT forwarding rule name.
+	L3ForwardingRuleIPv6Key = L3ForwardingRuleKey + IPv6Suffix
 	// BackendServiceKey is the annotation key used by l4 controller to record
 	// GCP Backend service name.
 	BackendServiceKey = ServiceStatusPrefix + "/" + BackendServiceResource

--- a/pkg/loadbalancers/l4syncresult.go
+++ b/pkg/loadbalancers/l4syncresult.go
@@ -29,6 +29,7 @@ var L4ResourceAnnotationKeys = []string{
 	annotations.BackendServiceKey,
 	annotations.TCPForwardingRuleKey,
 	annotations.UDPForwardingRuleKey,
+	annotations.L3ForwardingRuleKey,
 	annotations.HealthcheckKey,
 	annotations.FirewallRuleKey,
 	annotations.FirewallRuleForHealthcheckKey,
@@ -39,5 +40,6 @@ var l4IPv6ResourceAnnotationKeys = []string{
 	annotations.FirewallRuleForHealthcheckIPv6Key,
 	annotations.TCPForwardingRuleIPv6Key,
 	annotations.UDPForwardingRuleIPv6Key,
+	annotations.L3ForwardingRuleIPv6Key,
 }
 var L4DualStackResourceAnnotationKeys = append(L4ResourceAnnotationKeys, l4IPv6ResourceAnnotationKeys...)


### PR DESCRIPTION
- Adds L3 forwarding rules annotations to the ILB service.
- Adds missing code to use L3 protocol inside `GetFRName()`.
- Updates `getOldIPv4ForwardingRule()` to allow for deletion of L3 Forwarding rules. This isn't behind the feature flag to allow users to delete L3 Forwarding rule even after opting out of  `--enable-l4-mixed-protocol`.

I've tested it manually with various transitions including: from nothing to mixed, mixed to nothing, tcp to mixed to udp to nothing, various port changes while staying in L3. I also created the mixed protocol service when using `--enable-l4-mixed-protocol` and then after disabling the flag I've verified that the service has been recreated based on the first protocol (legacy) while still using the same IP.
