### PR TITLE
[Cherrypick #2882 to release-1.34] NEGController: rely on the presence of the V3 finalizer vs the RBS annotation

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -709,20 +709,26 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 
 // netLBServiceNeedsNEG determines if NEGs need to be created for L4 NetLB.
 // - service must be an L4 External Load Balancer service
-// - service must have the RBS annotation
 // - service is a multinetwork service on a non default network OR NEGs are enabled and V3 finalizer is present.
+// - service has the V3 finalizer
+// otherwise the service does not need NEGs.
 func (c *Controller) netLBServiceNeedsNEG(service *apiv1.Service, networkInfo *network.NetworkInfo) bool {
 	wantsNetLB, _ := annotations.WantsL4NetLB(service)
 	if !wantsNetLB {
 		return false
 	}
-	if !annotations.HasRBSAnnotation(service) {
-		return false
-	}
 	if !networkInfo.IsDefault {
 		return true
 	}
-	return c.runL4ForNetLB && utils.HasL4NetLBFinalizerV3(service)
+	// The multinet check should be above because the runL4ForNetLB decides if NEGs
+	// should be used for non multinet services.
+	if !c.runL4ForNetLB {
+		return false
+	}
+	if utils.HasL4NetLBFinalizerV3(service) {
+		return true
+	}
+	return false
 }
 
 // mergeDefaultBackendServicePortInfoMap merge the PortInfoMap for the default backend service into portInfoMap

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -1352,6 +1352,13 @@ func TestMergeVmIpNEGsPortInfo(t *testing.T) {
 			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4ExternalLB),
 		},
 		{
+			desc:           "RBS non-multinet Service with NEG without RBS annotations",
+			svc:            svcWithAnnotations(newTestRBSService(controller, true, 80, common.NetLBFinalizerV3), nil),
+			networkInfo:    defaultNetwork,
+			runL4NetLB:     true,
+			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4ExternalLB),
+		},
+		{
 			desc:           "RBS non-multinet Service with NEG but NEGs not enabled for NetLB",
 			svc:            newTestRBSService(controller, true, 80, common.NetLBFinalizerV3),
 			networkInfo:    defaultNetwork,
@@ -2150,6 +2157,11 @@ func newTestRBSService(c *Controller, onlyLocal bool, port int, finalizer string
 	}
 
 	c.client.CoreV1().Services(testServiceNamespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	return svc
+}
+
+func svcWithAnnotations(svc *apiv1.Service, annotations map[string]string) *apiv1.Service {
+	svc.Annotations = annotations
 	return svc
 }
 


### PR DESCRIPTION
When deciding if a NetLB requires NEGs rely on the presence of the V3 finalizer and not of the RBS annotation.

Sometimes customers create an RBS service but then remove annotations and/or finalizers. In that case the L4 NetLB can detect it is an RBS service and restore the V3 finalizer. The NEG controller always expected the RBS annotation, so it could result in missing NEGs.

(cherry picked from commit ec677131eb2b0b94f343b4c16096f3172304f754)