### PR TITLE
Add funcs to add/delete finalizer on ClusterSlice 

### DIFF
--- a/pkg/multiproject/finalizer/finalizer.go
+++ b/pkg/multiproject/finalizer/finalizer.go
@@ -1,0 +1,54 @@
+package finalizer
+
+import (
+	"fmt"
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	providerconfig "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
+	providerconfigclient "k8s.io/ingress-gce/pkg/providerconfig/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/utils/patch"
+	"k8s.io/ingress-gce/pkg/utils/slice"
+	"k8s.io/klog/v2"
+)
+
+const (
+	ProviderConfigNEGCleanupFinalizer = "multiproject.networking.gke.io/neg-cleanup"
+)
+
+func EnsureProviderConfigNEGCleanupFinalizer(cs *providerconfig.ProviderConfig, csClient providerconfigclient.Interface, logger klog.Logger) error {
+	return ensureProviderConfigFinalizer(cs, ProviderConfigNEGCleanupFinalizer, csClient, logger)
+}
+
+func DeleteProviderConfigNEGCleanupFinalizer(cs *providerconfig.ProviderConfig, csClient providerconfigclient.Interface, logger klog.Logger) error {
+	return deleteProviderConfigFinalizer(cs, ProviderConfigNEGCleanupFinalizer, csClient, logger)
+}
+
+func ensureProviderConfigFinalizer(pc *providerconfig.ProviderConfig, key string, csClient providerconfigclient.Interface, logger klog.Logger) error {
+	if HasGivenFinalizer(pc.ObjectMeta, key) {
+		return nil
+	}
+
+	// Make a deep copy of the ProviderConfig to avoid mutating the shared informer cache.
+	updatedObjectMeta := pc.ObjectMeta.DeepCopy()
+	updatedObjectMeta.Finalizers = append(updatedObjectMeta.Finalizers, key)
+
+	logger.V(2).Info("Adding finalizer to ProviderConfig", "finalizerKey", key, "providerConfig", fmt.Sprintf("%s/%s", pc.Namespace, pc.Name))
+	return patch.PatchProviderConfigObjectMetadata(csClient, pc, *updatedObjectMeta)
+}
+
+func deleteProviderConfigFinalizer(cs *providerconfig.ProviderConfig, key string, csClient providerconfigclient.Interface, logger klog.Logger) error {
+	if !HasGivenFinalizer(cs.ObjectMeta, key) {
+		return nil
+	}
+
+	updatedObjectMeta := cs.ObjectMeta.DeepCopy()
+	updatedObjectMeta.Finalizers = slice.RemoveString(updatedObjectMeta.Finalizers, key, nil)
+	logger.V(2).Info("Deleting finalizer from ProviderConfig", "finalizerKey", key, "providerConfig", fmt.Sprintf("%s/%s", cs.Namespace, cs.Name))
+	return patch.PatchProviderConfigObjectMetadata(csClient, cs, *updatedObjectMeta)
+}
+
+// HasGivenFinalizer is true if the passed in meta has the specified finalizer.
+func HasGivenFinalizer(m metav1.ObjectMeta, key string) bool {
+	return slices.Contains(m.Finalizers, key)
+}

--- a/pkg/multiproject/finalizer/finalizer_test.go
+++ b/pkg/multiproject/finalizer/finalizer_test.go
@@ -1,0 +1,141 @@
+package finalizer
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	providerconfigv1 "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
+	providerconfigfake "k8s.io/ingress-gce/pkg/providerconfig/client/clientset/versioned/fake"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestEnsureProviderConfigNEGCleanupFinalizer(t *testing.T) {
+	testCases := []struct {
+		desc                     string
+		cs                       *providerconfigv1.ProviderConfig
+		expectedFinalizerPresent bool
+	}{
+		{
+			desc: "Finalizer not present, should add it",
+			cs: &providerconfigv1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cs-add-finalizer",
+					Namespace:  "default",
+					Finalizers: []string{},
+				},
+			},
+			expectedFinalizerPresent: true,
+		},
+		{
+			desc: "Finalizer already present, should remain",
+			cs: &providerconfigv1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cs-finalizer-present",
+					Namespace: "default",
+					Finalizers: []string{
+						ProviderConfigNEGCleanupFinalizer,
+					},
+				},
+			},
+			expectedFinalizerPresent: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			csClient := providerconfigfake.NewSimpleClientset(tc.cs)
+			csInterface := csClient.FlagsV1().ProviderConfigs(tc.cs.Namespace)
+			// Create the initial ProviderConfig object
+			_, err := csInterface.Create(context.TODO(), tc.cs, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create ProviderConfig: %v", err)
+			}
+
+			logger, _ := ktesting.NewTestContext(t)
+
+			err = EnsureProviderConfigNEGCleanupFinalizer(tc.cs, csClient, logger)
+			if err != nil {
+				t.Fatalf("EnsureProviderConfigNEGCleanupFinalizer returned error: %v", err)
+			}
+
+			// Retrieve the updated ProviderConfig
+			updatedCS, err := csInterface.Get(context.TODO(), tc.cs.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get updated ProviderConfig: %v", err)
+			}
+
+			// Check if the finalizer is present as expected
+			hasFinalizer := slices.Contains(updatedCS.Finalizers, ProviderConfigNEGCleanupFinalizer)
+			if hasFinalizer != tc.expectedFinalizerPresent {
+				t.Errorf("Finalizer presence mismatch: expected %v, got %v", tc.expectedFinalizerPresent, hasFinalizer)
+			}
+		})
+	}
+}
+
+func TestDeleteProviderConfigNEGCleanupFinalizer(t *testing.T) {
+	testCases := []struct {
+		desc                     string
+		cs                       *providerconfigv1.ProviderConfig
+		expectedFinalizerPresent bool
+	}{
+		{
+			desc: "Finalizer present, should be removed",
+			cs: &providerconfigv1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cs-remove-finalizer",
+					Namespace: "default",
+					Finalizers: []string{
+						ProviderConfigNEGCleanupFinalizer,
+					},
+				},
+			},
+			expectedFinalizerPresent: false,
+		},
+		{
+			desc: "Finalizer not present, remains absent",
+			cs: &providerconfigv1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cs-finalizer-not-present",
+					Namespace:  "default",
+					Finalizers: []string{},
+				},
+			},
+			expectedFinalizerPresent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			csClient := providerconfigfake.NewSimpleClientset(tc.cs)
+			csInterface := csClient.FlagsV1().ProviderConfigs(tc.cs.Namespace)
+
+			// Create the initial ProviderConfig object
+			_, err := csInterface.Create(context.TODO(), tc.cs, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create ProviderConfig: %v", err)
+			}
+
+			logger, _ := ktesting.NewTestContext(t)
+
+			err = DeleteProviderConfigNEGCleanupFinalizer(tc.cs, csClient, logger)
+			if err != nil {
+				t.Fatalf("DeleteProviderConfigNEGCleanupFinalizer returned error: %v", err)
+			}
+
+			// Retrieve the updated ProviderConfig
+			updatedCS, err := csInterface.Get(context.TODO(), tc.cs.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get updated ProviderConfig: %v", err)
+			}
+
+			// Check if the finalizer is present as expected
+			hasFinalizer := slices.Contains(updatedCS.Finalizers, ProviderConfigNEGCleanupFinalizer)
+			if hasFinalizer != tc.expectedFinalizerPresent {
+				t.Errorf("Finalizer presence mismatch: expected %v, got %v", tc.expectedFinalizerPresent, hasFinalizer)
+			}
+		})
+	}
+}

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -15,6 +15,7 @@ package common
 
 import (
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
@@ -64,7 +65,7 @@ func HasFinalizer(m meta_v1.ObjectMeta) bool {
 
 // HasGivenFinalizer is true if the passed in meta has the specified finalizer.
 func HasGivenFinalizer(m meta_v1.ObjectMeta, key string) bool {
-	return slice.ContainsString(m.Finalizers, key, nil)
+	return slices.Contains(m.Finalizers, key)
 }
 
 // EnsureFinalizer ensures that the specified finalizer exists on given Ingress.

--- a/pkg/utils/patch/patch.go
+++ b/pkg/utils/patch/patch.go
@@ -14,15 +14,19 @@ limitations under the License.
 package patch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	svchelpers "k8s.io/cloud-provider/service/helpers"
+	providerconfig "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
+	providerconfigclient "k8s.io/ingress-gce/pkg/providerconfig/client/clientset/versioned"
 )
 
 // StrategicMergePatchBytes returns a patch between the old and new object using a strategic merge patch.
@@ -83,4 +87,40 @@ func PatchServiceLoadBalancerStatus(client coreclient.CoreV1Interface, svc *core
 	newSvc.Status.LoadBalancer = newStatus
 	_, err := svchelpers.PatchService(client, svc, newSvc)
 	return err
+}
+
+// PatchProviderConfigObjectMetadata patches the given ProviderConfig's metadata based on new metadata.
+func PatchProviderConfigObjectMetadata(client providerconfigclient.Interface, pc *providerconfig.ProviderConfig, newObjectMetadata metav1.ObjectMeta) error {
+	// Reset Spec to ensure only ObjectMeta is patched.
+	newPC := pc.DeepCopy()
+
+	newPC.ObjectMeta = newObjectMetadata
+
+	patchBytes, err := getProviderConfigPatchBytes(pc, newPC)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.FlagsV1().ProviderConfigs(newPC.Namespace).Patch(context.Background(), newPC.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
+}
+
+// getProviderConfigPatchBytes generates the patch bytes for updating a ProviderConfig.
+func getProviderConfigPatchBytes(oldCS, newCS *providerconfig.ProviderConfig) ([]byte, error) {
+	oldData, err := json.Marshal(oldCS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal old object: %v", err)
+	}
+
+	newData, err := json.Marshal(newCS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal new object: %v", err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, providerconfig.ProviderConfig{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create patch: %v", err)
+	}
+
+	return patchBytes, nil
 }


### PR DESCRIPTION
- Added general functions to patch ClusterSlice ObjectMetadata
- Added functions to add/delete neg cleanup finalizer on ClusterSlice.
  This will allow to properly clean neg controllers when cluster slice
  is deleted

/assign @gauravkghildiyal 