### PR TITLE
Compare health checks via resource path to support multi-version APIs

### DIFF
--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -347,6 +348,7 @@ func TestBackendSvcEqual(t *testing.T) {
 		oldBackendService         *composite.BackendService
 		newBackendService         *composite.BackendService
 		compareConnectionTracking bool
+		withZonalAffinityEnabled  bool
 		wantEqual                 bool
 	}{
 		{
@@ -477,6 +479,72 @@ func TestBackendSvcEqual(t *testing.T) {
 				HealthChecks: []string{"abc", "xyz"},
 			},
 			wantEqual: false,
+		},
+		{
+			desc: "Test with changed health-checks with Zonal Affinity Enabled",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"abc", "xyz"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                false,
+		},
+		{
+			desc: "Test with same health-checks version v1-beta",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/v1/abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/beta/abc"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                true,
+		},
+		{
+			desc: "Test with same health-checks version beta-v1",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/beta/abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/v1/abc"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                true,
+		},
+		{
+			desc: "Test with changed health-checks version beta-beta",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/beta/abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/beta/abcd"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                false,
+		},
+		{
+			desc: "Test with changed first part of health-checks version v1-v1",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/v1/abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.google.com/compute/v1/abc"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                false,
+		},
+		{
+			desc: "Test with changed health-checks version beta-v1",
+			oldBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/v1/abc"},
+			},
+			newBackendService: &composite.BackendService{
+				HealthChecks: []string{"https://www.googleapis.com/compute/beta/abcd"},
+			},
+			withZonalAffinityEnabled: true,
+			wantEqual:                false,
 		},
 		{
 			desc: "Test with deleted network",
@@ -728,7 +796,11 @@ func TestBackendSvcEqual(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
+			oldFlag := flags.F.EnableL4ILBZonalAffinity
+			flags.F.EnableL4ILBZonalAffinity = tc.withZonalAffinityEnabled
+			defer func() {
+				flags.F.EnableL4ILBZonalAffinity = oldFlag
+			}()
 			result := backendSvcEqual(tc.newBackendService, tc.oldBackendService, tc.compareConnectionTracking)
 			if result != tc.wantEqual {
 				t.Errorf("backendSvcEqual() returned %v, expected %v. Diff(oldScv, newSvc): %s",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -908,3 +908,33 @@ func GetDomainFromGABasePath(basePath string) string {
 	domain = strings.TrimSuffix(domain, "/compute/v1")
 	return domain
 }
+
+// FilterAPIversionFromResourcePath removes the /v1 /beta /alpha from the resource path
+func FilterAPIversionFromResourcePath(url string) string {
+	computeIndex := strings.Index(url, "/compute/")
+	if computeIndex == -1 {
+		return url
+	}
+
+	pathStartIndex := computeIndex + len("/compute/")
+
+	// if the URL ends with "/compute/" there is no version to remove
+	if pathStartIndex >= len(url) {
+		return url
+	}
+
+	baseUrlPart := url[:pathStartIndex]
+	pathAfterCompute := url[pathStartIndex:]
+
+	firstSlashIndex := strings.Index(pathAfterCompute, "/")
+	if firstSlashIndex == -1 {
+		// This case would mean the url is something like ".../compute/v1", without a resource path.
+		// in this case with return the first part of the url ".../compute/"
+		return baseUrlPart
+	}
+
+	// reconstruct the URL removing the version segment
+	resourcePathPart := pathAfterCompute[firstSlashIndex+1:]
+
+	return baseUrlPart + resourcePathPart
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1754,3 +1754,49 @@ func TestGetDomainFromGABasePath(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterAPIversionFromResourcePath(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		desc     string
+		basePath string
+		want     string
+	}{
+		{
+			desc: "empty string",
+		},
+		{
+			desc:     "v1 URL",
+			basePath: "https://www.googleapis.com/compute/v1/projects/my-project/global/backendServices/my-bs",
+			want:     "https://www.googleapis.com/compute/projects/my-project/global/backendServices/my-bs",
+		},
+		{
+			desc:     "beta URL",
+			basePath: "https://www.googleapis.com/compute/beta/projects/my-project/zones/us-central1-a/instanceGroups/my-ig",
+			want:     "https://www.googleapis.com/compute/projects/my-project/zones/us-central1-a/instanceGroups/my-ig",
+		},
+		{
+			desc:     "arbitrary path",
+			basePath: "mycompute.mydomain.com/mypath/compute/v1/abc/def",
+			want:     "mycompute.mydomain.com/mypath/compute/abc/def",
+		},
+		{
+			desc:     "path without compute",
+			basePath: "https://www.googleapis.com/storage/v1/b/my-bucket",
+			want:     "https://www.googleapis.com/storage/v1/b/my-bucket",
+		},
+		{
+			desc:     "path ends after version",
+			basePath: "https://www.googleapis.com/compute/v1/",
+			want:     "https://www.googleapis.com/compute/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := FilterAPIversionFromResourcePath(tc.basePath); got != tc.want {
+				t.Errorf("FilterAPIversionFromResourcePath(%q) = %q, want %q", tc.basePath, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR refactors the equality check between backend services (backendSvcEqual) to correctly handle health check links that may have been generated using different API versions (e.g., v1, beta).

Previously, the comparison was done on the full health check URL. This caused a mismatch if the existing backend service referenced a health check with a beta link while the controller generated an expected link using the GA API (v1), even though both URLs pointed to the exact same GCP resource. This would trigger unnecessary and redundant BackendService.Update calls.

This change makes the comparison logic for BackendService HealthCheks more robust by removing the API version from the health check links ensuring that we only compare the resource's identity.

A new utility function utils.FilterAPIversionFromResourcePath has been added. It takes a full resource URL (e.g., https://www.googleapis.com/compute/v1/...) and filters out the version API (e.g., https://www.googleapis.com/compute/projects/my-project/global/healthChecks/...).

The backendSvcEqual function now uses a new comparing function to convert both the new and old health check URL slices into slices without the API version.