### PR TITLE
Optimized apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/oauth2 v0.28.0
+	golang.org/x/sync v0.12.0
 	google.golang.org/api v0.226.0
 	istio.io/api v0.0.0-20190809125725-591cf32c1d0e
 	k8s.io/api v0.31.2
@@ -78,7 +79,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/pkg/forwardingrules/optimized/apply.go
+++ b/pkg/forwardingrules/optimized/apply.go
@@ -1,0 +1,81 @@
+package optimized
+
+import (
+	"fmt"
+
+	"k8s.io/ingress-gce/pkg/composite"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// ForwardingRulesModifier is used to not create a direct dependency on forwardingrules
+type ForwardingRulesModifier interface {
+	Create(fr *composite.ForwardingRule) error
+	Patch(fr *composite.ForwardingRule) error
+	Delete(name string) error
+}
+
+// Apply given APIOperations to the Forwarding Rules using the given ForwardingRulesModifier.
+//
+// To avoid port collisions we need to make sure all deletes happen before patches, and all patches happen between creates.
+// There are no dependencies between individual operations at each step, so this func runs individual operations in each step in parallel.
+func Apply(repo ForwardingRulesModifier, ops *APIOperations) error {
+	if err := applyDeletes(repo, ops.Delete); err != nil {
+		return err
+	}
+
+	if err := applyPatches(repo, ops.Update); err != nil {
+		return err
+	}
+
+	if err := applyCreates(repo, ops.Create); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func applyDeletes(repo ForwardingRulesModifier, names []string) error {
+	g := new(errgroup.Group)
+	for _, name := range names {
+		name := name
+		g.Go(func() error {
+			return repo.Delete(name)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("failed to delete forwarding rules: %w", err)
+	}
+	return nil
+}
+
+func applyPatches(repo ForwardingRulesModifier, patches []*composite.ForwardingRule) error {
+	g := new(errgroup.Group)
+	for _, fr := range patches {
+		fr := fr
+		g.Go(func() error {
+			return repo.Patch(fr)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("failed to patch forwarding rules: %w", err)
+	}
+	return nil
+}
+
+func applyCreates(repo ForwardingRulesModifier, frs []*composite.ForwardingRule) error {
+	g := new(errgroup.Group)
+	for _, fr := range frs {
+		fr := fr
+		g.Go(func() error {
+			return repo.Create(fr)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("failed to create forwarding rules: %w", err)
+	}
+	return nil
+}

--- a/pkg/forwardingrules/optimized/apply_test.go
+++ b/pkg/forwardingrules/optimized/apply_test.go
@@ -1,0 +1,279 @@
+package optimized_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/compute/v1"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/forwardingrules"
+	"k8s.io/ingress-gce/pkg/forwardingrules/optimized"
+	"k8s.io/klog/v2"
+)
+
+// TestApply verifies that Apply function correctly applies API operations to forwarding rules.
+// This creates a fake cloud, populates it with initial state, calls Apply and verifies the end state.
+func TestApply(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		haveFRs []*composite.ForwardingRule
+		ops     *optimized.APIOperations
+
+		wantFRs []*composite.ForwardingRule
+	}{
+		{
+			desc: "nothing changed",
+			haveFRs: []*composite.ForwardingRule{
+				{Name: "fr-1"},
+				{Name: "dont-touch-me"},
+			},
+			ops: &optimized.APIOperations{},
+
+			wantFRs: []*composite.ForwardingRule{
+				{Name: "fr-1"},
+				{Name: "dont-touch-me"},
+			},
+		},
+		{
+			desc: "simple create",
+			haveFRs: []*composite.ForwardingRule{
+				{Name: "dont-touch-me"},
+			},
+			ops: &optimized.APIOperations{
+				Create: []*composite.ForwardingRule{
+					{Name: "fr-1"},
+				},
+			},
+
+			wantFRs: []*composite.ForwardingRule{
+				{Name: "dont-touch-me"},
+				{Name: "fr-1"},
+			},
+		},
+		{
+			desc: "simple delete",
+			haveFRs: []*composite.ForwardingRule{
+				{Name: "fr-1"},
+				{Name: "dont-touch-me"},
+			},
+			ops: &optimized.APIOperations{
+				Delete: []string{"fr-1"},
+			},
+
+			wantFRs: []*composite.ForwardingRule{
+				{Name: "dont-touch-me"},
+			},
+		},
+		{
+			desc: "simple patch",
+			haveFRs: []*composite.ForwardingRule{
+				{Name: "fr-1"},
+				{Name: "dont-touch-me"},
+			},
+			ops: &optimized.APIOperations{
+				Update: []*composite.ForwardingRule{
+					{Name: "fr-1", AllowGlobalAccess: true},
+				},
+			},
+
+			wantFRs: []*composite.ForwardingRule{
+				{Name: "fr-1", AllowGlobalAccess: true},
+				{Name: "dont-touch-me"},
+			},
+		},
+		{
+			desc: "multiple operations",
+			haveFRs: []*composite.ForwardingRule{
+				{Name: "dont-touch-me"},
+
+				{Name: "fr-delete-1"},
+				{Name: "fr-delete-2"},
+
+				{Name: "fr-update-1"},
+				{Name: "fr-update-2"},
+				{Name: "fr-update-3"},
+			},
+			ops: &optimized.APIOperations{
+				Create: []*composite.ForwardingRule{
+					{Name: "fr-create-1"},
+					{Name: "fr-create-2"},
+				},
+				Update: []*composite.ForwardingRule{
+					{Name: "fr-update-1", AllowGlobalAccess: true},
+					{Name: "fr-update-2", NetworkTier: "PREMIUM"},
+					{Name: "fr-update-3", NetworkTier: "STANDARD"},
+				},
+				Delete: []string{"fr-delete-1", "fr-delete-2"},
+			},
+
+			wantFRs: []*composite.ForwardingRule{
+				{Name: "dont-touch-me"},
+
+				{Name: "fr-update-1", AllowGlobalAccess: true},
+				{Name: "fr-update-2", NetworkTier: "PREMIUM"},
+				{Name: "fr-update-3", NetworkTier: "STANDARD"},
+
+				{Name: "fr-create-1"},
+				{Name: "fr-create-2"},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		tC := tC
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			vals := gce.DefaultTestClusterValues()
+			fakeGCE := gce.NewFakeGCECloud(vals)
+			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+
+			// By default Patch in mock doesn't do anything,
+			// we need to add a hook to simulate the patch
+			mockGCE.MockForwardingRules.PatchHook = frPatchHook
+
+			provider := forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO())
+			for _, fr := range tC.haveFRs {
+				if err := provider.Create(fr); err != nil {
+					t.Fatalf("Create(%+v) returned error: %v, want nil", fr, err)
+				}
+			}
+
+			// Act
+			if err := optimized.Apply(provider, tC.ops); err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
+
+			// Assert by comparing all forwarding rules from the fake cloud
+			all := filter.None
+			got, err := provider.List(all)
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+
+			ignoreOpt := cmpopts.IgnoreFields(composite.ForwardingRule{}, "Version", "SelfLink", "Region")
+			sortOpt := cmpopts.SortSlices(func(x, y *composite.ForwardingRule) bool { return x.Name < y.Name })
+			if diff := cmp.Diff(tC.wantFRs, got, ignoreOpt, sortOpt); diff != "" {
+				t.Errorf("unexpected difference in Forwarding Rules (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestApplyErrs tests error cases for Apply function.
+// This is done by checking that each stage can return an error.
+func TestApplyErrs(t *testing.T) {
+	var (
+		deleteErr = errors.New("delete error")
+		patchErr  = errors.New("patch error")
+		createErr = errors.New("create error")
+	)
+
+	testCases := []struct {
+		desc      string
+		deleteErr error
+		patchErr  error
+		createErr error
+
+		wantErr error
+	}{
+		{
+			desc:    "no errors",
+			wantErr: nil,
+		},
+		{
+			desc:      "delete",
+			deleteErr: deleteErr,
+			wantErr:   deleteErr,
+		},
+		{
+			desc:     "patch",
+			patchErr: patchErr,
+			wantErr:  patchErr,
+		},
+		{
+			desc:      "create",
+			createErr: createErr,
+			wantErr:   createErr,
+		},
+		{
+			desc:      "all fail, return first",
+			deleteErr: deleteErr,
+			patchErr:  patchErr,
+			createErr: createErr,
+
+			wantErr: deleteErr,
+		},
+		{
+			desc:      "patch and create fail, return patch",
+			patchErr:  patchErr,
+			createErr: createErr,
+
+			wantErr: patchErr,
+		},
+	}
+	for _, tC := range testCases {
+		tC := tC
+		t.Run(tC.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			vals := gce.DefaultTestClusterValues()
+			fakeGCE := gce.NewFakeGCECloud(vals)
+
+			// Actual Forwarding Rules in fakeGCE don't matter
+			// We use mock hooks to inject errors/successes
+			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+			mockGCE.MockForwardingRules.DeleteHook = func(_ context.Context, _ *meta.Key, _ *cloud.MockForwardingRules, _ ...cloud.Option) (bool, error) {
+				if tC.deleteErr != nil {
+					return true, tC.deleteErr
+				}
+				return false, nil
+			}
+			mockGCE.MockForwardingRules.PatchHook = func(_ context.Context, _ *meta.Key, _ *compute.ForwardingRule, _ *cloud.MockForwardingRules, _ ...cloud.Option) error {
+				if tC.patchErr != nil {
+					return tC.patchErr
+				}
+				return nil
+			}
+			mockGCE.MockForwardingRules.InsertHook = func(_ context.Context, _ *meta.Key, _ *compute.ForwardingRule, _ *cloud.MockForwardingRules, _ ...cloud.Option) (bool, error) {
+				if tC.createErr != nil {
+					return true, tC.createErr
+				}
+				return false, nil
+			}
+
+			provider := forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO())
+			ops := &optimized.APIOperations{
+				Delete: []string{"fr-delete"},
+				Update: []*composite.ForwardingRule{{Name: "fr-update"}},
+				Create: []*composite.ForwardingRule{{Name: "fr-create"}},
+			}
+
+			// Act
+			err := optimized.Apply(provider, ops)
+
+			if diff := cmp.Diff(err, tC.wantErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Apply() returned unexpected error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func frPatchHook(_ context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules, _ ...cloud.Option) error {
+	existing, err := m.Get(context.TODO(), key)
+	if err != nil {
+		return err
+	}
+	existing.Description = obj.Description
+	existing.AllowGlobalAccess = obj.AllowGlobalAccess
+	existing.NetworkTier = obj.NetworkTier
+	return nil
+}

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,136 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+//
+// [errgroup.Group] is related to [sync.WaitGroup] but adds handling of tasks
+// returning errors.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func(error)
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel(g.err)
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+// A limit of zero will prevent any new goroutines from being added.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -330,6 +330,7 @@ golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.12.0
 ## explicit; go 1.23.0
+golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.31.0
 ## explicit; go 1.23.0


### PR DESCRIPTION
This will take in the output from Compare and apply the calls using already existing forwardingrules.ForwardingRules repository. Calls are paralellised at each stage: delete, patch, create to speed up the whole process.

This isn't used yet.

I also vendored in errgroup which is a wrapper for sync.Waitgroup with error handling. More info at golang.org/x/sync/errgroup. 