### PR TITLE
Fix test using t.Parallel() not capturing test cases

### DIFF
--- a/pkg/address/hold_test.go
+++ b/pkg/address/hold_test.go
@@ -195,6 +195,7 @@ func TestHoldExternalIPv4(t *testing.T) {
 		},
 	}
 	for _, tC := range testCases {
+		tC := tC
 		t.Run(tC.desc, func(t *testing.T) {
 			t.Parallel()
 			// Arrange

--- a/pkg/address/to_use_test.go
+++ b/pkg/address/to_use_test.go
@@ -111,6 +111,7 @@ func TestIPv4ToUse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			cloud, recorder := arrangeIPv4(t)
@@ -203,6 +204,7 @@ func TestIPv6ToUse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			cloud := arrangeIPv6(t)

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -892,6 +892,7 @@ func TestSelectAPIVersionForUpdate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			result := selectApiVersionForUpdate(tc.versionA, tc.versionB)
@@ -928,6 +929,7 @@ func TestFeatureVersionRequirements(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			params := L4BackendServiceParams{

--- a/pkg/forwardingrules/netlb_mixed_manager_test.go
+++ b/pkg/forwardingrules/netlb_mixed_manager_test.go
@@ -177,6 +177,7 @@ func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
 	for _, start := range startingState {
 		for _, end := range endState {
 			desc := start.desc + " -> " + end.desc
+			start, end := start, end
 			t.Run(desc, func(t *testing.T) {
 				t.Parallel()
 
@@ -267,6 +268,7 @@ func TestMixedManagerNetLB_AllRules(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -320,6 +322,7 @@ func TestMixedManagerNetLB_DeleteIPv4(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/loadbalancers/l4_mixed_test.go
+++ b/pkg/loadbalancers/l4_mixed_test.go
@@ -166,6 +166,7 @@ func TestEnsureMixedILB(t *testing.T) {
 	for _, s := range startState {
 		for _, e := range endState {
 			desc := s.desc + " -> " + e.desc
+			s, e := s, e
 			t.Run(desc, func(t *testing.T) {
 				t.Parallel()
 				svc := &api_v1.Service{
@@ -274,6 +275,7 @@ func TestDeleteMixedILB(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			svc := &api_v1.Service{

--- a/pkg/loadbalancers/l4_test.go
+++ b/pkg/loadbalancers/l4_test.go
@@ -1351,6 +1351,7 @@ func TestInternalLBBadCustomSubnet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/loadbalancers/l4netlb_mixed_test.go
+++ b/pkg/loadbalancers/l4netlb_mixed_test.go
@@ -97,6 +97,7 @@ func TestEnsureMixedNetLB(t *testing.T) {
 	for _, s := range startState {
 		for _, e := range endState {
 			desc := s.desc + " -> " + e.desc
+			s, e := s, e
 			t.Run(desc, func(t *testing.T) {
 				t.Parallel()
 				svc := &api_v1.Service{
@@ -226,6 +227,7 @@ func TestDeleteMixedNetLB(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			svc := &api_v1.Service{


### PR DESCRIPTION
I've found my tests from the past that don't capture testcases, potentially leading to some unexpected results. This fixes all of the t.Parallel table driven tests that didn't capture test case.