### PR TITLE
Update address.HoldExternal to allow holding IPv6 as well

### DIFF
--- a/pkg/address/hold_test.go
+++ b/pkg/address/hold_test.go
@@ -20,13 +20,17 @@ import (
 )
 
 const (
-	kubeSystemUID = "ksuid123"
-	namespace     = "test-ns"
-	name          = "test-svc"
-	tcpName       = "k8s2-tcp-axyqjz2d-test-ns-test-svc-pyn67fp6"
-	udpName       = "k8s2-udp-axyqjz2d-test-ns-test-svc-pyn67fp6"
-	legacyName    = "aksuid123"
-	region        = "us-central1"
+	kubeSystemUID  = "ksuid123"
+	namespace      = "test-ns"
+	name           = "test-svc"
+	legacyName     = "aksuid123"
+	tcpName        = "k8s2-tcp-axyqjz2d-test-ns-test-svc-pyn67fp6"
+	udpName        = "k8s2-udp-axyqjz2d-test-ns-test-svc-pyn67fp6"
+	legacyNameIPv6 = "aksuid123-ipv6"
+	tcpNameIPv6    = "k8s2-tcp-axyqjz2d-test-ns-test-svc-pyn67fp6-ipv6"
+	udpNameIPv6    = "k8s2-udp-axyqjz2d-test-ns-test-svc-pyn67fp6-ipv6"
+	region         = "us-central1"
+	subnetURL      = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/subnetworks/default"
 )
 
 func TestHoldExternalIPv4(t *testing.T) {
@@ -57,6 +61,40 @@ func TestHoldExternalIPv4(t *testing.T) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Annotations: map[string]string{
 						"networking.gke.io/load-balancer-ip-addresses": reservedIPv4Name,
+					},
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      reservedIPv4,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "existing address dual stack IPv4 first",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.gke.io/load-balancer-ip-addresses": reservedIPv4Name + "," + reservedIPv6Name,
+					},
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      reservedIPv4,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "existing address dual stack IPv6 first",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.gke.io/load-balancer-ip-addresses": reservedIPv6Name + "," + reservedIPv4Name,
 					},
 					Name:      name,
 					Namespace: namespace,
@@ -198,10 +236,10 @@ func TestHoldExternalIPv4(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			t.Parallel()
 			// Arrange
-			cfg := arrange(t, tC.existingRules, tC.service)
+			cfg := arrangeHoldExternal(t, tC.existingRules, tC.service, address.IPv4Version, "")
 
 			// Act
-			got, err := address.HoldExternalIPv4(cfg)
+			got, err := address.HoldExternal(cfg)
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}
@@ -254,19 +292,269 @@ func TestHoldExternalIPv4(t *testing.T) {
 	}
 }
 
-func arrange(t *testing.T, existingRules []*composite.ForwardingRule, service *api_v1.Service) address.HoldConfig {
+func TestHoldExternalIPv6(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		existingRules []*composite.ForwardingRule
+		service       *api_v1.Service
+		want          address.HoldResult
+		wantTearDown  bool
+	}{
+		{
+			desc: "no address passed",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      notReservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "existing address",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.gke.io/load-balancer-ip-addresses": reservedIPv6Name,
+					},
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      reservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "existing address dual stack IPv4 first",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.gke.io/load-balancer-ip-addresses": reservedIPv4Name + "," + reservedIPv6Name,
+					},
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      reservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "existing address dual stack IPv6 first",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.gke.io/load-balancer-ip-addresses": reservedIPv6Name + "," + reservedIPv4Name,
+					},
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			want: address.HoldResult{
+				IP:      reservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "legacy forwarding rule exists",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			existingRules: []*composite.ForwardingRule{
+				{
+					Name:      legacyNameIPv6,
+					IPAddress: notReservedIPv6,
+					Region:    region,
+				},
+			},
+			want: address.HoldResult{
+				IP:      notReservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "mixed protocol forwarding rule exist",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+				},
+			},
+			existingRules: []*composite.ForwardingRule{
+				{
+					Name:      tcpNameIPv6,
+					IPAddress: notReservedIPv6,
+					Region:    region,
+				},
+				{
+					Name:      udpNameIPv6,
+					IPAddress: notReservedIPv6,
+					Region:    region,
+				},
+			},
+			want: address.HoldResult{
+				IP:      notReservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+		},
+		{
+			desc: "tier from annotation: Premium to Premium",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+					Annotations: map[string]string{
+						annotations.NetworkTierAnnotationKey: "Premium",
+					},
+				},
+			},
+			existingRules: []*composite.ForwardingRule{
+				{
+					Name:        legacyNameIPv6,
+					IPAddress:   notReservedIPv6,
+					Region:      region,
+					NetworkTier: cloud.NetworkTierPremium.ToGCEValue(),
+				},
+			},
+			want: address.HoldResult{
+				IP:      notReservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+			wantTearDown: false,
+		},
+		{
+			// While this shouldn't be possible
+			// There was a bug that allowed to create Standard tier IPv6 Forwarding rules
+			desc: "tier from annotation: Standard to Premium",
+			service: &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					UID:       kubeSystemUID,
+					Annotations: map[string]string{
+						annotations.NetworkTierAnnotationKey: "Premium",
+					},
+				},
+			},
+			existingRules: []*composite.ForwardingRule{
+				{
+					Name:        legacyNameIPv6,
+					IPAddress:   notReservedIPv6,
+					Region:      region,
+					NetworkTier: cloud.NetworkTierStandard.ToGCEValue(),
+				},
+			},
+			want: address.HoldResult{
+				IP:      notReservedIPv6,
+				Managed: address.IPAddrManaged,
+			},
+			wantTearDown: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+			// Arrange
+			cfg := arrangeHoldExternal(t, tC.existingRules, tC.service, address.IPv6Version, subnetURL)
+
+			// Act
+			got, err := address.HoldExternal(cfg)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			// Assert
+			if got.IP != tC.want.IP {
+				t.Errorf("address.HoldExternal(_).IP = %q, want %q", got.IP, tC.want.IP)
+			}
+			if got.Managed != tC.want.Managed {
+				t.Errorf("address.HoldExternal(_).Managed = %q, want %q", got.Managed, tC.want.Managed)
+			}
+
+			// Verify that address exists
+			region := cfg.Cloud.Region()
+			addr, err := cfg.Cloud.GetRegionAddressByIP(region, got.IP)
+			if err != nil || addr == nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if addr.Subnetwork != subnetURL {
+				t.Errorf("addr.Subnetwork = %q, want %q", addr.Subnetwork, subnetURL)
+			}
+
+			// Check if release cleans up address
+			if got.Release == nil {
+				t.Fatal("address.HoldExternal(_).Release is nil")
+			}
+			if err := got.Release(); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			addr, err = cfg.Cloud.GetRegionAddress(legacyNameIPv6, region)
+			if utils.IgnoreHTTPNotFound(err) != nil {
+				t.Errorf("GetRegionAddress returned err: %v", err)
+			}
+			if addr != nil {
+				t.Errorf("address %v not deleted", legacyNameIPv6)
+			}
+
+			// Check teardown
+			for _, rule := range tC.existingRules {
+				if rule != nil {
+					got, err := cfg.Cloud.GetRegionForwardingRule(rule.Name, rule.Region)
+					if utils.IgnoreHTTPNotFound(err) != nil {
+						t.Errorf("GetRegionForwardingRule returned unexpected err: %v", err)
+						continue
+					}
+					wasDeleted := got == nil
+					if wasDeleted != tC.wantTearDown {
+						t.Errorf("%v deleted = %v, want %v", rule.Name, wasDeleted, tC.wantTearDown)
+					}
+				}
+			}
+		})
+	}
+}
+
+func arrangeHoldExternal(t *testing.T, existingRules []*composite.ForwardingRule, service *api_v1.Service, ipVersion address.IPVersion, subnet string) address.HoldConfig {
 	t.Helper()
 
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := gce.NewFakeGCECloud(vals)
 
-	addr := &compute.Address{
+	if err := fakeGCE.ReserveRegionAddress(&compute.Address{
 		Name:        reservedIPv4Name,
 		Region:      vals.Region,
 		Address:     reservedIPv4,
 		AddressType: "EXTERNAL",
+		IpVersion:   "IPV4",
+		Subnetwork:  subnet,
+	}, vals.Region); err != nil {
+		t.Fatal(err)
 	}
-	if err := fakeGCE.ReserveRegionAddress(addr, vals.Region); err != nil {
+	if err := fakeGCE.ReserveRegionAddress(&compute.Address{
+		Name:        reservedIPv6Name,
+		Region:      vals.Region,
+		Address:     reservedIPv6,
+		AddressType: "EXTERNAL",
+		IpVersion:   "IPV6",
+		NetworkTier: "PREMIUM",
+		Subnetwork:  subnet,
+	}, vals.Region); err != nil {
 		t.Fatal(err)
 	}
 
@@ -277,7 +565,12 @@ func arrange(t *testing.T, existingRules []*composite.ForwardingRule, service *a
 		if obj, ok := m.Objects[*key]; ok {
 			ga := obj.ToGA()
 			if ga.Address == "" {
-				ga.Address = notReservedIPv4
+				isIPv4 := ga.IpVersion == "IPV4" || ga.IpVersion == ""
+				if isIPv4 {
+					ga.Address = notReservedIPv4
+				} else {
+					ga.Address = notReservedIPv6
+				}
 			}
 			m.Objects[*key] = m.Obj(ga)
 			return true, obj.ToGA(), nil
@@ -298,5 +591,7 @@ func arrange(t *testing.T, existingRules []*composite.ForwardingRule, service *a
 		ExistingRules:         existingRules,
 		Service:               service,
 		ForwardingRuleDeleter: provider,
+		IPVersion:             ipVersion,
+		SubnetworkURL:         subnet,
 	}
 }

--- a/pkg/forwardingrules/netlb_mixed_manager.go
+++ b/pkg/forwardingrules/netlb_mixed_manager.go
@@ -79,13 +79,14 @@ func (m *MixedManagerNetLB) EnsureIPv4(backendServiceLink string) (EnsureNetLBRe
 		return res, err
 	}
 
-	addressHandle, err := address.HoldExternalIPv4(address.HoldConfig{
+	addressHandle, err := address.HoldExternal(address.HoldConfig{
 		Cloud:                 m.Cloud,
 		Recorder:              m.Recorder,
 		Logger:                m.Logger,
 		Service:               m.Service,
 		ExistingRules:         []*composite.ForwardingRule{existing.Legacy, existing.TCP, existing.UDP},
 		ForwardingRuleDeleter: m.Provider,
+		IPVersion:             address.IPv4Version,
 	})
 	if err != nil {
 		return res, err


### PR DESCRIPTION
This is done in order to reuse address holding logic in future mixed protocol NetLB IPv6 implementation. Similar thing has been already done in IPv4.

* Updates config with fields that are IPv4/IPv6 specific.
* Adds tests for HoldExternal IPv6 addresses.
* Updates forwarding_rules_ipv6.go to use address.HoldExternal.
* Removes tearDownResourcesWithWrongNetworkTier from l4netlb as it is already implemented inside address.HoldExternal.