### PR TITLE
Check for FirewallXPNError in IsUserError

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -306,7 +306,7 @@ func (l4c *L4Controller) processServiceCreateOrUpdate(service *v1.Service, svcLo
 	if syncResult.Error != nil {
 		l4c.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncLoadBalancerFailed",
 			"Error syncing load balancer: %v", syncResult.Error)
-		if utils.IsUserError(syncResult.Error) {
+		if loadbalancers.IsUserError(syncResult.Error) {
 			syncResult.MetricsLegacyState.IsUserError = true
 			if l4c.enableDualStack {
 				syncResult.MetricsState.Status = metrics.StatusUserError

--- a/pkg/l4lb/l4lbcommon.go
+++ b/pkg/l4lb/l4lbcommon.go
@@ -115,7 +115,7 @@ func isHealthCheckDeleted(cloud *gce.Cloud, hcName string, logger klog.Logger) b
 }
 
 func skipUserError(err error, svcLogger klog.Logger) error {
-	if utils.IsUserError(err) {
+	if loadbalancers.IsUserError(err) {
 		svcLogger.Info("Sync failed with user-caused error", "err", err)
 		return nil
 	}

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -593,7 +593,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 	if syncResult.Error != nil {
 		lc.ctx.Recorder(service.Namespace).Eventf(service, v1.EventTypeWarning, "SyncExternalLoadBalancerFailed",
 			"Error ensuring Resource for L4 External LoadBalancer, err: %v", syncResult.Error)
-		if utils.IsUserError(syncResult.Error) {
+		if loadbalancers.IsUserError(syncResult.Error) {
 			syncResult.MetricsLegacyState.IsUserError = true
 			syncResult.MetricsState.Status = metrics.StatusUserError
 		}

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1319,7 +1319,7 @@ func TestDualStackILBBadCustomSubnet(t *testing.T) {
 			if result.Error == nil {
 				t.Fatalf("Expected error ensuring internal dualstack loadbalancer in bad subnet, got: %v", result.Error)
 			}
-			if !utils.IsUserError(result.Error) {
+			if !IsUserError(result.Error) {
 				t.Errorf("Expected to get user error if external IPv6 subnet specified for internal IPv6 service, got %v", result.Error)
 			}
 			if !noInternalIPv6InSubnetError.MatchString(result.Error.Error()) {
@@ -1376,7 +1376,7 @@ func TestInternalLBBadCustomSubnet(t *testing.T) {
 				if result.Error == nil {
 					t.Fatalf("Expected error ensuring internal loadbalancer with non-existing subnet, got: %v", result.Error)
 				}
-				if !utils.IsUserError(result.Error) {
+				if !IsUserError(result.Error) {
 					t.Errorf("Expected to get user error if non-existing subnet specified for internal loadbalancer, got %v", result.Error)
 				}
 				expectedError := fmt.Sprintf("Subnetwork \"%s\" can't be found for project %s", tc.subnetName, l4.cloud.ProjectID())

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -239,7 +239,7 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 		l4netlb.svcLogger.Error(err, "Failed to get network for service")
 		result.Error = err
 		result.MetricsState.Status = metrics.StatusError
-		if utils.IsUserError(err) {
+		if IsUserError(err) {
 			result.MetricsLegacyState.IsUserError = true
 			result.MetricsState.Status = metrics.StatusUserError
 		}
@@ -253,7 +253,7 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service) 
 	if err := l4netlb.checkStrongSessionAffinityRequirements(); err != nil {
 		result.Error = err
 		result.MetricsState.Status = metrics.StatusError
-		if utils.IsUserError(err) {
+		if IsUserError(err) {
 			result.MetricsLegacyState.IsUserError = true
 			result.MetricsState.Status = metrics.StatusUserError
 		}
@@ -415,7 +415,7 @@ func (l4netlb *L4NetLB) ensureIPv4Resources(result *L4NetLBSyncResult, nodeNames
 		// User can misconfigure the forwarding rule if Network Tier will not match service level Network Tier.
 		result.GCEResourceInError = annotations.ForwardingRuleResource
 		result.Error = fmt.Errorf("failed to ensure forwarding rule - %w", err)
-		result.MetricsLegacyState.IsUserError = utils.IsUserError(err)
+		result.MetricsLegacyState.IsUserError = IsUserError(err)
 		return
 	}
 	if fr.IPProtocol == string(corev1.ProtocolTCP) {
@@ -443,7 +443,7 @@ func (l4netlb *L4NetLB) ensureIPv4MixedResources(result *L4NetLBSyncResult, node
 		// User can misconfigure the forwarding rule if Network Tier will not match service level Network Tier.
 		result.GCEResourceInError = annotations.ForwardingRuleResource
 		result.Error = fmt.Errorf("failed to ensure mixed protocol forwarding rules - %w", err)
-		result.MetricsLegacyState.IsUserError = utils.IsUserError(err)
+		result.MetricsLegacyState.IsUserError = IsUserError(err)
 		return
 	}
 

--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -781,7 +781,7 @@ func TestDualStackNetLBBadCustomSubnet(t *testing.T) {
 			if result.Error == nil {
 				t.Fatalf("Expected error ensuring external dualstack loadbalancer in bad subnet, got: %v", result.Error)
 			}
-			if !utils.IsUserError(result.Error) {
+			if !IsUserError(result.Error) {
 				t.Errorf("Expected to get user error if internal IPv6 subnet specified for external IPv6 service, got %v", result.Error)
 			}
 			if !noExternalIPv6InSubnetError.MatchString(result.Error.Error()) {
@@ -844,7 +844,7 @@ func TestDualStackNetLBNetworkTier(t *testing.T) {
 				if result.Error == nil {
 					t.Fatalf("Expected an error to be returned when ensuring the external load balancer, but the call succeeded unexpectedly.")
 				}
-				if !utils.IsUserError(result.Error) {
+				if !IsUserError(result.Error) {
 					t.Fatalf("Expected to get user error if ensuring external IPv6 service, got %v", result.Error)
 				}
 			} else {

--- a/pkg/loadbalancers/user_error.go
+++ b/pkg/loadbalancers/user_error.go
@@ -1,0 +1,23 @@
+package loadbalancers
+
+import (
+	"errors"
+
+	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// IsUserError checks if given error is caused by User.
+func IsUserError(err error) bool {
+	var userErr *utils.UserError
+	var firewallErr *firewalls.FirewallXPNError
+
+	return utils.IsNetworkTierError(err) ||
+		utils.IsIPConfigurationError(err) ||
+		utils.IsInvalidSubnetConfigurationError(err) ||
+		utils.IsInvalidLoadBalancerSourceRangesSpecError(err) ||
+		utils.IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
+		utils.IsUnsupportedNetworkTierError(err) ||
+		errors.As(err, &firewallErr) ||
+		errors.As(err, &userErr)
+}

--- a/pkg/loadbalancers/user_error_test.go
+++ b/pkg/loadbalancers/user_error_test.go
@@ -1,0 +1,68 @@
+package loadbalancers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/loadbalancers"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+func TestIsUserError(t *testing.T) {
+	testCases := []struct {
+		err  error
+		want bool
+	}{
+		{
+			err:  nil,
+			want: false,
+		},
+		{
+			err:  fmt.Errorf("other err"),
+			want: false,
+		},
+		{
+			err:  utils.NewNetworkTierErr("forwardingRule", "STANDARD", "PREMIUM"),
+			want: true,
+		},
+		{
+			err:  utils.NewUnsupportedNetworkTierErr("forwardingRule", "STANDARD"),
+			want: true,
+		},
+		{
+			err:  utils.NewUserError(fmt.Errorf("err")),
+			want: true,
+		},
+		{
+			err:  &firewalls.FirewallXPNError{Internal: fmt.Errorf("internal err"), Message: "message"},
+			want: true,
+		},
+		{
+			err:  utils.NewIPConfigurationError("123.123.123.456", "bad ip"),
+			want: true,
+		},
+		{
+			err:  utils.NewInvalidLoadBalancerSourceRangesAnnotationError("annotation", fmt.Errorf("bad")),
+			want: true,
+		},
+		{
+			err:  utils.NewInvalidLoadBalancerSourceRangesSpecError(nil, fmt.Errorf("bad")),
+			want: true,
+		},
+	}
+	for _, tC := range testCases {
+		tC := tC
+		testName := "nil"
+		if tC.err != nil {
+			testName = tC.err.Error()
+		}
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			if got := loadbalancers.IsUserError(tC.err); got != tC.want {
+				t.Errorf("IsUserError(%v) = %v, want %v", tC.err.Error(), got, tC.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/sourceranges.go
+++ b/pkg/utils/sourceranges.go
@@ -58,7 +58,7 @@ func getAllSourceRanges(service *v1.Service) (net.IPNetSet, error) {
 		}
 		ipnets, err := net.ParseIPNets(specs...)
 		if err != nil {
-			return nil, NewInvalidSpecLoadBalancerSourceRangesError(specs, err)
+			return nil, NewInvalidLoadBalancerSourceRangesSpecError(specs, err)
 		}
 		return ipnets, err
 	}
@@ -89,7 +89,7 @@ func (e *InvalidLoadBalancerSourceRangesSpecError) Error() string {
 	return fmt.Sprintf("service.Spec.LoadBalancerSourceRanges: %v is not valid. Expecting a list of IP ranges. For example, 10.0.0.0/24. Error msg: %v", e.LoadBalancerSourceRangesSpec, e.ParseErr)
 }
 
-func NewInvalidSpecLoadBalancerSourceRangesError(specLoadBalancerSourceRanges []string, err error) *InvalidLoadBalancerSourceRangesSpecError {
+func NewInvalidLoadBalancerSourceRangesSpecError(specLoadBalancerSourceRanges []string, err error) *InvalidLoadBalancerSourceRangesSpecError {
 	return &InvalidLoadBalancerSourceRangesSpecError{
 		specLoadBalancerSourceRanges,
 		err,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -276,18 +276,6 @@ func IsInvalidLoadBalancerSourceRangesAnnotationError(err error) bool {
 	return errors.As(err, &invalidLoadBalancerSourceRangesAnnotationError)
 }
 
-// IsUserError checks if given error is caused by User.
-func IsUserError(err error) bool {
-	var userError *UserError
-	return IsNetworkTierError(err) ||
-		IsIPConfigurationError(err) ||
-		IsInvalidSubnetConfigurationError(err) ||
-		IsInvalidLoadBalancerSourceRangesSpecError(err) ||
-		IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
-		IsUnsupportedNetworkTierError(err) ||
-		errors.As(err, &userError)
-}
-
 // UserError is a struct to define error caused by User misconfiguration.
 type UserError struct {
 	err error

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -276,9 +276,7 @@ func IsInvalidLoadBalancerSourceRangesAnnotationError(err error) bool {
 	return errors.As(err, &invalidLoadBalancerSourceRangesAnnotationError)
 }
 
-// IsUserError checks if given error is cause by User.
-// Right now User Error might be caused by Network Tier misconfiguration
-// or specifying non-existent or already used IP address.
+// IsUserError checks if given error is caused by User.
 func IsUserError(err error) bool {
 	var userError *UserError
 	return IsNetworkTierError(err) ||

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package utils_test
 
 import (
 	"context"
@@ -41,6 +41,7 @@ import (
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/common"
 )
 
@@ -65,7 +66,7 @@ func TestResourcePath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		res, _ := ResourcePath(tc.url)
+		res, _ := utils.ResourcePath(tc.url)
 		if res != tc.want {
 			t.Errorf("ResourcePath(%q) = %q, want %q", tc.url, res, tc.want)
 		}
@@ -94,7 +95,7 @@ func TestToNamespacedName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
-			gotOut, gotErr := ToNamespacedName(tc.input)
+			gotOut, gotErr := utils.ToNamespacedName(tc.input)
 			if tc.wantErr != (gotErr != nil) {
 				t.Errorf("ToNamespacedName(%v) = _, %v, want err? %v", tc.input, gotErr, tc.wantErr)
 			}
@@ -170,7 +171,7 @@ func TestEqualResourcePaths(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if got := EqualResourcePaths(tc.a, tc.b); got != tc.want {
+			if got := utils.EqualResourcePaths(tc.a, tc.b); got != tc.want {
 				t.Errorf("EqualResourcePathsOfURLs(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
 			}
 		})
@@ -238,7 +239,7 @@ func TestEqualResourceIDs(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if got := EqualResourceIDs(tc.a, tc.b); got != tc.want {
+			if got := utils.EqualResourceIDs(tc.a, tc.b); got != tc.want {
 				t.Errorf("EqualResourceIDs(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
 			}
 		})
@@ -508,7 +509,7 @@ func TestTraverseIngressBackends(t *testing.T) {
 
 	for _, tc := range testCases {
 		counter := 0
-		TraverseIngressBackends(tc.ing, func(id ServicePortID) bool {
+		utils.TraverseIngressBackends(tc.ing, func(id utils.ServicePortID) bool {
 			if tc.expectBackends[counter].Service.Name != id.Service.Name || tc.expectBackends[counter].Service.Port != id.Port {
 				t.Errorf("Test case %q, for backend %v, expecting service name %q and service port %+v, but got %q, %q", tc.desc, counter, tc.expectBackends[counter].Service.Name, tc.expectBackends[counter].Service.Port, id.Service.Name, id.Port.String())
 			}
@@ -664,7 +665,7 @@ func TestIsGCEIngress(t *testing.T) {
 			flags.F.EnableIngressRegionalExternal = tc.xlbRegionalEnabledFlag
 			flags.F.EnableIngressGlobalExternal = tc.enableIngressGlobalExternalFlag
 
-			result := IsGCEIngress(tc.ingress)
+			result := utils.IsGCEIngress(tc.ingress)
 			if result != tc.expected {
 				t.Fatalf("want %v, got %v", tc.expected, result)
 			}
@@ -721,7 +722,7 @@ func TestIsGCEL7ILBIngress(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := IsGCEL7ILBIngress(tc.ingress)
+			result := utils.IsGCEL7ILBIngress(tc.ingress)
 			if result != tc.expected {
 				t.Fatalf("want %v, got %v", tc.expected, result)
 			}
@@ -785,7 +786,7 @@ func TestIsGCEL7XLBRegionalIngress(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := IsGCEL7XLBRegionalIngress(tc.ingress)
+			result := utils.IsGCEL7XLBRegionalIngress(tc.ingress)
 			if result != tc.expected {
 				t.Fatalf("want %v, got %v", tc.expected, result)
 			}
@@ -846,7 +847,7 @@ func TestNeedsCleanup(t *testing.T) {
 				ingress.SetDeletionTimestamp(&ts)
 			}
 
-			if gotNeedsCleanup := NeedsCleanup(ingress); gotNeedsCleanup != tc.expectNeedsCleanup {
+			if gotNeedsCleanup := utils.NeedsCleanup(ingress); gotNeedsCleanup != tc.expectNeedsCleanup {
 				t.Errorf("NeedsCleanup() = %t, want %t (tc = %+v)", gotNeedsCleanup, tc.expectNeedsCleanup, tc)
 			}
 		})
@@ -916,7 +917,7 @@ func TestHasVIP(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if gotHasVIP := HasVIP(tc.ing); tc.expectHasVIP != gotHasVIP {
+			if gotHasVIP := utils.HasVIP(tc.ing); tc.expectHasVIP != gotHasVIP {
 				t.Errorf("Got diff HasVIP, expected %t got %t", tc.expectHasVIP, gotHasVIP)
 			}
 		})
@@ -936,7 +937,7 @@ func TestGetNodePrimaryIP(t *testing.T) {
 			},
 		},
 	}
-	out := GetNodePrimaryIP(node, klog.TODO())
+	out := utils.GetNodePrimaryIP(node, klog.TODO())
 	if out != internalIP {
 		t.Errorf("Expected Primary IP %s, got %s", internalIP, out)
 	}
@@ -951,7 +952,7 @@ func TestGetNodePrimaryIP(t *testing.T) {
 			},
 		},
 	}
-	out = GetNodePrimaryIP(node, klog.TODO())
+	out = utils.GetNodePrimaryIP(node, klog.TODO())
 	if out != "" {
 		t.Errorf("Expected Primary IP '', got %s", out)
 	}
@@ -973,13 +974,13 @@ func TestIsLegacyL4ILBService(t *testing.T) {
 			},
 		},
 	}
-	if !IsLegacyL4ILBService(svc) {
+	if !utils.IsLegacyL4ILBService(svc) {
 		t.Errorf("Expected True for Legacy service %s, got False", svc.Name)
 	}
 
 	// Remove the finalizer and ensure the check returns False.
 	svc.ObjectMeta.Finalizers = nil
-	if IsLegacyL4ILBService(svc) {
+	if utils.IsLegacyL4ILBService(svc) {
 		t.Errorf("Expected False for Legacy service %s, got True", svc.Name)
 	}
 }
@@ -1002,7 +1003,7 @@ func TestGetPortRanges(t *testing.T) {
 		{Desc: "One value", Input: []int{12}, Result: []string{"12"}},
 		{Desc: "Empty", Input: []int{}, Result: nil},
 	} {
-		result := GetPortRanges(tc.Input)
+		result := utils.GetPortRanges(tc.Input)
 		if diff := cmp.Diff(result, tc.Result); diff != "" {
 			t.Errorf("GetPortRanges(%s) mismatch, (-want +got): \n%s", tc.Desc, diff)
 		}
@@ -1025,7 +1026,7 @@ func TestIsHTTPErrorCode(t *testing.T) {
 		{"Wrapped error with code 200", fmt.Errorf("%w", &googleapi.Error{Code: 200}), 400, false},
 		{"Wrapped error with code 400", fmt.Errorf("%w", &googleapi.Error{Code: 400}), 400, true},
 	} {
-		got := IsHTTPErrorCode(tc.err, tc.code)
+		got := utils.IsHTTPErrorCode(tc.err, tc.code)
 		if got != tc.want {
 			t.Errorf("IsHTTPErrorCode(%v, %d) = %t; want %t", tc.err, tc.code, got, tc.want)
 		}
@@ -1050,18 +1051,18 @@ func TestIsQuotaExceededError(t *testing.T) {
 			Code:    403,
 			Message: "Quota exceeded",
 			Errors: []googleapi.ErrorItem{{
-				Reason: gceRateLimitExceeded,
+				Reason: "rateLimitExceeded",
 			}},
 		}, true},
 		{"Wrapped error with code 403 and reason rateLimitExceeded", fmt.Errorf("%w", &googleapi.Error{
 			Code:    403,
 			Message: "Quota exceeded",
 			Errors: []googleapi.ErrorItem{{
-				Reason: gceRateLimitExceeded,
+				Reason: "rateLimitExceeded",
 			}},
 		}), true},
 	} {
-		got := IsQuotaExceededError(tc.err)
+		got := utils.IsQuotaExceededError(tc.err)
 		if got != tc.want {
 			t.Errorf("IsQuotaExceededError(%v) = %t; want %t", tc.err, got, tc.want)
 		}
@@ -1084,7 +1085,7 @@ func TestGetErrorType(t *testing.T) {
 		{desc: "unknown error", err: fmt.Errorf("Got unknown error"), errType: ""},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if errType := GetErrorType(tc.err); errType != tc.errType {
+			if errType := utils.GetErrorType(tc.err); errType != tc.errType {
 				t.Errorf("Unexpected errType %q, want %q", errType, tc.errType)
 			}
 		})
@@ -1117,16 +1118,16 @@ func TestBackendToServicePortID(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			svcPortID, err := BackendToServicePortID(tc.backend, testNS)
+			svcPortID, err := utils.BackendToServicePortID(tc.backend, testNS)
 			if !tc.expectErr && err != nil {
 				t.Errorf("unexpected error: %q", err)
 			} else if tc.expectErr && err == nil {
 				t.Errorf("expected an error, but got none")
 			}
 
-			expectedID := ServicePortID{}
+			expectedID := utils.ServicePortID{}
 			if !tc.expectErr {
-				expectedID = ServicePortID{
+				expectedID = utils.ServicePortID{
 					Service: types.NamespacedName{
 						Name:      tc.backend.Service.Name,
 						Namespace: testNS,
@@ -1172,7 +1173,7 @@ func TestGetBasePath(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			fakeGCE.ComputeServices().GA.BasePath = tc.basePath
-			path := GetBasePath(fakeGCE)
+			path := utils.GetBasePath(fakeGCE)
 			if path != tc.expectedBasePath {
 				t.Errorf("wanted %s, but got %s", tc.expectedBasePath, path)
 			}
@@ -1237,7 +1238,7 @@ func TestMinMaxPortRange(t *testing.T) {
 			expectedRange: "",
 		},
 	} {
-		portsRange := MinMaxPortRange(tc.svcPorts)
+		portsRange := utils.MinMaxPortRange(tc.svcPorts)
 		if portsRange != tc.expectedRange {
 			t.Errorf("PortRange mismatch %v != %v", tc.expectedRange, portsRange)
 		}
@@ -1270,14 +1271,14 @@ func TestIsNetworkMismatchGCEError(t *testing.T) {
 			want: false,
 		},
 	} {
-		if got := IsNetworkTierMismatchGCEError(tc.err); got != tc.want {
+		if got := utils.IsNetworkTierMismatchGCEError(tc.err); got != tc.want {
 			t.Errorf("IsNetworkTierMismatchGCEError(%v) = %v, want %v", tc.err, got, tc.want)
 		}
 	}
 }
 
 func TestIsNetworkMismatchError(t *testing.T) {
-	netTierMismatchError := NewNetworkTierErr("forwarding-rule", "premium", "standard")
+	netTierMismatchError := utils.NewNetworkTierErr("forwarding-rule", "premium", "standard")
 	for _, tc := range []struct {
 		description string
 		err         error
@@ -1299,7 +1300,7 @@ func TestIsNetworkMismatchError(t *testing.T) {
 			want:        false,
 		},
 	} {
-		if got := IsNetworkTierError(tc.err); got != tc.want {
+		if got := utils.IsNetworkTierError(tc.err); got != tc.want {
 			t.Errorf("IsNetworkTierError(%v) = %v, want %v", tc.err, got, tc.want)
 		}
 	}
@@ -1341,7 +1342,7 @@ func TestIsLoadBalancerType(t *testing.T) {
 				},
 			}
 
-			isLoadBalancer := IsLoadBalancerServiceType(svc)
+			isLoadBalancer := utils.IsLoadBalancerServiceType(svc)
 
 			if isLoadBalancer != tc.wantIsLoadBalancerType {
 				t.Errorf("IsLoadBalancerServiceType(%v) returned %t, expected %t", svc, isLoadBalancer, tc.wantIsLoadBalancerType)
@@ -1389,7 +1390,7 @@ func TestGetProtocol(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			protocol := GetProtocol(tc.ports)
+			protocol := utils.GetProtocol(tc.ports)
 
 			if protocol != tc.expectedProtocol {
 				t.Errorf("GetProtocol returned %v, not equal to expected protocol = %v", protocol, tc.expectedProtocol)
@@ -1420,7 +1421,7 @@ func TestGetPorts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ports := GetPorts(tc.ports)
+			ports := utils.GetPorts(tc.ports)
 
 			if !reflect.DeepEqual(ports, tc.expectedPorts) {
 				t.Errorf("GetPorts returned %v, not equal to expected ports = %v", ports, tc.expectedPorts)
@@ -1506,7 +1507,7 @@ func TestGetServicePortRanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ranges := GetServicePortRanges(tc.ports)
+			ranges := utils.GetServicePortRanges(tc.ports)
 
 			if !reflect.DeepEqual(ranges, tc.expectedRanges) {
 				t.Errorf("GetServicePortRanges returned %v, not equal to expected ranges = %v", ranges, tc.expectedRanges)
@@ -1550,7 +1551,7 @@ func TestAddIPToLBStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			newStatus := AddIPToLBStatus(tc.status, tc.ipsToAdd...)
+			newStatus := utils.AddIPToLBStatus(tc.status, tc.ipsToAdd...)
 
 			if !reflect.DeepEqual(tc.expectedStatus, newStatus) {
 				t.Errorf("newStatus = %v, not equal to expectedStatus = %v", newStatus, tc.expectedStatus)
@@ -1612,8 +1613,8 @@ func TestIsUnsupportedFeatureError(t *testing.T) {
 				Message: tc.errorMessage,
 				Code:    tc.errorCode,
 			}
-			if IsUnsupportedFeatureError(&err, tc.featureName) != tc.expectedReturnValue {
-				t.Errorf("IsUnsupportedFeatureError returned unexpected result: %v, expectations: %v for error: %v", IsUnsupportedFeatureError(&err, tc.featureName), tc.expectedReturnValue, err)
+			if utils.IsUnsupportedFeatureError(&err, tc.featureName) != tc.expectedReturnValue {
+				t.Errorf("IsUnsupportedFeatureError returned unexpected result: %v, expectations: %v for error: %v", utils.IsUnsupportedFeatureError(&err, tc.featureName), tc.expectedReturnValue, err)
 			}
 		})
 	}
@@ -1659,7 +1660,7 @@ func TestIsGCEServerError(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := IsGCEServerError(tc.err)
+			got := utils.IsGCEServerError(tc.err)
 			if got != tc.want {
 				t.Errorf("Got %+v, expected %+v", got, tc.want)
 			}
@@ -1707,7 +1708,7 @@ func TestIsK8sServerError(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := IsK8sServerError(tc.err)
+			got := utils.IsK8sServerError(tc.err)
 			if got != tc.want {
 				t.Errorf("Got %+v, expected %+v", got, tc.want)
 			}
@@ -1748,7 +1749,7 @@ func TestGetDomainFromGABasePath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := GetDomainFromGABasePath(tc.basePath); got != tc.want {
+			if got := utils.GetDomainFromGABasePath(tc.basePath); got != tc.want {
 				t.Errorf("GetDomainFromGABasePath(%s) = %s, want %s", tc.basePath, got, tc.want)
 			}
 		})


### PR DESCRIPTION
Since utils package is dependend upon practicaly everywhere, it causes import cycles when trying to add additional `error.As` there. Since I don't want to grow this black hole pkg this commit moves IsUserError to pkg/loadbalancers as we actually use it there.

Also adds tests which were missing for that method.