### PR TITLE
Temporarily disable linters

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -23,6 +23,8 @@ cd "${REPO_ROOT}"
 
 hack/verify-gofmt.sh
 hack/verify-govet.sh
-hack/verify-lint.sh
+# TODO: re-enable this after g1.24 linters work in this project
+echo "Linters temporarily disabled, please run \`hack/verify-lint.sh\` manually using go version <1.24 to verify"
+# hack/verify-lint.sh
 hack/verify-codegen.sh
 hack/verify-vendor.sh


### PR DESCRIPTION
The recent upgrade to go 1.24 in kubernetes/kubernetes causes linters to fail in many ways for code that is correct. Temporarily disable not to block development, the linters will be enabled once we determine the cause of the issue.