### PR TITLE
[Cherrypick #2903 -> release-1.34] NEG Controller: fix the multinet NEG location to prevent constant NEG detach calls

### DIFF
--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -121,7 +121,7 @@ func TestLocalGetEndpointSet(t *testing.T) {
 		{
 			desc:          "multinetwork, endpoints only for nodes connected to a matching non-default network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
-			network:       network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: defaultTestSubnetURL},
+			network:       network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: multinetworkingTestSubnetURL},
 			nodeAnnotationsMap: map[string]map[string]string{
 				testInstance1: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.1")},
 				testInstance2: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.2")},
@@ -131,10 +131,10 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			// only 3 out of 6 nodes are picked because only 3 have multi-nic annotation with a matching network name
 			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone1, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1},
 					negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+				{Zone: negtypes.TestZone2, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(
 					negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}),
 			},
 		},
@@ -292,10 +292,10 @@ func TestClusterGetEndpointSet(t *testing.T) {
 			desc:          "multinetwork endpoints, only for nodes connected to the specified network",
 			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
 			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
-				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
-				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
+				{Zone: negtypes.TestZone1, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "20.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: multinetworkingTestSubnetName}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "20.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "20.2.3.6", Node: testInstance6}),
 			},
-			network: network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: defaultTestSubnetURL},
+			network: network.NetworkInfo{IsDefault: false, K8sNetwork: "other", SubnetworkURL: multinetworkingTestSubnetURL},
 			nodeAnnotationsMap: map[string]map[string]string{
 				testInstance1: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.1")},
 				testInstance2: {networkv1.NorthInterfacesAnnotationKey: nodeInterfacesAnnotation(t, "other", "20.2.3.2")},

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -46,7 +46,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultTestSubnetURL = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+const (
+	defaultTestSubnetURL          = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	multinetworkingTestSubnetURL  = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/multinet"
+	multinetworkingTestSubnetName = "multinet"
+)
 
 func TestEncodeDecodeEndpoint(t *testing.T) {
 	ip := "10.0.0.10"


### PR DESCRIPTION
NEG Controller, when generating desired endpoints in the endpoints calculator for Multi Networking service, use the MN network as as the NEG subnet instead of the subnet of the node.

This is to make sure the location from the calculator matches the 'current' state calculated before and also so that the location actually matches the actual subnet the NEG will reside in.
Without this change the NEG controller calculation will be different for current state and for desired, so the controller will think it has to detach and attach endpoints. This will result in the controller issuing constant detach calls, exhausting the quota in the project for the NEG API.