### PR TITLE
Rename EndpointGroupInfo to NEGLocation for a better representation of the concept

### DIFF
--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -294,7 +294,7 @@ func (sm *SyncerMetrics) computeEndpointStateMetrics() (negtypes.StateCountMap, 
 
 // CollectDualStackMigrationMetrics will be used by dualstack.Migrator to export
 // metrics.
-func (sm *SyncerMetrics) CollectDualStackMigrationMetrics(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, migrationCount int) {
+func (sm *SyncerMetrics) CollectDualStackMigrationMetrics(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, migrationCount int) {
 	sm.updateMigrationStartAndEndTime(key, migrationCount)
 	sm.updateEndpointsCountPerType(key, committedEndpoints, migrationCount)
 }
@@ -337,7 +337,7 @@ func (sm *SyncerMetrics) updateMigrationStartAndEndTime(key negtypes.NegSyncerKe
 	sm.dualStackMigrationStartTime[key] = sm.clock.Now()
 }
 
-func (sm *SyncerMetrics) updateEndpointsCountPerType(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, migrationCount int) {
+func (sm *SyncerMetrics) updateEndpointsCountPerType(key negtypes.NegSyncerKey, committedEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, migrationCount int) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 

--- a/pkg/neg/metrics/metricscollector/metrics_collector_test.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector_test.go
@@ -118,7 +118,7 @@ func TestUpdateMigrationStartAndEndTime(t *testing.T) {
 
 func TestUpdateEndpointsCountPerType(t *testing.T) {
 	syncerKey := syncerKey(1)
-	inputCommittedEndpoints := map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet{
+	inputCommittedEndpoints := map[negtypes.NEGLocation]types.NetworkEndpointSet{
 		{Zone: "zone1"}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "ipv4only-1"}, {IP: "ipv4only-2"}, {IP: "ipv4only-3"},
 			{IPv6: "ipv6only-1"},

--- a/pkg/neg/syncers/dualstack/migrator_test.go
+++ b/pkg/neg/syncers/dualstack/migrator_test.go
@@ -21,11 +21,11 @@ func TestFilter(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		migrator            *Migrator
-		addEndpoints        map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		removeEndpoints     map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		committedEndpoints  map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantAddEndpoints    map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantRemoveEndpoints map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		addEndpoints        map[types.NEGLocation]types.NetworkEndpointSet
+		removeEndpoints     map[types.NEGLocation]types.NetworkEndpointSet
+		committedEndpoints  map[types.NEGLocation]types.NetworkEndpointSet
+		wantAddEndpoints    map[types.NEGLocation]types.NetworkEndpointSet
+		wantRemoveEndpoints map[types.NEGLocation]types.NetworkEndpointSet
 		wantMigrationZone   bool
 	}{
 		{
@@ -35,29 +35,29 @@ func TestFilter(t *testing.T) {
 				m.Pause()
 				return m
 			}(),
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantAddEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantRemoveEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					// Migration-endpoints were filtered out but no new migration
 					// detachment was started.
@@ -68,29 +68,29 @@ func TestFilter(t *testing.T) {
 		{
 			desc:     "unpaused migrator should filter migration endpoints AND also start detachment",
 			migrator: newMigratorForTest(t, true),
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantAddEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantRemoveEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // Migration detachment started.
 					{IP: "c", IPv6: "C"},
@@ -101,30 +101,30 @@ func TestFilter(t *testing.T) {
 		{
 			desc:     "migrator should do nothing if enableDualStack is false",
 			migrator: newMigratorForTest(t, false),
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IPv6: "D"},
 				}...),
 			},
-			wantAddEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantAddEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
 				}...),
 			},
-			wantRemoveEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantRemoveEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "c", IPv6: "C"},
@@ -273,7 +273,7 @@ func TestFilter_FunctionalTest(t *testing.T) {
 	// filteredRemoveEndpoints.
 	//
 	// If shouldAttach is false, no attachments will be done.
-	doNEGAttachDetach := func(addEndpoints, removeEndpoints, committedEndpoints, filteredAddEndpoints, filteredRemoveEndpoints map[types.EndpointGroupInfo]types.NetworkEndpointSet, shouldAttach bool) {
+	doNEGAttachDetach := func(addEndpoints, removeEndpoints, committedEndpoints, filteredAddEndpoints, filteredRemoveEndpoints map[types.NEGLocation]types.NetworkEndpointSet, shouldAttach bool) {
 		// Endpoints are detachment by deleting them from the removeEndpoints set.
 		for zone, endpointSet := range filteredRemoveEndpoints {
 			removeEndpoints[zone].Delete(endpointSet.List()...)
@@ -295,11 +295,11 @@ func TestFilter_FunctionalTest(t *testing.T) {
 			// Step 1: Generate endpoints to be used as input.
 			/////////////////////////////////////////////////////////////////////////
 
-			addEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)       // Contains dual-stack endpoints which are to be added to the NEG.
-			removeEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)    // Contains single-stack endpoints which are to be removed from the NEG.
-			committedEndpoints := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet) // Initially empty.
+			addEndpoints := make(map[types.NEGLocation]types.NetworkEndpointSet)       // Contains dual-stack endpoints which are to be added to the NEG.
+			removeEndpoints := make(map[types.NEGLocation]types.NetworkEndpointSet)    // Contains single-stack endpoints which are to be removed from the NEG.
+			committedEndpoints := make(map[types.NEGLocation]types.NetworkEndpointSet) // Initially empty.
 			for i := 0; i < tc.initialNEGEndpointsCount; i++ {
-				epGroupInfo := types.EndpointGroupInfo{Zone: fmt.Sprintf("zone-%v", i%tc.zonesCount), Subnet: defaultTestSubnet}
+				epGroupInfo := types.NEGLocation{Zone: fmt.Sprintf("zone-%v", i%tc.zonesCount), Subnet: defaultTestSubnet}
 				ipv4 := fmt.Sprintf("ipv4-%v", 2*i+1)
 				ipv6 := fmt.Sprintf("ipv6-%v", 2*i+2)
 				if addEndpoints[epGroupInfo] == nil {
@@ -352,7 +352,7 @@ func TestFilter_FunctionalTest(t *testing.T) {
 }
 
 func TestPause(t *testing.T) {
-	addEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+	addEndpoints := map[types.NEGLocation]types.NetworkEndpointSet{
 		{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a", IPv6: "A"}, // migrating
 			{IP: "b"},
@@ -360,7 +360,7 @@ func TestPause(t *testing.T) {
 			{IP: "d"}, // migrating
 		}...),
 	}
-	removeEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+	removeEndpoints := map[types.NEGLocation]types.NetworkEndpointSet{
 		{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			{IP: "a"}, // migrating
 			{IP: "e", IPv6: "E"},
@@ -374,12 +374,12 @@ func TestPause(t *testing.T) {
 	// starting migration-detachments.
 	clonedAddEndpoints := cloneZoneNetworkEndpointsMap(addEndpoints)
 	clonedRemoveEndpoints := cloneZoneNetworkEndpointsMap(removeEndpoints)
-	migrator.Filter(clonedAddEndpoints, clonedRemoveEndpoints, map[types.EndpointGroupInfo]types.NetworkEndpointSet{})
+	migrator.Filter(clonedAddEndpoints, clonedRemoveEndpoints, map[types.NEGLocation]types.NetworkEndpointSet{})
 	possibleMigrationDetachments := []types.NetworkEndpoint{
 		{IP: "a"},            // migrating
 		{IP: "d", IPv6: "D"}, // migrating
 	}
-	if !clonedRemoveEndpoints[types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet}].HasAny(possibleMigrationDetachments...) {
+	if !clonedRemoveEndpoints[types.NEGLocation{Zone: "zone1", Subnet: defaultTestSubnet}].HasAny(possibleMigrationDetachments...) {
 		t.Fatalf("Precondition to verify the behaviour of Pause() not satisfied; Filter() should start migration-detachments; got removeEndpoints=%+v; want non-empty union with %+v", clonedRemoveEndpoints, possibleMigrationDetachments)
 	}
 
@@ -393,9 +393,9 @@ func TestPause(t *testing.T) {
 
 	// The effect of Pause() is observed by verifying that Filter() does not start
 	// any migration-detachments when paused.
-	migrator.Filter(addEndpoints, removeEndpoints, map[types.EndpointGroupInfo]types.NetworkEndpointSet{})
-	wantRemoveEndpoints := map[types.EndpointGroupInfo]types.NetworkEndpointSet{
-		types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
+	migrator.Filter(addEndpoints, removeEndpoints, map[types.NEGLocation]types.NetworkEndpointSet{})
+	wantRemoveEndpoints := map[types.NEGLocation]types.NetworkEndpointSet{
+		types.NEGLocation{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 			// Since we don't expect any migration-detachments, this set should be
 			// missing all migration endpoints.
 			{IP: "e", IPv6: "E"},
@@ -525,23 +525,23 @@ func TestContinue_NoInputError_ShouldChangeTimeSincePreviousDetach(t *testing.T)
 func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 	testCases := []struct {
 		desc                        string
-		addEndpoints                map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		removeEndpoints             map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		committedEndpoints          map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		migrationEndpoints          map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		addEndpoints                map[types.NEGLocation]types.NetworkEndpointSet
+		removeEndpoints             map[types.NEGLocation]types.NetworkEndpointSet
+		committedEndpoints          map[types.NEGLocation]types.NetworkEndpointSet
+		migrationEndpoints          map[types.NEGLocation]types.NetworkEndpointSet
 		migrator                    *Migrator
 		wantCurrentlyMigratingCount int
 	}{
 		{
 			desc:            "less than or equal to 10 (committed + migration) endpoints should only detach 1 at a time",
-			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints:    map[types.NEGLocation]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 				}...),
@@ -551,14 +551,14 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 		},
 		{
 			desc:            "more than 10 (committed + migration) endpoints can detach more than 1 at a time",
-			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints:    map[types.NEGLocation]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"}, {IP: "7"}, {IP: "8"}, {IP: "9"}, {IP: "10"},
 					{IP: "11"},
@@ -572,18 +572,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// migration was NOT too long ago, then we will not start any new
 			// detachments since we wait for the pending attaches to complete
 			desc: "many endpoints are waiting to be attached AND previous migration was quite recent",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
@@ -600,18 +600,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// migration was too long ago BUT we are in error state, then we will not
 			// start any new detachments since we wait to get out of error state.
 			desc: "many endpoints are waiting to be attached AND previous migration was too long ago BUT in error state",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
@@ -629,18 +629,18 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// want to keep waiting indefinitely for the next detach and we proceed
 			// with the detachments.
 			desc: "many endpoints are waiting to be attached BUT previous migration was too long ago AND not in error state",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"}, {IP: "5"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "6"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "7"},
 				}...),
@@ -650,22 +650,22 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 		},
 		{
 			desc: "no detachments started since nothing to migrate",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "2"},
 				}...),
 			},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "3"}, {IP: "4"}, {IP: "5"}, {IP: "6"},
 				}...),
 			},
-			migrationEndpoints:          map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			migrationEndpoints:          map[types.NEGLocation]types.NetworkEndpointSet{},
 			migrator:                    newMigratorForTest(t, true),
 			wantCurrentlyMigratingCount: 0,
 		},
@@ -674,9 +674,9 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 			// more than the number of endpoints in any single zone, we should not
 			// include endpoints from multiple zones.
 			desc:            "endpoints from multiple zones should not be detached at once",
-			addEndpoints:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			committedEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints:    map[types.NEGLocation]types.NetworkEndpointSet{},
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{},
+			committedEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "1"}, {IP: "2"}, {IP: "3"}, {IP: "4"},
 				}...),
@@ -684,7 +684,7 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 					{IP: "5"}, {IP: "6"}, {IP: "7"}, {IP: "8"},
 				}...),
 			},
-			migrationEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			migrationEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "9"}, {IP: "10"},
 				}...),
@@ -746,14 +746,14 @@ func TestCalculateMigrationEndpointsToDetach(t *testing.T) {
 func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 	testCases := []struct {
 		name                              string
-		addEndpoints                      map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		removeEndpoints                   map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantMigrationEndpointsInAddSet    map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantMigrationEndpointsInRemoveSet map[types.EndpointGroupInfo]types.NetworkEndpointSet
+		addEndpoints                      map[types.NEGLocation]types.NetworkEndpointSet
+		removeEndpoints                   map[types.NEGLocation]types.NetworkEndpointSet
+		wantMigrationEndpointsInAddSet    map[types.NEGLocation]types.NetworkEndpointSet
+		wantMigrationEndpointsInRemoveSet map[types.NEGLocation]types.NetworkEndpointSet
 	}{
 		{
 			name: "detect multiple migrating endpoints",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"}, // migrating
 					{IP: "b"},
@@ -764,7 +764,7 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 					{IP: "e", IPv6: "E"}, // migrating
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"}, // migrating
 					{IP: "f", IPv6: "F"},
@@ -774,7 +774,7 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 					{IPv6: "E"}, // migrating
 				}...),
 			},
-			wantMigrationEndpointsInAddSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantMigrationEndpointsInAddSet: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "d"},
@@ -783,7 +783,7 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 					{IP: "e", IPv6: "E"},
 				}...),
 			},
-			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantMigrationEndpointsInRemoveSet: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a"},
 					{IP: "d", IPv6: "D"},
@@ -795,35 +795,35 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 		},
 		{
 			name: "partial IP change without stack change is not considered migrating",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "B"},
 				}...),
 			},
-			wantMigrationEndpointsInAddSet:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInAddSet:    map[types.NEGLocation]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInRemoveSet: map[types.NEGLocation]types.NetworkEndpointSet{},
 		},
 		{
 			name: "difference in port or node is not considered migrating",
-			addEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			addEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A", Port: "80"},
 					{IP: "b", Node: "node2"},
 				}...),
 			},
-			removeEndpoints: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			removeEndpoints: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", Port: "81"},
 					{IP: "b", IPv6: "B", Node: "node1"},
 				}...),
 			},
-			wantMigrationEndpointsInAddSet:    map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
-			wantMigrationEndpointsInRemoveSet: map[types.EndpointGroupInfo]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInAddSet:    map[types.NEGLocation]types.NetworkEndpointSet{},
+			wantMigrationEndpointsInRemoveSet: map[types.NEGLocation]types.NetworkEndpointSet{},
 		},
 	}
 
@@ -843,88 +843,88 @@ func TestFindAndFilterMigrationEndpoints(t *testing.T) {
 
 func TestMoveEndpoint(t *testing.T) {
 	testCases := []struct {
-		name              string
-		endpoint          types.NetworkEndpoint
-		inputSource       map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		inputDest         map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantSource        map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		wantDest          map[types.EndpointGroupInfo]types.NetworkEndpointSet
-		endpointGroupInfo types.EndpointGroupInfo
-		wantSuccess       bool
+		name        string
+		endpoint    types.NetworkEndpoint
+		inputSource map[types.NEGLocation]types.NetworkEndpointSet
+		inputDest   map[types.NEGLocation]types.NetworkEndpointSet
+		wantSource  map[types.NEGLocation]types.NetworkEndpointSet
+		wantDest    map[types.NEGLocation]types.NetworkEndpointSet
+		negLocation types.NEGLocation
+		wantSuccess bool
 	}{
 		{
 			name:     "completely valid input, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet},
-			wantSuccess:       true,
+			negLocation: types.NEGLocation{Zone: "zone1", Subnet: defaultTestSubnet},
+			wantSuccess: true,
 		},
 		{
 			name:     "zone does not exist in source",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
 			},
-			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
+			negLocation: types.NEGLocation{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 		{
 			name:     "zone does not exist in destination, shoud successfully move",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone2", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "b", IPv6: "B"},
 				}...),
 			},
-			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "a", IPv6: "A"},
 				}...),
@@ -932,44 +932,44 @@ func TestMoveEndpoint(t *testing.T) {
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone1", Subnet: defaultTestSubnet},
-			wantSuccess:       true,
+			negLocation: types.NEGLocation{Zone: "zone1", Subnet: defaultTestSubnet},
+			wantSuccess: true,
 		},
 		{
 			name:     "source is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantDest: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantDest: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
+			negLocation: types.NEGLocation{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 		{
 			name:     "destination is nil",
 			endpoint: types.NetworkEndpoint{IP: "a", IPv6: "A"},
-			inputSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			inputSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			wantSource: map[types.EndpointGroupInfo]types.NetworkEndpointSet{
+			wantSource: map[types.NEGLocation]types.NetworkEndpointSet{
 				{Zone: "zone3", Subnet: defaultTestSubnet}: types.NewNetworkEndpointSet([]types.NetworkEndpoint{
 					{IP: "c", IPv6: "C"},
 				}...),
 			},
-			endpointGroupInfo: types.EndpointGroupInfo{Zone: "zone3", Subnet: defaultTestSubnet},
+			negLocation: types.NEGLocation{Zone: "zone3", Subnet: defaultTestSubnet},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSuccess := moveEndpoint(tc.endpoint, tc.inputSource, tc.inputDest, tc.endpointGroupInfo)
+			gotSuccess := moveEndpoint(tc.endpoint, tc.inputSource, tc.inputDest, tc.negLocation)
 
 			if gotSuccess != tc.wantSuccess {
 				t.Errorf("moveEndpoint(%v, ...) = %v, want = %v", tc.endpoint, gotSuccess, tc.wantSuccess)
@@ -984,10 +984,10 @@ func TestMoveEndpoint(t *testing.T) {
 	}
 }
 
-func cloneZoneNetworkEndpointsMap(m map[types.EndpointGroupInfo]types.NetworkEndpointSet) map[types.EndpointGroupInfo]types.NetworkEndpointSet {
-	clone := make(map[types.EndpointGroupInfo]types.NetworkEndpointSet)
-	for endpointGroupInfo, endpointSet := range m {
-		clone[endpointGroupInfo] = types.NewNetworkEndpointSet(endpointSet.List()...)
+func cloneZoneNetworkEndpointsMap(m map[types.NEGLocation]types.NetworkEndpointSet) map[types.NEGLocation]types.NetworkEndpointSet {
+	clone := make(map[types.NEGLocation]types.NetworkEndpointSet)
+	for negLocation, endpointSet := range m {
+		clone[negLocation] = types.NewNetworkEndpointSet(endpointSet.List()...)
 	}
 	return clone
 }

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -72,7 +72,7 @@ func (l *LocalL4EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
 	// List all nodes where the service endpoints are running. Get a subset of the desired count.
 	zoneNodeMap := make(map[string][]*nodeWithSubnet)
 	processedNodes := sets.String{}
@@ -126,7 +126,7 @@ func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsDat
 	return subsetMap, nil, 0, err
 }
 
-func (l *LocalL4EndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, currentMap map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, error) {
+func (l *LocalL4EndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, currentMap map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// this should be the same as CalculateEndpoints for L4 ec
 	subsetMap, podMap, _, err := l.CalculateEndpoints(eds, currentMap)
 	return subsetMap, podMap, err
@@ -174,7 +174,7 @@ func (l *ClusterL4EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(_ []types.EndpointsData, currentMap map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
 	nodes, _ := l.zoneGetter.ListNodes(zonegetter.CandidateAndUnreadyNodesFilter, l.logger)
 	zoneNodeMap := make(map[string][]*nodeWithSubnet)
@@ -197,7 +197,7 @@ func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(_ []types.EndpointsDat
 	return subsetMap, nil, 0, err
 }
 
-func (l *ClusterL4EndpointsCalculator) CalculateEndpointsDegradedMode(eps []types.EndpointsData, currentMap map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, error) {
+func (l *ClusterL4EndpointsCalculator) CalculateEndpointsDegradedMode(eps []types.EndpointsData, currentMap map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	// this should be the same as CalculateEndpoints for L4 ec
 	subsetMap, podMap, _, err := l.CalculateEndpoints(eps, currentMap)
 	return subsetMap, podMap, err
@@ -245,7 +245,7 @@ func (l *L7EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
+func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
 	result, err := toZoneNetworkEndpointMap(eds, l.zoneGetter, l.podLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG, l.enableMultiSubnetCluster, l.logger)
 	if err == nil { // If current calculation ends up in error, we trigger and emit metrics in degraded mode.
 		l.syncMetricsCollector.UpdateSyncerEPMetrics(l.syncerKey, result.EPCount, result.EPSCount)
@@ -254,7 +254,7 @@ func (l *L7EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, _ 
 }
 
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
-func (l *L7EndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, _ map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]types.NetworkEndpointSet, types.EndpointPodMap, error) {
+func (l *L7EndpointsCalculator) CalculateEndpointsDegradedMode(eds []types.EndpointsData, _ map[negtypes.NEGLocation]types.NetworkEndpointSet) (map[negtypes.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, error) {
 	result := toZoneNetworkEndpointMapDegradedMode(eds, l.zoneGetter, l.podLister, l.nodeLister, l.serviceLister, l.servicePortName, l.networkEndpointType, l.enableDualStackNEG, l.enableMultiSubnetCluster, l.logger)
 	l.syncMetricsCollector.UpdateSyncerEPMetrics(l.syncerKey, result.EPCount, result.EPSCount)
 	return result.NetworkEndpointSet, result.EndpointPodMap, nil

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -53,7 +53,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		endpointsData       []negtypes.EndpointsData
-		wantEndpointSets    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		wantEndpointSets    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
 		nodeLabelsMap       map[string]map[string]string
 		nodeAnnotationsMap  map[string]map[string]string
@@ -65,7 +65,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
@@ -77,7 +77,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, all nodes unready",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
@@ -99,7 +99,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			},
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 2 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes. 2 out of those 4 are non-candidates.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
 			},
@@ -127,7 +127,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			//networkEndpointType: negtypes.VmIpEndpointType,
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 3 out of 6 nodes are picked because only 3 have multi-nic annotation with a matching network name
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1},
 					negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
@@ -144,7 +144,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 				testInstance3: {utils.LabelNodeSubnet: secondaryTestSubnet1},
 			},
 			// only 4 out of 6 nodes are picked since there are > 4 endpoints, but they are found only on 4 nodes.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
 				{Zone: negtypes.TestZone1, Subnet: secondaryTestSubnet1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}),
 				{Zone: negtypes.TestZone1, Subnet: secondaryTestSubnet2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
@@ -208,7 +208,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		endpointsData       []negtypes.EndpointsData
-		wantEndpointSets    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		wantEndpointSets    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		networkEndpointType negtypes.NetworkEndpointType
 		nodeLabelsMap       map[string]map[string]string
 		nodeAnnotationsMap  map[string]map[string]string
@@ -220,7 +220,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
@@ -234,7 +234,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, all nodes unready",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
@@ -251,7 +251,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "default endpoints, some nodes marked as non-candidates",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all valid candidate nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
@@ -272,7 +272,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			// all nodes are picked since, in this mode, endpoints running do not need to run on the selected node.
 			// Even when there are no service endpoints, nodes are selected at random.
 			endpointsData: []negtypes.EndpointsData{},
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4},
 					negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: testInstance5}, negtypes.NetworkEndpoint{IP: "1.2.3.6", Node: testInstance6}),
@@ -285,7 +285,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 		{
 			desc:          "multinetwork endpoints, only for nodes connected to the specified network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
 			},
@@ -303,7 +303,7 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "endpoints with MSC nodes",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			// all nodes are picked up, but since nodes are spread across subnets there is a separate endpoint set per zone/subnet.
-			wantEndpointSets: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
 				{Zone: negtypes.TestZone1, Subnet: secondaryTestSubnet1}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}),
 				{Zone: negtypes.TestZone1, Subnet: secondaryTestSubnet2}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
@@ -458,7 +458,7 @@ func TestValidateEndpoints(t *testing.T) {
 		ec                 negtypes.NetworkEndpointsCalculator
 		ecMSC              negtypes.NetworkEndpointsCalculator
 		testEndpointSlices []*discovery.EndpointSlice
-		currentMap         map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		currentMap         map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		// Use mutation to inject error into that we cannot trigger currently.
 		mutation func([]negtypes.EndpointsData, negtypes.EndpointPodMap) ([]negtypes.EndpointsData, negtypes.EndpointPodMap)
 		expect   error
@@ -691,7 +691,7 @@ func TestValidateEndpoints(t *testing.T) {
 		desc               string
 		ecMSC              negtypes.NetworkEndpointsCalculator
 		testEndpointSlices []*discovery.EndpointSlice
-		currentMap         map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		currentMap         map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		// Use mutation to inject error into that we cannot trigger currently.
 		mutation             func([]negtypes.EndpointsData, negtypes.EndpointPodMap) ([]negtypes.EndpointsData, negtypes.EndpointPodMap)
 		expectCalculationErr error

--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -263,7 +263,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 		// expectEmpty indicates that some zones can have empty subsets
 		expectEmpty      bool
 		networkInfo      network.NetworkInfo
-		expectedNodesMap map[negtypes.EndpointGroupInfo]map[string]string
+		expectedNodesMap map[negtypes.NEGLocation]map[string]string
 	}{
 		{
 			description: "Default network, gets primary interface",
@@ -277,7 +277,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				SubnetworkURL: defaultTestSubnetURL,
 			},
 			// empty IPs since test can't get the primary IP
-			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
+			expectedNodesMap: map[negtypes.NEGLocation]map[string]string{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "", "n1_2": ""},
 				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "", "n2_2": ""},
 				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": ""},
@@ -296,7 +296,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				K8sNetwork:    "net1",
 				SubnetworkURL: defaultTestSubnetURL,
 			},
-			expectedNodesMap: map[negtypes.EndpointGroupInfo]map[string]string{
+			expectedNodesMap: map[negtypes.NEGLocation]map[string]string{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
 				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
 				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": "172.168.3.1"},

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -136,82 +136,82 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 
 		testCases := []struct {
 			desc            string
-			addEndpoints    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-			removeEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-			expectEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+			addEndpoints    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+			removeEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+			expectEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		}{
 			{
 				desc:            "no endpoints to add or remove",
-				addEndpoints:    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				addEndpoints:    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			},
 			{
 				desc: "add some endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc:         "remove some endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc: "add duplicate endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc: "add and remove endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
 			},
 			{
 				desc: "add more endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 			},
 			{
 				desc: "add and remove endpoints in both zones",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
@@ -222,7 +222,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 			// TODO(gauravkghildiyal): When the DualStack Migrator is fully
 			// implemented, check if we need to cover scenarios where `migrationZone`
 			// is not empty.
-			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, negtypes.EndpointGroupInfo{})
+			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, negtypes.NEGLocation{})
 			if err != nil {
 				t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -231,8 +231,8 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 			}
 
-			for endpointGroupInfo, endpoints := range tc.expectEndpoints {
-				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, endpointGroupInfo.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+			for negLocation, endpoints := range tc.expectEndpoints {
+				list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, negLocation.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 				if err != nil {
 					t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 				}
@@ -247,7 +247,7 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 				}
 
 				if !endpoints.Equal(endpointSet) {
-					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, endpointGroupInfo.Zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
+					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, negLocation.Zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
 				}
 			}
 		}
@@ -345,94 +345,94 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 
 		testCases := []struct {
 			desc            string
-			addEndpoints    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-			removeEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-			expectEndpoints map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+			addEndpoints    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+			removeEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+			expectEndpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		}{
 			{
 				desc:            "no endpoints to add or remove",
-				addEndpoints:    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+				addEndpoints:    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			},
 			{
 				desc: "add some endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc:         "remove some endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc: "add duplicate endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc: "add and remove endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)).Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 				},
 			},
 			{
 				desc: "add more endpoints",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
 			},
 			{
 				desc: "add and remove endpoints in both zones",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
 			},
 			{
 				desc: "add endpoints in non-default subnets",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.2.1.1"), 10, testInstance5, targetPort)),
 					{Zone: testZone2, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.2.2.1"), 10, testInstance6, targetPort)),
 				},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.2.1.1"), 10, testInstance5, targetPort)),
@@ -441,12 +441,12 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 			},
 			{
 				desc:         "remove endpoints in non-default subnets",
-				addEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-				removeEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				addEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+				removeEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.2.1.1"), 10, testInstance5, targetPort)),
 					{Zone: testZone2, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.2.2.1"), 10, testInstance6, targetPort)),
 				},
-				expectEndpoints: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				expectEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, targetPort)),
 					{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.4.1"), 10, testInstance4, targetPort)),
 				},
@@ -457,7 +457,7 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 			// TODO(gauravkghildiyal): When the DualStack Migrator is fully
 			// implemented, check if we need to cover scenarios where `migrationZone`
 			// is not empty.
-			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, negtypes.EndpointGroupInfo{})
+			err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, tc.removeEndpoints, labels.EndpointPodLabelMap{}, negtypes.NEGLocation{})
 			if err != nil {
 				t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -466,12 +466,12 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 				t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 			}
 
-			for endpointGroupInfo, endpoints := range tc.expectEndpoints {
+			for negLocation, endpoints := range tc.expectEndpoints {
 				negName := transactionSyncer.NegSyncerKey.NegName
-				if endpointGroupInfo.Subnet != defaultTestSubnet {
+				if negLocation.Subnet != defaultTestSubnet {
 					negName = nonDefaultNegName
 				}
-				list, err := fakeCloud.ListNetworkEndpoints(negName, endpointGroupInfo.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+				list, err := fakeCloud.ListNetworkEndpoints(negName, negLocation.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 				if err != nil {
 					t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 				}
@@ -486,7 +486,7 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 				}
 
 				if !endpoints.Equal(endpointSet) {
-					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, endpointGroupInfo.Zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
+					t.Errorf("For case %q, in zone %q, negType %q, endpointSets endpoints == %v, but got %v, difference: \n(want - got) = %v\n(got - want) = %v", tc.desc, negLocation.Zone, testNegType, endpoints, endpointSet, endpoints.Difference(endpointSet), endpointSet.Difference(endpoints))
 				}
 			}
 		}
@@ -521,7 +521,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		desc                    string
 		labelPropagationEnabled bool
 		negType                 negtypes.NetworkEndpointType
-		addEndpoints            map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		addEndpoints            map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		endpointPodLabelMap     labels.EndpointPodLabelMap
 		expectedNEAnnotation    labels.PodLabelMap
 	}{
@@ -529,7 +529,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"empty input",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			labels.EndpointPodLabelMap{},
 			nil,
 		},
@@ -537,7 +537,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L4 endpoints with label map populated",
 			true,
 			negtypes.VmIpEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
 			},
@@ -557,7 +557,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L4 endpoints with empty label map",
 			true,
 			negtypes.VmIpEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet1).Union(l4EndpointSet2),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l4EndpointSet3).Union(l4EndpointSet4),
 			},
@@ -574,7 +574,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints label map populated",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
@@ -597,7 +597,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints with empty label map",
 			true,
 			negtypes.VmIpPortEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
@@ -614,7 +614,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			"add L7 endpoints label map populated, but EnableNEGLabelPropagation flag disabled",
 			false,
 			negtypes.VmIpPortEndpointType,
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet1).Union(l7EndpointSet2),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(l7EndpointSet3).Union(l7EndpointSet4),
 			},
@@ -643,7 +643,7 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
-		err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}, tc.endpointPodLabelMap, negtypes.EndpointGroupInfo{})
+		err := transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}, tc.endpointPodLabelMap, negtypes.NEGLocation{})
 		if err != nil {
 			t.Errorf("For case %q, syncNetworkEndpoints() got %v, want nil", tc.desc, err)
 		}
@@ -651,8 +651,8 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 			t.Errorf("For case %q, waitForTransactions() got %v, want nil", tc.desc, err)
 		}
 
-		for endpointGroupInfo := range tc.addEndpoints {
-			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, endpointGroupInfo.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
+		for negLocation := range tc.addEndpoints {
+			list, err := fakeCloud.ListNetworkEndpoints(transactionSyncer.NegSyncerKey.NegName, negLocation.Zone, false, transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 			if err != nil {
 				t.Errorf("For case %q, ListNetworkEndpoints() got %v, want nil", tc.desc, err)
 			}
@@ -850,31 +850,31 @@ func TestCommitTransaction(t *testing.T) {
 func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		endpointMap       map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		table             func() networkEndpointTransactionTable
-		expectEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectEndpointMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 	}{
 		{
 			"empty map and transactions",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty transactions",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"empty map",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -894,14 +894,14 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add existing endpoints",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -924,14 +924,14 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -954,14 +954,14 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 20, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 20, testInstance3, "8080")),
 			},
 		},
 		{
 			"remove existing endpoints",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -974,14 +974,14 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"add non-existing endpoints and remove existing endpoints",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -999,7 +999,7 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")).Union(generateEndpointSet(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")),
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -1017,19 +1017,19 @@ func TestMergeTransactionIntoZoneEndpointMap(t *testing.T) {
 func TestFilterEndpointByTransaction(t *testing.T) {
 	testCases := []struct {
 		desc              string
-		endpointMap       map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		endpointMap       map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		table             func() networkEndpointTransactionTable
-		expectEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectEndpointMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 	}{
 		{
 			"both empty",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty map",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			func() networkEndpointTransactionTable {
 				table := NewTransactionTable()
 				generateTransaction(table, transactionEntry{
@@ -1044,28 +1044,28 @@ func TestFilterEndpointByTransaction(t *testing.T) {
 				}, net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 				return table
 			},
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		{
 			"empty transaction",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")),
 				{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 		},
 		{
 			"empty transaction",
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
 				{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
 			func() networkEndpointTransactionTable { return NewTransactionTable() },
-			map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.1.6"), 5, testInstance1, "8080")),
 				{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet().Union(generateEndpointSet(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")),
 			},
@@ -1097,12 +1097,12 @@ func TestCommitPods(t *testing.T) {
 		flags.F.EnableMultiSubnetClusterPhase1 = enableMultiSubnetPhase1
 		for _, tc := range []struct {
 			desc         string
-			input        func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
+			input        func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
 			expectOutput func() map[negMeta]negtypes.EndpointPodMap
 		}{
 			{
 				desc: "empty input",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
 					return nil, nil
 				},
 				expectOutput: func() map[negMeta]negtypes.EndpointPodMap {
@@ -1111,9 +1111,9 @@ func TestCommitPods(t *testing.T) {
 			},
 			{
 				desc: "10 endpoints from 1 instance in 1 zone",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
 					endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-					return map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{{Zone: testZone1, Subnet: defaultTestSubnet}: endpointSet}, endpointMap
+					return map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{{Zone: testZone1, Subnet: defaultTestSubnet}: endpointSet}, endpointMap
 				},
 				expectOutput: func() map[negMeta]negtypes.EndpointPodMap {
 					_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
@@ -1124,23 +1124,23 @@ func TestCommitPods(t *testing.T) {
 			},
 			{
 				desc: "40 endpoints from 4 instances in 2 zone",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-					retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+					retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 						{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 						{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					}
 					retMap := negtypes.EndpointPodMap{}
 					endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					return retSet, retMap
 				},
@@ -1162,30 +1162,30 @@ func TestCommitPods(t *testing.T) {
 			},
 			{
 				desc: "40 endpoints from 4 instances in 2 zone, but half of the endpoints does not have corresponding pod mapping",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-					retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+					retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 						{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 						{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					}
 					retMap := negtypes.EndpointPodMap{}
 
 					endpointSet, _ := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 5, testInstance1, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 5, testInstance2, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 5, testInstance3, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 5, testInstance4, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 					return retSet, retMap
@@ -1208,30 +1208,30 @@ func TestCommitPods(t *testing.T) {
 			},
 			{
 				desc: "40 endpoints from 4 instances in 2 zone, and more endpoints are in pod mapping",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-					retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+					retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 						{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 						{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					}
 					retMap := negtypes.EndpointPodMap{}
 
 					endpointSet, _ := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 15, testInstance1, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 15, testInstance2, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 15, testInstance3, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 
 					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					_, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 15, testInstance4, "8080")
 					retMap = unionEndpointMap(retMap, endpointMap)
 					return retSet, retMap
@@ -1254,22 +1254,22 @@ func TestCommitPods(t *testing.T) {
 			},
 			{
 				desc: "40 endpoints from 4 instances in 2 zone, but some nodes do not have endpoint pod mapping",
-				input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-					retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+				input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+					retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 						{Zone: testZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 						{Zone: testZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					}
 					retMap := negtypes.EndpointPodMap{}
 					endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-					retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					return retSet, retMap
 				},
 				expectOutput: func() map[negMeta]negtypes.EndpointPodMap {
@@ -1321,22 +1321,22 @@ func TestCommitPodsMSC(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc         string
-		input        func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
+		input        func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
 		expectOutput func() map[negMeta]negtypes.EndpointPodMap
 	}{
 		{
 			desc: "20 endpoints from 2 instance in different subnets, in 1 zone",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet(),
 				}
 				retMap := negtypes.EndpointPodMap{}
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
 			},
@@ -1354,8 +1354,8 @@ func TestCommitPodsMSC(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instance in different subnets, in 2 zones",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					{Zone: testZone2, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
@@ -1363,16 +1363,16 @@ func TestCommitPodsMSC(t *testing.T) {
 				}
 				retMap := negtypes.EndpointPodMap{}
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: additionalTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: additionalTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: additionalTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: additionalTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
 			},
@@ -1396,8 +1396,8 @@ func TestCommitPodsMSC(t *testing.T) {
 		},
 		{
 			desc: "40 endpoints from 4 instance in different subnets, in 2 zones",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
 					{Zone: testZone1, Subnet: additionalTestSubnet}: negtypes.NewNetworkEndpointSet(),
 					{Zone: testZone2, Subnet: defaultTestSubnet}:    negtypes.NewNetworkEndpointSet(),
@@ -1405,16 +1405,16 @@ func TestCommitPodsMSC(t *testing.T) {
 				}
 				retMap := negtypes.EndpointPodMap{}
 				endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: additionalTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
-				retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: additionalTestSubnet}] = retSet[negtypes.EndpointGroupInfo{Zone: testZone2, Subnet: additionalTestSubnet}].Union(endpointSet)
+				retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: additionalTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: additionalTestSubnet}].Union(endpointSet)
 				retMap = unionEndpointMap(retMap, endpointMap)
 				return retSet, retMap
 			},
@@ -2342,7 +2342,7 @@ func TestUnknownNodes(t *testing.T) {
 
 	testEndpointSlices := getDefaultEndpointSlices()
 	testEndpointSlices[0].Endpoints[0].NodeName = utilpointer.StringPtr("unknown-node")
-	testEndpointMap := map[negtypes.EndpointGroupInfo]*composite.NetworkEndpoint{
+	testEndpointMap := map[negtypes.NEGLocation]*composite.NetworkEndpoint{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: &composite.NetworkEndpoint{
 			Instance:  negtypes.TestInstance1,
 			IpAddress: testIP1,
@@ -2364,10 +2364,10 @@ func TestUnknownNodes(t *testing.T) {
 
 	// Create initial NetworkEndpointGroups in cloud
 	var objRefs []negv1beta1.NegObjectReference
-	for endpointGroupInfo, endpoint := range testEndpointMap {
-		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, endpointGroupInfo.Zone, klog.TODO())
-		fakeCloud.AttachNetworkEndpoints(testNegName, endpointGroupInfo.Zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
-		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, endpointGroupInfo.Zone, meta.VersionGA, klog.TODO())
+	for negLocation, endpoint := range testEndpointMap {
+		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negLocation.Zone, klog.TODO())
+		fakeCloud.AttachNetworkEndpoints(testNegName, negLocation.Zone, []*composite.NetworkEndpoint{endpoint}, meta.VersionGA, klog.TODO())
+		neg, err := fakeCloud.GetNetworkEndpointGroup(testNegName, negLocation.Zone, meta.VersionGA, klog.TODO())
 		if err != nil {
 			t.Fatalf("failed to get neg from fake cloud: %s", err)
 		}
@@ -2405,7 +2405,7 @@ func TestUnknownNodes(t *testing.T) {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
 
-	expectedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	expectedEndpoints := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: testIP1, Node: negtypes.TestInstance1, Port: strconv.Itoa(int(testPort))},
 		),
@@ -2475,7 +2475,7 @@ func TestEnableDegradedMode(t *testing.T) {
 		},
 	}
 
-	initialEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	initialEndpoints := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 		),
@@ -2487,7 +2487,7 @@ func TestEnableDegradedMode(t *testing.T) {
 		),
 	}
 
-	updateSucceedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	updateSucceedEndpoints := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
@@ -2499,7 +2499,7 @@ func TestEnableDegradedMode(t *testing.T) {
 		{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 	}
 
-	updateFailedEndpoints := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	updateFailedEndpoints := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 			networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
@@ -2515,7 +2515,7 @@ func TestEnableDegradedMode(t *testing.T) {
 		modify               func(ts *transactionSyncer)
 		negName              string // to distinguish endpoints in differnt NEGs
 		testEndpointSlices   []*discovery.EndpointSlice
-		expectedEndpoints    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpoints    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedInErrorState bool
 		expectErr            error
 	}{
@@ -2857,13 +2857,13 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc   string
-		input  func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
+		input  func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap)
 		expect func() labels.EndpointPodLabelMap
 	}{
 		{
 			desc: "empty inputs",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				return map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}, negtypes.EndpointPodMap{}
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				return map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}, negtypes.EndpointPodMap{}
 			},
 			expect: func() labels.EndpointPodLabelMap {
 				return labels.EndpointPodLabelMap{}
@@ -2871,8 +2871,8 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 		},
 		{
 			desc: "Add endpoints in diferent zones",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
 					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(endpointSet2),
 				}
@@ -2894,8 +2894,8 @@ func TestGetEndpointPodLabelMap(t *testing.T) {
 		},
 		{
 			desc: "Add endpoints in diferent zones with pod not found",
-			input: func() (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
-				retSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			input: func() (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, negtypes.EndpointPodMap) {
+				retSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 					{Zone: testZone1}: negtypes.NewNetworkEndpointSet().Union(endpointSet1),
 					{Zone: testZone2}: negtypes.NewNetworkEndpointSet().Union(endpointSet2).Union(endpointSet3),
 				}
@@ -2943,14 +2943,14 @@ func TestCollectLabelStats(t *testing.T) {
 		desc              string
 		curLabelMap       labels.EndpointPodLabelMap
 		addLabelMap       labels.EndpointPodLabelMap
-		targetEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		targetEndpointMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expect            metricscollector.LabelPropagationStats
 	}{
 		{
 			desc:              "Empty inputs",
 			curLabelMap:       labels.EndpointPodLabelMap{},
 			addLabelMap:       labels.EndpointPodLabelMap{},
-			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			targetEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			expect: metricscollector.LabelPropagationStats{
 				EndpointsWithAnnotation: 0,
 				NumberOfEndpoints:       0,
@@ -2964,7 +2964,7 @@ func TestCollectLabelStats(t *testing.T) {
 				},
 			},
 			addLabelMap: labels.EndpointPodLabelMap{},
-			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -2987,7 +2987,7 @@ func TestCollectLabelStats(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone1}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -3010,7 +3010,7 @@ func TestCollectLabelStats(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			targetEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: testZone2}: negtypes.NewNetworkEndpointSet(
 					endpoint3,
 					endpoint4,

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -89,20 +89,20 @@ func calculateDifference(targetMap, currentMap map[string]sets.String) (map[stri
 }
 
 // calculateNetworkEndpointDifference determines what endpoints needs to be added and removed in order to move current state to target state.
-func calculateNetworkEndpointDifference(targetMap, currentMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet) (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet) {
-	addSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}
-	removeSet := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}
-	for endpointGroupInfo, endpointSet := range targetMap {
-		diff := endpointSet.Difference(currentMap[endpointGroupInfo])
+func calculateNetworkEndpointDifference(targetMap, currentMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, map[negtypes.NEGLocation]negtypes.NetworkEndpointSet) {
+	addSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
+	removeSet := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
+	for negLocation, endpointSet := range targetMap {
+		diff := endpointSet.Difference(currentMap[negLocation])
 		if len(diff) > 0 {
-			addSet[endpointGroupInfo] = diff
+			addSet[negLocation] = diff
 		}
 	}
 
-	for endpointGroupInfo, endpointSet := range currentMap {
-		diff := endpointSet.Difference(targetMap[endpointGroupInfo])
+	for negLocation, endpointSet := range currentMap {
+		diff := endpointSet.Difference(targetMap[negLocation])
 		if len(diff) > 0 {
-			removeSet[endpointGroupInfo] = diff
+			removeSet[negLocation] = diff
 		}
 	}
 	return addSet, removeSet
@@ -236,7 +236,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 }
 
 type ZoneNetworkEndpointMapResult struct {
-	NetworkEndpointSet map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+	NetworkEndpointSet map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 	EndpointPodMap     negtypes.EndpointPodMap
 	EPCount            negtypes.StateCountMap
 	EPSCount           negtypes.StateCountMap
@@ -244,7 +244,7 @@ type ZoneNetworkEndpointMapResult struct {
 
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
 func toZoneNetworkEndpointMap(eds []negtypes.EndpointsData, zoneGetter *zonegetter.ZoneGetter, podLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG, enableMultiSubnetCluster bool, logger klog.Logger) (ZoneNetworkEndpointMapResult, error) {
-	zoneNetworkEndpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}
+	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	ipsForPod := ipsForPod(eds)
 	globalEPCount := make(negtypes.StateCountMap)
@@ -374,29 +374,29 @@ func mergeWithGlobalCounts(localEPCount, globalEPCount, globalEPSCount negtypes.
 }
 
 // getEndpointZoneSubnet use an endpoint's nodeName to get its corresponding zone and subnet
-func getEndpointZoneSubnet(endpointAddress negtypes.AddressData, zoneGetter *zonegetter.ZoneGetter, logger klog.Logger) (negtypes.EndpointGroupInfo, negtypes.StateCountMap, error) {
+func getEndpointZoneSubnet(endpointAddress negtypes.AddressData, zoneGetter *zonegetter.ZoneGetter, logger klog.Logger) (negtypes.NEGLocation, negtypes.StateCountMap, error) {
 	count := make(negtypes.StateCountMap)
 	if endpointAddress.NodeName == nil || len(*endpointAddress.NodeName) == 0 {
 		count[negtypes.NodeMissing]++
 		count[negtypes.ZoneMissing]++
-		return negtypes.EndpointGroupInfo{}, count, negtypes.ErrEPNodeMissing
+		return negtypes.NEGLocation{}, count, negtypes.ErrEPNodeMissing
 	}
 	zone, subnet, err := zoneGetter.ZoneAndSubnetForNode(*endpointAddress.NodeName, logger)
 	// Fail to get the node object.
 	if errors.Is(err, zonegetter.ErrNodeNotFound) {
 		count[negtypes.NodeNotFound]++
-		return negtypes.EndpointGroupInfo{}, count, fmt.Errorf("%w: %v", negtypes.ErrEPNodeNotFound, err)
+		return negtypes.NEGLocation{}, count, fmt.Errorf("%w: %v", negtypes.ErrEPNodeNotFound, err)
 	}
 	if errors.Is(err, zonegetter.ErrNodePodCIDRNotSet) {
 		count[negtypes.NodePodCIDRNotSet]++
-		return negtypes.EndpointGroupInfo{}, count, fmt.Errorf("%w: %w", negtypes.ErrEPNodePodCIDRNotSet, err)
+		return negtypes.NEGLocation{}, count, fmt.Errorf("%w: %w", negtypes.ErrEPNodePodCIDRNotSet, err)
 	}
 	// providerID missing in node or zone information missing in providerID.
 	if errors.Is(err, zonegetter.ErrProviderIDNotFound) || errors.Is(err, zonegetter.ErrSplitProviderID) {
 		count[negtypes.ZoneMissing]++
-		return negtypes.EndpointGroupInfo{}, count, fmt.Errorf("%w: zone is missing for node %v", negtypes.ErrEPZoneMissing, *endpointAddress.NodeName)
+		return negtypes.NEGLocation{}, count, fmt.Errorf("%w: zone is missing for node %v", negtypes.ErrEPZoneMissing, *endpointAddress.NodeName)
 	}
-	return negtypes.EndpointGroupInfo{Zone: zone, Subnet: subnet}, count, err
+	return negtypes.NEGLocation{Zone: zone, Subnet: subnet}, count, err
 }
 
 // getEndpointPod use an endpoint's pod name and namespace to get its corresponding pod object
@@ -423,7 +423,7 @@ func getEndpointPod(endpointAddress negtypes.AddressData, podLister cache.Indexe
 // toZoneNetworkEndpointMap translates addresses in endpoints object into zone and endpoints map, and also return the count for duplicated endpoints
 // we will not raise error in degraded mode for misconfigured endpoints, instead they will be filtered directly
 func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGetter *zonegetter.ZoneGetter, podLister, nodeLister, serviceLister cache.Indexer, servicePortName string, networkEndpointType negtypes.NetworkEndpointType, enableDualStackNEG, enableMultiSubnetCluster bool, logger klog.Logger) ZoneNetworkEndpointMapResult {
-	zoneNetworkEndpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}
+	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	networkEndpointPodMap := negtypes.EndpointPodMap{}
 	ipsForPod := ipsForPod(eds)
 	globalEPCount := make(negtypes.StateCountMap)
@@ -484,7 +484,7 @@ func toZoneNetworkEndpointMapDegradedMode(eds []negtypes.EndpointsData, zoneGett
 				localEPCount[negtypes.NodeNotFound]++
 				continue
 			}
-			epGroupInfo := negtypes.EndpointGroupInfo{Zone: zone, Subnet: subnet}
+			epGroupInfo := negtypes.NEGLocation{Zone: zone, Subnet: subnet}
 			if zoneNetworkEndpointMap[epGroupInfo] == nil {
 				zoneNetworkEndpointMap[epGroupInfo] = negtypes.NewNetworkEndpointSet()
 			}
@@ -698,7 +698,7 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter *zonegetter.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger) (map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, error) {
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter *zonegetter.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, error) {
 	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
 	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
 	zones, err := zoneGetter.ListZones(zonegetter.AllNodesFilter, logger)
@@ -712,7 +712,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 	}
 	candidateZonesMap := sets.NewString(candidateNodeZones...)
 
-	zoneNetworkEndpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{}
+	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	for subnet, negName := range subnetToNegMapping {
 		for _, zone := range zones {
@@ -727,7 +727,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 				}
 				return nil, nil, fmt.Errorf("Failed to lookup NEG in zone %q, candidate zones %v, err - %w", zone, candidateZonesMap, err)
 			}
-			zoneNetworkEndpointMap[negtypes.EndpointGroupInfo{Zone: zone, Subnet: subnet}] = negtypes.NewNetworkEndpointSet()
+			zoneNetworkEndpointMap[negtypes.NEGLocation{Zone: zone, Subnet: subnet}] = negtypes.NewNetworkEndpointSet()
 			for _, ne := range networkEndpointsWithHealthStatus {
 				newNE := negtypes.NetworkEndpoint{IP: ne.NetworkEndpoint.IpAddress, Node: ne.NetworkEndpoint.Instance}
 				if ne.NetworkEndpoint.Port != 0 {
@@ -736,7 +736,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 				if enableDualStackNEG {
 					newNE.IPv6 = ne.NetworkEndpoint.Ipv6Address
 				}
-				zoneNetworkEndpointMap[negtypes.EndpointGroupInfo{Zone: zone, Subnet: subnet}].Insert(newNE)
+				zoneNetworkEndpointMap[negtypes.NEGLocation{Zone: zone, Subnet: subnet}].Insert(newNE)
 				endpointPodLabelMap[newNE] = ne.NetworkEndpoint.Annotations
 			}
 		}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -188,107 +188,107 @@ func TestNetworkEndpointCalculateDifference(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		targetSet  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-		currentSet map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-		addSet     map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
-		removeSet  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		targetSet  map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+		currentSet map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+		addSet     map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+		removeSet  map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 	}{
 		// unchanged
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			addSet:    map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			addSet:    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		// unchanged
 		{
-			targetSet:  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			addSet:     map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			removeSet:  map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			targetSet:  map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			addSet:     map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			removeSet:  map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		// add in one zone
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		// add in 2 zones
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 		},
 		// remove in one zone
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
 		},
 		// remove in 2 zones
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("e"), genNetworkEndpoint("f"), genNetworkEndpoint("g")),
 			},
 		},
 		// add and delete in one zone
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
 			},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
 			},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
 			},
 		},
 		// add and delete in 2 zones
 		{
-			targetSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			targetSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a"), genNetworkEndpoint("b"), genNetworkEndpoint("c")),
 			},
-			currentSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			currentSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("b"), genNetworkEndpoint("c"), genNetworkEndpoint("d")),
 			},
-			addSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			addSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("a")),
 			},
-			removeSet: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			removeSet: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
 				{Zone: negtypes.TestZone2}: negtypes.NewNetworkEndpointSet(genNetworkEndpoint("d")),
 			},
@@ -502,7 +502,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 	testCases := []struct {
 		desc                       string
 		portName                   string
-		wantZoneNetworkEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		wantZoneNetworkEndpointMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		wantNetworkEndpointPodMap  negtypes.EndpointPodMap
 		networkEndpointType        negtypes.NetworkEndpointType
 		enableDualStackNEG         bool
@@ -510,14 +510,14 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:                       "target port does not exist",
 			portName:                   "non-exists",
-			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			wantZoneNetworkEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			wantNetworkEndpointPodMap:  negtypes.EndpointPodMap{},
 			networkEndpointType:        negtypes.VmIpPortEndpointType,
 		},
 		{
 			desc:     "default service port name",
 			portName: "",
-			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantZoneNetworkEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Node: "instance1", Port: "80"},
 					{IP: "10.100.1.2", Node: "instance1", Port: "80"},
@@ -542,7 +542,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "explicitly named service port",
 			portName: testNamedPort,
-			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantZoneNetworkEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
@@ -567,7 +567,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "dual stack enabled with explicitly named service ports",
 			portName: testNamedPort,
-			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantZoneNetworkEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.2.2", Node: "instance2", Port: "81"},
 				}...),
@@ -593,7 +593,7 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 		{
 			desc:     "non GCP network endpoints",
 			portName: "",
-			wantZoneNetworkEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			wantZoneNetworkEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet([]negtypes.NetworkEndpoint{
 					{IP: "10.100.1.1", Port: "80"},
 					{IP: "10.100.1.2", Port: "80"},
@@ -785,7 +785,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 		mutate              func(cloud negtypes.NetworkEndpointGroupCloud)
 		mode                negtypes.EndpointsCalculatorMode
 		subnetToNegMapping  map[string]string
-		expect              map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expect              map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectAnnotationMap labels.EndpointPodLabelMap
 		expectErr           bool
 	}{
@@ -818,7 +818,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: testNegName, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
@@ -841,7 +841,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(endpoint1),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
@@ -868,7 +868,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -909,7 +909,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -944,7 +944,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: nonDefaultSubnetNegName, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithAdditionalSubnet,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -999,7 +999,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithAdditionalSubnet,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -1047,7 +1047,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.DeleteNetworkEndpointGroup(nonDefaultSubnetNegName, negtypes.TestZone4, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -1091,7 +1091,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -1135,7 +1135,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				}, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
 					endpoint2,
@@ -1182,7 +1182,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 			// set mode to L4 since this scenario applies more to VM_IP NEGs.
 			mode:               negtypes.L4LocalMode,
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expect: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				// NEGs in zone1, zone2 and zone4 are created from previous test case.
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					endpoint1,
@@ -1800,7 +1800,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 		desc                string
 		testEndpointSlices  []*discovery.EndpointSlice
 		portName            string
-		expectedEndpointMap map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpointMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedPodMap      negtypes.EndpointPodMap
 		networkEndpointType negtypes.NetworkEndpointType
 	}{
@@ -1808,7 +1808,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:                "non exist target port",
 			testEndpointSlices:  getDefaultEndpointSlices(),
 			portName:            testNonExistPort,
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{},
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
 			expectedPodMap:      negtypes.EndpointPodMap{},
 			networkEndpointType: negtypes.VmIpPortEndpointType,
 		},
@@ -1816,7 +1816,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "empty named port",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||instance1||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||instance1||80"),
@@ -1840,7 +1840,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "named target port",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testNamedPort,
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.2.2||instance2||81")),
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
@@ -1864,7 +1864,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 			desc:               "Non-GCP network endpoints",
 			testEndpointSlices: getDefaultEndpointSlices(),
 			portName:           testEmptyNamedPort,
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.100.1.1||||80"),
 					networkEndpointFromEncodedEndpoint("10.100.1.2||||80"),
@@ -1917,7 +1917,7 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 				},
 			},
 			portName: testEmptyNamedPort,
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					networkEndpointFromEncodedEndpoint("10.10.0.1||instance1||80"),
 				),
@@ -2001,7 +2001,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	})
 
 	// endpointMap and podMap contain all correct endpoints.
-	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	endpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2020,7 +2020,7 @@ func TestValidateEndpointFields(t *testing.T) {
 	//
 	// In degraded mode, we should exclude the invalid endpoint for non-coverable cases(pod invalid or empty zone).
 	// We always inject to first endpoint, so the result only contain the second endpoint.
-	endpointMapExcluded := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	endpointMapExcluded := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
 		),
@@ -2032,11 +2032,11 @@ func TestValidateEndpointFields(t *testing.T) {
 	testCases := []struct {
 		desc                            string
 		testEndpointSlices              []*discovery.EndpointSlice
-		expectedEndpointMap             map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpointMap             map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedPodMap                  negtypes.EndpointPodMap
 		expectErr                       error
 		expectErrorState                bool
-		expectedEndpointMapDegradedMode map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpointMapDegradedMode map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedPodMapDegradedMode      negtypes.EndpointPodMap
 	}{
 		{
@@ -2411,7 +2411,7 @@ func TestValidateEndpointFields(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2521,7 +2521,7 @@ func TestValidateEndpointFields(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
@@ -2535,7 +2535,7 @@ func TestValidateEndpointFields(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMapDegradedMode: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.3.2", IPv6: "a:b::1", Node: instance3, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.4.2", IPv6: "a:b::2", Node: instance4, Port: "80"},
@@ -2702,7 +2702,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 		},
 	})
 
-	endpointMap := map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+	endpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 			negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 			negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2716,11 +2716,11 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 	testCases := []struct {
 		desc                            string
 		testEndpointSlices              []*discovery.EndpointSlice
-		expectedEndpointMap             map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpointMap             map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedPodMap                  negtypes.EndpointPodMap
 		expectErr                       error
 		expectErrorState                bool
-		expectedEndpointMapDegradedMode map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet
+		expectedEndpointMapDegradedMode map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectedPodMapDegradedMode      negtypes.EndpointPodMap
 	}{
 		{
@@ -2770,7 +2770,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2786,7 +2786,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMapDegradedMode: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2848,7 +2848,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 					},
 				},
 			},
-			expectedEndpointMap: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMap: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},
@@ -2864,7 +2864,7 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 			},
 			expectErr:        nil,
 			expectErrorState: false,
-			expectedEndpointMapDegradedMode: map[negtypes.EndpointGroupInfo]negtypes.NetworkEndpointSet{
+			expectedEndpointMapDegradedMode: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
 				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: instance1, Port: "80"},
 					negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: instance1, Port: "80"},

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -84,12 +84,11 @@ type NegSyncerManager interface {
 
 type NetworkEndpointsCalculator interface {
 	// CalculateEndpoints computes the NEG endpoints based on service endpoints
-	// and the current NEG state and returns a map of EndpointGroupInfo to
-	// network endpoint set. EndpointGroupInfo contains the zone and subnet of
-	// this NEG.
-	CalculateEndpoints(eds []EndpointsData, currentMap map[EndpointGroupInfo]NetworkEndpointSet) (map[EndpointGroupInfo]NetworkEndpointSet, EndpointPodMap, int, error)
+	// and the current NEG state. It returns a map of NEGLocation to network
+	// endpoint set for that NEGLocation.
+	CalculateEndpoints(eds []EndpointsData, currentMap map[NEGLocation]NetworkEndpointSet) (map[NEGLocation]NetworkEndpointSet, EndpointPodMap, int, error)
 	// CalculateEndpointsDegradedMode computes the NEG endpoints using degraded mode calculation
-	CalculateEndpointsDegradedMode(eds []EndpointsData, currentMap map[EndpointGroupInfo]NetworkEndpointSet) (map[EndpointGroupInfo]NetworkEndpointSet, EndpointPodMap, error)
+	CalculateEndpointsDegradedMode(eds []EndpointsData, currentMap map[NEGLocation]NetworkEndpointSet) (map[NEGLocation]NetworkEndpointSet, EndpointPodMap, error)
 	// Mode indicates the mode that the EndpointsCalculator is operating in.
 	Mode() EndpointsCalculatorMode
 	// ValidateEndpoints validates the NEG endpoint information is correct

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -415,7 +415,7 @@ func NegInfoFromNegRef(negRef negv1beta1.NegObjectReference) (NegInfo, error) {
 	return NegInfo{Name: resourceID.Key.Name, Zone: resourceID.Key.Zone}, nil
 }
 
-type EndpointGroupInfo struct {
+type NEGLocation struct {
 	Zone   string
 	Subnet string
 }


### PR DESCRIPTION
The idea we're trying to represent is that NEGs will be created in this zone and subnet. These two parameters combined are defining the location for that NEG, hence the name NEGLocation.

/assign @swetharepakula 