### PR TITLE
Adding annotation to enable Global Access for L7 ILBs

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -56,6 +56,9 @@ const (
 	// to the target proxies of the Ingress.
 	PreSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
 
+	// ILBGlobalAccessKey is the annotation key used to enable Global Access for the L7 ILB Forwarding Rule
+	ILBGlobalAccessKey = "ingress.gcp.kubernetes.io/ilb-allow-global-access"
+
 	// IngressClassKey picks a specific "class" for the Ingress. The controller
 	// only processes Ingresses with this annotation either unset, or set
 	// to either gceIngressClass or the empty string.

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -103,8 +103,10 @@ func (l7 *L7) checkForwardingRule(protocol namer.NamerProtocol, name, proxyLink,
 	env := &translator.Env{VIP: ip, Network: l7.cloud.NetworkURL(), Subnetwork: l7.cloud.SubnetworkURL()}
 	fr := tr.ToCompositeForwardingRule(env, protocol, version, proxyLink, description, l7.runtimeInfo.StaticIPSubnet)
 
+	fr.AllowGlobalAccess = utils.IsGCEL7ILBIngressGlobalAccessEnabled(&l7.ingress)
+	
 	existing, _ = composite.GetForwardingRule(l7.cloud, key, version, l7.logger)
-	if existing != nil && (fr.IPAddress != "" && existing.IPAddress != fr.IPAddress || existing.PortRange != fr.PortRange) {
+	if existing != nil && (fr.IPAddress != "" && existing.IPAddress != fr.IPAddress || existing.PortRange != fr.PortRange || existing.AllowGlobalAccess != fr.AllowGlobalAccess) {
 		l7.logger.Info("Recreating forwarding rule %v(%v), so it has %v(%v)",
 			"existingIp", existing.IPAddress, "existingPortRange", existing.PortRange,
 			"targetIp", fr.IPAddress, "targetPortRange", fr.PortRange)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -505,6 +505,18 @@ func IsGCEL7ILBIngress(ing *networkingv1.Ingress) bool {
 	return class == annotations.GceL7ILBIngressClass
 }
 
+// IsGCEL7ILBIngressGlobalAccessEnabled returns true if the given Ingress has
+// ingress.class annotation set to "gce-l7-ilb" and has Global Access enabled
+func IsGCEL7ILBIngressGlobalAccessEnabled(ing *networkingv1.Ingress) bool {
+	if !IsGCEL7ILBIngress(ing) {
+		return false
+	}
+	if ilbGlobalAccess, ilbGAExists := ing.Annotations[annotations.ILBGlobalAccessKey]; ilbGAExists && ilbGlobalAccess == "true" {
+		return true
+	}
+	return false
+}
+
 // IsGCEL7XLBRegionalIngress returns true if the given Ingress has
 // ingress.class annotation set to "gce-regional-external"
 func IsGCEL7XLBRegionalIngress(ing *networkingv1.Ingress) bool {


### PR DESCRIPTION
This addresses #1883 and #1887 . 

While I understand that Google doesn't intend to invest much in Ingress going forward, in favor of the Gateway API, there are enough existing Helm charts, etc. out there that use Ingress, where it arguably makes sense to add something like this which is both high impact and relatively low effort to implement.