### PR TITLE
Increase max number of subsets NetLB for ETP:local

### DIFF
--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -36,7 +36,7 @@ const (
 	// Max number of subsets in ExternalTrafficPolicy:Cluster, which is the default mode.
 	maxSubsetSizeDefault = 25
 	// Max number of subsets for NetLB in ExternalTrafficPolicy:Local
-	maxSubsetSizeNetLBLocal = 1000
+	maxSubsetSizeNetLBLocal = 3000
 	// Max number of subsets for NetLB in ExternalTrafficPolicy:Cluster
 	maxSubsetSizeNetLBCluster = 250
 )


### PR DESCRIPTION
Match the max subset size with IG per zone for NEG backed NetLB.