### PR TITLE
Multiproject: stop controllers when leadership ends

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -266,9 +266,10 @@ func main() {
 			if nodeTopologyClient != nil {
 				nodeTopologyFactory = informernodetopology.NewSharedInformerFactory(nodeTopologyClient, flags.F.ResyncPeriod)
 			}
+			ctx := context.Background()
 			if flags.F.LeaderElection.LeaderElect {
 				err := multiprojectstart.StartWithLeaderElection(
-					context.Background(),
+					ctx,
 					leaderElectKubeClient,
 					hostname,
 					rootLogger,
@@ -288,6 +289,7 @@ func main() {
 				if err != nil {
 					rootLogger.Error(err, "Failed to start multi-project syncer with leader election")
 				}
+				rOption.closeStopCh()
 			} else {
 				multiprojectstart.Start(
 					rootLogger,


### PR DESCRIPTION
- Scope: changes are confined to the multiproject leader-election flow.
- Controllers & informers now inherit the leader-election context, exiting immediately when the lease is lost or on SIGTERM.
- ReleaseOnCancel=true enables instant lease hand-off for smoother rollouts.


/assign @swetharepakula 