### PR TITLE
Add __debug_bin* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bin/
 .*-push
 bin/
 docs/deploy/resources/*.gen
+__debug_bin*


### PR DESCRIPTION
This ignores any binary produced by the delve debugger.

When running the controller using VSCode debugger, the debugger creates a temporary binary in cmd/glbc:
<img width="316" alt="image" src="https://github.com/user-attachments/assets/96189d62-6e7e-4795-8267-035ca7b666b1" />
This change ignores the binary.