### PR TITLE
Refactor context health check implementation

### DIFF
--- a/cmd/glbc/app/handlers.go
+++ b/cmd/glbc/app/handlers.go
@@ -29,14 +29,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 
-	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/systemhealth"
 	"k8s.io/ingress-gce/pkg/version"
 )
 
 // RunHTTPServer starts an HTTP server. `healthChecker` returns a mapping of component/controller
 // name to the result of its healthcheck.
-func RunHTTPServer(healthChecker func() context.HealthCheckResults, logger klog.Logger) {
+func RunHTTPServer(healthChecker func() systemhealth.HealthCheckResults, logger klog.Logger) {
 	http.HandleFunc("/healthz", healthCheckHandler(healthChecker, logger))
 	http.HandleFunc("/flag", flagHandler)
 	http.Handle("/metrics", promhttp.Handler())
@@ -56,7 +56,7 @@ func RunSIGTERMHandler(closeStopCh func(), logger klog.Logger) {
 	closeStopCh()
 }
 
-func healthCheckHandler(checker func() context.HealthCheckResults, logger klog.Logger) http.HandlerFunc {
+func healthCheckHandler(checker func() systemhealth.HealthCheckResults, logger klog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var hasErr bool
 		var s strings.Builder

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	l4NetLBControllerName          = "l4netlb-controller"
+	L4NetLBControllerName          = "l4netlb-controller"
 	l4NetLBDualStackControllerName = "l4netlb-dualstack-controller"
 
 	instanceGroupLink backendLinkType = 0
@@ -169,7 +169,7 @@ func NewL4NetLBController(
 			}
 		},
 	})
-	ctx.AddHealthCheck(l4NetLBControllerName, l4netLBc.checkHealth)
+
 	return l4netLBc
 }
 
@@ -406,7 +406,7 @@ func (lc *L4NetLBController) hasRBSForwardingRule(svc *v1.Service, svcLogger klo
 	return existingFR != nil && existingFR.LoadBalancingScheme == string(cloud.SchemeExternal) && existingFR.BackendService != ""
 }
 
-func (lc *L4NetLBController) checkHealth() error {
+func (lc *L4NetLBController) SystemHealth() error {
 	lastEnqueueTime := lc.enqueueTracker.Get()
 	lastSyncTime := lc.syncTracker.Get()
 	// if lastEnqueue time is more than 15 minutes before the last sync time, the controller is falling behind.
@@ -417,7 +417,7 @@ func (lc *L4NetLBController) checkHealth() error {
 		msg := fmt.Sprintf("L4 NetLB Sync happened at time %v, %v after enqueue time, last enqueue time %v, threshold is %v", lastSyncTime, lastSyncTime.Sub(lastEnqueueTime), lastEnqueueTime, enqueueToSyncDelayThreshold)
 		// Log here, context/http handler do no log the error.
 		lc.logger.Error(nil, msg)
-		l4metrics.PublishL4FailedHealthCheckCount(l4NetLBControllerName)
+		l4metrics.PublishL4FailedHealthCheckCount(L4NetLBControllerName)
 		controllerHealth = l4metrics.ControllerUnhealthyStatus
 		// Reset trackers. Otherwise, if there is nothing in the queue then it will report the FailedHealthCheckCount every time the checkHealth is called
 		// If checkHealth returned error (as it is meant to) then container would be restarted and trackers would be reset either
@@ -458,7 +458,7 @@ func (lc *L4NetLBController) syncWrapper(key string) (err error) {
 		if r := recover(); r != nil {
 			errMessage := fmt.Sprintf("Panic in L4 NetLB sync worker goroutine: %v", r)
 			svcLogger.Error(nil, errMessage)
-			l4metrics.PublishL4ControllerPanicCount(l4NetLBControllerName)
+			l4metrics.PublishL4ControllerPanicCount(L4NetLBControllerName)
 			err = fmt.Errorf(errMessage)
 		}
 	}()
@@ -468,7 +468,7 @@ func (lc *L4NetLBController) syncWrapper(key string) (err error) {
 
 func (lc *L4NetLBController) sync(key string, svcLogger klog.Logger) error {
 	lc.syncTracker.Track()
-	l4metrics.PublishL4controllerLastSyncTime(l4NetLBControllerName)
+	l4metrics.PublishL4controllerLastSyncTime(L4NetLBControllerName)
 
 	svc, exists, err := lc.ctx.Services().GetByKey(key)
 	if err != nil {
@@ -821,7 +821,7 @@ func (lc *L4NetLBController) publishSyncMetrics(result *loadbalancers.L4NetLBSyn
 	if result.MetricsState.Multinetwork {
 		l4metrics.PublishL4NetLBMultiNetSyncLatency(result.Error == nil, result.SyncType, result.StartTime, isResync)
 	}
-	l4metrics.PublishL4SyncDetails(l4NetLBControllerName, result.Error == nil, isResync, result.GCEResourceUpdate.WereAnyResourcesModified())
+	l4metrics.PublishL4SyncDetails(L4NetLBControllerName, result.Error == nil, isResync, result.GCEResourceUpdate.WereAnyResourcesModified())
 
 	isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
 	backendType := result.MetricsState.BackendType

--- a/pkg/systemhealth/systemhealth.go
+++ b/pkg/systemhealth/systemhealth.go
@@ -1,0 +1,50 @@
+package systemhealth
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// SystemHealth is responsible for checking the health of the ingress-gce
+// binary and the controllers running inside this binary.
+type SystemHealth struct {
+	hcLock       sync.Mutex
+	healthChecks map[string]func() error
+	logger       klog.Logger
+}
+
+// NewSystemHealth creates a new SystemHealth instance.
+func NewSystemHealth(logger klog.Logger) *SystemHealth {
+	return &SystemHealth{
+		healthChecks: make(map[string]func() error),
+		logger:       logger,
+	}
+}
+
+// AddHealthCheck registers a function to be called for health checking.
+func (sh *SystemHealth) AddHealthCheck(id string, hc func() error) {
+	sh.hcLock.Lock()
+	defer sh.hcLock.Unlock()
+
+	sh.logger.Info("Adding health check", "id", id)
+	sh.healthChecks[id] = hc
+}
+
+// HealthCheckResults contains a mapping of component -> health check results.
+type HealthCheckResults map[string]error
+
+// HealthCheck runs all registered health check functions.
+func (sh *SystemHealth) HealthCheck() HealthCheckResults {
+	sh.hcLock.Lock()
+	defer sh.hcLock.Unlock()
+
+	healthChecks := make(map[string]error)
+	for component, f := range sh.healthChecks {
+		sh.logger.Info("Running health check", "component", component)
+		healthChecks[component] = f()
+	}
+
+	sh.logger.Info("Health check results", "results", healthChecks)
+	return healthChecks
+}


### PR DESCRIPTION
- Move Health checks out of context to systemhealth package. Context is already doing too much and systemhealth is self-sufficient struct that can live in separate package, which makes code less entangled
- Modify existing calls for AddHealthCheck to use new struct
- This will also allow to run healthchecks when controller is not initialising full context (for example in multiproject mode)

also I could've added this into L4 and L4netlb controller and add health check inside their constructor. Buuut. It would need to change too much of the test code to add everywhere new argument....

/assign @gauravkghildiyal 