### PR TITLE
Fix linter warnings for pkg/neg/syncers

### DIFF
--- a/pkg/neg/syncers/subsets_test.go
+++ b/pkg/neg/syncers/subsets_test.go
@@ -24,7 +24,6 @@ import (
 
 	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
 	"k8s.io/ingress-gce/pkg/neg/types"
-	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -230,7 +229,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 				t.Errorf("Failed to get subset for test '%s', err %v", tc.description, err)
 			}
 			zones := make(map[string]struct{})
-			for egi, _ := range subsetMap {
+			for egi := range subsetMap {
 				zones[egi.Zone] = struct{}{}
 			}
 			if len(zones) != len(tc.nodesMap) {
@@ -238,7 +237,7 @@ func TestUnevenNodesInZones(t *testing.T) {
 					subsetMap, tc.nodesMap, tc.description)
 			}
 			totalSubsetSize := 0
-			for zone, _ := range zones {
+			for zone := range zones {
 				subset := getNetworkEndpointsForZone(zone, subsetMap)
 				if len(subset) == 0 && !tc.expectEmpty {
 					t.Errorf("Got empty subset in zone %s for test '%s'", zone, tc.description)
@@ -263,7 +262,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 		// expectEmpty indicates that some zones can have empty subsets
 		expectEmpty      bool
 		networkInfo      network.NetworkInfo
-		expectedNodesMap map[negtypes.NEGLocation]map[string]string
+		expectedNodesMap map[types.NEGLocation]map[string]string
 	}{
 		{
 			description: "Default network, gets primary interface",
@@ -277,7 +276,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				SubnetworkURL: defaultTestSubnetURL,
 			},
 			// empty IPs since test can't get the primary IP
-			expectedNodesMap: map[negtypes.NEGLocation]map[string]string{
+			expectedNodesMap: map[types.NEGLocation]map[string]string{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "", "n1_2": ""},
 				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "", "n2_2": ""},
 				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": ""},
@@ -296,7 +295,7 @@ func TestGetSubsetPerZoneMultinetwork(t *testing.T) {
 				K8sNetwork:    "net1",
 				SubnetworkURL: defaultTestSubnetURL,
 			},
-			expectedNodesMap: map[negtypes.NEGLocation]map[string]string{
+			expectedNodesMap: map[types.NEGLocation]map[string]string{
 				{Zone: "zone1", Subnet: defaultTestSubnet}: {"n1_1": "172.168.1.1", "n1_2": "172.168.1.2"},
 				{Zone: "zone2", Subnet: defaultTestSubnet}: {"n2_1": "172.168.2.1", "n2_2": "172.168.2.2"},
 				{Zone: "zone3", Subnet: defaultTestSubnet}: {"n3_1": "172.168.3.1"},

--- a/pkg/neg/syncers/syncer.go
+++ b/pkg/neg/syncers/syncer.go
@@ -54,7 +54,7 @@ type syncer struct {
 	shuttingDown bool
 
 	// sync signal and retry handling
-	syncCh  chan interface{}
+	syncCh  chan any
 	clock   clock.Clock
 	backoff backoff.BackoffHandler
 
@@ -77,10 +77,10 @@ func newSyncer(negSyncerKey negtypes.NegSyncerKey, serviceLister cache.Indexer, 
 
 func (s *syncer) Start() error {
 	if !s.IsStopped() {
-		return fmt.Errorf("NEG syncer for %s is already running.", s.NegSyncerKey.String())
+		return fmt.Errorf("NEG syncer for %s is already running", s.NegSyncerKey.String())
 	}
 	if s.IsShuttingDown() {
-		return fmt.Errorf("NEG syncer for %s is shutting down. ", s.NegSyncerKey.String())
+		return fmt.Errorf("NEG syncer for %s is shutting down", s.NegSyncerKey.String())
 	}
 
 	s.logger.V(2).Info("Starting NEG syncer for service port", "negSyncerKey", s.NegSyncerKey.String())

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -36,7 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1336,12 +1335,12 @@ func TestCommitPods(t *testing.T) {
 					endpointSet, endpointMap := generateEndpointSetAndMap(net.ParseIP("1.1.1.1"), 10, testInstance1, "8080")
 					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
-					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
+					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.2.1"), 10, testInstance2, "8080")
 					retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone1, Subnet: defaultTestSubnet}].Union(endpointSet)
 					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.3.1"), 10, testInstance3, "8080")
 					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					retMap = unionEndpointMap(retMap, endpointMap)
-					endpointSet, endpointMap = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
+					endpointSet, _ = generateEndpointSetAndMap(net.ParseIP("1.1.4.1"), 10, testInstance4, "8080")
 					retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}] = retSet[negtypes.NEGLocation{Zone: testZone2, Subnet: defaultTestSubnet}].Union(endpointSet)
 					return retSet, retMap
 				},
@@ -1725,10 +1724,10 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			}
 
 			// Since timestamp gets truncated to the second, there is a chance that the timestamps will be the same as LastTransitionTime or LastSyncTime so use creation TS from an earlier date.
-			creationTS := v1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
+			creationTS := metav1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
 			//Create NEG CR for Syncer to update status on
 			origCR := createNegCR(testNegName, creationTS, tc.crStatusPopulated, tc.crStatusPopulated, refs)
-			neg, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+			neg, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Failed to create test NEG CR: %s", err)
 			}
@@ -1742,7 +1741,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 				t.Errorf("Expected error, but got none")
 			}
 
-			negCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, v1.GetOptions{})
+			negCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Failed to get NEG from neg client: %s", err)
 			}
@@ -1815,7 +1814,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			}
 		})
 
-		negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Delete(context.TODO(), testNegName, v1.DeleteOptions{})
+		negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Delete(context.TODO(), testNegName, metav1.DeleteOptions{})
 
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone1, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 		syncer.cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
@@ -1965,8 +1964,8 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 			for _, neg := range negRefByZone {
 				refs = append(refs, neg)
 			}
-			origCR := createNegCR(negName, v1.Now(), true, true, refs)
-			initialNegCr, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+			origCR := createNegCR(negName, metav1.Now(), true, true, refs)
+			initialNegCr, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create test NEG CR: %s", err)
 			}
@@ -1987,7 +1986,7 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 				t.Errorf("Got errors %v after ensureNetworkEndpointGroupsFromNodeTopology(), expected no errors", err)
 			}
 
-			syncedNegCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), negName, v1.GetOptions{})
+			syncedNegCR, err := negClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), negName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get NEG from neg client: %s", err)
 			}
@@ -2126,9 +2125,9 @@ func TestUpdateInitStatusWithMultiSubnetCluster(t *testing.T) {
 			}
 
 			// Create NEG CR.
-			creationTS := v1.Now()
+			creationTS := metav1.Now()
 			origCR := createNegCR(testNegName, creationTS, true, true, initialNegRefs)
-			svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+			svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Failed to create test NEG CR: %s", err)
 			}
@@ -2160,7 +2159,7 @@ func TestUpdateInitStatusWithMultiSubnetCluster(t *testing.T) {
 			syncer.updateInitStatus(activeNegList, nil)
 
 			// gather negCR to validate the updates
-			negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, v1.GetOptions{})
+			negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Failed to create test NEG CR: %s", err)
 			}
@@ -2244,9 +2243,9 @@ func TestUpdateInitStatusTransitions(t *testing.T) {
 	allRefs := createNEGs(t, syncer, fakeCloud, testNegName, defaultTestSubnetURL, allZones, negv1beta1.ActiveState)
 
 	// Create NEG CR.
-	creationTS := v1.Now()
+	creationTS := metav1.Now()
 	origCR := createNegCR(testNegName, creationTS, true, true, initialNegRefs)
-	svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+	svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test NEG CR: %s", err)
 	}
@@ -2259,7 +2258,7 @@ func TestUpdateInitStatusTransitions(t *testing.T) {
 	syncer.updateInitStatus(allRefs, nil)
 
 	// gather negCR to validate the updates
-	negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, v1.GetOptions{})
+	negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test NEG CR: %s", err)
 	}
@@ -2337,9 +2336,9 @@ func TestSubnetChanges(t *testing.T) {
 	allRefs = append(allRefs, createNEGs(t, ts, fakeCloud, subnetToNameMap[secondarySubnetConfig1], secondarySubnetConfig1.SubnetPath, allZones, negv1beta1.ActiveState)...)
 
 	// Create NEG CR.
-	creationTS := v1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
+	creationTS := metav1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
 	origCR := createNegCR(testNegName, creationTS, true, true, allRefs)
-	svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+	svcNeg, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test NEG CR: %s", err)
 	}
@@ -2349,7 +2348,7 @@ func TestSubnetChanges(t *testing.T) {
 	ts.sync()
 
 	// gather negCR to validate the updates
-	negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, v1.GetOptions{})
+	negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test NEG CR: %s", err)
 	}
@@ -2483,7 +2482,7 @@ func TestIsSubnetChange(t *testing.T) {
 				}
 			}
 
-			negCR := createNegCR(ts.NegName, v1.Now(), true, true, allRefs)
+			negCR := createNegCR(ts.NegName, metav1.Now(), true, true, allRefs)
 			if err = ts.svcNegLister.Add(negCR); err != nil {
 				t.Errorf("failed to add neg to store:%s", err)
 			}
@@ -2647,6 +2646,9 @@ func TestUpdateStatus(t *testing.T) {
 						Subnetwork:          fakeCloud.SubnetworkURL(),
 						Description:         "",
 					}, testZone1, klog.TODO())
+					if err != nil {
+						t.Errorf("failed to create test NEG: %s", err)
+					}
 
 					_, err = fakeCloud.GetNetworkEndpointGroup(testNegName, testZone1, syncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
 					if err != nil {
@@ -2655,9 +2657,9 @@ func TestUpdateStatus(t *testing.T) {
 				}
 
 				// Since timestamp gets truncated to the second, there is a chance that the timestamps will be the same as LastTransitionTime or LastSyncTime so use creation TS from an earlier date
-				creationTS := v1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
+				creationTS := metav1.Date(2020, time.July, 23, 0, 0, 0, 0, time.UTC)
 				origCR := createNegCR(testNegName, creationTS, tc.populateConditions[negv1beta1.Initialized], tc.populateConditions[negv1beta1.Synced], tc.negRefs)
-				origCR, err = svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, v1.CreateOptions{})
+				origCR, err = svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), origCR, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("Failed to create test NEG CR: %s", err)
 				}
@@ -2665,7 +2667,7 @@ func TestUpdateStatus(t *testing.T) {
 
 				syncer.updateStatus(syncErr)
 
-				negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, v1.GetOptions{})
+				negCR, err := svcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Get(context.Background(), testNegName, metav1.GetOptions{})
 				if err != nil {
 					t.Errorf("Failed to create test NEG CR: %s", err)
 				}
@@ -2766,7 +2768,7 @@ func TestIsZoneChange(t *testing.T) {
 			for _, neg := range negRefMap {
 				refs = append(refs, neg)
 			}
-			negCR := createNegCR(syncer.NegName, v1.Now(), true, true, refs)
+			negCR := createNegCR(syncer.NegName, metav1.Now(), true, true, refs)
 			if err = syncer.svcNegLister.Add(negCR); err != nil {
 				t.Errorf("failed to add neg to store:%s", err)
 			}
@@ -2849,19 +2851,19 @@ func TestUnknownNodes(t *testing.T) {
 	testEndpointSlices := getDefaultEndpointSlices()
 	testEndpointSlices[0].Endpoints[0].NodeName = utilpointer.StringPtr("unknown-node")
 	testEndpointMap := map[negtypes.NEGLocation]*composite.NetworkEndpoint{
-		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: &composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: {
 			Instance:  negtypes.TestInstance1,
 			IpAddress: testIP1,
 			Port:      testPort,
 		},
 
-		{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: &composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: {
 			Instance:  negtypes.TestInstance3,
 			IpAddress: testIP2,
 			Port:      testPort,
 		},
 
-		{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: &composite.NetworkEndpoint{
+		{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: {
 			Instance:  negtypes.TestUpgradeInstance1,
 			IpAddress: testIP3,
 			Port:      testPort,
@@ -3780,7 +3782,6 @@ func (r *testRetryHandler) Retry() error {
 }
 
 func (r *testRetryHandler) Reset() {
-	return
 }
 
 // negMeta references a GCE NEG resource

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -69,9 +69,9 @@ func decodeEndpoint(str string) (string, string, string) {
 }
 
 // calculateDifference determines what endpoints needs to be added and removed in order to move current state to target state.
-func calculateDifference(targetMap, currentMap map[string]sets.String) (map[string]sets.String, map[string]sets.String) {
-	addSet := map[string]sets.String{}
-	removeSet := map[string]sets.String{}
+func calculateDifference(targetMap, currentMap map[string]sets.Set[string]) (map[string]sets.Set[string], map[string]sets.Set[string]) {
+	addSet := map[string]sets.Set[string]{}
+	removeSet := map[string]sets.Set[string]{}
 	for zone, endpointSet := range targetMap {
 		diff := endpointSet.Difference(currentMap[zone])
 		if len(diff) > 0 {
@@ -725,7 +725,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 					metrics.PublishNegControllerErrorCountMetrics(err, true)
 					continue
 				}
-				return nil, nil, fmt.Errorf("Failed to lookup NEG in zone %q, candidate zones %v, err - %w", zone, candidateZonesMap, err)
+				return nil, nil, fmt.Errorf("failed to lookup NEG in zone %q, candidate zones %v, err - %w", zone, candidateZonesMap, err)
 			}
 			zoneNetworkEndpointMap[negtypes.NEGLocation{Zone: zone, Subnet: subnet}] = negtypes.NewNetworkEndpointSet()
 			for _, ne := range networkEndpointsWithHealthStatus {

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -64,109 +64,109 @@ func TestCalculateDifference(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		targetSet  map[string]sets.String
-		currentSet map[string]sets.String
-		addSet     map[string]sets.String
-		removeSet  map[string]sets.String
+		targetSet  map[string]sets.Set[string]
+		currentSet map[string]sets.Set[string]
+		addSet     map[string]sets.Set[string]
+		removeSet  map[string]sets.Set[string]
 	}{
 		// unchanged
 		{
-			targetSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			targetSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			currentSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			currentSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			addSet:    map[string]sets.String{},
-			removeSet: map[string]sets.String{},
+			addSet:    map[string]sets.Set[string]{},
+			removeSet: map[string]sets.Set[string]{},
 		},
 		// unchanged
 		{
-			targetSet:  map[string]sets.String{},
-			currentSet: map[string]sets.String{},
-			addSet:     map[string]sets.String{},
-			removeSet:  map[string]sets.String{},
+			targetSet:  map[string]sets.Set[string]{},
+			currentSet: map[string]sets.Set[string]{},
+			addSet:     map[string]sets.Set[string]{},
+			removeSet:  map[string]sets.Set[string]{},
 		},
 		// add in one zone
 		{
-			targetSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			targetSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			currentSet: map[string]sets.String{},
-			addSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			currentSet: map[string]sets.Set[string]{},
+			addSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			removeSet: map[string]sets.String{},
+			removeSet: map[string]sets.Set[string]{},
 		},
 		// add in 2 zones
 		{
-			targetSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
-				negtypes.TestZone2: sets.NewString("e", "f", "g"),
+			targetSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
+				negtypes.TestZone2: sets.New("e", "f", "g"),
 			},
-			currentSet: map[string]sets.String{},
-			addSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
-				negtypes.TestZone2: sets.NewString("e", "f", "g"),
+			currentSet: map[string]sets.Set[string]{},
+			addSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
+				negtypes.TestZone2: sets.New("e", "f", "g"),
 			},
-			removeSet: map[string]sets.String{},
+			removeSet: map[string]sets.Set[string]{},
 		},
 		// remove in one zone
 		{
-			targetSet: map[string]sets.String{},
-			currentSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			targetSet: map[string]sets.Set[string]{},
+			currentSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			addSet: map[string]sets.String{},
-			removeSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			addSet: map[string]sets.Set[string]{},
+			removeSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
 		},
 		// remove in 2 zones
 		{
-			targetSet: map[string]sets.String{},
-			currentSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
-				negtypes.TestZone2: sets.NewString("e", "f", "g"),
+			targetSet: map[string]sets.Set[string]{},
+			currentSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
+				negtypes.TestZone2: sets.New("e", "f", "g"),
 			},
-			addSet: map[string]sets.String{},
-			removeSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
-				negtypes.TestZone2: sets.NewString("e", "f", "g"),
+			addSet: map[string]sets.Set[string]{},
+			removeSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
+				negtypes.TestZone2: sets.New("e", "f", "g"),
 			},
 		},
 		// add and delete in one zone
 		{
-			targetSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
+			targetSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
 			},
-			currentSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("b", "c", "d"),
+			currentSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("b", "c", "d"),
 			},
-			addSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a"),
+			addSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a"),
 			},
-			removeSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("d"),
+			removeSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("d"),
 			},
 		},
 		// add and delete in 2 zones
 		{
-			targetSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a", "b", "c"),
-				negtypes.TestZone2: sets.NewString("a", "b", "c"),
+			targetSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a", "b", "c"),
+				negtypes.TestZone2: sets.New("a", "b", "c"),
 			},
-			currentSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("b", "c", "d"),
-				negtypes.TestZone2: sets.NewString("b", "c", "d"),
+			currentSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("b", "c", "d"),
+				negtypes.TestZone2: sets.New("b", "c", "d"),
 			},
-			addSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("a"),
-				negtypes.TestZone2: sets.NewString("a"),
+			addSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("a"),
+				negtypes.TestZone2: sets.New("a"),
 			},
-			removeSet: map[string]sets.String{
-				negtypes.TestZone1: sets.NewString("d"),
-				negtypes.TestZone2: sets.NewString("d"),
+			removeSet: map[string]sets.Set[string]{
+				negtypes.TestZone1: sets.New("d"),
+				negtypes.TestZone2: sets.New("d"),
 			},
 		},
 	}


### PR DESCRIPTION
This includes fixing:
* error strings should not end with punctuation or newlines (ST1005)
* redundant type from array, slice, or map composite literal
* simplify range expression
* duplicate imports
* deprecated sets.Strings
* package "xxx" is being imported more than once (ST1019)
* redundant return statement

Doesn't touch logic.