### PR TITLE
Add zonal affinity support

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -335,6 +335,7 @@ func main() {
 		EnableL4NetLBNEGsDefault:      flags.F.EnableL4NetLBNEGDefault,
 		EnableL4ILBMixedProtocol:      flags.F.EnableL4ILBMixedProtocol,
 		EnableL4NetLBMixedProtocol:    flags.F.EnableL4NetLBMixedProtocol,
+		EnableL4ILBZonalAffinity:      flags.F.EnableL4ILBZonalAffinity,
 	}
 	ctx, err := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	if err != nil {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -133,6 +133,7 @@ type ControllerContextConfig struct {
 	EnableIngressRegionalExternal bool
 	EnableWeightedL4ILB           bool
 	EnableWeightedL4NetLB         bool
+	EnableL4ILBZonalAffinity      bool
 	DisableL4LBFirewall           bool
 	EnableL4NetLBNEGs             bool
 	EnableL4NetLBNEGsDefault      bool

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -140,6 +140,7 @@ var F = struct {
 	EnableWeightedL4NetLB                    bool
 	EnableDiscretePortForwarding             bool
 	EnableMultiProjectMode                   bool
+	EnableL4ILBZonalAffinity                 bool
 	ProviderConfigNameLabelKey               string
 	EnableL4ILBMixedProtocol                 bool
 	EnableL4NetLBMixedProtocol               bool
@@ -329,6 +330,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.NodeTopologyCRName, "node-topology-cr-name", "default", "The name of the Node Topology CR.")
 	flag.BoolVar(&F.EnableWeightedL4ILB, "enable-weighted-l4-ilb", false, "Enable Weighted Load balancing for L4 ILB.")
 	flag.BoolVar(&F.EnableWeightedL4NetLB, "enable-weighted-l4-netlb", false, "EnableWeighted Load balancing for  L4 NetLB .")
+	flag.BoolVar(&F.EnableL4ILBZonalAffinity, "enable-l4ilb-zonal-affinity", false, "Enable Zonal Affinity for L4 ILB.")
 	flag.Float32Var(&F.KubeClientQPS, "kube-client-qps", 0.0, "The QPS that the controllers' kube client should adhere to through client side throttling. If zero, client will be created with default settings.")
 	flag.IntVar(&F.KubeClientBurst, "kube-client-burst", 0, "The burst QPS that the controllers' kube client should adhere to through client side throttling. If zero, client will be created with default settings.")
 	flag.BoolVar(&F.EnableDiscretePortForwarding, "enable-discrete-port-forwarding", false, "Enable forwarding of individual ports instead of port ranges.")

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -287,6 +287,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
 		EnableMixedProtocol:              l4c.ctx.EnableL4ILBMixedProtocol,
+		EnableZonalAffinity:              l4c.ctx.EnableL4ILBZonalAffinity,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	syncResult := l4.EnsureInternalLoadBalancer(utils.GetNodeNames(nodes), service)
@@ -369,6 +370,7 @@ func (l4c *L4Controller) processServiceDeletion(key string, svc *v1.Service, svc
 		EnableWeightedLB:                 l4c.ctx.EnableWeightedL4ILB,
 		DisableNodesFirewallProvisioning: l4c.ctx.DisableL4LBFirewall,
 		EnableMixedProtocol:              l4c.ctx.EnableL4ILBMixedProtocol,
+		EnableZonalAffinity:              l4c.ctx.EnableL4ILBZonalAffinity,
 	}
 	l4 := loadbalancers.NewL4Handler(l4ilbParams, svcLogger)
 	l4c.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting load balancer for %s", key)
@@ -577,6 +579,11 @@ func (l4c *L4Controller) needsUpdate(oldService *v1.Service, newService *v1.Serv
 	if oldService.Spec.HealthCheckNodePort != newService.Spec.HealthCheckNodePort {
 		recorder.Eventf(newService, v1.EventTypeNormal, "HealthCheckNodePort", "%v -> %v",
 			oldService.Spec.HealthCheckNodePort, newService.Spec.HealthCheckNodePort)
+		return true
+	}
+	if oldService.Spec.TrafficDistribution != newService.Spec.TrafficDistribution {
+		recorder.Eventf(newService, v1.EventTypeNormal, "TrafficDistribution", "%v -> %v",
+			oldService.Spec.TrafficDistribution, newService.Spec.TrafficDistribution)
 		return true
 	}
 	if l4c.enableDualStack && !reflect.DeepEqual(oldService.Spec.IPFamilies, newService.Spec.IPFamilies) {


### PR DESCRIPTION
## Overview
This PR implements zonal affinity capabilities for L4 Internal Load Balancers, allowing traffic to stay within zones when possible for improved performance and reduced cross-zone data transfer costs.

## Changes
- Add zonal affinity flag for L4 ILB controllers
- Implement backendService zonal affinity control logic
- Add backendService minimum API version control for zonal features
- Update backendService tests to include zonal affinity cases with expected NetworkPassThroughLbTrafficPolicy
- Add handler for service spec Spec.TrafficDistribution change events
- Add L4 TestZonalAffinity integration tests

## Usage
Users can enable zonal affinity by configuring their service with `Spec.TrafficDistribution=PreferClose`.

## Testing
- Added unit tests for backendService with zonal affinity configurations
- Added L4 TestZonalAffinity integration tests to verify controller functionality