### PR TITLE
script: Use instance zone instead of cluster location in setup-local script

### DIFF
--- a/hack/setup-local.sh
+++ b/hack/setup-local.sh
@@ -78,4 +78,4 @@ node-tags = ${nodeTag}
 local-zone = ${zone}
 EOF
 
-echo "Run glbc with hack/run-glbc.sh"
+echo "Run glbc with hack/run-local-glbc.sh"


### PR DESCRIPTION
Fixes a bug that prevented the script from working with regional clusters. 

Previously, the script incorrectly used the cluster's region as the instance group zone. This change now extracts the correct zone from the instance group's URL, ensuring compatibility with regional clusters.
