### PR TITLE
Add forwardingrules.NetLBMixedManager

### DIFF
--- a/pkg/forwardingrules/netlb_mixed_manager.go
+++ b/pkg/forwardingrules/netlb_mixed_manager.go
@@ -1,0 +1,339 @@
+package forwardingrules
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/address"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/events"
+	"k8s.io/ingress-gce/pkg/utils"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	// maxForwardedPorts is the maximum number of ports that can be specified in an Forwarding Rule
+	maxForwardedPorts = 5
+)
+
+// Namer is used to get names for forwarding rules.
+type Namer interface {
+	L4ForwardingRule(namespace, name, protocol string) string
+}
+
+// Provider is the interface for the ForwardingRules provider.
+// We can't use the *ForwardingRules directly, since L4NetLB uses interface.
+//
+// It is assumed that delete doesn't return 404 errors when forwarding rule doesn't exist.
+type Provider interface {
+	Get(name string) (*composite.ForwardingRule, error)
+	Create(forwardingRule *composite.ForwardingRule) error
+	Delete(name string) error
+	Patch(forwardingRule *composite.ForwardingRule) error
+}
+
+// MixedManagerNetLB is responsible for Ensuring and Deleting Forwarding Rules
+// for mixed protocol NetLBs.
+type MixedManagerNetLB struct {
+	Namer    Namer
+	Provider Provider
+	Recorder record.EventRecorder
+	Logger   logr.Logger
+	Cloud    *gce.Cloud
+
+	Service *api_v1.Service
+}
+
+// EnsureNetLBResult contains relevant results for Ensure method
+type EnsureNetLBResult struct {
+	UDPFwdRule *composite.ForwardingRule
+	TCPFwdRule *composite.ForwardingRule
+	IPManaged  address.IPAddressType
+	SyncStatus utils.ResourceSyncStatus
+}
+
+// EnsureIPv4 will try to create or update forwarding rules for mixed protocol service.
+func (m *MixedManagerNetLB) EnsureIPv4(backendServiceLink string) (EnsureNetLBResult, error) {
+	m.Logger = m.Logger.WithName("MixedManagerNetLB")
+	svcPorts := m.Service.Spec.Ports
+	res := EnsureNetLBResult{
+		SyncStatus: utils.ResourceResync,
+	}
+
+	if !NeedsMixed(svcPorts) {
+		return res, fmt.Errorf("MixedManagerELB shouldn't be used to ensure single protocol forwarding rules to be backwards compatible")
+	}
+
+	existing, err := m.AllRules()
+	if err != nil {
+		return res, err
+	}
+
+	addressHandle, err := address.HoldExternalIPv4(address.HoldConfig{
+		Cloud:                 m.Cloud,
+		Recorder:              m.Recorder,
+		Logger:                m.Logger,
+		Service:               m.Service,
+		ExistingRules:         []*composite.ForwardingRule{existing.Legacy, existing.TCP, existing.UDP},
+		ForwardingRuleDeleter: m.Provider,
+	})
+	if err != nil {
+		return res, err
+	}
+	defer func() {
+		err = addressHandle.Release()
+		if err != nil {
+			m.Logger.Error(err, "failed to release address reservation, possibly causing an orphan")
+		}
+	}()
+	res.IPManaged = addressHandle.Managed
+
+	// We need to delete legacy named forwarding rule to avoid port collisions
+	if err := m.deleteLegacy(); err != nil {
+		return res, err
+	}
+
+	var tcpErr, udpErr error
+	var tcpSync, udpSync utils.ResourceSyncStatus
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		res.TCPFwdRule, tcpSync, tcpErr = m.ensure(existing.TCP, backendServiceLink, "TCP", addressHandle.IP)
+	}()
+	go func() {
+		defer wg.Done()
+		res.UDPFwdRule, udpSync, udpErr = m.ensure(existing.UDP, backendServiceLink, "UDP", addressHandle.IP)
+	}()
+
+	wg.Wait()
+	if tcpSync == utils.ResourceUpdate || udpSync == utils.ResourceUpdate {
+		res.SyncStatus = utils.ResourceUpdate
+	}
+	err = errors.Join(tcpErr, udpErr)
+
+	return res, err
+}
+
+// ensure has similar implementation to the L4NetLB.ensureIPv4ForwardingRule,
+// but can use multiple names for fwd rule.
+// This will:
+// * compare existing rule to wanted
+// * if doesnt exist 	-> create
+// * if equal 			-> do nothing
+// * if can be patched 	-> patch
+// * else 				-> delete and recreate
+func (m *MixedManagerNetLB) ensure(existing *composite.ForwardingRule, backendServiceLink, protocol, ip string) (*composite.ForwardingRule, utils.ResourceSyncStatus, error) {
+	name := m.name(protocol)
+	start := time.Now()
+	log := m.Logger.
+		WithName("ensure").
+		WithValues("forwardingRuleName", name).
+		WithValues("protocol", protocol)
+	log.Info("Ensuring external forwarding rule for L4 NetLB Service", "backendServiceLink", backendServiceLink)
+	defer func() {
+		log.Info("Finished ensuring external forwarding rule for L4 NetLB Service", "timeTaken", time.Since(start))
+	}()
+
+	wanted, err := m.buildWanted(backendServiceLink, name, protocol, ip)
+	if err != nil {
+		log.Error(err, "buildWanted returned error")
+		return nil, utils.ResourceResync, err
+	}
+
+	// Exists
+	if existing == nil {
+		if err := m.Provider.Create(wanted); err != nil {
+			log.Error(err, "Provider.Create returned error")
+			return nil, utils.ResourceUpdate, err
+		}
+		return m.getAfterUpdate(name)
+	}
+
+	// Can't update
+	if networkMismatch := existing.NetworkTier != wanted.NetworkTier; networkMismatch {
+		resource := fmt.Sprintf("Forwarding rule (%v)", name)
+		networkTierMismatchErr := utils.NewNetworkTierErr(resource, wanted.NetworkTier, wanted.NetworkTier)
+		return nil, utils.ResourceUpdate, networkTierMismatchErr
+	}
+
+	// Equal
+	if equal, err := EqualIPv4(existing, wanted); err != nil {
+		log.Error(err, "EqualIPV4 returned error")
+		return nil, utils.ResourceResync, err
+	} else if equal {
+		return existing, utils.ResourceResync, err
+	}
+
+	// Patchable
+	if patchable, filtered := PatchableIPv4(existing, wanted); patchable {
+		if err := m.Provider.Patch(filtered); err != nil {
+			return nil, utils.ResourceUpdate, err
+		}
+		m.recordEventf("ForwardingRule %s patched", name)
+		return m.getAfterUpdate(name)
+	}
+
+	// Recreate
+	if err := m.recreate(wanted); err != nil {
+		return nil, utils.ResourceResync, err
+	}
+	return m.getAfterUpdate(name)
+}
+
+func (m *MixedManagerNetLB) recreate(wanted *composite.ForwardingRule) error {
+	if err := m.Provider.Delete(wanted.Name); err != nil {
+		return err
+	}
+	m.recordEventf("ForwardingRule %s deleted", wanted.Name)
+
+	if err := m.Provider.Create(wanted); err != nil {
+		return err
+	}
+	m.recordEventf("ForwardingRule %s re-created", wanted.Name)
+
+	return nil
+}
+
+func (m *MixedManagerNetLB) buildWanted(backendServiceLink, name, protocol, ip string) (*composite.ForwardingRule, error) {
+	const version = meta.VersionGA
+	const scheme = string(cloud.SchemeExternal)
+	protocol = strings.ToUpper(protocol)
+	if protocol != "TCP" && protocol != "UDP" {
+		return nil, fmt.Errorf("Unknown protocol %s, expected TCP or UDP", protocol)
+	}
+
+	svcKey := utils.ServiceKeyFunc(m.Service.Namespace, m.Service.Name)
+	desc, err := utils.MakeL4LBServiceDescription(svcKey, ip, version, false, utils.XLB)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %w", name, err)
+	}
+
+	ports := GetPorts(m.Service.Spec.Ports, api_v1.Protocol(protocol))
+	var portRange string
+	if len(ports) > maxForwardedPorts {
+		portRange = utils.MinMaxPortRange(ports)
+		ports = nil
+	}
+
+	netTier, _ := annotations.NetworkTier(m.Service)
+
+	return &composite.ForwardingRule{
+		Name:                name,
+		Description:         desc,
+		IPAddress:           ip,
+		IPProtocol:          protocol,
+		Ports:               ports,
+		PortRange:           portRange,
+		LoadBalancingScheme: scheme,
+		BackendService:      backendServiceLink,
+		NetworkTier:         netTier.ToGCEValue(),
+	}, nil
+}
+
+func (m *MixedManagerNetLB) getAfterUpdate(name string) (*composite.ForwardingRule, utils.ResourceSyncStatus, error) {
+	found, err := m.Provider.Get(name)
+	if err != nil {
+		return nil, utils.ResourceUpdate, err
+	}
+	if found == nil {
+		return nil, utils.ResourceUpdate, fmt.Errorf("Forwarding rule %s not found", name)
+	}
+
+	return found, utils.ResourceUpdate, nil
+}
+
+// NetLBManagedRules contains rules managed by NetLB loadbalancer.
+// Under normal conditions one of three results is possible:
+// a) TCP and UDP both present - rules have been created for mixed protocol
+// b) Legacy present - rule has been created for single protocol
+// c) empty - nothing has been yet created
+type NetLBManagedRules struct {
+	// TCP forwarding rule with '-tcp-' in a name
+	TCP *composite.ForwardingRule
+	// UDP forwarding rule with '-udp-' in a name
+	UDP *composite.ForwardingRule
+	// Legacy named forwarding rule (staring with 'a')
+	Legacy *composite.ForwardingRule
+}
+
+// AllRules returns all forwarding rules for a service specified in the manager
+func (m *MixedManagerNetLB) AllRules() (NetLBManagedRules, error) {
+	var wg sync.WaitGroup
+	var tcp, udp, legacy *composite.ForwardingRule
+	var tcpErr, udpErr, legacyErr error
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		tcp, tcpErr = m.Provider.Get(m.name("tcp"))
+	}()
+	go func() {
+		defer wg.Done()
+		udp, udpErr = m.Provider.Get(m.name("udp"))
+	}()
+	go func() {
+		defer wg.Done()
+		legacy, legacyErr = m.Provider.Get(m.nameLegacy())
+	}()
+	wg.Wait()
+
+	return NetLBManagedRules{
+		TCP: tcp, UDP: udp, Legacy: legacy,
+	}, errors.Join(tcpErr, udpErr, legacyErr)
+}
+
+// DeleteIPv4 will try to delete forwarding rules for mixed protocol NetLB service.
+func (m *MixedManagerNetLB) DeleteIPv4() error {
+	var wg sync.WaitGroup
+	var tcpErr, udpErr error
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		tcpErr = m.delete("tcp")
+	}()
+	go func() {
+		defer wg.Done()
+		udpErr = m.delete("udp")
+	}()
+
+	wg.Wait()
+	return errors.Join(tcpErr, udpErr)
+}
+
+func (m *MixedManagerNetLB) delete(protocol string) error {
+	name := m.name(protocol)
+	return m.Provider.Delete(name)
+}
+
+// We need to clean up existing forwarding rule so that there isn't a port collision.
+// This means deleting forwarding rule with legacy name - starting with 'a'
+// and using protocol specific names identical to those used by ILB.
+func (m *MixedManagerNetLB) deleteLegacy() error {
+	return m.Provider.Delete(m.nameLegacy())
+}
+
+func (m *MixedManagerNetLB) name(protocol string) string {
+	return m.Namer.L4ForwardingRule(
+		m.Service.Namespace, m.Service.Name, strings.ToLower(protocol),
+	)
+}
+
+func (m *MixedManagerNetLB) nameLegacy() string {
+	return utils.LegacyForwardingRuleName(m.Service)
+}
+
+func (m *MixedManagerNetLB) recordEventf(messageFmt string, args ...any) {
+	m.Recorder.Eventf(m.Service, api_v1.EventTypeNormal, events.SyncIngress, messageFmt, args)
+}

--- a/pkg/forwardingrules/netlb_mixed_manager_test.go
+++ b/pkg/forwardingrules/netlb_mixed_manager_test.go
@@ -1,0 +1,398 @@
+package forwardingrules_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/compute/v1"
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
+)
+
+const (
+	kubeSystemUID = "ksuid123"
+	namespace     = "test-ns"
+	name          = "test-svc"
+	ip            = "1.2.3.4"
+	tcpName       = "k8s2-tcp-axyqjz2d-test-ns-test-svc-pyn67fp6"
+	udpName       = "k8s2-udp-axyqjz2d-test-ns-test-svc-pyn67fp6"
+	bsLink        = "http://compute.googleapis.com/projects/test/regions/us-central1/backendServices/bs1"
+	legacyName    = "aksuid123"
+)
+
+func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
+	startingState := []struct {
+		desc   string
+		tcp    *compute.ForwardingRule
+		udp    *compute.ForwardingRule
+		legacy *compute.ForwardingRule
+	}{
+		{
+			desc: "nothing",
+		},
+		{
+			desc: "tcp 80",
+			legacy: &compute.ForwardingRule{
+				Name:           legacyName,
+				IPAddress:      ip,
+				IPProtocol:     "TCP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"80"},
+			},
+		},
+		{
+			desc: "tcp 80, udp 53",
+			tcp: &compute.ForwardingRule{
+				Name:           tcpName,
+				IPAddress:      ip,
+				IPProtocol:     "TCP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"80"},
+			},
+			udp: &compute.ForwardingRule{
+				Name:           udpName,
+				IPAddress:      ip,
+				IPProtocol:     "UDP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"53"},
+			},
+		},
+		{
+			desc: "tcp 80, udp 53,60",
+			tcp: &compute.ForwardingRule{
+				Name:           tcpName,
+				IPAddress:      ip,
+				IPProtocol:     "TCP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"80"},
+			},
+			udp: &compute.ForwardingRule{
+				Name:           udpName,
+				IPAddress:      ip,
+				IPProtocol:     "UDP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"53", "60"},
+			},
+		},
+		{
+			desc: "tcp 80,81,82,83,84,85,86, udp 53",
+			tcp: &compute.ForwardingRule{
+				Name:           tcpName,
+				IPAddress:      ip,
+				IPProtocol:     "TCP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				PortRange:      "80-86",
+			},
+			udp: &compute.ForwardingRule{
+				Name:           udpName,
+				IPAddress:      ip,
+				IPProtocol:     "UDP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"53"},
+			},
+		},
+	}
+
+	var moreThanMaxTCPPorts []api_v1.ServicePort
+	for i := 0; i <= 6; i++ {
+		moreThanMaxTCPPorts = append(moreThanMaxTCPPorts, api_v1.ServicePort{
+			Protocol: api_v1.ProtocolTCP,
+			Port:     int32(80 + i),
+		})
+	}
+	maxPorts := append(moreThanMaxTCPPorts, api_v1.ServicePort{
+		Protocol: api_v1.ProtocolUDP,
+		Port:     53,
+	})
+
+	rangeTCPRule := fwdRule(tcpName, "TCP", nil)
+	rangeTCPRule.PortRange = "80-86"
+
+	endState := []struct {
+		desc  string
+		ports []api_v1.ServicePort
+		tcp   *composite.ForwardingRule
+		udp   *composite.ForwardingRule
+	}{
+		{
+			desc: "tcp 80, udp 53",
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     53,
+				},
+			},
+			tcp: fwdRule(tcpName, "TCP", []string{"80"}),
+			udp: fwdRule(udpName, "UDP", []string{"53"}),
+		},
+		{
+			desc: "tcp 80, udp 53,60",
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     53,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     60,
+				},
+			},
+			tcp: fwdRule(tcpName, "TCP", []string{"80"}),
+			udp: fwdRule(udpName, "UDP", []string{"53", "60"}),
+		},
+		{
+			desc:  "tcp 80,81,82,83,84,85,86, udp 53",
+			ports: maxPorts,
+			tcp:   rangeTCPRule,
+			udp:   fwdRule(udpName, "UDP", []string{"53"}),
+		},
+	}
+
+	for _, start := range startingState {
+		for _, end := range endState {
+			desc := start.desc + " -> " + end.desc
+			t.Run(desc, func(t *testing.T) {
+				t.Parallel()
+
+				// Arrange
+				fakeGCE, mgr := arrange(end.ports)
+				region := fakeGCE.Region()
+				for _, rule := range []*compute.ForwardingRule{start.legacy, start.tcp, start.udp} {
+					if rule != nil {
+						if err := fakeGCE.CreateRegionForwardingRule(rule, region); err != nil {
+							t.Fatalf("Couldn't set up forwarding rule %v for test", rule)
+						}
+					}
+				}
+
+				// Act
+				result, err := mgr.EnsureIPv4(bsLink)
+				// Assert
+				if err != nil {
+					t.Errorf("EnsureIPv4() error = %v", err)
+				}
+
+				fwdRuleIgnoreFields := cmpopts.IgnoreFields(composite.ForwardingRule{}, "SelfLink")
+				if diff := cmp.Diff(end.tcp, result.TCPFwdRule, fwdRuleIgnoreFields); diff != "" {
+					t.Errorf("EnsureIPv4().TCPFwdRule mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(end.udp, result.UDPFwdRule, fwdRuleIgnoreFields); diff != "" {
+					t.Errorf("EnsureIPv4().UDPFwdRule mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	}
+}
+
+func fwdRule(name, protocol string, ports []string) *composite.ForwardingRule {
+	return &composite.ForwardingRule{
+		Version:             "ga",
+		Scope:               "regional",
+		BackendService:      bsLink,
+		Description:         `{"networking.gke.io/service-name":"test-ns/test-svc","networking.gke.io/api-version":"ga","networking.gke.io/service-ip":"1.2.3.4"}`,
+		IPAddress:           ip,
+		IPProtocol:          protocol,
+		LoadBalancingScheme: "EXTERNAL",
+		Name:                name,
+		NetworkTier:         "PREMIUM",
+		Ports:               ports,
+		Region:              "us-central1",
+	}
+}
+
+func TestMixedManagerNetLB_EnsureIPv4_SingleProtocol(t *testing.T) {
+	t.Parallel()
+	// Arrange
+	_, mgr := arrange([]api_v1.ServicePort{
+		{
+			Protocol: api_v1.ProtocolTCP,
+			Port:     8080,
+		},
+	})
+
+	// Act
+	_, err := mgr.EnsureIPv4(bsLink)
+
+	// Assert
+	if err == nil {
+		t.Errorf("Expected to receive error for single protocol service")
+	}
+}
+
+func TestMixedManagerNetLB_AllRules(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		tcp    *compute.ForwardingRule
+		udp    *compute.ForwardingRule
+		legacy *compute.ForwardingRule
+	}{
+		{
+			desc: "no rules",
+		},
+		{
+			desc:   "single protocol exists",
+			legacy: &compute.ForwardingRule{Name: legacyName},
+		},
+		{
+			desc: "mixed protocol exists",
+			tcp:  &compute.ForwardingRule{Name: tcpName},
+			udp:  &compute.ForwardingRule{Name: udpName},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fakeGCE, mgr := arrange(nil)
+			region := fakeGCE.Region()
+			for _, rule := range []*compute.ForwardingRule{tc.tcp, tc.udp, tc.legacy} {
+				if rule != nil {
+					fakeGCE.CreateRegionForwardingRule(rule, region)
+				}
+			}
+
+			// Act
+			rules, err := mgr.AllRules()
+			// Assert
+			if err != nil {
+				t.Errorf("AllRules() error = %v", err)
+			}
+			if tc.legacy != nil && rules.Legacy == nil {
+				t.Errorf("single protocol named forwarding rule was not found")
+			}
+			if tc.tcp != nil && rules.TCP == nil {
+				t.Errorf("tcp forwarding rule for mixed protocol was not found")
+			}
+			if tc.udp != nil && rules.UDP == nil {
+				t.Errorf("udp forwarding rule for mixed protocol was not found")
+			}
+		})
+	}
+}
+
+func TestMixedManagerNetLB_DeleteIPv4(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		tcp    *compute.ForwardingRule
+		udp    *compute.ForwardingRule
+		legacy *compute.ForwardingRule
+	}{
+		{
+			desc: "no rules",
+		},
+		{
+			desc:   "single protocol exists",
+			legacy: &compute.ForwardingRule{Name: legacyName},
+		},
+		{
+			desc: "mixed protocol exists",
+			tcp:  &compute.ForwardingRule{Name: tcpName},
+			udp:  &compute.ForwardingRule{Name: udpName},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			fakeGCE, mgr := arrange(nil)
+			region := fakeGCE.Region()
+			for _, rule := range []*compute.ForwardingRule{tc.tcp, tc.udp, tc.legacy} {
+				if rule != nil {
+					fakeGCE.CreateRegionForwardingRule(rule, region)
+				}
+			}
+
+			// Act
+			err := mgr.DeleteIPv4()
+			// Assert
+			if err != nil {
+				t.Errorf("DeleteIPv4() error = %v", err)
+			}
+
+			if tc.legacy != nil {
+				rule, err := fakeGCE.GetRegionForwardingRule(legacyName, region)
+				if err != nil || rule == nil {
+					t.Errorf("single protocol named forwarding rule was deleted by mixed manager")
+				}
+			}
+
+			ruleTCP, err := fakeGCE.GetRegionForwardingRule(tcpName, region)
+			if ruleTCP != nil || !utils.IsNotFoundError(err) {
+				t.Errorf("tcp forwarding rule for mixed protocol wasn't deleted")
+			}
+
+			ruleUDP, err := fakeGCE.GetRegionForwardingRule(udpName, region)
+			if ruleUDP != nil || !utils.IsNotFoundError(err) {
+				t.Errorf("udp forwarding rule for mixed protocol wasn't deleted")
+			}
+		})
+	}
+}
+
+func arrange(ports []api_v1.ServicePort) (*gce.Cloud, *forwardingrules.MixedManagerNetLB) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+	mockGCE.MockAddresses.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockAddresses, options ...cloud.Option) (bool, *compute.Address, error) {
+		// fakeGCE by default returns just inserted values
+		// however if we insert empty address we should get address automatically filed by GCE
+		if key.Name == "aksuid123" {
+			return true, &compute.Address{
+				Name:        "aksuid123",
+				AddressType: "EXTERNAL",
+				IpVersion:   "IPv4",
+				NetworkTier: "PREMIUM",
+				Address:     ip,
+			}, nil
+		}
+		return false, nil, nil
+	}
+
+	m := &forwardingrules.MixedManagerNetLB{
+		Namer:    namer.NewL4Namer(kubeSystemUID, nil),
+		Provider: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
+		Recorder: &record.FakeRecorder{},
+		Logger:   klog.TODO(),
+		Cloud:    fakeGCE,
+		Service: &api_v1.Service{
+			ObjectMeta: meta_v1.ObjectMeta{
+				UID:       kubeSystemUID,
+				Namespace: namespace,
+				Name:      name,
+			},
+			Spec: api_v1.ServiceSpec{
+				Ports: ports,
+			},
+		},
+	}
+	return fakeGCE, m
+}


### PR DESCRIPTION
MixedManagerNetLB will be run inside the L4NetLB loadbalancer.
* EnsureIPv4 will be used manage forwarding rules when the mixed protocol flag is enabled and service has both TCP and UDP ports defined.
* DeleteIPv4 will be used when either service is deleted or there will be conversion from mixed to single protocol.
* AllRules will be used in single protocol implementation to hold address from mixed protocol forwarding rules.