### PR TITLE
Safeguard gcpfirewalls cr creation to not return sync errors in Shadow run

### DIFF
--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -106,7 +106,7 @@ func NewFirewallController(
 	sourceRanges := lbSourceRanges(logger, flags.F.OverrideHealthCheckSourceCIDRs)
 	logger.Info("Using source ranges", "ranges", sourceRanges)
 	if enableCR {
-		firewallCRPool := NewFirewallCRPool(ctx.FirewallClient, ctx.Cloud, ctx.ClusterNamer, sourceRanges, portRanges, disableFWEnforcement, logger)
+		firewallCRPool := NewFirewallCRPool(ctx.FirewallClient, ctx.Cloud, ctx.ClusterNamer, sourceRanges, portRanges, !disableFWEnforcement, logger)
 		compositeFirewallPool.pools = append(compositeFirewallPool.pools, firewallCRPool)
 	}
 	if !disableFWEnforcement {


### PR DESCRIPTION
Make sure that during gcpfirewalls cr creation, sync errors are not returned in Shadow run (when l7LB still reconciles the FWs).

Also fix dryRun flag to properly mean "testing" flow (the logic of the flag usage has not been changed)