### PR TITLE
Disable linter in hack/verify-all.sh

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -23,6 +23,5 @@ cd "${REPO_ROOT}"
 
 hack/verify-gofmt.sh
 hack/verify-govet.sh
-hack/verify-lint.sh
 hack/verify-codegen.sh
 hack/verify-vendor.sh


### PR DESCRIPTION
The linter is still enabled by the make test run which runs inside the build image. This ensures that the go version matches what we expect the code to run in. hack/verify-all.sh runs with the host go version which may not always be compatible.

Temporarily disable the linters in hack/verify-all.sh due to a bump in go image for kubekinsv2 image
(https://github.com/kubernetes/test-infra/commit/6d1f25d314508c3968c6c15cd586086fe0a50540). This image is used in our GH testing which caused our linters to fail as our build is still on Go 1.22 but the image is now in Go 1.24.

/assign @gauravkghildiyal 
/assign @mmamczur 