### PR TITLE
[cherrypick #2757 to release-1.32] Trigger node sync on PodCIDR chang…

### DIFF
--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -111,6 +111,9 @@ func nodeStatusChanged(old, cur *apiv1.Node) bool {
 	if utils.NodeIsReady(old) != utils.NodeIsReady(cur) {
 		return true
 	}
+	if old.Spec.PodCIDR != cur.Spec.PodCIDR {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
…e in the IG controller.

Nodes with missing PodCIDR can be skipped during IG sync. When the PodCIDR is added nodes should be reprocessed.

(cherry picked from commit 9889c417818ca1c956597f4241d24925d95f0cd5)