### PR TITLE
Fix firewall cr creation

### DIFF
--- a/pkg/firewalls/firewalls_l7_cr.go
+++ b/pkg/firewalls/firewalls_l7_cr.go
@@ -169,6 +169,15 @@ func NewFirewallCR(name string, ports, srcRanges, dstRanges []string, enforced b
 		}
 		protocolPorts = append(protocolPorts, protocolPort)
 	}
+
+	// TCP:all is the default if the ports' list is empty.
+	if len(protocolPorts) == 0 {
+		protocolPort := gcpfirewallv1.ProtocolPort{
+			Protocol: gcpfirewallv1.ProtocolTCP,
+		}
+		protocolPorts = append(protocolPorts, protocolPort)
+	}
+
 	firewallCR.Spec.Ports = protocolPorts
 
 	var src_cidrs, dst_cidrs []gcpfirewallv1.CIDR


### PR DESCRIPTION
While testing gcpfirewalls cr creation inside ingress-gce we encountered an issue when Allow - TPC:all rule is requested.

The former implementation would create a cr with Allow:all instead, which is a violation of the specification:
https://cloud.google.com/kubernetes-engine/docs/concepts/firewall-rules#ingress-fws
