### PR TITLE
Replace depracated filter expression in setup-local.sh

### DIFF
--- a/hack/setup-local.sh
+++ b/hack/setup-local.sh
@@ -33,9 +33,9 @@ fi
 
 fmt='value(networkConfig.network,networkConfig.subnetwork,zone,selfLink,name)'
 if [ -z "$clusterLocation" ]; then
-    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name=${clusterName}")
+    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name:${clusterName}")
 else
-    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name=${clusterName} location=${clusterLocation}")
+    clusters=$(gcloud container clusters list --format="${fmt}" --filter="name:${clusterName} location:${clusterLocation}")
 fi
 if [ $(echo "${cluster}" | wc -l) -gt 1 ]; then
     echo "ERROR: more than one cluster matches '${clusterName}'"


### PR DESCRIPTION
When trying to filter clusters with "key=value" gcloud returns a warning:
```
WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  name=kluster currently does not match but will match in the near future.  Run `gcloud topic filters` for details.
```

Based on the `gcloud topic filters` it is enough to replace `=` with `:`. Context:
```
key :( simple-pattern ... )
            True if key matches any simple-pattern in the (space, tab, newline,
            comma) separated list.

key = value
            True if key is equal to value, or [deprecated] equivalent to : with
            the exception that the trailing * prefix match is not supported.

            For historical reasons, this operation currently behaves
            differently for different Google APIs. For many APIs, this is True
            if key is equal to value. For a few APIs, this is currently
            equivalent to :, with the exception that the trailing * prefix
            match is not supported. However, this behaviour is being phased
            out, and use of = for those APIs is deprecated; for those APIs, if
            you want matching, you should use : instead of =, and if you want
            to test for equality, you can use key <= value AND key >= value.
```

Tested manually with and without location. This change gets rid off the warning:
```
➜ before ✗ ./hack/setup-local.sh kluster europe-west4-b
WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  name=kluster currently does not match but will match in the near future.  Run `gcloud topic filters` for details.
Writing /tmp/gce.conf
----
[global]
token-url = nil
...
```
```
➜  after ✗ ./hack/setup-local.sh kluster europe-west4-b
Writing /tmp/gce.conf
----
[global]
token-url = nil
...
```