### PR TITLE
Trigger node sync on PodCIDR change in the IG controller.

### DIFF
--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -111,6 +111,9 @@ func nodeStatusChanged(old, cur *apiv1.Node) bool {
 	if utils.NodeIsReady(old) != utils.NodeIsReady(cur) {
 		return true
 	}
+	if old.Spec.PodCIDR != cur.Spec.PodCIDR {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
Nodes with missing PodCIDR can be skipped during IG sync. When the PodCIDR is added nodes should be reprocessed.