### PR TITLE
Ensure all nodes are considered default subnet for legacy networks

### DIFF
--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -354,8 +354,17 @@ func (z *ZoneGetter) IsDefaultSubnetNode(nodeName string, logger klog.Logger) (b
 // For any new nodes created after multi-subnet cluster is enabled, they are
 // guaranteed to have the subnet label if PodCIDR is populated. For any
 // existing nodes, they will not have label and can only be in the default
-// subnet.
+// subnet. If defaultSubnetURL is empty, then consider as part of legacy GCE
+// network and return true.
 func isNodeInDefaultSubnet(node *api_v1.Node, defaultSubnetURL string, nodeLogger klog.Logger) (bool, error) {
+
+	// Defaut Subnet URL can only be empty with legacy GCE networks.
+	// No subnets exist for legacy GCE Networks, and all nodes should be included, so always
+	// return true for the node.
+	if defaultSubnetURL == "" {
+		return true, nil
+	}
+
 	nodeSubnet, err := getSubnet(node, defaultSubnetURL)
 	if err != nil {
 		nodeLogger.Error(err, "Failed to get node subnet", "nodeName", node.Name)

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -801,6 +801,7 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 		node                  *apiv1.Node
 		expectInDefaultSubnet bool
 		expectNil             bool
+		defaultSubnetURL      string
 	}{
 		{
 			desc: "Node in the default subnet",
@@ -818,6 +819,7 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 			},
 			expectInDefaultSubnet: true,
 			expectNil:             true,
+			defaultSubnetURL:      defaultTestSubnetURL,
 		},
 		{
 			desc: "Node without PodCIDR",
@@ -832,6 +834,7 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 			},
 			expectInDefaultSubnet: false,
 			expectNil:             false,
+			defaultSubnetURL:      defaultTestSubnetURL,
 		},
 		{
 			desc: "Node with PodCIDR, without subnet label",
@@ -846,6 +849,7 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 			},
 			expectInDefaultSubnet: true,
 			expectNil:             true,
+			defaultSubnetURL:      defaultTestSubnetURL,
 		},
 		{
 			desc: "Node with PodCIDR, with empty Label",
@@ -863,6 +867,7 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 			},
 			expectInDefaultSubnet: true,
 			expectNil:             true,
+			defaultSubnetURL:      defaultTestSubnetURL,
 		},
 		{
 			desc: "Node in non-default subnet",
@@ -880,19 +885,35 @@ func TestIsNodeInDefaultSubnet(t *testing.T) {
 			},
 			expectInDefaultSubnet: false,
 			expectNil:             true,
+			defaultSubnetURL:      defaultTestSubnetURL,
+		},
+		{
+			desc: "Legacy Networks - empty defaultSubnetURL",
+			node: &apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "NodeWithoutSubnetLabel",
+				},
+				Spec: apiv1.NodeSpec{
+					PodCIDR:  "10.100.1.0/24",
+					PodCIDRs: []string{"10.100.1.0/24"},
+				},
+			},
+			expectInDefaultSubnet: true,
+			expectNil:             true,
+			defaultSubnetURL:      "",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			gotInDefaultSubnet, gotErr := isNodeInDefaultSubnet(tc.node, defaultTestSubnetURL, klog.TODO())
+			gotInDefaultSubnet, gotErr := isNodeInDefaultSubnet(tc.node, tc.defaultSubnetURL, klog.TODO())
 			if gotErr != nil && tc.expectNil {
-				t.Errorf("isNodeInDefaultSubnet(%v, %s) = err %v, want nil", tc.node, defaultTestSubnetURL, gotErr)
+				t.Errorf("isNodeInDefaultSubnet(%v, %s) = err %v, want nil", tc.node, tc.defaultSubnetURL, gotErr)
 			}
 			if gotErr == nil && !tc.expectNil {
-				t.Errorf("isNodeInDefaultSubnet(%v, %s) = err nil, want not nil", tc.node, defaultTestSubnetURL)
+				t.Errorf("isNodeInDefaultSubnet(%v, %s) = err nil, want not nil", tc.node, tc.defaultSubnetURL)
 			}
 			if gotInDefaultSubnet != tc.expectInDefaultSubnet {
-				t.Errorf("isNodeInDefaultSubnet(%v, %s) = %v, want %v", tc.node, defaultTestSubnetURL, gotInDefaultSubnet, tc.expectInDefaultSubnet)
+				t.Errorf("isNodeInDefaultSubnet(%v, %s) = %v, want %v", tc.node, tc.defaultSubnetURL, gotInDefaultSubnet, tc.expectInDefaultSubnet)
 			}
 		})
 	}


### PR DESCRIPTION
In legacy GCE networks, no subnets exist and therefore the controller & zone getter are initialized with an empty defaultSubnetURL. If the defaultSubnetURL is empty, we should assume that the cluster is running on a legacy network and always return true when checking if the node is in the default subnet.

/cc @sypakine
/assign @gauravkghildiyal
/assign @mmamczur 