### PR TITLE
NEG controller, generateSubnetToNegNameMap multinet fix

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -396,7 +396,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 }
 
 func (s *transactionSyncer) generateSubnetToNegNameMap(subnetConfigs []nodetopologyv1.SubnetConfig) (map[string]string, error) {
-	defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
+	defaultSubnet, err := utils.KeyName(s.cloud.SubnetworkURL())
 	if err != nil {
 		s.logger.Error(err, "Errored getting default subnet from NetworkInfo when retrieving existing endpoints")
 		return nil, err


### PR DESCRIPTION
NEG Controller, when generating subnet to NEG name map, for mutlinet services return one element mapping of cluster default subnetwork to default NEG name. Do not use the network from networkInfo since it will not contain the cluster default network but the service multinet network.