### PR TITLE
Add Ensure tests for mixed protocol ILB

### DIFF
--- a/pkg/loadbalancers/l4_mixed_test.go
+++ b/pkg/loadbalancers/l4_mixed_test.go
@@ -1,0 +1,572 @@
+package loadbalancers
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/compute/v1"
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/healthchecksl4"
+	"k8s.io/ingress-gce/pkg/loadbalancers/mixedprotocoltest"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
+	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
+)
+
+// TestEnsureMixedILB tests transitions between mixed and single protocol ILBs
+// Steps:
+//  1. Arrange:
+//     a) Create existing GCE resources with fakeGCE based on starting state.
+//     b) Create L4 struct with mixed protocol feature flag enabled
+//  2. Act:
+//     a) Run l4.Ensure(service)
+//  3. Assert:
+//     a) Verify result
+//     b) Verify resources from fakeGCE with resources in the end state
+//     c) Verify resources from starting state not used in end state are cleaned up
+func TestEnsureMixedILB(t *testing.T) {
+	startState := []struct {
+		desc string
+		// have
+		resources   mixedprotocoltest.GCEResources
+		annotations map[string]string
+		ingress     []api_v1.LoadBalancerIngress
+	}{
+		{
+			desc: "nothing",
+		},
+		{
+			desc:        "ipv4 tcp",
+			resources:   mixedprotocoltest.TCPResources(),
+			annotations: mixedprotocoltest.AnnotationsTCP(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv4 udp",
+			resources:   mixedprotocoltest.UDPResources(),
+			annotations: mixedprotocoltest.AnnotationsUDP(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv4 mixed",
+			resources:   mixedprotocoltest.L3Resources(),
+			annotations: mixedprotocoltest.AnnotationsL3(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv6 tcp",
+			resources:   mixedprotocoltest.TCPResourcesIPv6(),
+			annotations: mixedprotocoltest.AnnotationsTCPIPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "ipv6 udp",
+			resources:   mixedprotocoltest.UDPResourcesIPv6(),
+			annotations: mixedprotocoltest.AnnotationsUDPIPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "ipv6 mixed",
+			resources:   mixedprotocoltest.L3ResourcesIPv6(),
+			annotations: mixedprotocoltest.AnnotationsL3IPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "dual stack tcp",
+			resources:   mixedprotocoltest.TCPResourcesDualStack(),
+			annotations: mixedprotocoltest.AnnotationsTCPDualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack udp",
+			resources:   mixedprotocoltest.UDPResourcesDualStack(),
+			annotations: mixedprotocoltest.AnnotationsUDPDualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack mixed",
+			resources:   mixedprotocoltest.L3ResourcesDualStack(),
+			annotations: mixedprotocoltest.AnnotationsL3DualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+	}
+
+	endState := []struct {
+		desc string
+		// have
+		spec api_v1.ServiceSpec
+		// want
+		resources   mixedprotocoltest.GCEResources
+		annotations map[string]string
+	}{
+		{
+			desc:        "ipv4 tcp",
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCP(),
+			resources:   mixedprotocoltest.TCPResources(),
+		},
+		{
+			desc:        "ipv4 udp",
+			spec:        mixedprotocoltest.SpecIPv4(nil, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsUDP(),
+			resources:   mixedprotocoltest.UDPResources(),
+		},
+		{
+			desc:        "ipv4 mixed",
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3(),
+			resources:   mixedprotocoltest.L3Resources(),
+		},
+		{
+			desc:        "ipv6 tcp",
+			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCPIPv6(),
+			resources:   mixedprotocoltest.TCPResourcesIPv6(),
+		},
+		{
+			desc:        "ipv6 udp",
+			spec:        mixedprotocoltest.SpecIPv6(nil, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsUDPIPv6(),
+			resources:   mixedprotocoltest.UDPResourcesIPv6(),
+		},
+		{
+			desc:        "ipv6 mixed",
+			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3IPv6(),
+			resources:   mixedprotocoltest.L3ResourcesIPv6(),
+		},
+		{
+			desc:        "dual stack tcp",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCPDualStack(),
+			resources:   mixedprotocoltest.TCPResourcesDualStack(),
+		},
+		{
+			desc:        "dual stack udp",
+			spec:        mixedprotocoltest.SpecDualStack(nil, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsUDPDualStack(),
+			resources:   mixedprotocoltest.UDPResourcesDualStack(),
+		},
+		{
+			desc:        "dual stack mixed",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3DualStack(),
+			resources:   mixedprotocoltest.L3ResourcesDualStack(),
+		},
+	}
+
+	for _, s := range startState {
+		for _, e := range endState {
+			desc := s.desc + " -> " + e.desc
+			t.Run(desc, func(t *testing.T) {
+				t.Parallel()
+				svc := &api_v1.Service{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name:        mixedprotocoltest.TestName,
+						Namespace:   mixedprotocoltest.TestNamespace,
+						Annotations: s.annotations,
+					},
+					Spec: e.spec,
+					Status: api_v1.ServiceStatus{
+						LoadBalancer: api_v1.LoadBalancerStatus{
+							Ingress: s.ingress,
+						},
+					},
+				}
+				l4, fakeGCE := arrange(t, s.resources, svc)
+
+				result := l4.EnsureInternalLoadBalancer([]string{mixedprotocoltest.TestNode}, svc)
+
+				wantResult := &L4ILBSyncResult{
+					Annotations: e.annotations,
+					SyncType:    "create",
+				}
+				if s.resources.BS != nil {
+					wantResult.SyncType = "update"
+				}
+				assertResult(t, result, wantResult)
+				assertResources(t, fakeGCE, e.resources, s.resources)
+			})
+		}
+	}
+}
+
+func TestDeleteMixedILB(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		resources   mixedprotocoltest.GCEResources
+		spec        api_v1.ServiceSpec
+		annotations map[string]string
+		ingress     []api_v1.LoadBalancerIngress
+	}{
+		{
+			desc:        "ipv4 tcp",
+			resources:   mixedprotocoltest.TCPResources(),
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCP(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv4 udp",
+			resources:   mixedprotocoltest.UDPResources(),
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsUDP(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv4 mixed",
+			resources:   mixedprotocoltest.L3Resources(),
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3(),
+			ingress:     mixedprotocoltest.IPv4Ingress(),
+		},
+		{
+			desc:        "ipv6 tcp",
+			resources:   mixedprotocoltest.TCPResourcesIPv6(),
+			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCPIPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "ipv6 udp",
+			resources:   mixedprotocoltest.UDPResourcesIPv6(),
+			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsUDPIPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "ipv6 mixed",
+			resources:   mixedprotocoltest.L3ResourcesIPv6(),
+			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3IPv6(),
+			ingress:     mixedprotocoltest.IPv6Ingress(),
+		},
+		{
+			desc:        "dual stack tcp",
+			resources:   mixedprotocoltest.TCPResourcesDualStack(),
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, nil),
+			annotations: mixedprotocoltest.AnnotationsTCPDualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack udp",
+			resources:   mixedprotocoltest.UDPResourcesDualStack(),
+			spec:        mixedprotocoltest.SpecDualStack(nil, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsUDPDualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack mixed",
+			resources:   mixedprotocoltest.L3ResourcesDualStack(),
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocoltest.AnnotationsL3DualStack(),
+			ingress:     mixedprotocoltest.DualStackIngress(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			svc := &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:        mixedprotocoltest.TestName,
+					Namespace:   mixedprotocoltest.TestNamespace,
+					Annotations: tc.annotations,
+				},
+				Spec: tc.spec,
+				Status: api_v1.ServiceStatus{
+					LoadBalancer: api_v1.LoadBalancerStatus{
+						Ingress: tc.ingress,
+					},
+				},
+			}
+			l4, fakeGCE := arrange(t, tc.resources, svc)
+
+			result := l4.EnsureInternalLoadBalancerDeleted(svc)
+
+			wantResult := &L4ILBSyncResult{
+				Annotations: map[string]string{},
+				SyncType:    "delete",
+			}
+			assertResult(t, result, wantResult)
+			assertCleanedUpResources(t, fakeGCE, mixedprotocoltest.GCEResources{}, tc.resources)
+		})
+	}
+}
+
+// arrange creates necessary mocks and services for mixed protocol ilb tests
+func arrange(t *testing.T, existing mixedprotocoltest.GCEResources, svc *api_v1.Service) (*L4, *gce.Cloud) {
+	t.Helper()
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := gce.NewFakeGCECloud(vals)
+	// Update hooks to be able to perform updates
+	mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+	mockGCE.MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
+	mockGCE.MockRegionBackendServices.PatchHook = mock.UpdateRegionBackendServiceHook
+	mockGCE.MockFirewalls.UpdateHook = mock.UpdateFirewallHook
+	mockGCE.MockFirewalls.PatchHook = mock.UpdateFirewallHook
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
+	l4ILBParams := &L4ILBParams{
+		Service:             svc,
+		Cloud:               fakeGCE,
+		Namer:               namer,
+		Recorder:            record.NewFakeRecorder(100),
+		NetworkResolver:     network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+		EnableMixedProtocol: true,
+		DualStackEnabled:    true,
+	}
+	l4 := NewL4Handler(l4ILBParams, klog.TODO())
+	// For testing use Fake
+	l4.healthChecks = healthchecksl4.Fake(fakeGCE, l4ILBParams.Recorder)
+
+	if err := fakeGCE.InsertInstance(vals.ProjectID, vals.ZoneName, &compute.Instance{
+		Name: mixedprotocoltest.TestNode,
+		Tags: &compute.Tags{Items: []string{mixedprotocoltest.TestNode}},
+	}); err != nil {
+		t.Errorf("fakeGCE.InsertInstance() returned error %v", err)
+	}
+
+	dualStackSubnetwork := &compute.Subnetwork{
+		StackType:      "IPV4_IPV6",
+		Ipv6AccessType: "INTERNAL",
+	}
+	if err := fakeGCE.Compute().Subnetworks().Insert(context.TODO(), meta.RegionalKey("", vals.Region), dualStackSubnetwork); err != nil {
+		t.Errorf("fakeGCE.Compute().Subnetworks().Insert() returned error %v", err)
+	}
+
+	if existing.BS != nil {
+		if err := fakeGCE.CreateRegionBackendService(existing.BS, vals.Region); err != nil {
+			t.Errorf("fakeGCE.CreateBackendService() returned error %v", err)
+		}
+	}
+	if existing.FirewallIPv4 != nil {
+		if err := fakeGCE.CreateFirewall(existing.FirewallIPv4); err != nil {
+			t.Errorf("fakeGCE.CreateFirewall() returned error %v", err)
+		}
+	}
+	if existing.FwdRuleIPv4 != nil {
+		if err := fakeGCE.CreateRegionForwardingRule(existing.FwdRuleIPv4, vals.Region); err != nil {
+			t.Errorf("fakeGCE.CreateRegionForwardingRule() returned error %v", err)
+		}
+	}
+	if existing.FirewallIPv6 != nil {
+		if err := fakeGCE.CreateFirewall(existing.FirewallIPv6); err != nil {
+			t.Errorf("fakeGCE.CreateFirewall() returned error %v", err)
+		}
+	}
+	if existing.FwdRuleIPv6 != nil {
+		if err := fakeGCE.CreateRegionForwardingRule(existing.FwdRuleIPv6, vals.Region); err != nil {
+			t.Errorf("fakeGCE.CreateRegionForwardingRule() returned error %v", err)
+		}
+	}
+	if existing.HC != nil {
+		if err := fakeGCE.CreateHealthCheck(existing.HC); err != nil {
+			t.Errorf("fakeGCE.CreateHealthCheck() returned error %v", err)
+		}
+	}
+	if existing.HCFirewallIPv4 != nil {
+		if err := fakeGCE.CreateFirewall(existing.HCFirewallIPv4); err != nil {
+			t.Errorf("fakeGCE.CreateFirewall() returned error %v", err)
+		}
+	}
+	if existing.HCFirewallIPv6 != nil {
+		if err := fakeGCE.CreateFirewall(existing.HCFirewallIPv6); err != nil {
+			t.Errorf("fakeGCE.CreateFirewall() returned error %v", err)
+		}
+	}
+
+	return l4, fakeGCE
+}
+
+// assertResult compares received result to the wanted
+func assertResult(t *testing.T, got, want *L4ILBSyncResult) {
+	t.Helper()
+
+	if got.Error != want.Error {
+		t.Errorf("got.Error != want.Error: got %v, want %v", got.Error, want.Error)
+	}
+	if got.SyncType != want.SyncType {
+		t.Errorf("got.SyncType != want.SyncType: got %v, want %v", got.SyncType, want.SyncType)
+	}
+	if diff := cmp.Diff(got.Annotations, want.Annotations); diff != "" {
+		t.Errorf("got.Annotations != want.Annotations: (-got +want):\n%s", diff)
+	}
+}
+
+// assertResources checks if resources specified in want are present in fakeGCE and old unused resources are cleaned up
+func assertResources(t *testing.T, fakeGCE *gce.Cloud, want, old mixedprotocoltest.GCEResources) {
+	t.Helper()
+
+	assertExistingResources(t, fakeGCE, want)
+	assertCleanedUpResources(t, fakeGCE, want, old)
+}
+
+func assertExistingResources(t *testing.T, fakeGCE *gce.Cloud, want mixedprotocoltest.GCEResources) {
+	t.Helper()
+
+	bsIgnoreFields := cmpopts.IgnoreFields(compute.BackendService{}, "SelfLink", "ConnectionDraining", "Region")
+	fwdRuleIgnoreFields := cmpopts.IgnoreFields(compute.ForwardingRule{}, "SelfLink")
+	hcIgnoreFields := cmpopts.IgnoreFields(compute.HealthCheck{}, "SelfLink")
+	firewallIgnoreFields := cmpopts.IgnoreFields(compute.Firewall{}, "SelfLink")
+
+	if want.BS != nil {
+		bs, err := fakeGCE.GetRegionBackendService(want.BS.Name, want.BS.Region)
+		if err != nil {
+			t.Errorf("fakeGCE.GetBackendService() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.BS, bs, bsIgnoreFields); diff != "" {
+			t.Errorf("Backend service mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.FwdRuleIPv4 != nil {
+		fwdRule, err := fakeGCE.GetRegionForwardingRule(want.FwdRuleIPv4.Name, want.FwdRuleIPv4.Region)
+		if err != nil {
+			t.Errorf("fakeGCE.GetForwardingRule() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.FwdRuleIPv4, fwdRule, fwdRuleIgnoreFields); diff != "" {
+			t.Errorf("Forwarding rule mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.FirewallIPv4 != nil {
+		firewall, err := fakeGCE.GetFirewall(want.FirewallIPv4.Name)
+		if err != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.FirewallIPv4, firewall, firewallIgnoreFields); diff != "" {
+			t.Errorf("Firewall mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.FwdRuleIPv6 != nil {
+		fwdRule, err := fakeGCE.GetRegionForwardingRule(want.FwdRuleIPv6.Name, want.FwdRuleIPv6.Region)
+		if err != nil {
+			t.Errorf("fakeGCE.GetForwardingRule() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.FwdRuleIPv6, fwdRule, fwdRuleIgnoreFields); diff != "" {
+			t.Errorf("Forwarding rule mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.FirewallIPv6 != nil {
+		firewall, err := fakeGCE.GetFirewall(want.FirewallIPv6.Name)
+		if err != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.FirewallIPv6, firewall, firewallIgnoreFields); diff != "" {
+			t.Errorf("Firewall mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.HC != nil {
+		hc, err := fakeGCE.GetHealthCheck(want.HC.Name)
+		if err != nil {
+			t.Errorf("fakeGCE.GetHealthCheck() returned error %v", err)
+		}
+		if diff := cmp.Diff(want.HC, hc, hcIgnoreFields); diff != "" {
+			t.Errorf("Health check mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.HCFirewallIPv4 != nil {
+		hcFirewall, err := fakeGCE.GetFirewall(want.HCFirewallIPv4.Name)
+		if err != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		slices.Sort(hcFirewall.SourceRanges)
+		slices.Sort(want.HCFirewallIPv4.SourceRanges)
+		if diff := cmp.Diff(want.HCFirewallIPv4, hcFirewall, firewallIgnoreFields); diff != "" {
+			t.Errorf("Health check firewall mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	if want.HCFirewallIPv6 != nil {
+		hcFirewall, err := fakeGCE.GetFirewall(want.HCFirewallIPv6.Name)
+		if err != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		slices.Sort(hcFirewall.SourceRanges)
+		slices.Sort(want.HCFirewallIPv6.SourceRanges)
+		if diff := cmp.Diff(want.HCFirewallIPv6, hcFirewall, firewallIgnoreFields); diff != "" {
+			t.Errorf("Health check firewall mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
+
+func assertCleanedUpResources(t *testing.T, fakeGCE *gce.Cloud, want, old mixedprotocoltest.GCEResources) {
+	t.Helper()
+
+	if old.BS != nil && (want.BS == nil || want.BS.Name != old.BS.Name) {
+		bs, err := fakeGCE.GetRegionBackendService(old.BS.Name, old.BS.Region)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetBackendService() returned error %v", err)
+		}
+		if bs != nil {
+			t.Errorf("found backend service %v, which should have been deleted", bs.Name)
+		}
+	}
+
+	if old.FwdRuleIPv4 != nil && (want.FwdRuleIPv4 == nil || want.FwdRuleIPv4.Name != old.FwdRuleIPv4.Name) {
+		fwdRule, err := fakeGCE.GetRegionForwardingRule(old.FwdRuleIPv4.Name, old.FwdRuleIPv4.Region)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetForwardingRule() returned error %v", err)
+		}
+		if fwdRule != nil {
+			t.Errorf("found forwarding rule %v, which should have been deleted", fwdRule.Name)
+		}
+	}
+
+	if old.FirewallIPv4 != nil && (want.FwdRuleIPv4 == nil || want.FirewallIPv4.Name != old.FirewallIPv4.Name) {
+		firewall, err := fakeGCE.GetFirewall(old.FirewallIPv4.Name)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		if firewall != nil {
+			t.Errorf("found firewall %v, which should have been deleted", firewall.Name)
+		}
+	}
+
+	if old.FwdRuleIPv6 != nil && (want.FwdRuleIPv6 == nil || want.FwdRuleIPv6.Name != old.FwdRuleIPv6.Name) {
+		fwdRule, err := fakeGCE.GetRegionForwardingRule(old.FwdRuleIPv6.Name, old.FwdRuleIPv6.Region)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetForwardingRule() returned error %v", err)
+		}
+		if fwdRule != nil {
+			t.Errorf("found forwarding rule %v, which should have been deleted", fwdRule.Name)
+		}
+	}
+
+	if old.FirewallIPv6 != nil && (want.FirewallIPv6 == nil || want.FirewallIPv6.Name != old.FirewallIPv6.Name) {
+		firewall, err := fakeGCE.GetFirewall(old.FirewallIPv6.Name)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetFirewall() returned error %v", err)
+		}
+		if firewall != nil {
+			t.Errorf("found firewall %v, which should have been deleted", firewall.Name)
+		}
+	}
+
+	if old.HC != nil && (want.HC == nil || want.HC.Name != old.HC.Name) {
+		hc, err := fakeGCE.GetHealthCheck(old.HC.Name)
+		if utils.IgnoreHTTPNotFound(err) != nil {
+			t.Errorf("fakeGCE.GetHealthCheck() returned error %v", err)
+		}
+		if hc != nil {
+			t.Errorf("found health check %v, which should have been deleted", hc.Name)
+		}
+	}
+
+	// We don't need to clean up firewall for health checks, since they are shared
+}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1612,7 +1612,7 @@ func TestDualStackInternalLoadBalancerModifyProtocol(t *testing.T) {
 
 			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, v1.ServiceExternalTrafficPolicyTypeCluster)
 			l4 := mustSetupILBTestHandler(t, svc, nodeNames)
-			var vals = gce.DefaultTestClusterValues()
+			vals := gce.DefaultTestClusterValues()
 
 			// This function simulates the error where backend service protocol cannot be changed
 			// before deleting the forwarding rule.

--- a/pkg/loadbalancers/mixedprotocoltest/annotations.go
+++ b/pkg/loadbalancers/mixedprotocoltest/annotations.go
@@ -1,0 +1,109 @@
+package mixedprotocoltest
+
+// AnnotationsTCP returns annotations for TCP ILB
+func AnnotationsTCP() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":      "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/tcp-forwarding-rule":  "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+	}
+}
+
+// AnnotationsTCPIPv6 returns annotations for TCP ILB
+func AnnotationsTCPIPv6() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/tcp-forwarding-rule-ipv6":  "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}
+
+// AnnotationsTCPDualStack returns annotations for TCP ILB
+func AnnotationsTCPDualStack() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc":      "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/tcp-forwarding-rule":       "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":             "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/tcp-forwarding-rule-ipv6":  "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}
+
+// AnnotationsUDP returns annotations for UDP ILB
+func AnnotationsUDP() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":      "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/udp-forwarding-rule":  "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+	}
+}
+
+// AnnotationsUDPIPv6 returns annotations for UDP ILB
+func AnnotationsUDPIPv6() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/udp-forwarding-rule-ipv6":  "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}
+
+// AnnotationsUDPDualStack returns annotations for UDP ILB
+func AnnotationsUDPDualStack() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc":      "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/udp-forwarding-rule":       "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":             "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/udp-forwarding-rule-ipv6":  "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}
+
+// AnnotationsL3 returns annotations for mixed protocol ILB
+func AnnotationsL3() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":      "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/l3-forwarding-rule":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+	}
+}
+
+// AnnotationsL3IPv6 returns annotations for mixed protocol ILB
+func AnnotationsL3IPv6() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/l3-forwarding-rule-ipv6":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}
+
+// AnnotationsL3DualStack returns annotations for dual stack ILB
+func AnnotationsL3DualStack() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc":      "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/l3-forwarding-rule":        "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":             "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		"service.kubernetes.io/l3-forwarding-rule-ipv6":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+	}
+}

--- a/pkg/loadbalancers/mixedprotocoltest/consts.go
+++ b/pkg/loadbalancers/mixedprotocoltest/consts.go
@@ -1,0 +1,14 @@
+package mixedprotocoltest
+
+const (
+	// TestNode is the name of the node used for mixed protocol tests
+	TestNode = "test-node"
+	// TestName is the name of the service used for mixed protocol tests
+	TestName = "test-name"
+	// TestNamespace is the name of the Kubernetes namespace used for mixed protocol tests
+	TestNamespace = "test-namespace"
+	// IPv4Address is the internal IPv4 address used for mixed protocol tests
+	IPv4Address = "10.0.0.10"
+	// IPv6Address is the internal IPv6 address used for mixed protocol tests
+	IPv6Address = "fd20:dd1:549d:7000:0:b:0:0"
+)

--- a/pkg/loadbalancers/mixedprotocoltest/ingress.go
+++ b/pkg/loadbalancers/mixedprotocoltest/ingress.go
@@ -1,0 +1,42 @@
+package mixedprotocoltest
+
+import (
+	api_v1 "k8s.io/api/core/v1"
+)
+
+// IPv4Ingress is an Ingress for already existing IPv4 load balancers
+func IPv4Ingress() []api_v1.LoadBalancerIngress {
+	mode := api_v1.LoadBalancerIPModeVIP
+	return []api_v1.LoadBalancerIngress{
+		{
+			IP:     IPv4Address,
+			IPMode: &mode,
+		},
+	}
+}
+
+// IPv6Ingress is an Ingress for already existing IPv6 load balancers
+func IPv6Ingress() []api_v1.LoadBalancerIngress {
+	mode := api_v1.LoadBalancerIPModeVIP
+	return []api_v1.LoadBalancerIngress{
+		{
+			IP:     IPv6Address,
+			IPMode: &mode,
+		},
+	}
+}
+
+// DualStackIngress is an Ingress for already existing Dual Stack load balancers
+func DualStackIngress() []api_v1.LoadBalancerIngress {
+	mode := api_v1.LoadBalancerIPModeVIP
+	return []api_v1.LoadBalancerIngress{
+		{
+			IP:     IPv4Address,
+			IPMode: &mode,
+		},
+		{
+			IP:     IPv6Address,
+			IPMode: &mode,
+		},
+	}
+}

--- a/pkg/loadbalancers/mixedprotocoltest/resources.go
+++ b/pkg/loadbalancers/mixedprotocoltest/resources.go
@@ -1,0 +1,317 @@
+package mixedprotocoltest
+
+import (
+	"google.golang.org/api/compute/v1"
+)
+
+// GCEResources collects all GCE resources that are managed by the mixed protocol ILB
+type GCEResources struct {
+	FwdRuleIPv4    *compute.ForwardingRule
+	FirewallIPv4   *compute.Firewall
+	FwdRuleIPv6    *compute.ForwardingRule
+	FirewallIPv6   *compute.Firewall
+	HC             *compute.HealthCheck
+	HCFirewallIPv4 *compute.Firewall
+	HCFirewallIPv6 *compute.Firewall
+	BS             *compute.BackendService
+}
+
+// TCPResources returns GCE resources for a TCP IPv4 ILB that listens on ports 80 and 443
+func TCPResources() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleTCP([]string{"80", "443"}),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("TCP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+	}
+}
+
+// UDPResources returns GCE resources for an UDP IPv4 ILB that listens on port 53
+func UDPResources() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleUDP([]string{"53"}),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		}),
+		BS:             BackendService("UDP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+	}
+}
+
+// L3Resources returns GCE resources for a mixed protocol IPv4 ILB, that listens on tcp:80, tcp:443 and udp:53
+func L3Resources() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleL3(),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("UNSPECIFIED"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+	}
+}
+
+// TCPResourcesIPv6 returns GCE resources for a TCP IPv6 ILB that listens on ports 80 and 443
+func TCPResourcesIPv6() GCEResources {
+	return GCEResources{
+		FwdRuleIPv6: ForwardingrukeRuleTCPIPv6([]string{"80", "443"}),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("TCP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// UDPResourcesIPv6 returns GCE resources for an UDP IPv6 ILB that listens on port 53
+func UDPResourcesIPv6() GCEResources {
+	return GCEResources{
+		FwdRuleIPv6: ForwardingRuleUDPIPv6([]string{"53"}),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		}),
+		BS:             BackendService("UDP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// L3ResourcesIPv6 returns GCE resources for a mixed protocol IPv6 ILB, that listens on tcp:80, tcp:443 and udp:53
+func L3ResourcesIPv6() GCEResources {
+	return GCEResources{
+		FwdRuleIPv6: ForwardingRuleL3IPv6(),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("UNSPECIFIED"),
+		HC:             HealthCheck(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// TCPResourcesDualStack returns GCE resources for a TCP dual stack ILB that listens on ports 80 and 443
+func TCPResourcesDualStack() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleTCP([]string{"80", "443"}),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		FwdRuleIPv6: ForwardingrukeRuleTCPIPv6([]string{"80", "443"}),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("TCP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// UDPResourcesDualStack returns GCE resources for an UDP dual stack ILB that listens on port 53
+func UDPResourcesDualStack() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleUDP([]string{"53"}),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		}),
+		FwdRuleIPv6: ForwardingRuleUDPIPv6([]string{"53"}),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		}),
+		BS:             BackendService("UDP"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// L3ResourcesDualStack returns GCE resources for a mixed protocol dual stack ILB, that listens on tcp:80, tcp:443 and udp:53
+func L3ResourcesDualStack() GCEResources {
+	return GCEResources{
+		FwdRuleIPv4: ForwardingRuleL3(),
+		FirewallIPv4: Firewall([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		FwdRuleIPv6: ForwardingRuleL3IPv6(),
+		FirewallIPv6: FirewallIPv6([]*compute.FirewallAllowed{
+			{IPProtocol: "udp", Ports: []string{"53"}},
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+		}),
+		BS:             BackendService("UNSPECIFIED"),
+		HC:             HealthCheck(),
+		HCFirewallIPv4: HealthCheckFirewall(),
+		HCFirewallIPv6: HealthCheckFirewallIPv6(),
+	}
+}
+
+// HealthCheck returns shared HealthCheck
+func HealthCheck() *compute.HealthCheck {
+	return &compute.HealthCheck{
+		Name:               "k8s2-axyqjz2d-l4-shared-hc",
+		CheckIntervalSec:   8,
+		TimeoutSec:         1,
+		HealthyThreshold:   1,
+		UnhealthyThreshold: 3,
+		Type:               "HTTP",
+		HttpHealthCheck:    &compute.HTTPHealthCheck{Port: 10256, RequestPath: "/healthz"},
+		Description:        `{"networking.gke.io/service-name":"","networking.gke.io/api-version":"ga","networking.gke.io/resource-description":"This resource is shared by all L4 ILB Services using ExternalTrafficPolicy: Cluster."}`,
+	}
+}
+
+// HealthCheckFirewall returns Firewall for HealthCheck
+func HealthCheckFirewall() *compute.Firewall {
+	return &compute.Firewall{
+		Name:    "k8s2-axyqjz2d-l4-shared-hc-fw",
+		Allowed: []*compute.FirewallAllowed{{IPProtocol: "TCP", Ports: []string{"10256"}}},
+		// GCE defined health check ranges
+		SourceRanges: []string{"130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"},
+		TargetTags:   []string{TestNode},
+		Description:  `{"networking.gke.io/service-name":"","networking.gke.io/api-version":"ga","networking.gke.io/resource-description":"This resource is shared by all L4  Services using ExternalTrafficPolicy: Cluster."}`,
+	}
+}
+
+// HealthCheckFirewallIPv6 returns Firewall for HealthCheck
+func HealthCheckFirewallIPv6() *compute.Firewall {
+	return &compute.Firewall{
+		Name:    "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
+		Allowed: []*compute.FirewallAllowed{{IPProtocol: "TCP", Ports: []string{"10256"}}},
+		// GCE defined health check ranges
+		SourceRanges: []string{"2600:2d00:1:b029::/64"},
+		TargetTags:   []string{TestNode},
+		Description:  `{"networking.gke.io/service-name":"","networking.gke.io/api-version":"ga","networking.gke.io/resource-description":"This resource is shared by all L4  Services using ExternalTrafficPolicy: Cluster."}`,
+	}
+}
+
+// ForwardingRuleL3 returns an L3 Forwarding Rule for ILB
+func ForwardingRuleL3() *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		Region:              "us-central1",
+		IPProtocol:          "L3_DEFAULT",
+		AllPorts:            true,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+	}
+}
+
+// ForwardingRuleL3IPv6 returns an L3 Forwarding Rule for ILB
+func ForwardingRuleL3IPv6() *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		Region:              "us-central1",
+		IPProtocol:          "L3_DEFAULT",
+		IpVersion:           "IPV6",
+		AllPorts:            true,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name"}`,
+	}
+}
+
+// ForwardingRuleUDP returns a UDP Forwarding Rule with specified ports
+func ForwardingRuleUDP(ports []string) *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		Region:              "us-central1",
+		IPProtocol:          "UDP",
+		Ports:               ports,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+	}
+}
+
+// ForwardingRuleUDPIPv6 returns a UDP Forwarding Rule with specified ports
+func ForwardingRuleUDPIPv6(ports []string) *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		Region:              "us-central1",
+		IPProtocol:          "UDP",
+		IpVersion:           "IPV6",
+		Ports:               ports,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name"}`,
+	}
+}
+
+// ForwardingRuleTCP returns a TCP Forwarding Rule with specified ports
+func ForwardingRuleTCP(ports []string) *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		Region:              "us-central1",
+		IPProtocol:          "TCP",
+		Ports:               ports,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+	}
+}
+
+// ForwardingrukeRuleTCPIPv6 returns a TCP Forwarding Rule with specified ports
+func ForwardingrukeRuleTCPIPv6(ports []string) *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		Region:              "us-central1",
+		IPProtocol:          "TCP",
+		IpVersion:           "IPV6",
+		Ports:               ports,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "INTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name"}`,
+	}
+}
+
+// BackendService returns Backend Service for ILB
+// protocol should be set to:
+// - `UNSPECIFIED` for mixed protocol (L3)
+// - `TCP` for TCP only
+// - `UDP` for UDP only
+func BackendService(protocol string) *compute.BackendService {
+	return &compute.BackendService{
+		Name:                "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		Region:              "us-central1",
+		Protocol:            protocol,
+		SessionAffinity:     "NONE",
+		LoadBalancingScheme: "INTERNAL",
+		HealthChecks:        []string{"https://www.googleapis.com/compute/v1/projects/test-project/global/healthChecks/k8s2-axyqjz2d-l4-shared-hc"},
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+	}
+}
+
+// Firewall returns ILB Firewall with specified allowed rules
+func Firewall(allowed []*compute.FirewallAllowed) *compute.Firewall {
+	return &compute.Firewall{
+		Name:         "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		Allowed:      allowed,
+		Description:  `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+		SourceRanges: []string{"0.0.0.0/0"},
+		TargetTags:   []string{TestNode},
+	}
+}
+
+// FirewallIPv6 returns ILB Firewall with specified allowed rules
+func FirewallIPv6(allowed []*compute.FirewallAllowed) *compute.Firewall {
+	return &compute.Firewall{
+		Name:         "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		Allowed:      allowed,
+		Description:  `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
+		SourceRanges: []string{"0::0/0"},
+		TargetTags:   []string{TestNode},
+	}
+}

--- a/pkg/loadbalancers/mixedprotocoltest/spec.go
+++ b/pkg/loadbalancers/mixedprotocoltest/spec.go
@@ -1,0 +1,56 @@
+package mixedprotocoltest
+
+import (
+	api_v1 "k8s.io/api/core/v1"
+)
+
+// SpecIPv4 returns a specification for a IPv6 LB with specified tcp and udp ports
+func SpecIPv4(tcpPorts []int32, udpPorts []int32) api_v1.ServiceSpec {
+	return api_v1.ServiceSpec{
+		Type:  api_v1.ServiceTypeLoadBalancer,
+		Ports: getPorts(tcpPorts, udpPorts),
+	}
+}
+
+// SpecIPv6 returns a specification for a IPv6 LB with specified tcp and udp ports
+func SpecIPv6(tcpPorts []int32, udpPorts []int32) api_v1.ServiceSpec {
+	policy := api_v1.IPFamilyPolicySingleStack
+
+	return api_v1.ServiceSpec{
+		IPFamilies:     []api_v1.IPFamily{"IPv6"},
+		IPFamilyPolicy: &policy,
+		Type:           api_v1.ServiceTypeLoadBalancer,
+		Ports:          getPorts(tcpPorts, udpPorts),
+	}
+}
+
+// SpecDualStack returns a specification for a Dual Stack LB with specified tcp and udp ports
+func SpecDualStack(tcpPorts []int32, udpPorts []int32) api_v1.ServiceSpec {
+	policy := api_v1.IPFamilyPolicyRequireDualStack
+
+	return api_v1.ServiceSpec{
+		IPFamilies:     []api_v1.IPFamily{"IPv4", "IPv6"},
+		IPFamilyPolicy: &policy,
+		Type:           api_v1.ServiceTypeLoadBalancer,
+		Ports:          getPorts(tcpPorts, udpPorts),
+	}
+}
+
+func getPorts(tcpPorts []int32, udpPorts []int32) []api_v1.ServicePort {
+	var ports []api_v1.ServicePort
+	for _, port := range tcpPorts {
+		ports = append(ports, api_v1.ServicePort{
+			Name:     "tcp" + string(port),
+			Port:     port,
+			Protocol: api_v1.ProtocolTCP,
+		})
+	}
+	for _, port := range udpPorts {
+		ports = append(ports, api_v1.ServicePort{
+			Name:     "udp" + string(port),
+			Port:     port,
+			Protocol: api_v1.ProtocolUDP,
+		})
+	}
+	return ports
+}


### PR DESCRIPTION
- Adds IPv6 and Dual Stack support for mixed protocol ILBs
- Adds test data in `pkg/loadbalancers/mixedprotocoltest` for {TCP, UDP, Mixed} x {IPv4, IPv6, DualStack}, including:
    -  annotations
    -  consts for names of nodes, services, namespaces, ip addresses
    - Kubernetes Ingress definitions
    - Cloud resources (fakeGCE): forwarding rules, backend services, firewalls, health checks
- Adds TestEnsureMixedILB:
    - Tests for {IPv4, IPv6, DualStack} x {TCP, UDP, Mixed}
    - create
    - transitions
    - delete
- Fixes forwarding rule resource leak when switching both protocol and stack f.e. IPv4 UDP to IPv6 TCP, by deleting all potential forwarding rules for a service. This leak will be created because the delete logic tries to create forwarding rule name for the old state stack based on the new protocol. So instead of deleting IPv4 UDP it tries to delete IPv4 TCP, which doesn't exist.
  
    