### PR TITLE
fix: Corrently handle endpoint attachment overlap between MSC and MN

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -671,7 +671,12 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, epGroupIn
 			return err
 		}
 
-		if epGroupInfo.Subnet != defaultSubnet {
+		// In the case where this is the default network of the cluster
+		// (s.networkInfo.IsDefault) but the subnet of the NEG
+		// (epGroupInfo.Subnet) is not the defaultSubnet, we are dealing with
+		// the Multi-Subnet Cluster use case, wherein the name of the NEG would
+		// need to be different.
+		if s.networkInfo.IsDefault && epGroupInfo.Subnet != defaultSubnet {
 			negName, err = s.getNonDefaultSubnetNEGName(epGroupInfo.Subnet)
 			if err != nil {
 				s.logger.Error(err, "Errored getting non-default subnet NEG name when updating NEG endpoints")


### PR DESCRIPTION
When multi-subnet-cluster feature flag is enabled, ensure that the endpoints under multi-networking are correctly attached to the right NEG name. NEGs in Multi-network still use the default NEG name (unlike the name for the additional subnets in MSC)

/assign @mmamczur 