### PR TITLE
Fix race when changing between NetLB and ILB

### DIFF
--- a/pkg/annotations/service_test.go
+++ b/pkg/annotations/service_test.go
@@ -21,9 +21,103 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/utils/common"
 )
+
+func TestWantsLB(t *testing.T) {
+	type wants struct {
+		ILB   bool
+		NetLB bool
+	}
+
+	testCases := []struct {
+		desc string
+		svc  *v1.Service
+		want wants
+	}{
+		{
+			desc: "nil",
+			svc:  nil,
+			want: wants{},
+		},
+		{
+			desc: "empty service",
+			svc:  &v1.Service{},
+			want: wants{},
+		},
+		{
+			desc: "ilb",
+			svc: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal),
+					},
+				},
+			},
+			want: wants{
+				ILB: true,
+			},
+		},
+		{
+			desc: "netlb rbs",
+			svc: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cloud.google.com/l4-rbs": "enabled",
+					},
+				},
+			},
+			want: wants{
+				NetLB: true,
+			},
+		},
+		{
+			desc: "ilb to netlb with finalizer",
+			svc: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.ILBFinalizerV2},
+					Annotations: map[string]string{
+						"cloud.google.com/l4-rbs": "enabled",
+					},
+				},
+			},
+			want: wants{},
+		},
+		{
+			desc: "netlb to ilb with finalizer",
+			svc: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{common.NetLBFinalizerV2},
+					Annotations: map[string]string{
+						gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal),
+					},
+				},
+			},
+			want: wants{},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+
+		})
+	}
+}
 
 func TestNEGAnnotation(t *testing.T) {
 	for _, tc := range []struct {
@@ -711,6 +805,101 @@ func TestHasStrongSessionAffinityAnnotation(t *testing.T) {
 			got := HasStrongSessionAffinityAnnotation(tc.svc)
 			if tc.want != got {
 				t.Errorf("output of HasStrongSessionAffinityAnnotation differed, want=%v, got=%v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsLegacyL4ILBService(t *testing.T) {
+	t.Parallel()
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testsvc",
+			Namespace:   "default",
+			Annotations: map[string]string{gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal)},
+			Finalizers:  []string{common.LegacyILBFinalizer},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{
+				{Name: "testport", Port: int32(80)},
+			},
+		},
+	}
+	if !IsLegacyL4ILBService(svc) {
+		t.Errorf("Expected True for Legacy service %s, got False", svc.Name)
+	}
+
+	// Remove the finalizer and ensure the check returns False.
+	svc.ObjectMeta.Finalizers = nil
+	if IsLegacyL4ILBService(svc) {
+		t.Errorf("Expected False for Legacy service %s, got True", svc.Name)
+	}
+}
+
+func TestLBBasedOnFinalizer(t *testing.T) {
+	type wants struct {
+		IsLegacyL4ILBService     bool
+		IsSubsettingL4ILBService bool
+		HasL4ILBFinalizerV2      bool
+
+		IsRBSL4NetLB          bool
+		HasL4NetLBFinalizerV2 bool
+		HasL4NetLBFinalizerV3 bool
+	}
+
+	testCases := []struct {
+		finalizer string
+		want      wants
+	}{
+		{
+			finalizer: common.LegacyILBFinalizer,
+			want: wants{
+				IsLegacyL4ILBService: true,
+			},
+		},
+		{
+			finalizer: common.ILBFinalizerV2,
+			want: wants{
+				IsSubsettingL4ILBService: true,
+				HasL4ILBFinalizerV2:      true,
+			},
+		},
+		{
+			finalizer: common.NetLBFinalizerV2,
+			want: wants{
+				IsRBSL4NetLB:          true,
+				HasL4NetLBFinalizerV2: true,
+			},
+		},
+		{
+			finalizer: common.NetLBFinalizerV3,
+			want: wants{
+				IsRBSL4NetLB:          true,
+				HasL4NetLBFinalizerV3: true,
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.finalizer, func(t *testing.T) {
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{tC.finalizer},
+				},
+			}
+
+			got := wants{
+				IsLegacyL4ILBService:     IsLegacyL4ILBService(svc),
+				IsSubsettingL4ILBService: IsSubsettingL4ILBService(svc),
+				HasL4ILBFinalizerV2:      HasL4ILBFinalizerV2(svc),
+
+				IsRBSL4NetLB:          IsRBSL4NetLB(svc),
+				HasL4NetLBFinalizerV2: HasL4NetLBFinalizerV2(svc),
+				HasL4NetLBFinalizerV3: HasL4NetLBFinalizerV3(svc),
+			}
+
+			if diff := cmp.Diff(tC.want, got); diff != "" {
+				t.Errorf("got != want, diff(-tc.want +got) = %s", diff)
 			}
 		})
 	}

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -241,7 +241,7 @@ func (l4c *L4Controller) shouldProcessService(service *v1.Service, svcLogger klo
 		}
 	}
 	// skip services that are being handled by the legacy service controller.
-	if utils.IsLegacyL4ILBService(service) {
+	if annotations.IsLegacyL4ILBService(service) {
 		svcLogger.Info("Ignoring update for service managed by service controller")
 		return false
 	}
@@ -508,7 +508,7 @@ func (l4c *L4Controller) sync(key string, svcLogger klog.Logger) error {
 }
 
 func (l4c *L4Controller) needsDeletion(svc *v1.Service) bool {
-	if !utils.IsSubsettingL4ILBService(svc) {
+	if !annotations.IsSubsettingL4ILBService(svc) {
 		return false
 	}
 	if common.IsDeletionCandidateForGivenFinalizer(svc.ObjectMeta, common.ILBFinalizerV2) {

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -185,7 +185,7 @@ func (lc *L4NetLBController) needsAddition(newSvc, oldSvc *v1.Service) bool {
 // needsDeletion return true if svc required deleting RBS based NetLB
 func (lc *L4NetLBController) needsDeletion(svc *v1.Service, svcLogger klog.Logger) bool {
 	// Check if service was provisioned by RBS controller before -- if it has rbs finalizer, rbs loadBalancerClass or rbs forwarding rule
-	if !utils.HasL4NetLBFinalizerV2(svc) && !utils.HasL4NetLBFinalizerV3(svc) &&
+	if !annotations.HasL4NetLBFinalizerV2(svc) && !annotations.HasL4NetLBFinalizerV3(svc) &&
 		!lc.hasRBSForwardingRule(svc, svcLogger) &&
 		!annotations.HasLoadBalancerClass(svc, annotations.RegionalExternalLoadBalancerClass) {
 		return false
@@ -335,12 +335,12 @@ func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service, svcLogger klog.L
 	if svc.Spec.LoadBalancerClass != nil {
 		return annotations.HasLoadBalancerClass(svc, annotations.RegionalExternalLoadBalancerClass)
 	}
-	return annotations.HasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || utils.HasL4NetLBFinalizerV3(svc) || lc.hasRBSForwardingRule(svc, svcLogger)
+	return annotations.HasRBSAnnotation(svc) || annotations.HasL4NetLBFinalizerV2(svc) || annotations.HasL4NetLBFinalizerV3(svc) || lc.hasRBSForwardingRule(svc, svcLogger)
 }
 
 func (lc *L4NetLBController) preventLegacyServiceHandling(service *v1.Service, key string, svcLogger klog.Logger) (bool, error) {
 	if (annotations.HasRBSAnnotation(service) || annotations.HasLoadBalancerClass(service, annotations.RegionalExternalLoadBalancerClass)) && lc.hasTargetPoolForwardingRule(service, svcLogger) {
-		if utils.HasL4NetLBFinalizerV2(service) || utils.HasL4NetLBFinalizerV3(service) {
+		if annotations.HasL4NetLBFinalizerV2(service) || annotations.HasL4NetLBFinalizerV3(service) {
 			// If we found that RBS finalizer was attached to service, it means that RBS controller
 			// had a race condition on Service creation with Legacy Controller.
 			// It should only happen during service creation, and we should clean up RBS resources
@@ -647,10 +647,10 @@ func (lc *L4NetLBController) shouldUseNEGBackends(service *v1.Service) bool {
 	if !lc.enableNEGSupport {
 		return false
 	}
-	if utils.HasL4NetLBFinalizerV2(service) {
+	if annotations.HasL4NetLBFinalizerV2(service) {
 		return false
 	}
-	if utils.HasL4NetLBFinalizerV3(service) {
+	if annotations.HasL4NetLBFinalizerV3(service) {
 		return true
 	}
 	return lc.enableNEGAsDefault

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -397,7 +397,7 @@ func validateAnnotationsDeleted(svc *v1.Service) error {
 func verifyNetLBServiceProvisioned(t *testing.T, svc *v1.Service) {
 	t.Helper()
 
-	if !utils.HasL4NetLBFinalizerV2(svc) && !utils.HasL4NetLBFinalizerV3(svc) {
+	if !annotations.HasL4NetLBFinalizerV2(svc) && !annotations.HasL4NetLBFinalizerV3(svc) {
 		t.Errorf("Expected %q or %q finalizer in Finalizer list - %v", common.NetLBFinalizerV2, common.NetLBFinalizerV3, svc.Finalizers)
 	}
 
@@ -424,7 +424,7 @@ func verifyNetLBServiceProvisioned(t *testing.T, svc *v1.Service) {
 func verifyNetLBServiceNotProvisioned(t *testing.T, svc *v1.Service) {
 	t.Helper()
 
-	if utils.HasL4NetLBFinalizerV2(svc) || utils.HasL4NetLBFinalizerV3(svc) {
+	if annotations.HasL4NetLBFinalizerV2(svc) || annotations.HasL4NetLBFinalizerV3(svc) {
 		t.Errorf("Unexpected %q or %q finalizer in Finalizer list - %v", common.NetLBFinalizerV2, common.NetLBFinalizerV3, svc.Finalizers)
 	}
 
@@ -659,7 +659,7 @@ func TestProcessNEGServiceCreate(t *testing.T) {
 	prevMetrics.ValidateDiff(currMetrics, &test.L4LBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
 
 	validateNetLBSvcStatus(svc, t)
-	if !utils.HasL4NetLBFinalizerV3(svc) {
+	if !annotations.HasL4NetLBFinalizerV3(svc) {
 		t.Errorf("the service %s should have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
 	if err := checkBackendServiceWithNEG(lc, svc); err != nil {
@@ -689,7 +689,7 @@ func TestProcessNEGServiceUpdateAfterNEGFlagTurnOff(t *testing.T) {
 
 	svc = syncNetLBSvc(t, lc, svc)
 
-	if !utils.HasL4NetLBFinalizerV2(svc) {
+	if !annotations.HasL4NetLBFinalizerV2(svc) {
 		t.Errorf("the service %s should have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
 	// validate that IG is attached
@@ -720,10 +720,10 @@ func TestProcessNEGServiceUpdateAfterDefaultFlagTurnOff(t *testing.T) {
 	svc = syncNetLBSvc(t, lc, svc)
 
 	validateNetLBSvcStatus(svc, t)
-	if !utils.HasL4NetLBFinalizerV3(svc) {
+	if !annotations.HasL4NetLBFinalizerV3(svc) {
 		t.Errorf("the service %s should have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
-	if utils.HasL4NetLBFinalizerV2(svc) {
+	if annotations.HasL4NetLBFinalizerV2(svc) {
 		t.Errorf("the service %s should not have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
 	// validate that NEG is still attached
@@ -762,10 +762,10 @@ func TestProcessIGServiceWhenNEGIsEnabled(t *testing.T) {
 	prevMetrics.ValidateDiff(currMetrics, &test.L4LBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
 
 	validateNetLBSvcStatus(svc, t)
-	if !utils.HasL4NetLBFinalizerV2(svc) {
+	if !annotations.HasL4NetLBFinalizerV2(svc) {
 		t.Errorf("the service %s should have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
-	if utils.HasL4NetLBFinalizerV3(svc) {
+	if annotations.HasL4NetLBFinalizerV3(svc) {
 		t.Errorf("the service %s should not have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
 	}
 	validateNetLBSvcStatus(svc, t)
@@ -1893,7 +1893,7 @@ func TestPreventTargetPoolToRBSMigration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("controller.ctx.KubeClient.CoreV1().Services(%s).Get(_, %s, _) returned error %v, want nil", svc.Namespace, svc.Name, err)
 			}
-			hasV2Finalizer := utils.HasL4NetLBFinalizerV2(resultSvc)
+			hasV2Finalizer := annotations.HasL4NetLBFinalizerV2(resultSvc)
 			if hasV2Finalizer != testCase.expectV2NetLBFinalizerAfterSync {
 				t.Errorf("After preventLegacyServiceHandling, hasV2Finalizer = %t, testCase.expectV2NetLBFinalizerAfterSync = %t, want equal", hasV2Finalizer, testCase.expectV2NetLBFinalizerAfterSync)
 			}
@@ -1921,7 +1921,7 @@ func TestPreventTargetPoolToRBSMigration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("controller.ctx.KubeClient.CoreV1().Services(%s).Get(_, %s, _) returned error %v, want nil", svc2.Namespace, svc2.Name, err)
 			}
-			hasV2Finalizer = utils.HasL4NetLBFinalizerV2(resultSvc)
+			hasV2Finalizer = annotations.HasL4NetLBFinalizerV2(resultSvc)
 			if hasV2Finalizer != testCase.expectV2NetLBFinalizerAfterSync {
 				t.Errorf("After sync, hasV2NetLBFinalizer = %t, testCase.expectV2NetLBFinalizerAfterSync = %t, want equal", hasV2Finalizer, testCase.expectV2NetLBFinalizerAfterSync)
 			}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -681,7 +681,7 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 		return nil
 	}
 	// Only process ILB services after L4 controller has marked it with v2 finalizer.
-	if needsNEGForILB && !utils.HasL4ILBFinalizerV2(service) {
+	if needsNEGForILB && !annotations.HasL4ILBFinalizerV2(service) {
 		msg := fmt.Sprintf("Ignoring ILB Service %s, namespace %s as it does not have the v2 finalizer", service.Name, service.Namespace)
 		c.logger.Info(msg)
 		c.recorder.Eventf(service, apiv1.EventTypeWarning, "ProcessServiceSkipped", msg)
@@ -726,7 +726,7 @@ func (c *Controller) netLBServiceNeedsNEG(service *apiv1.Service, networkInfo *n
 	if !networkInfo.IsDefault {
 		return true
 	}
-	return c.runL4ForNetLB && utils.HasL4NetLBFinalizerV3(service)
+	return c.runL4ForNetLB && annotations.HasL4NetLBFinalizerV3(service)
 }
 
 // mergeDefaultBackendServicePortInfoMap merge the PortInfoMap for the default backend service into portInfoMap

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/utils/common"
-	"k8s.io/ingress-gce/pkg/utils/slice"
 	"k8s.io/klog/v2"
 )
 
@@ -746,37 +745,6 @@ func TranslateAffinityType(affinityType string, logger klog.Logger) string {
 		logger.Error(nil, "Unexpected affinity type", "affinityType", affinityType)
 		return gceAffinityTypeNone
 	}
-}
-
-// IsLegacyL4ILBService returns true if the given LoadBalancer service is managed by service controller.
-func IsLegacyL4ILBService(svc *api_v1.Service) bool {
-	if svc.Spec.LoadBalancerClass != nil {
-		return annotations.HasLoadBalancerClass(svc, annotations.LegacyRegionalInternalLoadBalancerClass)
-	}
-	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.LegacyILBFinalizer, nil)
-}
-
-// IsSubsettingL4ILBService returns true if the given LoadBalancer service is managed by NEG and L4 controller.
-func IsSubsettingL4ILBService(svc *api_v1.Service) bool {
-	if svc.Spec.LoadBalancerClass != nil {
-		return annotations.HasLoadBalancerClass(svc, annotations.RegionalInternalLoadBalancerClass)
-	}
-	return HasL4ILBFinalizerV2(svc)
-}
-
-// HasL4ILBFinalizerV2 returns true if the given Service has ILBFinalizerV2
-func HasL4ILBFinalizerV2(svc *api_v1.Service) bool {
-	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.ILBFinalizerV2, nil)
-}
-
-// HasL4NetLBFinalizerV2 returns true if the given Service has NetLBFinalizerV2
-func HasL4NetLBFinalizerV2(svc *api_v1.Service) bool {
-	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV2, nil)
-}
-
-// HasL4NetLBFinalizerV3 returns true if the given Service has NetLBFinalizerV3
-func HasL4NetLBFinalizerV3(svc *api_v1.Service) bool {
-	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV3, nil)
 }
 
 func LegacyForwardingRuleName(svc *api_v1.Service) string {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -957,33 +957,6 @@ func TestGetNodePrimaryIP(t *testing.T) {
 	}
 }
 
-func TestIsLegacyL4ILBService(t *testing.T) {
-	t.Parallel()
-	svc := &api_v1.Service{
-		ObjectMeta: v1.ObjectMeta{
-			Name:        "testsvc",
-			Namespace:   "default",
-			Annotations: map[string]string{gce.ServiceAnnotationLoadBalancerType: string(gce.LBTypeInternal)},
-			Finalizers:  []string{common.LegacyILBFinalizer},
-		},
-		Spec: api_v1.ServiceSpec{
-			Type: api_v1.ServiceTypeLoadBalancer,
-			Ports: []api_v1.ServicePort{
-				{Name: "testport", Port: int32(80)},
-			},
-		},
-	}
-	if !IsLegacyL4ILBService(svc) {
-		t.Errorf("Expected True for Legacy service %s, got False", svc.Name)
-	}
-
-	// Remove the finalizer and ensure the check returns False.
-	svc.ObjectMeta.Finalizers = nil
-	if IsLegacyL4ILBService(svc) {
-		t.Errorf("Expected False for Legacy service %s, got True", svc.Name)
-	}
-}
-
 func TestGetPortRanges(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {


### PR DESCRIPTION
When we change from NetLB to ILB or vice versa independent loops will try to update resources at the same time. This commit adds an additional check to wait until the other controller removes its finalizer from the service.

It also moves some helper functions from pkg/utils to pkg/annotations to prevent import cycle.