### PR TITLE
Add validation for health check source CIDRs and refactor related functions

### DIFF
--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -61,7 +61,10 @@ func newFirewallController() (*FirewallController, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controller context: %v", err)
 	}
-	fwc := NewFirewallController(ctx, []string{"30000-32767"}, false, false, true, make(chan struct{}), klog.TODO())
+	fwc, err := NewFirewallController(ctx, []string{"30000-32767"}, false, false, true, make(chan struct{}), klog.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize firewall controller: %v", err)
+	}
 	fwc.hasSynced = func() bool { return true }
 
 	return fwc, nil
@@ -221,7 +224,10 @@ func TestLBSourceRanges(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			got := lbSourceRanges(klog.TODO(), tc.overrideRanges)
+			got, err := lbSourceRanges(klog.TODO(), tc.overrideRanges)
+			if err != nil {
+				t.Fatalf("lbSourceRanges(%q) returned error: %v", tc.overrideRanges, err)
+			}
 			sort.Strings(got)
 			sort.Strings(tc.want)
 			if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/config"
 	leaderelectionconfig "k8s.io/component-base/config/options"
+	"k8s.io/ingress-gce/pkg/validation"
 	"k8s.io/klog/v2"
 )
 
@@ -350,7 +351,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NetLBForwardingRulesOptimizations, "enable-l4netlb-forwarding-rules-optimizations", false, "Enable optimized processing of forwarding rules for L4 NetLB.")
 	flag.BoolVar(&F.EnableIPV6OnlyNEG, "enable-ipv6-only-neg", false, "Enable support for IPV6 Only NEG's.")
 	flag.StringVar(&F.MultiProjectOwnerLabelKey, "multi-project-owner-label-key", "multiproject.gke.io/owner", "The label key for multi-project owner, which is used to identify the owner of objects in multi-project mode.")
-	flag.StringVar(&F.OverrideHealthCheckSourceCIDRs, "override-health-check-src-cidrs", "", "Overrides the default source IP ranges used when configuring firewall rules to allow health check probes for L7 load balancers. Provide the ranges as a comma-separated list of CIDRs.")
+	flag.StringVar(&F.OverrideHealthCheckSourceCIDRs, "override-health-check-src-cidrs", "", "Overrides the default source IP ranges used when configuring firewall rules to allow health check probes for L7 load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-health-check-src-cidrs=130.211.0.0/22,35.191.0.0/16")
 }
 
 func Validate() {
@@ -361,6 +362,10 @@ func Validate() {
 	// There is no information available whether --transparent-health-checks-port is set, but it is certainly set if F.THCPort stores a non-default value.
 	if F.THCPort != 7877 && !F.EnableTransparentHealthChecks {
 		klog.Fatalf("The flag --transparent-health-checks-port cannot be used without --enable-transparent-health-checks.")
+	}
+
+	if err := validation.ValidateHealthCheckSourceCIDRs(F.OverrideHealthCheckSourceCIDRs); err != nil {
+		klog.Fatalf("Invalid --override-health-check-src-cidrs flag: %v", err)
 	}
 }
 

--- a/pkg/validation/cidr.go
+++ b/pkg/validation/cidr.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ValidateHealthCheckSourceCIDRs validates a comma-separated string of CIDR ranges.
+// This is a convenience function that calls ParseHealthCheckSourceCIDRs and discards
+// the result, only returning validation errors.
+func ValidateHealthCheckSourceCIDRs(cidrsInput string) error {
+	_, err := ParseHealthCheckSourceCIDRs(cidrsInput)
+	return err
+}
+
+// ParseHealthCheckSourceCIDRs parses a comma-separated string of CIDR ranges
+// and returns a slice of valid CIDR strings. It trims whitespace and validates
+// each CIDR using net.ParseCIDR.
+func ParseHealthCheckSourceCIDRs(cidrsInput string) ([]string, error) {
+	if cidrsInput == "" {
+		return nil, nil
+	}
+
+	cidrs := strings.Split(cidrsInput, ",")
+	var result []string
+
+	for _, cidr := range cidrs {
+		trimmed := strings.TrimSpace(cidr)
+
+		if err := ValidateCIDR(trimmed); err != nil {
+			return nil, fmt.Errorf("invalid CIDR format %q: %v", trimmed, err)
+		}
+
+		result = append(result, trimmed)
+	}
+
+	return result, nil
+}
+
+// ValidateCIDR validates that a string is a valid CIDR range using net.ParseCIDR.
+func ValidateCIDR(cidr string) error {
+	_, _, err := net.ParseCIDR(cidr)
+	return err
+}

--- a/pkg/validation/cidr_test.go
+++ b/pkg/validation/cidr_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseHealthCheckSourceCIDRs(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		want      []string
+		wantError bool
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single valid CIDR",
+			input: "192.168.1.0/24",
+			want:  []string{"192.168.1.0/24"},
+		},
+		{
+			name:  "multiple valid CIDRs",
+			input: "130.211.0.0/22,35.191.0.0/16",
+			want:  []string{"130.211.0.0/22", "35.191.0.0/16"},
+		},
+		{
+			name:  "multiple valid CIDRs with spaces",
+			input: "130.211.0.0/22, 35.191.0.0/16",
+			want:  []string{"130.211.0.0/22", "35.191.0.0/16"},
+		},
+		{
+			name:  "valid IPv6 CIDR",
+			input: "2001:db8::/32",
+			want:  []string{"2001:db8::/32"},
+		},
+		{
+			name:  "mixed IPv4 and IPv6 CIDRs",
+			input: "192.168.1.0/24,2001:db8::/32",
+			want:  []string{"192.168.1.0/24", "2001:db8::/32"},
+		},
+		{
+			name:  "multiple IPv6 CIDRs",
+			input: "2001:db8::/32,fe80::/64",
+			want:  []string{"2001:db8::/32", "fe80::/64"},
+		},
+		{
+			name:  "IPv6 CIDRs with spaces",
+			input: "2001:db8::/32, fe80::/64",
+			want:  []string{"2001:db8::/32", "fe80::/64"},
+		},
+		{
+			name:  "IPv6 with different prefix lengths",
+			input: "2001:db8::/48,::1/128",
+			want:  []string{"2001:db8::/48", "::1/128"},
+		},
+		{
+			name:  "IPv6 loopback CIDR",
+			input: "::1/128",
+			want:  []string{"::1/128"},
+		},
+		{
+			name:  "IPv6 link-local CIDR",
+			input: "fe80::/64",
+			want:  []string{"fe80::/64"},
+		},
+		{
+			name:  "IPv6 multicast CIDR",
+			input: "ff00::/8",
+			want:  []string{"ff00::/8"},
+		},
+		{
+			name:  "mixed IPv4, IPv6 with spaces",
+			input: "192.168.1.0/24, 2001:db8::/32, fe80::/64",
+			want:  []string{"192.168.1.0/24", "2001:db8::/32", "fe80::/64"},
+		},
+		{
+			name:      "empty CIDR entries cause error",
+			input:     "192.168.1.0/24,,35.191.0.0/16",
+			wantError: true,
+		},
+		{
+			name:      "trailing comma causes error",
+			input:     "192.168.1.0/24,",
+			wantError: true,
+		},
+		{
+			name:      "leading comma causes error",
+			input:     ",192.168.1.0/24",
+			wantError: true,
+		},
+		{
+			name:      "multiple spaces and commas cause error",
+			input:     " 192.168.1.0/24 , , 35.191.0.0/16 ",
+			wantError: true,
+		},
+		// Error cases
+		{
+			name:      "single IP without netmask",
+			input:     "192.168.1.1",
+			wantError: true,
+		},
+		{
+			name:      "invalid IP address",
+			input:     "300.300.300.300/24",
+			wantError: true,
+		},
+		{
+			name:      "invalid netmask",
+			input:     "192.168.1.0/33",
+			wantError: true,
+		},
+		{
+			name:      "invalid CIDR format",
+			input:     "not-an-ip/24",
+			wantError: true,
+		},
+		{
+			name:      "valid and invalid CIDRs mixed",
+			input:     "192.168.1.0/24,invalid-cidr",
+			wantError: true,
+		},
+		{
+			name:      "IPv6 single IP without netmask",
+			input:     "2001:db8::1",
+			wantError: true,
+		},
+		{
+			name:      "invalid IPv6 address",
+			input:     "gggg::/32",
+			wantError: true,
+		},
+		{
+			name:      "invalid IPv6 netmask",
+			input:     "2001:db8::/129",
+			wantError: true,
+		},
+		{
+			name:      "invalid IPv6 format",
+			input:     "2001:db8:::/32",
+			wantError: true,
+		},
+		{
+			name:      "valid IPv4 and invalid IPv6 mixed",
+			input:     "192.168.1.0/24,2001:db8:::/32",
+			wantError: true,
+		},
+		{
+			name:      "valid IPv6 and invalid IPv4 mixed",
+			input:     "2001:db8::/32,300.300.300.300/24",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseHealthCheckSourceCIDRs(tc.input)
+			if (err != nil) != tc.wantError {
+				t.Errorf("ParseHealthCheckSourceCIDRs(%q) expected error=%v, got error=%v", tc.input, tc.wantError, err != nil)
+			}
+			if err == nil {
+				if diff := cmp.Diff(tc.want, got); diff != "" {
+					t.Errorf("ParseHealthCheckSourceCIDRs(%q) returned diff (-want +got):\n%s", tc.input, diff)
+				}
+			}
+
+			validateErr := ValidateHealthCheckSourceCIDRs(tc.input)
+			if (validateErr != nil) != tc.wantError {
+				t.Errorf("ValidateHealthCheckSourceCIDRs(%q) expected error=%v, got error=%v", tc.input, tc.wantError, validateErr != nil)
+			}
+		})
+	}
+}
+
+func TestValidateCIDR(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{
+			name:  "valid IPv4 CIDR",
+			input: "192.168.1.0/24",
+		},
+		{
+			name:  "valid IPv6 CIDR",
+			input: "2001:db8::/32",
+		},
+		{
+			name:      "invalid IPv4 CIDR",
+			input:     "192.168.1.0/33",
+			wantError: true,
+		},
+		{
+			name:      "invalid IPv6 CIDR",
+			input:     "2001:db8::/129",
+			wantError: true,
+		},
+		{
+			name:      "IP without netmask",
+			input:     "192.168.1.1",
+			wantError: true,
+		},
+		{
+			name:      "invalid format",
+			input:     "not-an-ip/24",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDR(tc.input)
+			if (err != nil) != tc.wantError {
+				t.Errorf("ValidateCIDR(%q) expected error=%v, got error=%v", tc.input, tc.wantError, err != nil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Introduced `validateHealthCheckSourceCIDRs` function to validate CIDR format for health check source ranges.
- Refactored `lbSourceRanges` to utilize a new `parseOverrideRanges` function for better clarity and validation.
- Added `isValidIPRange` function to check the validity of IP ranges.
- Created unit tests for health check source CIDR validation in `flags_test.go`.

/assign @gauravkghildiyal 
/cc @bowei 