### PR TITLE
Add flag for IPV6 only NEG's

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -143,6 +143,7 @@ var F = struct {
 	ProviderConfigAPIGroup                   string
 	EnableL4ILBMixedProtocol                 bool
 	EnableL4NetLBMixedProtocol               bool
+	EnableIPV6OnlyNEG                        bool
 }{
 	GCERateLimitScale: 1.0,
 }
@@ -334,6 +335,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NetLBMixedProtocol, "enable-l4netlb-mixed-protocol", false, "Enable support for mixed protocol L4 external load balancers.")
 	flag.StringVar(&F.ProviderConfigAPIGroup, "provider-config-api-group", "", "The API group for the ProviderConfig CRD.")
 	flag.StringVar(&F.ProviderConfigNameLabelKey, "provider-config-name-label-key", "", "The label key for provider-config name, which is used to identify the provider-config of objects in multi-project mode.")
+	flag.BoolVar(&F.EnableIPV6OnlyNEG, "enable-ipv6-only-neg", false, "Enable support for IPV6 Only NEG's.")
 }
 
 func Validate() {

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -559,10 +559,12 @@ func (c *Controller) processService(key string) error {
 	}
 	if len(svcPortInfoMap) != 0 {
 		c.logger.V(2).Info("Syncing service", "service", key)
-		// TODO(cheungdavid): Remove this validation when single stack ipv6 endpoint is supported
-		if service.Spec.Type != apiv1.ServiceTypeLoadBalancer && isSingleStackIPv6Service(service) {
-			return fmt.Errorf("NEG is not supported for ipv6 only service (%T)", service)
+		if !flags.F.EnableIPV6OnlyNEG {
+			if service.Spec.Type != apiv1.ServiceTypeLoadBalancer && isSingleStackIPv6Service(service) {
+				return fmt.Errorf("NEG is not supported for ipv6 only service (%T)", service)
+			}
 		}
+
 		if err = c.syncNegStatusAnnotation(namespace, name, svcPortInfoMap); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds a flag for IPV6 only NEG's. If the flag is false, then the NEG Controller will still error if an IPV6 only service is configured.

The plan is to flag flip in a patch release once IPV6 NEG support is available in production (requires GCP LB support for IPV6 only NEG's).