### PR TITLE
NEG Controller: fix the multinet NEG location to prevent constant NEG detach calls

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 )
@@ -76,6 +77,10 @@ func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsDat
 	zoneNodeMap := make(map[string][]*nodeWithSubnet)
 	processedNodes := sets.String{}
 	numEndpoints := 0
+	networkInfoSubnetName, err := utils.KeyName(l.networkInfo.SubnetworkURL)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -110,6 +115,10 @@ func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsDat
 				l.logger.Error(err, "Unable to find zone for node, skipping", "nodeName", node.Name)
 				metrics.PublishNegControllerErrorCountMetrics(err, true)
 				continue
+			}
+			// For MN services, use the MN subnet as the subnet for the NEG.
+			if !l.networkInfo.IsDefault {
+				subnet = networkInfoSubnetName
 			}
 			zoneNodeMap[zone] = append(zoneNodeMap[zone], newNodeWithSubnet(node, subnet))
 		}
@@ -181,6 +190,10 @@ func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsD
 	nodes, _ := l.zoneGetter.ListNodes(zonegetter.CandidateAndUnreadyNodesFilter, l.logger)
 	zoneNodeMap := make(map[string][]*nodeWithSubnet)
 	zoneSubnetPairs := make(map[string]any)
+	networkInfoSubnetName, err := utils.KeyName(l.networkInfo.SubnetworkURL)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 	for _, node := range nodes {
 		if !l.networkInfo.IsNodeConnected(node) {
 			l.logger.Info("Node not connected to service network", "nodeName", node.Name, "network", l.networkInfo.K8sNetwork)
@@ -191,6 +204,10 @@ func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsD
 			l.logger.Error(err, "Unable to find zone for node skipping", "nodeName", node.Name)
 			metrics.PublishNegControllerErrorCountMetrics(err, true)
 			continue
+		}
+		// For MN services, use the MN subnet as the subnet for the NEG.
+		if !l.networkInfo.IsDefault {
+			subnet = networkInfoSubnetName
 		}
 		zoneNodeMap[zone] = append(zoneNodeMap[zone], newNodeWithSubnet(node, subnet))
 		zoneSubnetPairs[zone+":"+subnet] = struct{}{}

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -122,7 +122,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 		{
 			desc:          "multinetwork, endpoints only for nodes connected to a matching non-default network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
-			network:       network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: defaultTestSubnetURL},
+			network:       network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: multinetworkingTestSubnetURL},
 			nodeAnnotationsMap: map[string]map[string]string{
 				testInstance1: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.1")},
 				testInstance2: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.2")},
@@ -132,10 +132,10 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 3 out of 6 nodes are picked because only 3 have multi-nic annotation with a matching network name
 			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1},
 					negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}),
 			},
 		},
@@ -288,10 +288,10 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "multinetwork endpoints, only for nodes connected to the specified network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
+				{Zone: negtypes.TestZone1, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
 			},
-			network: network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: defaultTestSubnetURL},
+			network: network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: multinetworkingTestSubnetURL},
 			nodeAnnotationsMap: map[string]map[string]string{
 				testInstance1: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.1")},
 				testInstance2: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.2")},

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -46,7 +46,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+const (
+	defaultTestSubnetURL          = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	multinetworkingTestSubnetURL  = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/multinet"
+	multinetworkingTestSubnetName = "multinet"
+)
 
 func TestEncodeDecodeEndpoint(t *testing.T) {
 	ip := "10.0.0.10"


### PR DESCRIPTION
NEG Controller, when generating desired endpoints in the endpoints calculator for Multi Networking service, use the MN network as as the NEG subnet instead of the subnet of the node.

This is to make sure the location from the calculator matches the 'current' state calculated before and also so that the location actually matches the actual subnet the NEG will reside in.
Without this change the NEG controller calculation will be different for current state and for desired, so the controller will think it has to detach and attach endpoints. This will result in the controller issuing constant detach calls, exhausting the quota in the project for the NEG API.