### PR TITLE
fix: NEG Readiness gate for MSC is no longer prematurely marked ready

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -206,9 +206,7 @@ func NewController(
 			podInformer.GetIndexer(),
 			cloud,
 			manager,
-			zoneGetter,
 			enableDualStackNEG,
-			flags.F.EnableMultiSubnetCluster,
 			logger,
 		)
 	} else {

--- a/pkg/neg/readiness/poller_test.go
+++ b/pkg/neg/readiness/poller_test.go
@@ -68,7 +68,7 @@ func (p *testPatcher) Eval(t *testing.T, pod string, negKey, bsKey *meta.Key) {
 }
 
 func newFakePoller() (*poller, error) {
-	reflector, err := newTestReadinessReflector(negtypes.NewTestContext(), false)
+	reflector, err := newTestReadinessReflector(negtypes.NewTestContext())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize reflector: %s", err)
 	}

--- a/pkg/neg/readiness/reflector.go
+++ b/pkg/neg/readiness/reflector.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
-	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -74,16 +73,10 @@ type readinessReflector struct {
 
 	queue workqueue.RateLimitingInterface
 
-	zoneGetter *zonegetter.ZoneGetter
-
-	// If enabled, the reflector will mark pods that are from the non-default
-	// subnet as ready without processing.
-	enableMultiSubnetCluster bool
-
 	logger klog.Logger
 }
 
-func NewReadinessReflector(kubeClient, eventRecorderClient kubernetes.Interface, podLister cache.Indexer, negCloud negtypes.NetworkEndpointGroupCloud, lookup NegLookup, zoneGetter *zonegetter.ZoneGetter, enableDualStackNEG, enableMultiSubnetCluster bool, logger klog.Logger) Reflector {
+func NewReadinessReflector(kubeClient, eventRecorderClient kubernetes.Interface, podLister cache.Indexer, negCloud negtypes.NetworkEndpointGroupCloud, lookup NegLookup, enableDualStackNEG bool, logger klog.Logger) Reflector {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
 	broadcaster.StartRecordingToSink(&unversionedcore.EventSinkImpl{
@@ -92,15 +85,13 @@ func NewReadinessReflector(kubeClient, eventRecorderClient kubernetes.Interface,
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "neg-readiness-reflector"})
 	logger = logger.WithName("ReadinessReflector")
 	reflector := &readinessReflector{
-		client:                   kubeClient,
-		podLister:                podLister,
-		clock:                    clock.RealClock{},
-		lookup:                   lookup,
-		eventRecorder:            recorder,
-		queue:                    workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		zoneGetter:               zoneGetter,
-		enableMultiSubnetCluster: enableMultiSubnetCluster,
-		logger:                   logger,
+		client:        kubeClient,
+		podLister:     podLister,
+		clock:         clock.RealClock{},
+		lookup:        lookup,
+		eventRecorder: recorder,
+		queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		logger:        logger,
 	}
 	poller := NewPoller(podLister, lookup, reflector, negCloud, enableDualStackNEG, logger)
 	reflector.poller = poller
@@ -218,28 +209,6 @@ func (r *readinessReflector) getExpectedNegCondition(pod *v1.Pod, neg, backendSe
 		expectedCondition.Reason = negReadyTimedOutReason
 		expectedCondition.Message = fmt.Sprintf("Timeout waiting for pod to become healthy in at least one of the NEG(s): %v. Marking condition %q to True.", negs, shared.NegReadinessGate)
 		return expectedCondition
-	}
-
-	if r.enableMultiSubnetCluster {
-		if pod.Spec.NodeName == "" {
-			r.logger.Error(nil, "Unable to determine the pod's node name.", "podNamespace", pod.Namespace, "podName", pod.Name)
-			expectedCondition.Reason = negNotReadyReason
-			expectedCondition.Message = "Unable to determine the pod's node name."
-			return expectedCondition
-		}
-		isInDefaultSubnet, err := r.zoneGetter.IsDefaultSubnetNode(pod.Spec.NodeName, r.logger)
-		if err != nil {
-			r.logger.Error(err, "Unable to determine if the pod is in the default subnet.", "podNamespace", pod.Namespace, "podName", pod.Name)
-			expectedCondition.Reason = negNotReadyReason
-			expectedCondition.Message = "Unable to determine if the pod is in the default subnet."
-			return expectedCondition
-		}
-		if !isInDefaultSubnet {
-			expectedCondition.Status = v1.ConditionTrue
-			expectedCondition.Reason = negReadyReason
-			expectedCondition.Message = fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate)
-			return expectedCondition
-		}
 	}
 
 	// do not patch condition status in this case to prevent race condition:

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -28,18 +28,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
-	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
 const (
-	defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
-
-	defaultTestSubnet    = "default"
-	nonDefaultTestSubnet = "non-default"
-
 	testServiceNamespace = "test-ns"
 )
 
@@ -58,20 +52,14 @@ func (f *fakeLookUp) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool 
 	return f.readinessGateEnabled
 }
 
-func newTestReadinessReflector(testContext *negtypes.TestContext, enableMultiSubnetCluster bool) (*readinessReflector, error) {
-	fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, testContext.NodeTopologyInformer, defaultTestSubnetURL, enableMultiSubnetCluster)
-	if err != nil {
-		return nil, err
-	}
+func newTestReadinessReflector(testContext *negtypes.TestContext) (*readinessReflector, error) {
 	reflector := NewReadinessReflector(
 		testContext.KubeClient,
 		testContext.KubeClient,
 		testContext.PodInformer.GetIndexer(),
 		negtypes.NewAdapter(testContext.Cloud),
 		&fakeLookUp{},
-		fakeZoneGetter,
 		false,
-		enableMultiSubnetCluster,
 		klog.TODO(),
 	)
 	ret := reflector.(*readinessReflector)
@@ -85,7 +73,7 @@ func TestSyncPod(t *testing.T) {
 	podLister := fakeContext.PodInformer.GetIndexer()
 	nodeLister := fakeContext.NodeInformer.GetIndexer()
 	fakeClock := clocktesting.NewFakeClock(time.Now())
-	testReadinessReflector, err := newTestReadinessReflector(fakeContext, false)
+	testReadinessReflector, err := newTestReadinessReflector(fakeContext)
 	if err != nil {
 		t.Fatalf("failed to initialize readiness reflector")
 	}
@@ -141,9 +129,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod1",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -175,9 +160,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod2",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -212,9 +194,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod3",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -250,9 +229,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod4",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -288,9 +264,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod5",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -326,9 +299,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod6",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -364,9 +334,6 @@ func TestSyncPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testServiceNamespace,
 					Name:      "pod7",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
 				},
 				Spec: v1.PodSpec{
 					NodeName: nodeName,
@@ -389,259 +356,22 @@ func TestSyncPod(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			for _, enableMultiSubnetCluster := range []bool{true, false} {
-				testReadinessReflector.enableMultiSubnetCluster = enableMultiSubnetCluster
-				tc.mutateState(testlookUp)
-				err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
-				if err != nil {
-					t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect syncPod() return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
-				}
-
-				if tc.expectExists {
-					pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
-					if err != nil {
-						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect GetPod() to return nil, but got %v", tc.desc, enableMultiSubnetCluster, err)
-					}
-					// ignore creation timestamp for comparison
-					pod.CreationTimestamp = tc.expectPod.CreationTimestamp
-					if !reflect.DeepEqual(pod, tc.expectPod) {
-						t.Errorf("For test case %q with enableMultiSubnetCluster = %v, expect pod to be %v, but got %v", tc.desc, enableMultiSubnetCluster, tc.expectPod, pod)
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestSyncPodMultipleSubnets(t *testing.T) {
-	t.Parallel()
-	fakeContext := negtypes.NewTestContext()
-	client := fakeContext.KubeClient
-	podLister := fakeContext.PodInformer.GetIndexer()
-	fakeClock := clocktesting.NewFakeClock(time.Now())
-	testReadinessReflector, err := newTestReadinessReflector(fakeContext, true)
-	if err != nil {
-		t.Fatalf("failed to initialize readiness reflector")
-	}
-	testReadinessReflector.clock = fakeClock
-	testlookUp := testReadinessReflector.lookup.(*fakeLookUp)
-	testlookUp.readinessGateEnabledNegs = []string{"neg1", "neg2"}
-
-	now := metav1.NewTime(fakeClock.Now()).Rfc3339Copy()
-	// Set creation time to be some time in the past so it exceeds unreadyTimeout.
-	timeoutTime := metav1.NewTime(fakeClock.Now().Add(-unreadyTimeout)).Rfc3339Copy()
-	nodeMissingPod := "node-missing-pod"
-
-	zonegetter.PopulateFakeNodeInformer(fakeContext.NodeInformer, true)
-
-	testCases := []struct {
-		desc                string
-		podName             string
-		mutateState         func(*fakeLookUp)
-		inputKey            string
-		inputNeg            *meta.Key
-		inputBackendService *meta.Key
-		expectPod           *v1.Pod
-	}{
-		{
-			desc: "need to update pod: pod belongs to a node in non-default subnet",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, negtypes.TestNonDefaultSubnetPod, true, false, false)
-				pod.Spec.NodeName = negtypes.TestNonDefaultSubnetInstance
-				pod.CreationTimestamp = now
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, negtypes.TestNonDefaultSubnetPod),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      negtypes.TestNonDefaultSubnetPod,
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: negtypes.TestNonDefaultSubnetInstance,
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Status:  v1.ConditionTrue,
-							Reason:  negReadyReason,
-							Message: fmt.Sprintf("Pod belongs to a node in non-default subnet. Marking condition %q to True.", shared.NegReadinessGate),
-						},
-					},
-				},
-			},
-		},
-		{
-			desc: "need to update pod: pod belongs to a node without PodCIDR, timeout not reached yet",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, negtypes.TestNoPodCIDRPod+"-1", true, false, false)
-				pod.Spec.NodeName = negtypes.TestNoPodCIDRInstance
-				pod.CreationTimestamp = now
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, negtypes.TestNoPodCIDRPod+"-1"),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      negtypes.TestNoPodCIDRPod + "-1",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: negtypes.TestNoPodCIDRInstance,
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Reason:  negNotReadyReason,
-							Message: "Unable to determine if the pod is in the default subnet.",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc: "need to update pod: pod belongs to a node without PodCIDR, timeout reached",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, negtypes.TestNoPodCIDRPod+"-2", true, false, false)
-				pod.Spec.NodeName = negtypes.TestNoPodCIDRInstance
-				pod.CreationTimestamp = timeoutTime
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, negtypes.TestNoPodCIDRPod+"-2"),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      negtypes.TestNoPodCIDRPod + "-2",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: negtypes.TestNoPodCIDRInstance,
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Reason:  negReadyTimedOutReason,
-							Status:  v1.ConditionTrue,
-							Message: fmt.Sprintf("Timeout waiting for pod to become healthy in at least one of the NEG(s): %v. Marking condition %q to True.", []string{"neg1", "neg2"}, shared.NegReadinessGate)},
-					},
-				},
-			},
-		},
-		{
-			desc: "need to update pod: pod does not have nodeName specified, timeout not reached yet",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, nodeMissingPod+"-1", true, false, false)
-				pod.Spec.NodeName = ""
-				pod.CreationTimestamp = now
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, nodeMissingPod+"-1"),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      nodeMissingPod + "-1",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: "",
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Reason:  negNotReadyReason,
-							Message: "Unable to determine the pod's node name.",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc: "need to update pod: pod does not have nodeName specified, timeout reached",
-			mutateState: func(testlookUp *fakeLookUp) {
-				pod := generatePod(testServiceNamespace, nodeMissingPod+"-2", true, false, false)
-				pod.Spec.NodeName = ""
-				pod.CreationTimestamp = timeoutTime
-				podLister.Add(pod)
-				client.CoreV1().Pods(testServiceNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-			},
-			inputKey: keyFunc(testServiceNamespace, nodeMissingPod+"-2"),
-			inputNeg: nil,
-			expectPod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testServiceNamespace,
-					Name:      nodeMissingPod + "-2",
-					Labels: map[string]string{
-						utils.LabelNodeSubnet: defaultTestSubnet,
-					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: "",
-					ReadinessGates: []v1.PodReadinessGate{
-						{ConditionType: shared.NegReadinessGate},
-					},
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:    shared.NegReadinessGate,
-							Reason:  negReadyTimedOutReason,
-							Status:  v1.ConditionTrue,
-							Message: fmt.Sprintf("Timeout waiting for pod to become healthy in at least one of the NEG(s): %v. Marking condition %q to True.", []string{"neg1", "neg2"}, shared.NegReadinessGate)},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
 			tc.mutateState(testlookUp)
 			err := testReadinessReflector.syncPod(tc.inputKey, tc.inputNeg, tc.inputBackendService)
 			if err != nil {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
+				t.Errorf("For test case %q, expect syncPod() return nil, but got %v", tc.desc, err)
 			}
 
-			pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect err to be nil, but got %v", tc.desc, err)
-			}
-			// ignore creation timestamp for comparison
-			pod.CreationTimestamp = tc.expectPod.CreationTimestamp
-			if !reflect.DeepEqual(pod, tc.expectPod) {
-				t.Errorf("For test case %q with multi-subnet cluster enabled, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
+			if tc.expectExists {
+				pod, err := fakeContext.KubeClient.CoreV1().Pods(testServiceNamespace).Get(context.TODO(), tc.expectPod.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("For test case %q, expect GetPod() to return nil, but got %v", tc.desc, err)
+				}
+				// ignore creation timestamp for comparison
+				pod.CreationTimestamp = tc.expectPod.CreationTimestamp
+				if !reflect.DeepEqual(pod, tc.expectPod) {
+					t.Errorf("For test case %q, expect pod to be %v, but got %v", tc.desc, tc.expectPod, pod)
+				}
 			}
 		})
 	}

--- a/pkg/neg/readiness/utils_test.go
+++ b/pkg/neg/readiness/utils_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
-	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -583,9 +582,6 @@ func generatePod(namespace, name string, hasNegReadinessGate, hasNegCondition, n
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels: map[string]string{
-				utils.LabelNodeSubnet: defaultTestSubnet,
-			},
 		},
 		Spec: v1.PodSpec{
 			NodeName: "instance1",


### PR DESCRIPTION
Previously, when we didn't create NEGs for the additinoal subnets, we had the logic in place to make sure that the pods which exist in nodes from the additional subnet are always marked ready for the NEG readiness gate. This was done since the pod will never get added to a NEG and hence won't have it's readiness gate ready in a natural way.

But now that we DO have NEGs in additional subnets, we no longer need this explicit handling.

/assign @swetharepakula 