### PR TITLE
Make the subset sizes configurable for L4 NetLB NEG.

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -143,6 +143,8 @@ var F = struct {
 	EnableL4ILBMixedProtocol                 bool
 	EnableL4NetLBMixedProtocol               bool
 	EnableIPV6OnlyNEG                        bool
+	L4NetLBLocalSubsetSize                   int
+	L4NetLBClusterSubsetSize                 int
 }{
 	GCERateLimitScale: 1.0,
 }
@@ -334,6 +336,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NetLBMixedProtocol, "enable-l4netlb-mixed-protocol", false, "Enable support for mixed protocol L4 external load balancers.")
 	flag.StringVar(&F.ProviderConfigNameLabelKey, "provider-config-name-label-key", "cloud.gke.io/provider-config-name", "The label key for provider-config name, which is used to identify the provider-config of objects in multi-project mode.")
 	flag.BoolVar(&F.EnableIPV6OnlyNEG, "enable-ipv6-only-neg", false, "Enable support for IPV6 Only NEG's.")
+	flag.IntVar(&F.L4NetLBLocalSubsetSize, "l4-netlb-local-subset-size", 1000, "The size of the subset to use for endpoints calculation for L4NetLB with externalTrafficPolicy:Local")
+	flag.IntVar(&F.L4NetLBClusterSubsetSize, "l4-netlb-cluster-subset-size", 250, "The size of the subset to use for endpoints calculation for L4NetLB with externalTrafficPolicy:Cluster")
 }
 
 func Validate() {

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -53,7 +53,7 @@ type LocalL4EndpointsCalculator struct {
 func NewLocalL4EndpointsCalculator(nodeLister listers.NodeLister, zoneGetter *zonegetter.ZoneGetter, svcId string, logger klog.Logger, networkInfo *network.NetworkInfo, lbType types.L4LBType) *LocalL4EndpointsCalculator {
 	subsetSize := maxSubsetSizeLocal
 	if lbType == negtypes.L4ExternalLB {
-		subsetSize = maxSubsetSizeNetLBLocal
+		subsetSize = flags.F.L4NetLBLocalSubsetSize
 	}
 
 	return &LocalL4EndpointsCalculator{
@@ -157,7 +157,7 @@ type ClusterL4EndpointsCalculator struct {
 func NewClusterL4EndpointsCalculator(nodeLister listers.NodeLister, zoneGetter *zonegetter.ZoneGetter, svcId string, logger klog.Logger, networkInfo *network.NetworkInfo, l4LBtype negtypes.L4LBType) *ClusterL4EndpointsCalculator {
 	subsetSize := maxSubsetSizeDefault
 	if l4LBtype == negtypes.L4ExternalLB {
-		subsetSize = maxSubsetSizeNetLBCluster
+		subsetSize = flags.F.L4NetLBClusterSubsetSize
 	}
 	return &ClusterL4EndpointsCalculator{
 		zoneGetter:      zoneGetter,

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -35,10 +35,6 @@ const (
 	maxSubsetSizeLocal = 250
 	// Max number of subsets in ExternalTrafficPolicy:Cluster, which is the default mode.
 	maxSubsetSizeDefault = 25
-	// Max number of subsets for NetLB in ExternalTrafficPolicy:Local
-	maxSubsetSizeNetLBLocal = 1000
-	// Max number of subsets for NetLB in ExternalTrafficPolicy:Cluster
-	maxSubsetSizeNetLBCluster = 250
 )
 
 // NodeInfo stores node metadata used to sort nodes and pick a subset.


### PR DESCRIPTION
Add `--l4-netlb-local-subset-size` and `--l4-netlb-local-subset-size` flags that allow to configure the subset sizes for the L4 NetLB endpoint calculators.