### PR TITLE
Separate L4 specific metrics from `pkg/metrics` to `pkg/l4lb/metrics`

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -334,6 +334,8 @@ func main() {
 		DefaultBackendSvcPort:                     defaultBackendServicePort,
 		HealthCheckPath:                           flags.F.HealthCheckPath,
 		MaxIGSize:                                 flags.F.MaxIGSize,
+		RunL4ILBController:                        flags.F.RunL4Controller,
+		RunL4NetLBController:                      flags.F.RunL4NetLBController,
 		EnableL4ILBDualStack:                      flags.F.EnableL4ILBDualStack,
 		EnableL4NetLBDualStack:                    flags.F.EnableL4NetLBDualStack,
 		EnableL4StrongSessionAffinity:             flags.F.EnableL4StrongSessionAffinity,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -41,6 +41,7 @@ import (
 	frontendconfigclient "k8s.io/ingress-gce/pkg/frontendconfig/client/clientset/versioned"
 	informerfrontendconfig "k8s.io/ingress-gce/pkg/frontendconfig/client/informers/externalversions/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/instancegroups"
+	l4metrics "k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/metrics"
 	"k8s.io/ingress-gce/pkg/recorders"
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
@@ -95,6 +96,7 @@ type ControllerContext struct {
 	NodeTopologyInformer     cache.SharedIndexInformer
 
 	ControllerMetrics *metrics.ControllerMetrics
+	L4Metrics         *l4metrics.Collector
 
 	// NOTE: If the flag GKEClusterType is empty, then cluster will default to zonal. This field should not be used for
 	// controller logic and should only be used for providing additional information to the user.
@@ -176,8 +178,9 @@ func NewControllerContext(
 		ClusterNamer:            clusterNamer,
 		L4Namer:                 namer.NewL4Namer(string(kubeSystemUID), clusterNamer),
 		KubeSystemUID:           kubeSystemUID,
-		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval, flags.F.L4NetLBProvisionDeadline, flags.F.EnableL4NetLBDualStack, flags.F.EnableL4ILBDualStack, logger),
+		ControllerMetrics:       metrics.NewControllerMetrics(flags.F.MetricsExportInterval, logger),
 		ControllerContextConfig: config,
+		L4Metrics:               l4metrics.NewCollector(flags.F.MetricsExportInterval, flags.F.L4NetLBProvisionDeadline, flags.F.EnableL4NetLBDualStack, flags.F.EnableL4ILBDualStack, logger),
 		IngressInformer:         informernetworking.NewIngressInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		ServiceInformer:         informerv1.NewServiceInformer(kubeClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
 		BackendConfigInformer:   informerbackendconfig.NewBackendConfigInformer(backendConfigClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer()),
@@ -347,6 +350,8 @@ func (ctx *ControllerContext) Start(stopCh <-chan struct{}) {
 	}
 	// Export ingress usage metrics.
 	go ctx.ControllerMetrics.Run(stopCh)
+	// Export L4LB usage metrics
+	go ctx.L4Metrics.Run(stopCh)
 }
 
 // Ingresses returns the store of Ingresses.

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -121,6 +121,8 @@ type ControllerContextConfig struct {
 	DefaultBackendSvcPort                     utils.ServicePort
 	HealthCheckPath                           string
 	MaxIGSize                                 int
+	RunL4ILBController                        bool
+	RunL4NetLBController                      bool
 	EnableL4ILBDualStack                      bool
 	EnableL4NetLBDualStack                    bool
 	EnableL4StrongSessionAffinity             bool
@@ -350,8 +352,11 @@ func (ctx *ControllerContext) Start(stopCh <-chan struct{}) {
 	}
 	// Export ingress usage metrics.
 	go ctx.ControllerMetrics.Run(stopCh)
-	// Export L4LB usage metrics
-	go ctx.L4Metrics.Run(stopCh)
+
+	if runL4 := ctx.RunL4ILBController || ctx.RunL4NetLBController; runL4 {
+		// Export L4LB usage metrics
+		go ctx.L4Metrics.Run(stopCh)
+	}
 }
 
 // Ingresses returns the store of Ingresses.

--- a/pkg/l4lb/l4controller_test.go
+++ b/pkg/l4lb/l4controller_test.go
@@ -26,8 +26,8 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
-	"k8s.io/ingress-gce/pkg/metrics"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -53,8 +53,8 @@ import (
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/healthchecksl4"
+	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
-	"k8s.io/ingress-gce/pkg/metrics"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 
 	"k8s.io/ingress-gce/pkg/forwardingrules"

--- a/pkg/l4lb/metrics/collector.go
+++ b/pkg/l4lb/metrics/collector.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// Collector contains the state of all of the L4 LBs in the cluster
+type Collector struct {
+	// l4ILBServiceLegacyMap is a map between service key and L4 ILB service state. It's used in the legacy metric.
+	l4ILBServiceLegacyMap map[string]L4ILBServiceLegacyState
+	// l4NetLBServiceLegacyMap is a map between service key and L4 NetLB service state. It's used in the legacy metric.
+	l4NetLBServiceLegacyMap map[string]L4NetLBServiceLegacyState
+	// l4NetLBProvisionDeadlineForLegacyMetric is a time after which a failing NetLB will be marked as persistent error in the legacy metric.
+	l4NetLBProvisionDeadlineForLegacyMetric time.Duration
+	// l4ILBServiceMap is a map between service key and L4 ILB service state.
+	l4ILBServiceMap map[string]L4ServiceState
+	// l4NetLBServiceMap is a map between service key and L4 NetLB service state.
+	l4NetLBServiceMap map[string]L4ServiceState
+
+	sync.Mutex
+
+	// duration between metrics exports
+	exportsInterval time.Duration
+
+	enableILBDualStack   bool
+	enableNetLBDualStack bool
+
+	logger klog.Logger
+}
+
+// NewCollector initializes Collector for gathering L4 metrics
+func NewCollector(exportInterval, l4NetLBProvisionDeadline time.Duration, enableNetLBDualStack, enableILBDualStack bool, logger klog.Logger) *Collector {
+	return &Collector{
+		exportsInterval:                         exportInterval,
+		l4ILBServiceLegacyMap:                   make(map[string]L4ILBServiceLegacyState),
+		l4NetLBServiceLegacyMap:                 make(map[string]L4NetLBServiceLegacyState),
+		l4ILBServiceMap:                         make(map[string]L4ServiceState),
+		l4NetLBServiceMap:                       make(map[string]L4ServiceState),
+		l4NetLBProvisionDeadlineForLegacyMetric: l4NetLBProvisionDeadline,
+		enableILBDualStack:                      enableILBDualStack,
+		enableNetLBDualStack:                    enableNetLBDualStack,
+		logger:                                  logger.WithName("L4MetricsCollector"),
+	}
+}
+
+// NewFakeCollector creates an L4LB Collector for unit tests with default values
+func NewFakeCollector() *Collector {
+	return NewCollector(10*time.Minute, 20*time.Minute, true, true, klog.TODO())
+}
+
+// Run starts exporting metrics periodically
+func (c *Collector) Run(stopCh <-chan struct{}) {
+	c.logger.V(3).Info("L4 Contoller Metrics Collector initialized",
+		"exportInterval", c.exportsInterval,
+		"l4NetLBProvisionDeadlineForLegacyMetric", c.l4NetLBProvisionDeadlineForLegacyMetric,
+		"enableILBDualStack", c.enableILBDualStack,
+		"enableNetLBDualStack", c.enableNetLBDualStack,
+	)
+
+	go func() {
+		time.Sleep(c.exportsInterval)
+		wait.Until(c.export, c.exportsInterval, stopCh)
+	}()
+	<-stopCh
+}
+
+func (c *Collector) export() {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error(nil, "failed to export metrics due to a panic", "recoverMessage", r)
+		}
+	}()
+
+	c.exportIPv4()
+	c.exportDualStack()
+	c.exportLegacy()
+}

--- a/pkg/l4lb/metrics/dualstack_metrics.go
+++ b/pkg/l4lb/metrics/dualstack_metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -22,7 +23,12 @@ var (
 	)
 )
 
-func (im *ControllerMetrics) exportL4ILBDualStackMetrics() {
+func (c *Collector) exportDualStack() {
+	c.exportL4ILBDualStackMetrics()
+	c.exportL4NetLBDualStackMetrics()
+}
+
+func (im *Collector) exportL4ILBDualStackMetrics() {
 	// Do not report any dual stack information if it is not enabled.
 	if !im.enableILBDualStack {
 		return
@@ -47,7 +53,7 @@ func (im *ControllerMetrics) exportL4ILBDualStackMetrics() {
 	im.logger.V(3).Info("L4 ILB DualStack usage metrics exported")
 }
 
-func (im *ControllerMetrics) exportL4NetLBDualStackMetrics() {
+func (im *Collector) exportL4NetLBDualStackMetrics() {
 	// Do not report any dual stack information if it is not enabled.
 	if !im.enableNetLBDualStack {
 		return

--- a/pkg/l4lb/metrics/dualstack_metrics_test.go
+++ b/pkg/l4lb/metrics/dualstack_metrics_test.go
@@ -102,7 +102,7 @@ func TestComputeL4ILBDualStackMetrics(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			newMetrics := FakeControllerMetrics()
+			newMetrics := NewFakeCollector()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4ILBService(fmt.Sprint(i), serviceState)
 			}
@@ -202,7 +202,7 @@ func TestComputeL4NetLBDualStackMetrics(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			newMetrics := FakeControllerMetrics()
+			newMetrics := NewFakeCollector()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4NetLBService(fmt.Sprint(i), serviceState)
 			}
@@ -225,7 +225,7 @@ func TestRetryPeriodForL4ILBDualStackServices(t *testing.T) {
 	before5min := currTime.Add(-5 * time.Minute)
 
 	svcName1 := "svc1"
-	metrics := FakeControllerMetrics()
+	metrics := NewFakeCollector()
 
 	errorState := newL4ServiceState("IPv4", "SingleStack", StatusError, &currTime)
 	metrics.SetL4ILBService(svcName1, errorState)
@@ -251,7 +251,7 @@ func TestRetryPeriodForL4NetLBDualStackServices(t *testing.T) {
 	before5min := currTime.Add(-5 * time.Minute)
 
 	svcName1 := "svc1"
-	metrics := FakeControllerMetrics()
+	metrics := NewFakeCollector()
 
 	errorState := newL4ServiceState("IPv4", "SingleStack", StatusError, &currTime)
 	metrics.SetL4NetLBService(svcName1, errorState)

--- a/pkg/l4lb/metrics/features.go
+++ b/pkg/l4lb/metrics/features.go
@@ -1,0 +1,36 @@
+package metrics
+
+type feature string
+
+func (f feature) String() string {
+	return string(f)
+}
+
+const (
+	l4ILBService      = feature("L4ILBService")
+	l4ILBGlobalAccess = feature("L4ILBGlobalAccess")
+	l4ILBCustomSubnet = feature("L4ILBCustomSubnet")
+	// l4ILBInSuccess feature specifies that ILB VIP is configured.
+	l4ILBInSuccess = feature("L4ILBInSuccess")
+	// l4ILBInInError feature specifies that an error had occurred while creating/
+	// updating GCE Load Balancer.
+	l4ILBInError = feature("L4ILBInError")
+	// l4ILBInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
+	l4ILBInUserError = feature("L4ILBInUserError")
+)
+
+const (
+	l4NetLBService = feature("L4NetLBService")
+	// l4NetLBPremiumNetworkTier feature specifies that NetLB VIP is configured in Premium Network Tier.
+	l4NetLBPremiumNetworkTier = feature("L4NetLBPremiumNetworkTier")
+	// l4NetLBManagedStaticIP feature specifies that static IP Address is managed by controller.
+	l4NetLBManagedStaticIP = feature("L4NetLBManagedStaticIP")
+	// l4NetLBStaticIP feature specifies number of all static IP Address managed by controller and by user.
+	l4NetLBStaticIP = feature("L4NetLBStaticIP")
+	// l4NetLBInSuccess feature specifies that NetLB VIP is configured.
+	l4NetLBInSuccess = feature("L4NetLBInSuccess")
+	// l4NetLBInInError feature specifies that an error had occurred while creating/updating GCE Load Balancer.
+	l4NetLBInError = feature("L4NetLBInError")
+	// l4NetLBInInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
+	l4NetLBInUserError = feature("L4NetLBInUserError")
+)

--- a/pkg/l4lb/metrics/ipv4_metrics_test.go
+++ b/pkg/l4lb/metrics/ipv4_metrics_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 func TestExportILBMetric(t *testing.T) {
-	newMetrics := FakeControllerMetrics()
+	newMetrics := NewFakeCollector()
 	pastPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime - time.Minute)
 	notExceedingPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime + 5*time.Minute)
 
@@ -116,7 +116,7 @@ func verifyL4ILBMetric(t *testing.T, expectedCount int, status L4ServiceStatus, 
 }
 
 func TestExportNetLBMetric(t *testing.T) {
-	newMetrics := FakeControllerMetrics()
+	newMetrics := NewFakeCollector()
 	pastPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime - time.Minute)
 	notExceedingPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime + 5*time.Minute)
 

--- a/pkg/l4lb/metrics/legacy_metrics_test.go
+++ b/pkg/l4lb/metrics/legacy_metrics_test.go
@@ -183,7 +183,7 @@ func TestComputeL4ILBMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := FakeControllerMetrics()
+			newMetrics := NewFakeCollector()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4ILBServiceForLegacyMetric(fmt.Sprint(i), serviceState)
 			}
@@ -367,7 +367,7 @@ func TestComputeL4NetLBMetrics(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			newMetrics := FakeControllerMetrics()
+			newMetrics := NewFakeCollector()
 			for i, serviceState := range tc.serviceStates {
 				newMetrics.SetL4NetLBServiceForLegacyMetric(fmt.Sprint(i), serviceState)
 			}
@@ -397,7 +397,7 @@ func TestRetryPeriodForL4NetLBServices(t *testing.T) {
 
 	svcName1 := "svc1"
 	svcName2 := "svc2"
-	newMetrics := FakeControllerMetrics()
+	newMetrics := NewFakeCollector()
 	errorState := newL4NetLBServiceState(isError, managed, premium, noUserError, &currTime)
 	newMetrics.SetL4NetLBServiceForLegacyMetric(svcName1, errorState)
 
@@ -420,7 +420,7 @@ func TestRetryPeriodForL4NetLBServices(t *testing.T) {
 	}
 }
 
-func checkMetricsComputation(newMetrics *ControllerMetrics, expErrorCount, expSvcCount int) error {
+func checkMetricsComputation(newMetrics *Collector, expErrorCount, expSvcCount int) error {
 	got := newMetrics.computeL4NetLBLegacyMetrics()
 	if got.inError != expErrorCount {
 		return fmt.Errorf("Error count mismatch expected: %v got: %v", expErrorCount, got.inError)

--- a/pkg/l4lb/metrics/types.go
+++ b/pkg/l4lb/metrics/types.go
@@ -1,0 +1,100 @@
+package metrics
+
+import "time"
+
+// L4ILBServiceLegacyState defines if global access and subnet features are enabled
+// for an L4 ILB service.
+type L4ILBServiceLegacyState struct {
+	// EnabledGlobalAccess specifies if Global Access is enabled.
+	EnabledGlobalAccess bool
+	// EnabledCustomSubNet specifies if Custom Subnet is enabled.
+	EnabledCustomSubnet bool
+	// InSuccess specifies if the ILB service VIP is configured.
+	InSuccess bool
+	// IsUserError specifies if the error was caused by User misconfiguration.
+	IsUserError bool
+}
+
+// L4ServiceStatus denotes the status of the service
+type L4ServiceStatus string
+
+// L4ServiceStatus denotes the status of the service
+const (
+	StatusSuccess         = L4ServiceStatus("Success")
+	StatusUserError       = L4ServiceStatus("UserError")
+	StatusError           = L4ServiceStatus("Error")
+	StatusPersistentError = L4ServiceStatus("PersistentError")
+)
+
+// L4BackendType specifies the Backend Type used by the new LB services
+type L4BackendType string
+
+// L4BackendType specifies the Backend Type used by the new LB services
+const (
+	L4BackendTypeInstanceGroup = L4BackendType("IG")
+	L4BackendTypeNEG           = L4BackendType("NEG")
+)
+
+// L4DualStackServiceLabels defines ipFamilies, ipFamilyPolicy
+// of L4 DualStack service
+type L4DualStackServiceLabels struct {
+	// IPFamilies stores spec.ipFamilies of Service
+	IPFamilies string
+	// IPFamilyPolicy specifies spec.IPFamilyPolicy of Service
+	IPFamilyPolicy string
+}
+
+// L4FeaturesServiceLabels defines various properties we want to track for L4 LBs
+type L4FeaturesServiceLabels struct {
+	// Multinetwork specifies if the service is a multinetworked service
+	Multinetwork bool
+	// StrongSessionAffinity is true if String Session Affinity is enabled
+	StrongSessionAffinity bool
+	// WeightedLBPodsPerNode is true if weighted load balancing is enabled by pods per node
+	WeightedLBPodsPerNode bool
+	// BackendType is the type of the backend the LB uses (IGs or NEGs).
+	BackendType L4BackendType
+	// ZonalAffinity is true if Zonal Affinity is enabled
+	ZonalAffinity bool
+}
+
+// L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.
+// FirstSyncErrorTime of an L4 service
+type L4ServiceState struct {
+	L4DualStackServiceLabels
+	L4FeaturesServiceLabels
+	// Status specifies status of an L4 Service
+	Status L4ServiceStatus
+	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
+	FirstSyncErrorTime *time.Time
+}
+
+// L4NetLBServiceLegacyState defines if network tier is premium and
+// if static ip address is managed by controller
+// for an L4 NetLB service.
+type L4NetLBServiceLegacyState struct {
+	// IsManagedIP specifies if Static IP is managed by controller.
+	IsManagedIP bool
+	// IsPremiumTier specifies if network tier for forwarding rule is premium.
+	IsPremiumTier bool
+	// InSuccess specifies if the NetLB service VIP is configured.
+	InSuccess bool
+	// IsUserError specifies if the error was caused by User misconfiguration.
+	IsUserError bool
+	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
+	FirstSyncErrorTime *time.Time
+}
+
+// InitL4NetLBServiceLegacyState created and inits the L4NetLBServiceLegacyState struct by setting FirstSyncErrorTime.
+func InitL4NetLBServiceLegacyState(syncTime *time.Time) L4NetLBServiceLegacyState {
+	return L4NetLBServiceLegacyState{FirstSyncErrorTime: syncTime}
+}
+
+// L4ILBMetricsCollector is an interface to update/delete L4 ILb service states
+// in the cache that is used for computing L4 ILB usage metrics.
+type L4ILBMetricsCollector interface {
+	// SetL4ILBServiceForLegacyMetric adds/updates L4 ILB service state for given service key.
+	SetL4ILBServiceForLegacyMetric(svcKey string, state L4ILBServiceLegacyState)
+	// DeleteL4ILBServiceForLegacyMetric removes the given L4 ILB service key.
+	DeleteL4ILBServiceForLegacyMetric(svcKey string)
+}

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/healthchecksl4"
-	"k8s.io/ingress-gce/pkg/metrics"
+	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/healthchecksl4"
-	"k8s.io/ingress-gce/pkg/metrics"
+	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/healthchecksl4"
-	"k8s.io/ingress-gce/pkg/metrics"
+	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"

--- a/pkg/metrics/features.go
+++ b/pkg/metrics/features.go
@@ -103,31 +103,6 @@ const (
 	sslPolicy      = feature("SSLPolicy")
 	httpsRedirects = feature("HTTPSRedirects")
 
-	l4ILBService      = feature("L4ILBService")
-	l4ILBGlobalAccess = feature("L4ILBGlobalAccess")
-	l4ILBCustomSubnet = feature("L4ILBCustomSubnet")
-	// l4ILBInSuccess feature specifies that ILB VIP is configured.
-	l4ILBInSuccess = feature("L4ILBInSuccess")
-	// l4ILBInInError feature specifies that an error had occurred while creating/
-	// updating GCE Load Balancer.
-	l4ILBInError = feature("L4ILBInError")
-	// l4ILBInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
-	l4ILBInUserError = feature("L4ILBInUserError")
-
-	l4NetLBService = feature("L4NetLBService")
-	// l4NetLBPremiumNetworkTier feature specifies that NetLB VIP is configured in Premium Network Tier.
-	l4NetLBPremiumNetworkTier = feature("L4NetLBPremiumNetworkTier")
-	// l4NetLBManagedStaticIP feature specifies that static IP Address is managed by controller.
-	l4NetLBManagedStaticIP = feature("L4NetLBManagedStaticIP")
-	// l4NetLBStaticIP feature specifies number of all static IP Address managed by controller and by user.
-	l4NetLBStaticIP = feature("L4NetLBStaticIP")
-	// l4NetLBInSuccess feature specifies that NetLB VIP is configured.
-	l4NetLBInSuccess = feature("L4NetLBInSuccess")
-	// l4NetLBInInError feature specifies that an error had occurred while creating/updating GCE Load Balancer.
-	l4NetLBInError = feature("L4NetLBInError")
-	// l4NetLBInInUserError feature specifies that an error cause by User misconfiguration had occurred while creating/updating GCE Load Balancer.
-	l4NetLBInUserError = feature("L4NetLBInUserError")
-
 	// PSC Features
 	sa          = feature("ServiceAttachments")
 	saInSuccess = feature("ServiceAttachmentInSuccess")

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"time"
-
 	v1 "k8s.io/api/networking/v1"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -31,86 +29,6 @@ type IngressState struct {
 	servicePorts   []utils.ServicePort
 }
 
-// L4ILBServiceLegacyState defines if global access and subnet features are enabled
-// for an L4 ILB service.
-type L4ILBServiceLegacyState struct {
-	// EnabledGlobalAccess specifies if Global Access is enabled.
-	EnabledGlobalAccess bool
-	// EnabledCustomSubNet specifies if Custom Subnet is enabled.
-	EnabledCustomSubnet bool
-	// InSuccess specifies if the ILB service VIP is configured.
-	InSuccess bool
-	// IsUserError specifies if the error was caused by User misconfiguration.
-	IsUserError bool
-}
-
-type L4ServiceStatus string
-
-const StatusSuccess = L4ServiceStatus("Success")
-const StatusUserError = L4ServiceStatus("UserError")
-const StatusError = L4ServiceStatus("Error")
-const StatusPersistentError = L4ServiceStatus("PersistentError")
-
-type L4BackendType string
-
-const L4BackendTypeInstanceGroup = L4BackendType("IG")
-const L4BackendTypeNEG = L4BackendType("NEG")
-
-// L4DualStackServiceLabels defines ipFamilies, ipFamilyPolicy
-// of L4 DualStack service
-type L4DualStackServiceLabels struct {
-	// IPFamilies stores spec.ipFamilies of Service
-	IPFamilies string
-	// IPFamilyPolicy specifies spec.IPFamilyPolicy of Service
-	IPFamilyPolicy string
-}
-
-// L4FeaturesServiceLabels defines various properties we want to track for L4 LBs
-type L4FeaturesServiceLabels struct {
-	// Multinetwork specifies if the service is a multinetworked service
-	Multinetwork bool
-	// StrongSessionAffinity is true if String Session Affinity is enabled
-	StrongSessionAffinity bool
-	// WeightedLBPodsPerNode is true if weighted load balancing is enabled by pods per node
-	WeightedLBPodsPerNode bool
-	// BackendType is the type of the backend the LB uses (IGs or NEGs).
-	BackendType L4BackendType
-	// ZonalAffinity is true if Zonal Affinity is enabled
-	ZonalAffinity bool
-}
-
-// L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.
-// FirstSyncErrorTime of an L4 service
-type L4ServiceState struct {
-	L4DualStackServiceLabels
-	L4FeaturesServiceLabels
-	// Status specifies status of an L4 Service
-	Status L4ServiceStatus
-	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
-	FirstSyncErrorTime *time.Time
-}
-
-// L4NetLBServiceLegacyState defines if network tier is premium and
-// if static ip address is managed by controller
-// for an L4 NetLB service.
-type L4NetLBServiceLegacyState struct {
-	// IsManagedIP specifies if Static IP is managed by controller.
-	IsManagedIP bool
-	// IsPremiumTier specifies if network tier for forwarding rule is premium.
-	IsPremiumTier bool
-	// InSuccess specifies if the NetLB service VIP is configured.
-	InSuccess bool
-	// IsUserError specifies if the error was caused by User misconfiguration.
-	IsUserError bool
-	// FirstSyncErrorTime specifies the time timestamp when the service sync ended up with error for the first time.
-	FirstSyncErrorTime *time.Time
-}
-
-// InitL4NetLBServiceLegacyState created and inits the L4NetLBServiceLegacyState struct by setting FirstSyncErrorTime.
-func InitL4NetLBServiceLegacyState(syncTime *time.Time) L4NetLBServiceLegacyState {
-	return L4NetLBServiceLegacyState{FirstSyncErrorTime: syncTime}
-}
-
 // IngressMetricsCollector is an interface to update/delete ingress states in the cache
 // that is used for computing ingress usage metrics.
 type IngressMetricsCollector interface {
@@ -118,13 +36,4 @@ type IngressMetricsCollector interface {
 	SetIngress(ingKey string, ing IngressState)
 	// DeleteIngress removes the given ingress key.
 	DeleteIngress(ingKey string)
-}
-
-// L4ILBMetricsCollector is an interface to update/delete L4 ILb service states
-// in the cache that is used for computing L4 ILB usage metrics.
-type L4ILBMetricsCollector interface {
-	// SetL4ILBServiceForLegacyMetric adds/updates L4 ILB service state for given service key.
-	SetL4ILBServiceForLegacyMetric(svcKey string, state L4ILBServiceLegacyState)
-	// DeleteL4ILBServiceForLegacyMetric removes the given L4 ILB service key.
-	DeleteL4ILBServiceForLegacyMetric(svcKey string)
 }


### PR DESCRIPTION
This commit moves all of the L4 releated metrics to another package. It also creates a separate Collector to export those metrics and adds missing comments.

<details>
<summary>Logs from LB after the change</summary>

```log
I0415 12:20:36.369684  433963 ipv4_metrics.go:146] "Exporting L4 ILB usage metrics for services" logger="ControllerContext.L4MetricsCollector" serviceCount=0
I0415 12:20:36.369781  433963 ipv4_metrics.go:156] "L4 ILB usage metrics exported" logger="ControllerContext.L4MetricsCollector"
I0415 12:20:36.369806  433963 ipv4_metrics.go:162] "Exporting L4 NetLB usage metrics for services" logger="ControllerContext.L4MetricsCollector" serviceCount=1
I0415 12:20:36.369848  433963 metrics.go:244] "Exporting ingress usage metrics" logger="ControllerContext.ControllerMetrics" ingressCount={"BackendConnectionDraining":0,"BackendTimeout":0,"ClientIPAffinity":0,"CloudArmor":0,"CloudCDN":0,"CloudIAP":0,"CookieAffinity":0,"CustomRequestHeaders":0,"ExternalIngress":0,"HTTPEnabled":0,"HostBasedRouting":0,"Ingress":0,"InternalIngress":0,"ManagedCertsForTLS":0,"ManagedStaticGlobalIP":0,"NEG":0,"PathBasedRouting":0,"PreSharedCertsForTLS":0,"RegionalExternalIngress":0,"SSLPolicy":0,"SecretBasedCertsForTLS":0,"SpecifiedStaticGlobalIP":0,"StaticGlobalIP":0,"TLSTermination":0} servicePortCount={"BackendConnectionDraining":0,"BackendTimeout":0,"ClientIPAffinity":0,"CloudArmor":0,"CloudArmorEmptyString":0,"CloudArmorNil":0,"CloudArmorSet":0,"CloudCDN":0,"CloudIAP":0,"CookieAffinity":0,"CustomRequestHeaders":0,"L7ILBServicePort":0,"L7LBServicePort":0,"L7RegionalXLBServicePort":0,"L7XLBServicePort":0,"NEG":0,"TransparentHC":0}
I0415 12:20:36.369860  433963 ipv4_metrics.go:173] "L4 NetLB usage metrics exported" logger="ControllerContext.L4MetricsCollector"
I0415 12:20:36.370066  433963 metrics.go:253] "Ingress usage metrics exported" logger="ControllerContext.ControllerMetrics"
I0415 12:20:36.370100  433963 metrics.go:256] "Exporting PSC Usage Metrics" logger="ControllerContext.ControllerMetrics" serviceAttachmentsCount={"ServiceAttachmentInError":0,"ServiceAttachmentInSuccess":0,"ServiceAttachments":0}
I0415 12:20:36.370135  433963 metrics.go:260] "Exported PSC Usage Metrics" logger="ControllerContext.ControllerMetrics" serviceAttachmentsCount={"ServiceAttachmentInError":0,"ServiceAttachmentInSuccess":0,"ServiceAttachments":0}
```
</details>

<details>
<summary>Part results from localhost:8081/metrics for L4</summary>

```
# HELP number_of_l4_ilbs Number of L4 ILBs
# TYPE number_of_l4_ilbs gauge
number_of_l4_ilbs{feature="L4ILBCustomSubnet"} 0
number_of_l4_ilbs{feature="L4ILBGlobalAccess"} 0
number_of_l4_ilbs{feature="L4ILBInError"} 0
number_of_l4_ilbs{feature="L4ILBInSuccess"} 0
number_of_l4_ilbs{feature="L4ILBInUserError"} 0
number_of_l4_ilbs{feature="L4ILBService"} 0
# HELP number_of_l4_netlbs Number of L4 NetLBs
# TYPE number_of_l4_netlbs gauge
number_of_l4_netlbs{feature="L4NetLBInError"} 0
number_of_l4_netlbs{feature="L4NetLBInSuccess"} 1
number_of_l4_netlbs{feature="L4NetLBInUserError"} 0
number_of_l4_netlbs{feature="L4NetLBManagedStaticIP"} 1
number_of_l4_netlbs{feature="L4NetLBPremiumNetworkTier"} 1
number_of_l4_netlbs{feature="L4NetLBService"} 1
number_of_l4_netlbs{feature="L4NetLBStaticIP"} 1
```
</details>