### PR TITLE
Split the enable-mixed-protocol flag into ILB and NetLB

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -264,7 +264,8 @@ func main() {
 		DisableL4LBFirewall:           flags.F.DisableL4LBFirewall,
 		EnableL4NetLBNEGs:             flags.F.EnableL4NetLBNEG,
 		EnableL4NetLBNEGsDefault:      flags.F.EnableL4NetLBNEGDefault,
-		EnableL4MixedProtocol:         flags.F.EnableL4MixedProtocol,
+		EnableL4ILBMixedProtocol:      flags.F.EnableL4ILBMixedProtocol,
+		EnableL4NetLBMixedProtocol:    flags.F.EnableL4NetLBMixedProtocol,
 	}
 	ctx := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	go app.RunHTTPServer(ctx.HealthCheck, rootLogger)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -147,7 +147,8 @@ type ControllerContextConfig struct {
 	DisableL4LBFirewall           bool
 	EnableL4NetLBNEGs             bool
 	EnableL4NetLBNEGsDefault      bool
-	EnableL4MixedProtocol         bool
+	EnableL4ILBMixedProtocol      bool
+	EnableL4NetLBMixedProtocol    bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -141,7 +141,8 @@ var F = struct {
 	EnableMultiProjectMode                   bool
 	MultiProjectCRDProjectNameLabel          string
 	ClusterSliceAPIGroup                     string
-	EnableL4MixedProtocol                    bool
+	EnableL4ILBMixedProtocol                 bool
+	EnableL4NetLBMixedProtocol               bool
 }{
 	GCERateLimitScale: 1.0,
 }
@@ -330,7 +331,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableDiscretePortForwarding, "enable-discrete-port-forwarding", false, "Enable forwarding of individual ports instead of port ranges.")
 	flag.BoolVar(&F.EnableMultiProjectMode, "enable-multi-project-mode", false, "Enable running in multi-project mode.")
 	flag.StringVar(&F.MultiProjectCRDProjectNameLabel, "multi-project-crd-project-name-label", "", "The label key for project name of Project in a Project CRD in the Multi-Project cluster.")
-	flag.BoolVar(&F.EnableL4MixedProtocol, "enable-l4-mixed-protocol", false, "Enable support for mixed protocol L4 load balancers.")
+	flag.BoolVar(&F.EnableL4ILBMixedProtocol, "enable-l4ilb-mixed-protocol", false, "Enable support for mixed protocol L4 internal load balancers.")
+	flag.BoolVar(&F.EnableL4NetLBMixedProtocol, "enable-l4netlb-mixed-protocol", false, "Enable support for mixed protocol L4 external load balancers.")
 	flag.StringVar(&F.ClusterSliceAPIGroup, "cluster-slice-api-group", "", "The API group for the ClusterSlice CRD.")
 }
 

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -288,7 +288,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
-		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
+		EnableMixedProtocol:              l4c.ctx.EnableL4ILBMixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -370,7 +370,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 		NetworkResolver:                  l4c.networkResolver,
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
-		EnableMixedProtocol:              l4c.ctx.EnableL4MixedProtocol,
+		EnableMixedProtocol:              l4c.ctx.EnableL4ILBMixedProtocol,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -732,7 +732,7 @@ func (lc *L4NetLBController) garbageCollectRBSNetLB(key string, svc *v1.Service,
 		StrongSessionAffinityEnabled:     lc.enableStrongSessionAffinity,
 		NetworkResolver:                  lc.networkResolver,
 		EnableWeightedLB:                 lc.ctx.EnableWeightedL4NetLB,
-		EnableMixedProtocol:              lc.ctx.EnableL4MixedProtocol,
+		EnableMixedProtocol:              lc.ctx.EnableL4NetLBMixedProtocol,
 		DisableNodesFirewallProvisioning: lc.ctx.DisableL4LBFirewall,
 	}
 	l4netLB := loadbalancers.NewL4NetLB(l4NetLBParams, svcLogger)


### PR DESCRIPTION
Since the implementation for ILB is ready it makes sense to separate the flag to enable ILBs in e2e tests, while having currently WIP NetLB be disabled. 

It uses the same naming convention as DualStack:
```
EnableL4ILBDualStack:          flags.F.EnableL4ILBDualStack,
EnableL4NetLBDualStack:        flags.F.EnableL4NetLBDualStack,
````