### PR TITLE
Firewall Allowed for ILB mixed protocol

### DIFF
--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -641,6 +641,16 @@ func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, resu
 	servicePorts := l4.Service.Spec.Ports
 	protocol := utils.GetProtocol(servicePorts)
 	portRanges := utils.GetServicePortRanges(servicePorts)
+	allowed := []*compute.FirewallAllowed{
+		{
+			IPProtocol: string(protocol),
+			Ports:      portRanges,
+		},
+	}
+
+	if l4.enableMixedProtocol {
+		allowed = firewalls.AllowedForService(servicePorts)
+	}
 
 	fwLogger := l4.svcLogger.WithValues("firewallName", firewallName)
 	fwLogger.V(2).Info("Ensuring IPv4 nodes firewall for L4 ILB Service", "ipAddress", ipAddress, "protocol", protocol, "len(nodeNames)", len(nodeNames), "portRanges", portRanges)
@@ -656,12 +666,7 @@ func (l4 *L4) ensureIPv4NodesFirewall(nodeNames []string, ipAddress string, resu
 	}
 	// Add firewall rule for ILB traffic to nodes
 	nodesFWRParams := firewalls.FirewallParams{
-		Allowed: []*compute.FirewallAllowed{
-			{
-				IPProtocol: string(protocol),
-				Ports:      portRanges,
-			},
-		},
+		Allowed:           allowed,
 		SourceRanges:      ipv4SourceRanges,
 		DestinationRanges: []string{ipAddress},
 		Name:              firewallName,


### PR DESCRIPTION
When specifying multi protocol service ILB Controller needs to update firewall rules to allow traffic to flow on both TCP and UDP ports. Used only when the mixed protocol feature flag is enabled.

Similar to #2740, but for ILB.