### PR TITLE
Refactor ListSubnets

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -319,7 +319,10 @@ func main() {
 		EnableL4ILBMixedProtocol:      flags.F.EnableL4ILBMixedProtocol,
 		EnableL4NetLBMixedProtocol:    flags.F.EnableL4NetLBMixedProtocol,
 	}
-	ctx := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
+	ctx, err := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
+	if err != nil {
+		klog.Fatalf("unable to set up controller context: %v", err)
+	}
 
 	leOption := leaderElectionOption{
 		client:   leaderElectKubeClient,

--- a/pkg/backends/ig_linker_test.go
+++ b/pkg/backends/ig_linker_test.go
@@ -59,7 +59,10 @@ func TestLink(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{
@@ -101,7 +104,10 @@ func TestLinkWithCreationModeError(t *testing.T) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	zonegetter.AddFakeNodes(fakeZoneGetter, defaultTestZone, "test-instance")
 
 	fakeNodePool := instancegroups.NewManager(&instancegroups.ManagerConfig{

--- a/pkg/backends/regional_ig_linker_test.go
+++ b/pkg/backends/regional_ig_linker_test.go
@@ -49,11 +49,14 @@ func linkerTestClusterValues() gce.TestClusterValues {
 	}
 }
 
-func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Pool, l4Namer *namer.L4Namer) *RegionalInstanceGroupLinker {
+func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Pool, l4Namer *namer.L4Namer) (*RegionalInstanceGroupLinker, error) {
 	fakeIGs := instancegroups.NewEmptyFakeInstanceGroups()
 
 	nodeInformer := zonegetter.FakeNodeInformer()
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		return nil, err
+	}
 	zonegetter.AddFakeNodes(fakeZoneGetter, usCentral1AZone, "test-instance1")
 	zonegetter.AddFakeNodes(fakeZoneGetter, "us-central1-c", "test-instance2")
 
@@ -68,7 +71,7 @@ func newTestRegionalIgLinker(fakeGCE *gce.Cloud, backendPool *Pool, l4Namer *nam
 
 	(fakeGCE.Compute().(*cloud.MockGCE)).MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 
-	return &RegionalInstanceGroupLinker{fakeInstancePool, backendPool, klog.TODO()}
+	return &RegionalInstanceGroupLinker{fakeInstancePool, backendPool, klog.TODO()}, nil
 }
 
 func TestRegionalLink(t *testing.T) {
@@ -78,7 +81,10 @@ func TestRegionalLink(t *testing.T) {
 	l4Namer := namer.NewL4Namer("uid1", namer.NewNamer(clusterID, "", klog.TODO()))
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
-	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	linker, err := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	if err != nil {
+		t.Fatalf("failed to generate test regional ig linker: %v", err)
+	}
 
 	if err := linker.Link(sp, fakeGCE.ProjectID(), []string{usCentral1AZone}); err == nil {
 		t.Fatalf("Linking when instances does not exist should return error")
@@ -116,7 +122,10 @@ func TestRegionalUpdateLink(t *testing.T) {
 	l4Namer := namer.NewL4Namer("uid1", namer.NewNamer(clusterID, "", klog.TODO()))
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
-	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	linker, err := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	if err != nil {
+		t.Fatalf("failed to generate test regional ig linker: %v", err)
+	}
 	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
@@ -152,7 +161,10 @@ func TestRegionalUpdateLinkWithNewBackends(t *testing.T) {
 	l4Namer := namer.NewL4Namer("uid1", namer.NewNamer(clusterID, "", klog.TODO()))
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
-	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	linker, err := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	if err != nil {
+		t.Fatalf("failed to generate test regional ig linker: %v", err)
+	}
 	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}
@@ -196,7 +208,10 @@ func TestRegionalUpdateLinkWithRemovedBackends(t *testing.T) {
 	l4Namer := namer.NewL4Namer("uid1", namer.NewNamer(clusterID, "", klog.TODO()))
 	sp := utils.ServicePort{NodePort: 8080, BackendNamer: l4Namer}
 	fakeBackendPool := NewPool(fakeGCE, l4Namer)
-	linker := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	linker, err := newTestRegionalIgLinker(fakeGCE, fakeBackendPool, l4Namer)
+	if err != nil {
+		t.Fatalf("failed to generate test regional ig linker: %v", err)
+	}
 	if _, err := linker.instancePool.EnsureInstanceGroupsAndPorts(l4Namer.InstanceGroup(), []int64{sp.NodePort}, klog.TODO()); err != nil {
 		t.Fatalf("Unexpected error when ensuring IG for ServicePort %+v: %v", sp, err)
 	}

--- a/pkg/common/operator/ingress_test.go
+++ b/pkg/common/operator/ingress_test.go
@@ -48,7 +48,7 @@ func TestReferencesSvcNeg(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := fake.NewSimpleClientset()
-	gceClient := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	gceClient := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
 	namer := namer_util.NewNamer(clusterUID, "", klog.TODO())
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:                     apiv1.NamespaceAll,
@@ -57,7 +57,10 @@ func TestReferencesSvcNeg(t *testing.T) {
 		HealthCheckPath:               "/",
 		EnableIngressRegionalExternal: true,
 	}
-	ctx := context.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to initialize controller context: %v", err)
+	}
 
 	if err := addTestService(ctx); err != nil {
 		t.Fatalf("Failed to add test service: %v", err)

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -156,7 +156,7 @@ func NewControllerContext(
 	kubeSystemUID types.UID,
 	config ControllerContextConfig,
 	logger klog.Logger,
-) *ControllerContext {
+) (*ControllerContext, error) {
 	logger = logger.WithName("ControllerContext")
 
 	podInformer := informerv1.NewPodInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())
@@ -239,7 +239,8 @@ func NewControllerContext(
 		logger,
 	)
 	// The subnet specified in gce.conf is considered as the default subnet.
-	context.ZoneGetter = zonegetter.NewZoneGetter(context.NodeInformer, context.NodeTopologyInformer, context.Cloud.SubnetworkURL())
+	var err error
+	context.ZoneGetter, err = zonegetter.NewZoneGetter(context.NodeInformer, context.NodeTopologyInformer, context.Cloud.SubnetworkURL())
 	context.InstancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      context.Cloud,
 		Namer:      context.ClusterNamer,
@@ -249,7 +250,7 @@ func NewControllerContext(
 		MaxIGSize:  config.MaxIGSize,
 	})
 
-	return context
+	return context, err
 }
 
 func (ctx *ControllerContext) Recorder(ns string) record.EventRecorder {

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -34,7 +34,10 @@ import (
 )
 
 func TestZoneListing(t *testing.T) {
-	lbc := newLoadBalancerController()
+	lbc, err := newLoadBalancerController()
+	if err != nil {
+		t.Fatalf("failed to initialize load balancer controller: %v", err)
+	}
 	zoneToNode := map[string][]string{
 		"zone-1": {"n1"},
 		"zone-2": {"n2"},

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -18,6 +18,7 @@ package firewalls
 
 import (
 	context2 "context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -43,29 +44,35 @@ import (
 )
 
 // newFirewallController creates a firewall controller.
-func newFirewallController() *FirewallController {
+func newFirewallController() (*FirewallController, error) {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
 	firewallClient := firewallclient.NewSimpleClientset()
-	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
 
 	ctxConfig := context.ControllerContextConfig{
 		Namespace:             api_v1.NamespaceAll,
 		ResyncPeriod:          1 * time.Minute,
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
 	}
-	ctx := context.NewControllerContext(kubeClient, backendConfigClient, nil, firewallClient, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, nil, firewallClient, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize controller context: %v", err)
+	}
 	fwc := NewFirewallController(ctx, []string{"30000-32767"}, false, false, true, make(chan struct{}), klog.TODO())
 	fwc.hasSynced = func() bool { return true }
 
-	return fwc
+	return fwc, nil
 }
 
 // TestFirewallCreateDelete asserts that `sync` will ensure the L7 firewall with
 // the correct ports. It also asserts that when no ingresses exist, that the
 // firewall rule is deleted.
 func TestFirewallCreateDelete(t *testing.T) {
-	fwc := newFirewallController()
+	fwc, err := newFirewallController()
+	if err != nil {
+		t.Fatalf("failed to initialize firewall controller: %v", err)
+	}
 
 	// Create the default-backend service.
 	defaultSvc := test.NewService(test.DefaultBeSvcPort.ID.Service, api_v1.ServiceSpec{
@@ -92,7 +99,7 @@ func TestFirewallCreateDelete(t *testing.T) {
 	}
 
 	// Verify a firewall rule was created.
-	_, err := fwc.ctx.Cloud.GetFirewall(ruleName)
+	_, err = fwc.ctx.Cloud.GetFirewall(ruleName)
 	if err != nil {
 		t.Fatalf("cloud.GetFirewall(%v) = _, %v, want _, nil", ruleName, err)
 	}
@@ -160,7 +167,10 @@ func TestGetCustomHealthCheckPorts(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			flags.F.EnableTransparentHealthChecks = tc.enableTHC
-			fwc := newFirewallController()
+			fwc, err := newFirewallController()
+			if err != nil {
+				t.Fatalf("failed to initialize firewall controller: %v", err)
+			}
 			result := fwc.getCustomHealthCheckPorts(tc.svcPorts)
 			if diff := cmp.Diff(tc.expect, result); diff != "" {
 				t.Errorf("unexpected diff of ports (-want +got): \n%s", diff)

--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -140,7 +140,11 @@ func TestSync(t *testing.T) {
 	config.HasSynced = func() bool {
 		return true
 	}
-	config.ZoneGetter = zonegetter.NewFakeZoneGetter(informer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	var err error
+	config.ZoneGetter, err = zonegetter.NewFakeZoneGetter(informer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 
 	controller := NewController(config, logr.Logger{})
 

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -951,7 +951,7 @@ func TestDualStackNetLBStaticIPAnnotation(t *testing.T) {
 func mustSetupNetLBTestHandler(t *testing.T, svc *v1.Service, nodeNames []string) *L4NetLB {
 	t.Helper()
 
-	vals := gce.DefaultTestClusterValues()
+	vals := test.DefaultTestClusterValues()
 	namer := namer_util.NewL4Namer(kubeSystemUID, nil)
 	fakeGCE := getFakeGCECloud(vals)
 
@@ -970,7 +970,7 @@ func mustSetupNetLBTestHandler(t *testing.T, svc *v1.Service, nodeNames []string
 		t.Fatalf("unexpected error when adding nodes %v", err)
 	}
 
-	// Create cluster subnet. Mock GCE uses subnet with empty string name.
+	// Create cluster subnet. Mock GCE uses test.DefaultSubnetURL.
 	test.MustCreateDualStackClusterSubnet(t, l4NetLB.cloud, subnetExternalIPv6AccessType)
 	return l4NetLB
 }

--- a/pkg/multiproject/neg/neg.go
+++ b/pkg/multiproject/neg/neg.go
@@ -79,11 +79,11 @@ func StartNEGController(
 		return nil, err
 	}
 
-	zoneGetter := zonegetter.NewZoneGetter(
-		informers.nodeInformer,
-		informers.providerConfigFilteredNodeTopologyInformer,
-		cloud.SubnetworkURL(),
-	)
+	zoneGetter, err := zonegetter.NewZoneGetter(informers.nodeInformer, informers.providerConfigFilteredNodeTopologyInformer, cloud.SubnetworkURL())
+	if err != nil {
+		logger.Error(err, "failed to initialize zone getter")
+		return nil, fmt.Errorf("failed to initialize zonegetter: %v", err)
+	}
 
 	negController := createNEGController(
 		kubeClient,

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -58,8 +58,11 @@ func (f *fakeLookUp) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool 
 	return f.readinessGateEnabled
 }
 
-func newTestReadinessReflector(testContext *negtypes.TestContext, enableMultiSubnetCluster bool) *readinessReflector {
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, enableMultiSubnetCluster)
+func newTestReadinessReflector(testContext *negtypes.TestContext, enableMultiSubnetCluster bool) (*readinessReflector, error) {
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, enableMultiSubnetCluster)
+	if err != nil {
+		return nil, err
+	}
 	reflector := NewReadinessReflector(
 		testContext.KubeClient,
 		testContext.KubeClient,
@@ -72,7 +75,7 @@ func newTestReadinessReflector(testContext *negtypes.TestContext, enableMultiSub
 		klog.TODO(),
 	)
 	ret := reflector.(*readinessReflector)
-	return ret
+	return ret, nil
 }
 
 func TestSyncPod(t *testing.T) {
@@ -82,7 +85,10 @@ func TestSyncPod(t *testing.T) {
 	podLister := fakeContext.PodInformer.GetIndexer()
 	nodeLister := fakeContext.NodeInformer.GetIndexer()
 	fakeClock := clocktesting.NewFakeClock(time.Now())
-	testReadinessReflector := newTestReadinessReflector(fakeContext, false)
+	testReadinessReflector, err := newTestReadinessReflector(fakeContext, false)
+	if err != nil {
+		t.Fatalf("failed to initialize readiness reflector")
+	}
 	testReadinessReflector.clock = fakeClock
 	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
 
@@ -413,7 +419,10 @@ func TestSyncPodMultipleSubnets(t *testing.T) {
 	client := fakeContext.KubeClient
 	podLister := fakeContext.PodInformer.GetIndexer()
 	fakeClock := clocktesting.NewFakeClock(time.Now())
-	testReadinessReflector := newTestReadinessReflector(fakeContext, true)
+	testReadinessReflector, err := newTestReadinessReflector(fakeContext, true)
+	if err != nil {
+		t.Fatalf("failed to initialize readiness reflector")
+	}
 	testReadinessReflector.clock = fakeClock
 	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
 	testlookUp.readinessGateEnabledNegs = []string{"neg1", "neg2"}

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -445,7 +445,10 @@ func TestNeedToProcess(t *testing.T) {
 }
 
 func TestNeedToPoll(t *testing.T) {
-	poller := newFakePoller()
+	poller, err := newFakePoller()
+	if err != nil {
+		t.Fatalf("failed to create fake poller")
+	}
 	fakeLookUp := poller.lookup.(*fakeLookUp)
 	podLister := poller.podLister
 	namespace := "ns"

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -42,7 +42,10 @@ import (
 // The L7 implementation is tested in TestToZoneNetworkEndpointMapUtil.
 func TestLocalGetEndpointSet(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
 	zonegetter.SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default", SubnetworkURL: defaultTestSubnetURL}
@@ -197,7 +200,10 @@ func nodeInterfacesAnnotation(t *testing.T, network, ip string) string {
 // TestClusterGetEndpointSet verifies the GetEndpointSet method implemented by the ClusterL4EndpointsCalculator.
 func TestClusterGetEndpointSet(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
 	zonegetter.SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
 	defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default", SubnetworkURL: defaultTestSubnetURL}
@@ -399,10 +405,16 @@ func TestValidateEndpoints(t *testing.T) {
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	serviceLister := testContext.ServiceInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, true)
-	zoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	L7EndpointsCalculator := NewL7EndpointsCalculator(zoneGetter, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics())
 
-	zoneGetterMSC := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
+	zoneGetterMSC, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, true)
+	if err != nil {
+		t.Fatalf("failed to initialize msc zone getter: %v", err)
+	}
 	L7EndpointsCalculatorMSC := NewL7EndpointsCalculator(zoneGetterMSC, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics())
 	L7EndpointsCalculatorMSC.enableMultiSubnetCluster = true
 	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL}, negtypes.L4InternalLB)

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -721,7 +721,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 				// It is possible for a NEG to be missing in a zone without candidate nodes. Log and ignore this error.
 				// NEG not found in a candidate zone is an error.
 				if utils.IsNotFoundError(err) && !candidateZonesMap.Has(zone) {
-					logger.Info("Ignoring NotFound error for NEG", "negName", negName, "zone", zone)
+					logger.Info("Ignoring NotFound error for NEG", "negName", negName, "zone", zone, "subnet", subnet)
 					metrics.PublishNegControllerErrorCountMetrics(err, true)
 					continue
 				}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -495,7 +495,11 @@ func TestToZoneNetworkEndpointMap(t *testing.T) {
 	t.Parallel()
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
+
 	podLister := negtypes.NewTestContext().PodInformer.GetIndexer()
 	testEndpointSlice := getDefaultEndpointSlices()
 	addPodsToLister(podLister, testEndpointSlice)
@@ -749,7 +753,10 @@ func TestIpsForPod(t *testing.T) {
 func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	negCloud := negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	defaultSubnetNegName := "test-neg-name"
 	nonDefaultSubnetNegName := "non-default-neg-name"
@@ -1732,7 +1739,10 @@ func TestToZoneNetworkEndpointMapDegradedMode(t *testing.T) {
 
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 	testContext := negtypes.NewTestContext()
 	podLister := testContext.PodInformer.GetIndexer()
 	addPodsToLister(podLister, getDefaultEndpointSlices())
@@ -1962,7 +1972,10 @@ func TestValidateEndpointFields(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, false)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, false)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 
 	// Add the pod that corresponds to empty zone instance.
 	podLister.Add(&v1.Pod{
@@ -2598,7 +2611,10 @@ func TestValidateEndpointFieldsMultipleSubnets(t *testing.T) {
 	addPodsToLister(podLister, getDefaultEndpointSlices())
 	nodeLister := testContext.NodeInformer.GetIndexer()
 	zonegetter.PopulateFakeNodeInformer(testContext.NodeInformer, true)
-	fakeZoneGetter := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, true)
+	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, true)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
 
 	// Add defaultSubnetLabelPod that corresponds to defaultSubnetLabelInstance.
 	podLister.Add(&v1.Pod{

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -764,7 +764,10 @@ func TestNodePredicateForEndpointCalculatorMode(t *testing.T) {
 			predicate := NodeFilterForEndpointCalculatorMode(tc.epCalculatorMode)
 			nodeInformer := zonegetter.FakeNodeInformer()
 			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-			zoneGetter := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+			zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+			if err != nil {
+				t.Errorf("failed to initalize zone getter: %v", err)
+			}
 			zones, err := zoneGetter.ListZones(predicate, klog.TODO())
 			if err != nil {
 				t.Errorf("Failed listing zones with predicate, err - %v", err)

--- a/pkg/test/gcehooks.go
+++ b/pkg/test/gcehooks.go
@@ -26,13 +26,15 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	"k8s.io/cloud-provider-gcp/providers/gce"
 )
 
 const (
 	FwIPAddress = "10.0.0.1"
 	// backend-service url, was created based on project and region set in test function DefaultTestClusterValues().
 	// We need whole url for forwarding rule validation.
-	bsUrl = "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-default-netbtest-hgray14h"
+	bsUrl                = "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-default-netbtest-hgray14h"
+	DefaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default"
 )
 
 func ListErrorHook(ctx context.Context, zone string, fl *filter.F, m *cloud.MockInstanceGroups, options ...cloud.Option) (bool, []*compute.InstanceGroup, error) {
@@ -127,4 +129,10 @@ func InsertAddressNetworkErrorHook(ctx context.Context, key *meta.Key, obj *comp
 
 func InsertAddressNotAllocatedToProjectErrorHook(ctx context.Context, key *meta.Key, obj *compute.Address, m *cloud.MockAddresses, options ...cloud.Option) (bool, error) {
 	return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "Specified IP address is not allocated to the project or does not belong to the specified scope."}
+}
+
+func DefaultTestClusterValues() gce.TestClusterValues {
+	values := gce.DefaultTestClusterValues()
+	values.SubnetworkURL = DefaultTestSubnetURL
+	return values
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -570,8 +570,9 @@ func InstancesListToNameSet(instancesList []*compute.InstanceWithNamedPorts) (se
 func MustCreateDualStackClusterSubnet(t *testing.T, gcecloud *gce.Cloud, ipv6AccessType string) {
 	t.Helper()
 	// Mock GCE uses subnet with empty string name.
-	MustCreateDualStackSubnet(t, gcecloud, "", ipv6AccessType)
+	MustCreateDualStackSubnetWithURL(t, gcecloud, DefaultTestSubnetURL, ipv6AccessType)
 }
+
 func MustCreateDualStackSubnet(t *testing.T, gcecloud *gce.Cloud, subnetName, ipv6AccessType string) {
 	t.Helper()
 
@@ -581,6 +582,25 @@ func MustCreateDualStackSubnet(t *testing.T, gcecloud *gce.Cloud, subnetName, ip
 		StackType:      "IPV4_IPV6",
 	}
 	err := gcecloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), subnetKey, subnetToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// MustCreateSubnet an empty subnet with a key generated from the provided subnetURLinto GCE
+func MustCreateDualStackSubnetWithURL(t *testing.T, gcecloud *gce.Cloud, subnetURL, ipv6AccessType string) {
+	t.Helper()
+
+	resID, err := cloud.ParseResourceURL(subnetURL)
+	if err != nil {
+		t.Fatalf("failed to parse subnet URL : %v", err)
+	}
+
+	subnetToCreate := &compute.Subnetwork{
+		Ipv6AccessType: ipv6AccessType,
+		StackType:      "IPV4_IPV6",
+	}
+	err = gcecloud.Compute().(*cloud.MockGCE).Subnetworks().Insert(context2.TODO(), resID.Key, subnetToCreate)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
 * As part of ZoneGetter initialization, generate the default subnet config to stop re-generating the config in every ListSubnets call
 * ListSubnets will always return the current list of subnets
 * TransactionSyncer syncInternalImpl depends on ListSubnets to determine which set of subnets are valid (flag gate occurs in ListSubnet). This abstracts the subnet determination to the zone getter
 * Add unit tests for ListSubnets


/assign @gauravkghildiyal 