### PR TITLE
NetLB: workaround for the finalizer removal case

### DIFF
--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -550,7 +551,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 		svcLogger.Info("Finished syncing L4 NetLB RBS service", "timeTaken", time.Since(startTime))
 	}()
 
-	usesNegBackends := lc.shouldUseNEGBackends(service)
+	usesNegBackends := lc.shouldUseNEGBackends(service, svcLogger)
 
 	l4NetLBParams := &loadbalancers.L4NetLBParams{
 		Service:                          service,
@@ -645,7 +646,7 @@ func (lc *L4NetLBController) syncInternal(service *v1.Service, svcLogger klog.Lo
 	return syncResult
 }
 
-func (lc *L4NetLBController) shouldUseNEGBackends(service *v1.Service) bool {
+func (lc *L4NetLBController) shouldUseNEGBackends(service *v1.Service, svcLogger klog.Logger) bool {
 	if !lc.enableNEGSupport {
 		return false
 	}
@@ -655,7 +656,51 @@ func (lc *L4NetLBController) shouldUseNEGBackends(service *v1.Service) bool {
 	if utils.HasL4NetLBFinalizerV3(service) {
 		return true
 	}
-	return lc.enableNEGAsDefault
+	if !lc.enableNEGAsDefault {
+		return false
+	}
+	// Do an extra check in case the customer removes the required finalizers
+	// Get the backend service if one exists and see what kind of backend
+	// is attached. If it's an IG keep using IGs.
+	backendType, err := lc.getBackendLinkType(service, svcLogger)
+	if err != nil {
+		svcLogger.Error(err, "Could not determine the backend type of the existing backend service, deferring to default")
+		return true
+	}
+	if backendType != nil && *backendType == instanceGroupLink {
+		return false
+	}
+	return backendType == nil || *backendType == negLink
+}
+
+func (lc *L4NetLBController) getBackendLinkType(service *v1.Service, svcLogger klog.Logger) (*backendLinkType, error) {
+	bsName := lc.namer.L4Backend(service.Namespace, service.Name)
+	backendService, err := lc.backendPool.Get(bsName, meta.VersionGA, meta.Regional, svcLogger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if backendService == nil {
+		return nil, nil
+	}
+	// When moving from subsetting ILB the BackendService could exist with
+	// a different load balancing scheme. Here we should treat this as
+	// a non-existent Backend Service.
+	if backendService.LoadBalancingScheme != string(cloud.SchemeExternal) {
+		return nil, nil
+	}
+	if len(backendService.Backends) > 0 {
+		firstBackend := backendService.Backends[0]
+		if strings.Contains(firstBackend.Group, "/instanceGroups/") {
+			return ptr.To(instanceGroupLink), nil
+		}
+		if strings.Contains(firstBackend.Group, "/networkEndpointGroups/") {
+			return ptr.To(negLink), nil
+		}
+	}
+	return nil, nil
 }
 
 func (lc *L4NetLBController) emitEnsuredDualStackEvent(service *v1.Service) {

--- a/pkg/l4lb/l4netlbcontroller_test.go
+++ b/pkg/l4lb/l4netlbcontroller_test.go
@@ -778,6 +778,107 @@ func TestProcessIGServiceWhenNEGIsEnabled(t *testing.T) {
 	deleteNetLBService(lc, svc)
 }
 
+func TestFinalizerRemovalIGServiceWhenNEGIsEnabled(t *testing.T) {
+	lc := newL4NetLBServiceController()
+	lc.enableNEGSupport = true
+	lc.enableNEGAsDefault = true
+
+	svc := test.NewL4NetLBRBSService(8080)
+	// add a finalizer that marks the service as IG service.
+	svc.Finalizers = append(svc.Finalizers, common.NetLBFinalizerV2)
+
+	prevMetrics, err := test.GetL4NetLBLatencyMetric()
+	if err != nil {
+		t.Errorf("Error getting L4 NetLB latency metrics err: %v", err)
+	}
+	if prevMetrics == nil {
+		t.Fatalf("Cannot get prometheus metrics for L4NetLB latency")
+	}
+
+	svc = syncNetLBSvc(t, lc, svc)
+
+	currMetrics, metricErr := test.GetL4NetLBLatencyMetric()
+	if metricErr != nil {
+		t.Errorf("Error getting L4 NetLB latency metrics err: %v", metricErr)
+	}
+	prevMetrics.ValidateDiff(currMetrics, &test.L4LBLatencyMetricInfo{CreateCount: 1, UpperBoundSeconds: 1}, t)
+
+	if !utils.HasL4NetLBFinalizerV2(svc) {
+		t.Errorf("the service %s should have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	if utils.HasL4NetLBFinalizerV3(svc) {
+		t.Errorf("the service %s should not have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	validateNetLBSvcStatus(svc, t)
+	if err := checkBackendService(lc, svc); err != nil {
+		t.Errorf("UnexpectedError %v", err)
+	}
+	if err := validateAnnotations(svc); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	// Update the service with all annotations and all finalizers removed.
+	svc.Finalizers = []string{}
+	svc.Annotations = make(map[string]string)
+
+	updateNetLBService(lc, svc)
+	svc = syncNetLBSvc(t, lc, svc)
+	if !utils.HasL4NetLBFinalizerV2(svc) {
+		t.Errorf("the service %s should have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	if utils.HasL4NetLBFinalizerV3(svc) {
+		t.Errorf("the service %s should not have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	validateNetLBSvcStatus(svc, t)
+	if err := checkBackendService(lc, svc); err != nil {
+		t.Errorf("UnexpectedError %v", err)
+	}
+	if err := validateAnnotations(svc); err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+// Test the scenario when the finalizers are removed along with all annotations.
+func TestFinalizerRemoveNEGServiceUpdate(t *testing.T) {
+	lc := newL4NetLBServiceController()
+	lc.enableNEGSupport = true
+	lc.enableNEGAsDefault = true
+
+	svc := createAndSyncNetLBSvcWithNEGs(t, lc)
+	if err := checkBackendServiceWithNEG(lc, svc); err != nil {
+		t.Errorf("UnexpectedError %v", err)
+	}
+	if !utils.HasL4NetLBFinalizerV3(svc) {
+		t.Errorf("the service %s should have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	if utils.HasL4NetLBFinalizerV2(svc) {
+		t.Errorf("the service %s should not have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+
+	// Update the service with all annotations and all finalizers removed.
+	svc.Finalizers = []string{}
+	svc.Annotations = make(map[string]string)
+
+	// Refresh the informer content
+	updateNetLBService(lc, svc)
+	svc = syncNetLBSvc(t, lc, svc)
+
+	validateNetLBSvcStatus(svc, t)
+	if !utils.HasL4NetLBFinalizerV3(svc) {
+		t.Errorf("the service %s should have the V3 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	if utils.HasL4NetLBFinalizerV2(svc) {
+		t.Errorf("the service %s should not have the V2 finalizer but instead it had %v", svc.Name, svc.Finalizers)
+	}
+	// validate that NEG is still attached
+	if err := checkBackendServiceWithNEG(lc, svc); err != nil {
+		t.Errorf("UnexpectedError %v", err)
+	}
+	if err := validateAnnotations(svc); err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
 func TestProcessServiceCreateWithUsersProvidedIP(t *testing.T) {
 	lc := newL4NetLBServiceController()
 


### PR DESCRIPTION
When determining which backend to use for a NetLB service in addition to the finalizers also check the actual backend service backends.

This is to work around the situations where the customers remove finalizers and can cause an unexpected move to NEG backends.