### PR TITLE
Clean up Neg controller code

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -155,7 +155,10 @@ func NewController(
 	runL4ForNetLB bool,
 	stopCh <-chan struct{},
 	logger klog.Logger,
-) *Controller {
+) (*Controller, error) {
+	if svcNegClient == nil {
+		return nil, fmt.Errorf("svcNegClient is nil")
+	}
 	// init event recorder
 	// TODO: move event recorder initializer to main. Reuse it among controllers.
 	eventBroadcaster := record.NewBroadcaster()
@@ -369,7 +372,7 @@ func NewController(
 		negController.enableASM = enableAsm
 		negController.asmServiceNEGSkipNamespaces = asmServiceNEGSkipNamespaces
 	}
-	return negController
+	return negController, nil
 }
 
 func (c *Controller) Run() {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -166,7 +166,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		false,
 		make(<-chan struct{}),
 		klog.TODO(),
-	), nil
+	)
 }
 func newTestControllerWithASM(kubeClient kubernetes.Interface) (*Controller, error) {
 	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)


### PR DESCRIPTION
#cleanup Clean up Neg controller code

Removed unnecessary checks in the code for checking whether svcNegClient is null or not. It is initialized properly in the main function at ingress-gce/blob/master/cmd/glbc/main.go#L176, if initialization fails it causes the program to exit.

It is safe to assume in the other parts of code that it is fully initialized and value is not null.

