### PR TITLE
Add Compare for sets of Forwarding Rules

### DIFF
--- a/pkg/forwardingrules/optimized/compare.go
+++ b/pkg/forwardingrules/optimized/compare.go
@@ -1,0 +1,106 @@
+package optimized
+
+import "k8s.io/ingress-gce/pkg/composite"
+
+// APIOperations is a struct that contains the operations that need to be performed later to get desired state of Forwarding Rules.
+type APIOperations struct {
+	Create []*composite.ForwardingRule
+	Update []*composite.ForwardingRule
+	Delete []string
+}
+
+// Equal is a function that compares two forwarding rules.
+// It returns true if they are equal, false otherwise.
+// The error is returned if the comparison fails.
+type Equal func(got, want *composite.ForwardingRule) (bool, error)
+
+// Patchable is a function that checks if got can be patched to want.
+// It returns true if they can be patched along with the diff of the updated fields.
+// Otherwise it returns false and nil.
+type Patchable func(got, want *composite.ForwardingRule) (bool, *composite.ForwardingRule)
+
+// Compare compares two lists of forwarding rules and returns the operations
+// that need to be performed to reconcile the differences.
+//
+// equal is used to determine if two Forwarding Rules are equal.
+// patchable checks if two Forwarding Rules can be patched.
+// Both of these are parameters as equal and patchable funcs are IP specific.
+func Compare(got, want []*composite.ForwardingRule, equal Equal, patchable Patchable) (*APIOperations, error) {
+	// We use maps to have O(1) lookups.
+	gotMap := keyByNameMap(got)
+	wantMap := keyByNameMap(want)
+
+	// Update existing Forwarding Rules (both in "got" and "want")
+	//
+	// This handles both update and recreate (Delete and then Create) operations
+	// and this is why we need to return all operations (Create, Update, Delete)
+	// in the operations struct.
+	ops, err := updateOps(gotMap, wantMap, equal, patchable)
+	if err != nil {
+		return nil, err
+	}
+
+	// We add other delete and create operations:
+	// Delete is when there are forwarding rules in "got" that are not in "want".
+	ops.Delete = append(ops.Delete, deleteOps(gotMap, wantMap)...)
+	// Create is when there are forwarding rules in "want" that are not in "got".
+	ops.Create = append(ops.Create, createOps(gotMap, wantMap)...)
+
+	return ops, nil
+}
+
+func keyByNameMap(frs []*composite.ForwardingRule) map[string]*composite.ForwardingRule {
+	m := make(map[string]*composite.ForwardingRule, len(frs))
+	for _, fr := range frs {
+		m[fr.Name] = fr
+	}
+	return m
+}
+
+func updateOps(gotMap, wantMap map[string]*composite.ForwardingRule, equal Equal, patchable Patchable) (*APIOperations, error) {
+	ops := &APIOperations{}
+
+	for name, got := range gotMap {
+		want, ok := wantMap[name]
+		if !ok {
+			continue
+		}
+
+		if eq, err := equal(got, want); err != nil {
+			return nil, err
+		} else if eq {
+			continue
+		}
+
+		if patch, diff := patchable(got, want); patch {
+			ops.Update = append(ops.Update, diff)
+			continue
+		}
+
+		// If we reach here, it means that the forwarding rule needs to be recreated.
+		ops.Delete = append(ops.Delete, name)
+		ops.Create = append(ops.Create, want)
+	}
+
+	return ops, nil
+}
+
+func createOps(got, want map[string]*composite.ForwardingRule) []*composite.ForwardingRule {
+	var ops []*composite.ForwardingRule
+	for name, fr := range want {
+		if _, ok := got[name]; !ok {
+			ops = append(ops, fr)
+		}
+	}
+	return ops
+}
+
+func deleteOps(got, want map[string]*composite.ForwardingRule) []string {
+	var ops []string
+	for name := range got {
+		if _, ok := want[name]; !ok {
+			ops = append(ops, name)
+		}
+	}
+	return ops
+}

--- a/pkg/forwardingrules/optimized/compare_test.go
+++ b/pkg/forwardingrules/optimized/compare_test.go
@@ -1,0 +1,206 @@
+package optimized_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+	"k8s.io/ingress-gce/pkg/forwardingrules/optimized"
+)
+
+// TestCompare verifies Compare logic against a set of Forwarding Rules.
+// Specific tests for equality and patchability are covered in corresponding unit tests.
+func TestCompare(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		haveFRs   []*composite.ForwardingRule
+		wantFRs   []*composite.ForwardingRule
+		equal     optimized.Equal
+		patchable optimized.Patchable
+
+		wantCalls *optimized.APIOperations
+	}{
+		{
+			desc: "nothing changed",
+			haveFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			wantFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{},
+		},
+		{
+			desc:    "simple create",
+			haveFRs: nil,
+			wantFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{
+				Create: []*composite.ForwardingRule{
+					{
+						Name:           "fr-1",
+						BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+					},
+				},
+			},
+		},
+		{
+			desc: "simple delete",
+			haveFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			wantFRs:   nil,
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{
+				Delete: []string{"fr-1"},
+			},
+		},
+		{
+			desc: "simple patch",
+			haveFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			wantFRs: []*composite.ForwardingRule{
+				{
+					Name:              "fr-1",
+					AllowGlobalAccess: true,
+					BackendService:    "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{
+				Update: []*composite.ForwardingRule{
+					{
+						Name:              "fr-1",
+						AllowGlobalAccess: true,
+					},
+				},
+			},
+		},
+		{
+			desc: "recreate",
+			haveFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					IPProtocol:     "TCP",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			wantFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-1",
+					IPProtocol:     "UDP",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{
+				Delete: []string{"fr-1"},
+				Create: []*composite.ForwardingRule{
+					{
+						Name:           "fr-1",
+						IPProtocol:     "UDP",
+						BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+					},
+				},
+			},
+		},
+		{
+			desc: "multiple operations",
+			haveFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-delete",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+				{
+					Name:           "fr-update",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+				{
+					Name:           "fr-recreate",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			wantFRs: []*composite.ForwardingRule{
+				{
+					Name:           "fr-create",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+				{
+					Name:              "fr-update",
+					AllowGlobalAccess: true,
+					BackendService:    "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+				{
+					Name:           "fr-recreate",
+					IPProtocol:     "UDP",
+					BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+				},
+			},
+			equal:     forwardingrules.EqualIPv4,
+			patchable: forwardingrules.PatchableIPv4,
+			wantCalls: &optimized.APIOperations{
+				Create: []*composite.ForwardingRule{
+					{
+						Name:           "fr-recreate",
+						IPProtocol:     "UDP",
+						BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+					},
+					{
+						Name:           "fr-create",
+						BackendService: "https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/bs-1",
+					},
+				},
+				Update: []*composite.ForwardingRule{
+					{
+						Name:              "fr-update",
+						AllowGlobalAccess: true,
+					},
+				},
+				Delete: []string{"fr-recreate", "fr-delete"},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		tC := tC
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Act
+			ops, err := optimized.Compare(tC.haveFRs, tC.wantFRs, tC.equal, tC.patchable)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("optimized.Compare() error = %v", err)
+			}
+
+			if diff := cmp.Diff(ops, tC.wantCalls); diff != "" {
+				t.Errorf("want != got, (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows to compare two slices of Forwarding Rules. It has Equal and Patchable as parameters to allow it to be used for both IPv4 and IPv6 which have different func implementations.

We also add tests for verifying logic specific to compare, as exact equal/patchable logic are tested elsewhere.