### PR TITLE
Fix flakiness on optimized tests by sorting results by name

### DIFF
--- a/pkg/forwardingrules/optimized/compare_test.go
+++ b/pkg/forwardingrules/optimized/compare_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/forwardingrules/optimized"
@@ -198,7 +199,11 @@ func TestCompare(t *testing.T) {
 				t.Fatalf("optimized.Compare() error = %v", err)
 			}
 
-			if diff := cmp.Diff(ops, tC.wantCalls); diff != "" {
+			// We execute those in parallel so we don't care about the order at each stage
+			sortFROpt := cmpopts.SortSlices(func(a, b *composite.ForwardingRule) bool { return a.Name < b.Name })
+			sortDeletesOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+			if diff := cmp.Diff(ops, tC.wantCalls, sortFROpt, sortDeletesOpt); diff != "" {
 				t.Errorf("want != got, (-want, +got):\n%s", diff)
 			}
 		})

--- a/pkg/forwardingrules/optimized/fetch_test.go
+++ b/pkg/forwardingrules/optimized/fetch_test.go
@@ -89,7 +89,9 @@ func TestFetch(t *testing.T) {
 			}
 
 			ignoreOpts := cmpopts.IgnoreFields(composite.ForwardingRule{}, "Version", "SelfLink", "Region")
-			if diff := cmp.Diff(tC.want, got, ignoreOpts); diff != "" {
+			sortOpt := cmpopts.SortSlices(func(a, b *composite.ForwardingRule) bool { return a.Name < b.Name })
+
+			if diff := cmp.Diff(tC.want, got, ignoreOpts, sortOpt); diff != "" {
 				t.Errorf("Fetch(%q) returned diff (-want +got):\n%s", tC.link, diff)
 			}
 		})


### PR DESCRIPTION
Since results where created in parallel the order of want and got could be different. This is fine as we don't care about the order, however it lead to tests being flaky.

This commit sorts slices in cmp.Diff by name to remove flakiness.

To test this is actually fixed I run it without using cache (`-count=1`)

Before (flaky):
```zsh
➜  ingress-gce git:(master) go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
--- FAIL: TestFetch (0.00s)
    --- FAIL: TestFetch/single_Backend_Service (0.00s)
        fetch_test.go:93: Fetch("https://compute.googleapis.com/projects/test-project/regions/us-central1/backendServices/test-be") returned diff (-want +got):
              []*composite.ForwardingRule{
                &{
                        ... // 1 ignored and 21 identical fields
                        LoadBalancingScheme: "",
                        MetadataFilters:     nil,
            -           Name:                "test-fr-1",
            +           Name:                "test-fr-2",
                        Network:             "",
                        NetworkTier:         "",
                        ... // 2 ignored and 15 identical fields
                },
                &{
                        ... // 1 ignored and 21 identical fields
                        LoadBalancingScheme: "",
                        MetadataFilters:     nil,
            -           Name:                "test-fr-2",
            +           Name:                "test-fr-1",
                        Network:             "",
                        NetworkTier:         "",
                        ... // 2 ignored and 15 identical fields
                },
              }
FAIL
FAIL    k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.312s
FAIL
➜  ingress-gce git:(master) go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.309s
➜  ingress-gce git:(master) go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.314s
```

After:
```zsh
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.306s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.310s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.307s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.324s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.311s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.309s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.308s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.321s
➜  ingress-gce git:(fix-flaky-fetch-test) ✗ go test -count=1 k8s.io/ingress-gce/pkg/forwardingrules/optimized
ok      k8s.io/ingress-gce/pkg/forwardingrules/optimized        0.315s
```

/assign @mmamczur