### PR TITLE
Enable CR updates after NEG GC always

### DIFF
--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
-	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
@@ -658,10 +657,11 @@ func (manager *syncerManager) processNEGDeletionCandidate(svcNegCR *negv1beta1.S
 			shouldDeleteNegCR = shouldDeleteNegCR && negDeleted
 		}
 	}
-	// Since no more NEG deletion will be happening at this point, and NEG
-	// CR will not be deleted, clear the reference for deleted NEGs in the
-	// NEG CR.
-	if flags.F.EnableMultiSubnetClusterPhase1 {
+
+	if !shouldDeleteNegCR {
+		// Since no more NEG deletion will be happening at this point, and NEG
+		// CR will not be deleted, clear the reference for deleted NEGs in the
+		// NEG CR.
 		if len(deletedNegs) != 0 {
 			updatedCR := svcNegCR.DeepCopy()
 
@@ -672,9 +672,6 @@ func (manager *syncerManager) processNEGDeletionCandidate(svcNegCR *negv1beta1.S
 				errList = append(errList, err)
 			}
 		}
-	}
-
-	if !shouldDeleteNegCR {
 		return errList
 	}
 

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1520,6 +1520,12 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 					if !tc.expectCrGC && crDeleted && !tc.markedForDeletion {
 						t.Errorf("expected neg %s to not be deleted", negName)
 					}
+
+					if !tc.expectCrGC && !crDeleted && tc.negCrGCError == nil {
+						if len(crs[0].Status.NetworkEndpointGroups) != tc.expectedNegCount {
+							t.Errorf("SvcNeg CR contains %d Negs, expected %d", len(crs[0].Status.NetworkEndpointGroups), tc.expectedNegCount)
+						}
+					}
 				}
 			}
 		})


### PR DESCRIPTION
 * NEG CRs should be updated with current state of NEGs. This provides the most accurate picture of the NEG and allows the CR to be consumed by other downstream clients

 * Remove flag gating as this change is not specific to the multi subnet clusters feature.

/assign @gauravkghildiyal 