### PR TITLE
This PR introduces three new folders inside the cmd directory.

### DIFF
--- a/Dockerfile.ingress-controller-e2e-test
+++ b/Dockerfile.ingress-controller-e2e-test
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check End of Life Date wiki.debian.org/DebianReleases
+# and replace with a new one if needed
+# debian_component_based google-cloud-cli image supports arm64/amd64 architectures
+# and has curl, gcloud, and ca-certificated preinstalled
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:debian_component_based
+
+ARG TARGETARCH
+ADD bin/${TARGETARCH}/ingress-controller-e2e-test /ingress-controller-e2e-test
+COPY cmd/ingress-controller-e2e-test/run.sh /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.neg-e2e-test
+++ b/Dockerfile.neg-e2e-test
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check End of Life Date wiki.debian.org/DebianReleases
+# and replace with a new one if needed
+# debian_component_based google-cloud-cli image supports arm64/amd64 architectures
+# and has curl, gcloud, and ca-certificated preinstalled
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:debian_component_based
+
+ARG TARGETARCH
+ADD bin/${TARGETARCH}/neg-e2e-test /neg-e2e-test
+COPY cmd/neg-e2e-test/run.sh /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.psc-e2e-test
+++ b/Dockerfile.psc-e2e-test
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check End of Life Date wiki.debian.org/DebianReleases
+# and replace with a new one if needed
+# debian_component_based google-cloud-cli image supports arm64/amd64 architectures
+# and has curl, gcloud, and ca-certificated preinstalled
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:debian_component_based
+
+ARG TARGETARCH
+ADD bin/${TARGETARCH}/psc-e2e-test /psc-e2e-test
+COPY cmd/psc-e2e-test/run.sh /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ CONTAINER_BINARIES ?= \
 	404-server \
 	404-server-with-metrics \
 	e2e-test \
+	neg-e2e-test \
+	psc-e2e-test \
+	ingress-controller-e2e-test \
 	echo \
 	fuzzer \
 	glbc \

--- a/cmd/ingress-controller-e2e-test/affinity_beta_test.go
+++ b/cmd/ingress-controller-e2e-test/affinity_beta_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfigbeta "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestAffinityBeta(t *testing.T) {
+	t.Parallel()
+
+	affinityTransitions := []affinityTransition{
+		// "http with cookie based affinity."
+		{affinity: "GENERATED_COOKIE"},
+		// no affinity
+		{affinity: "NONE"},
+		// http with cookie based affinity and 60s ttl.
+		{affinity: "GENERATED_COOKIE", ttl: 60},
+		// client ip affinity.
+		{affinity: "CLIENT_IP"},
+	}
+
+	Framework.RunWithSandbox("affinity-v1beta1", t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+		ctx := context.Background()
+
+		backendConfigAnnotation := map[string]string{
+			annotations.BetaBackendConfigKey: `{"default":"backendconfigbeta"}`,
+		}
+		affinityType := "CLIENT_IP"
+		beConfig := &backendconfigbeta.BackendConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "backendconfigbeta",
+			},
+			Spec: backendconfigbeta.BackendConfigSpec{
+				SessionAffinity: &backendconfigbeta.SessionAffinityConfig{
+					AffinityType: affinityType,
+				},
+			},
+		}
+		if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Create(context.TODO(), beConfig, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("CloudV1beta1().BackendConfigs(%q).Create(%#v) = %v, want nil", s.Namespace, beConfig, err)
+		}
+		t.Logf("BackendConfig created (%s/%s) ", s.Namespace, beConfig.Name)
+
+		svcName := "service-1"
+		_, err := e2e.CreateEchoService(s, svcName, backendConfigAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(_, %q, %q) = %v, want nil", svcName, backendConfigAnnotation, err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+		ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			AddPath("test.com", "/", svcName, networkingv1.ServiceBackendPort{Number: 80}).
+			Build()
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("crud.Create(%#v) = %v, want nil", ing, err)
+		}
+		ingKey := fmt.Sprintf("%s/%s", s.Namespace, ing.Name)
+		t.Logf("Ingress created (%s)", ingKey)
+
+		ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+		if err != nil {
+			t.Fatalf("e2e.WaitForIngress(_, %q, nil) = %v, want nil", ingKey, err)
+		}
+		t.Logf("GCLB resources created (%s)", ingKey)
+
+		vip := ing.Status.LoadBalancer.Ingress[0].IP
+		t.Logf("Ingress %s VIP = %s", ingKey, vip)
+
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+		gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("fuzz.GCLBForVIP(_, _, %q) = %v, want nil; fail to get GCP resources for LB with IP(%q)", vip, err, vip)
+		}
+
+		// Check conformity.
+		if err := verifyAffinity(gclb, s.Namespace, svcName, affinityType, 0); err != nil {
+			t.Error(err)
+		}
+
+		for _, transition := range affinityTransitions {
+			t.Run(fmt.Sprintf("%v", transition), func(t *testing.T) {
+				// Test modifications.
+				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					bc, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Get(context.TODO(), beConfig.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if bc.Spec.SessionAffinity == nil {
+						bc.Spec.SessionAffinity = &backendconfigbeta.SessionAffinityConfig{}
+					}
+					bc.Spec.SessionAffinity.AffinityType = transition.affinity
+					bc.Spec.SessionAffinity.AffinityCookieTtlSec = &transition.ttl
+					_, err = Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(s.Namespace).Update(context.TODO(), bc, metav1.UpdateOptions{})
+					return err
+				}); err != nil {
+					t.Errorf("CloudV1beta1().BackendConfigs(%q).Update(%#v) = %v, want nil", s.Namespace, transition, err)
+				}
+				var logicErr error
+				if waitErr := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+					gclb, logicErr = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+					if logicErr != nil {
+						t.Logf("Error getting GCP resources for LB with IP(%q): %v", vip, logicErr)
+						return false, nil
+					}
+					if logicErr = verifyAffinity(gclb, s.Namespace, svcName, transition.affinity, transition.ttl); logicErr != nil {
+						return false, nil
+					}
+					return true, nil
+				}); waitErr != nil {
+					t.Errorf("Error waiting for BackendConfig affinity transition propagation to GCLB, last seen error: %v", logicErr)
+				}
+			})
+		}
+
+		// Wait for GCLB resources to be deleted.
+		if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+			t.Errorf("crud.Delete(%q) = %v, want nil", ingKey, err)
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		t.Logf("Waiting for GCLB resources to be deleted (%s)", ingKey)
+		if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForGCLBDeletion(_, _, %q, %#v) = %v, want nil", gclb.VIP, deleteOptions, err)
+		}
+		t.Logf("GCLB resources deleted (%s)", ingKey)
+	})
+}

--- a/cmd/ingress-controller-e2e-test/affinity_test.go
+++ b/cmd/ingress-controller-e2e-test/affinity_test.go
@@ -1,0 +1,475 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	transitionPollTimeout  = 15 * time.Minute
+	transitionPollInterval = 30 * time.Second
+)
+
+type affinityTransition struct {
+	affinity string
+	ttl      int64
+}
+
+func TestAffinity(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc       string
+		ttl        int64
+		expect     string
+		transition affinityTransition
+		beConfig   *backendconfig.BackendConfig
+	}{
+		{
+			desc:       "http with no affinity.",
+			beConfig:   fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			expect:     "NONE",
+			transition: affinityTransition{"CLIENT_IP", 10},
+		},
+		{
+			desc: "http with cookie based affinity.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			transition: affinityTransition{"NONE", 20},
+		},
+		{
+			desc: "http with cookie based affinity and 60s ttl.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				SetAffinityCookieTtlSec(60).
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			ttl:        60,
+			transition: affinityTransition{"CLIENT_IP", 30},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Check conformity
+			if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.expect, tc.ttl); err != nil {
+				t.Error(err)
+			}
+
+			// Test modifications
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				if bc.Spec.SessionAffinity == nil {
+					bc.Spec.SessionAffinity = &backendconfig.SessionAffinityConfig{}
+				}
+				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
+				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("Failed to update BackendConfig affinity settings for %s: %v", t.Name(), err)
+			}
+
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.transition.affinity, tc.transition.ttl); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Errorf("error waiting for BackendConfig affinity transition propagation to GCLB: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+// Session affinity test for L7-ILB
+// Named without "Affinity" to avoid running this test accidentally
+func TestILBSA(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc       string
+		ttl        int64
+		expect     string
+		transition affinityTransition
+		beConfig   *backendconfig.BackendConfig
+	}{
+		{
+			desc:       "http with no affinity.",
+			beConfig:   fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			expect:     "NONE",
+			transition: affinityTransition{"CLIENT_IP", 0},
+		},
+		{
+			desc: "http with cookie based affinity.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			transition: affinityTransition{"NONE", 0},
+		},
+		{
+			desc: "http with cookie based affinity and 60s ttl.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				SetAffinityCookieTtlSec(60).
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			ttl:        60,
+			transition: affinityTransition{"CLIENT_IP", 0},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey:     negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				ConfigureForILB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Check conformity
+			if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.expect, tc.ttl); err != nil {
+				t.Error(err)
+			}
+
+			// Test modifications
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				if bc.Spec.SessionAffinity == nil {
+					bc.Spec.SessionAffinity = &backendconfig.SessionAffinityConfig{}
+				}
+				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
+				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("Failed to update BackendConfig affinity settings for %s: %v", t.Name(), err)
+			}
+
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.transition.affinity, tc.transition.ttl); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Errorf("error waiting for BackendConfig affinity transition propagation to GCLB: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+// Session affinity test for L7 Regional XLB.
+func TestRegionalXLBSA(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc       string
+		ttl        int64
+		expect     string
+		transition affinityTransition
+		beConfig   *backendconfig.BackendConfig
+	}{
+		{
+			desc:       "http with no affinity.",
+			beConfig:   fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			expect:     "NONE",
+			transition: affinityTransition{"CLIENT_IP", 10},
+		},
+		{
+			desc: "http with cookie based affinity.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			transition: affinityTransition{"NONE", 20},
+		},
+		{
+			desc: "http with cookie based affinity and 60s ttl.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetSessionAffinity("GENERATED_COOKIE").
+				SetAffinityCookieTtlSec(60).
+				Build(),
+			expect:     "GENERATED_COOKIE",
+			ttl:        60,
+			transition: affinityTransition{"CLIENT_IP", 30},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey:     negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Check conformity
+			if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.expect, tc.ttl); err != nil {
+				t.Error(err)
+			}
+
+			// Test modifications
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				if bc.Spec.SessionAffinity == nil {
+					bc.Spec.SessionAffinity = &backendconfig.SessionAffinityConfig{}
+				}
+				bc.Spec.SessionAffinity.AffinityType = tc.transition.affinity
+				bc.Spec.SessionAffinity.AffinityCookieTtlSec = &tc.transition.ttl
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("Failed to update BackendConfig affinity settings for %s: %v", t.Name(), err)
+			}
+
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyAffinity(gclb, s.Namespace, "service-1", tc.transition.affinity, tc.transition.ttl); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Errorf("error waiting for BackendConfig affinity transition propagation to GCLB: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyAffinity(gclb *fuzz.GCLB, svcNamespace, svcName, expect string, ttl int64) error {
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.Beta.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		if bs.GA.SessionAffinity != expect {
+			return fmt.Errorf("Backend Service %s verifyAffinity(..., %q, %q, ...) = %s, want %s (SessionAffinity)", bs.GA.Name,
+				svcNamespace, svcName, bs.GA.SessionAffinity, expect)
+		}
+		if bs.GA.AffinityCookieTtlSec != ttl {
+			return fmt.Errorf("Backend Service %s verifyAffinity(..., %q, %q, ...) = %v, want %v (AffinityCookieTtlSec)", bs.GA.Name,
+				svcNamespace, svcName, bs.GA.AffinityCookieTtlSec, ttl)
+		}
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/app_protocols_test.go
+++ b/cmd/ingress-controller-e2e-test/app_protocols_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestAppProtocol(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc          string
+		annotationVal string
+	}{
+		{
+			desc:          "https",
+			annotationVal: `{"https-port":"HTTPS"}`,
+		},
+		{
+			desc:          "http2",
+			annotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestAppProtocolTransition(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc             string
+		annotationVal    string
+		newAnnotationVal string
+	}{
+		{
+			desc:             "https",
+			annotationVal:    `{"https-port":"HTTPS"}`,
+			newAnnotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+			}
+			_, err := e2e.EnsureEchoService(s, "service-1", svcAnnotation, corev1.ServiceTypeNodePort, 1)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			_, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Update the service with the new app protocol.
+			svcAnnotation = map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.newAnnotationVal,
+			}
+
+			if _, err = e2e.EnsureEchoService(s, "service-1", svcAnnotation, corev1.ServiceTypeNodePort, 1); err != nil {
+				t.Fatalf("Error updating echo service: %v", err)
+			}
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestRegionalXLBAppProtocol(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc          string
+		annotationVal string
+	}{
+		{
+			desc:          "https",
+			annotationVal: `{"https-port":"HTTPS"}`,
+		},
+		{
+			desc:          "http2",
+			annotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.GoogleServiceApplicationProtocolKey: tc.annotationVal,
+				annotations.NEGAnnotationKey:                    negVal.String(),
+			}
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestRegionalXLBProtocolTransition(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc             string
+		annotationVal    string
+		newAnnotationVal string
+	}{
+		{
+			desc:             "https",
+			annotationVal:    `{"https-port":"HTTPS"}`,
+			newAnnotationVal: `{"https-port":"HTTP2"}`,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.annotationVal,
+				annotations.NEGAnnotationKey:              negVal.String(),
+			}
+			_, err := e2e.EnsureEchoService(s, "service-1", svcAnnotation, corev1.ServiceTypeNodePort, 1)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Name: "https-port"}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			_, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Update the service with the new app protocol.
+			svcAnnotation = map[string]string{
+				annotations.ServiceApplicationProtocolKey: tc.newAnnotationVal,
+				annotations.NEGAnnotationKey:              negVal.String(),
+			}
+
+			if _, err = e2e.EnsureEchoService(s, "service-1", svcAnnotation, corev1.ServiceTypeNodePort, 1); err != nil {
+				t.Fatalf("Error updating echo service: %v", err)
+			}
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/backend_config_test.go
+++ b/cmd/ingress-controller-e2e-test/backend_config_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfigv1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	backendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/backendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/test"
+)
+
+var (
+	eventPollInterval = 15 * time.Second
+	eventPollTimeout  = 10 * time.Minute
+)
+
+func TestBackendConfigNegatives(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc           string
+		svcAnnotations map[string]string
+		backendConfig  *backendconfigv1.BackendConfig
+		secretName     string
+		expectedMsg    string
+	}{
+		{
+			desc: "backend config not exist",
+			svcAnnotations: map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			},
+			expectedMsg: "no BackendConfig",
+		},
+		{
+			desc: "invalid format in backend config annotation",
+			svcAnnotations: map[string]string{
+				annotations.BetaBackendConfigKey: `invalid`,
+			},
+			expectedMsg: fmt.Sprintf("%v", annotations.ErrBackendConfigInvalidJSON),
+		},
+		{
+			desc: "enable both IAP and CDN in backend config",
+			svcAnnotations: map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			},
+			backendConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				EnableCDN(true).
+				SetIAPConfig(true, "bar").
+				Build(),
+			secretName:  "bar",
+			expectedMsg: "iap and cdn cannot be enabled at the same time",
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			if tc.backendConfig != nil {
+				tc.backendConfig.Namespace = s.Namespace
+				bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+				if _, err := bcCRUD.Create(tc.backendConfig); err != nil {
+					t.Fatalf("Error creating backend config: %v", err)
+				}
+				t.Logf("Backend config %s/%s created", s.Namespace, tc.backendConfig.Name)
+			}
+
+			if tc.secretName != "" {
+				if _, err := e2e.CreateSecret(s, tc.secretName,
+					map[string][]byte{
+						"client_id":     []byte("my-id"),
+						"client_secret": []byte("my-secret"),
+					}); err != nil {
+					t.Fatalf("Error creating secret %q: %v", tc.secretName, err)
+				}
+			}
+
+			if _, err := e2e.CreateEchoService(s, "service-1", tc.svcAnnotations); err != nil {
+				t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", tc.svcAnnotations, err)
+			}
+
+			port80 := networkingv1.ServiceBackendPort{Number: 80}
+			testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", port80).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			testIng, err := crud.Create(testIng)
+			if err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
+
+			t.Logf("Waiting %v for warning event to be emitted", eventPollTimeout)
+			if err := wait.Poll(eventPollInterval, eventPollTimeout, func() (bool, error) {
+				events, err := Framework.Clientset.CoreV1().Events(s.Namespace).List(context.TODO(), metav1.ListOptions{})
+				if err != nil {
+					return false, fmt.Errorf("error in listing events: %s", err)
+				}
+				for _, event := range events.Items {
+					if event.InvolvedObject.Kind != "Ingress" ||
+						event.InvolvedObject.Name != "ingress-1" ||
+						event.Type != v1.EventTypeWarning {
+						continue
+					}
+					if strings.Contains(event.Message, tc.expectedMsg) {
+						t.Logf("Warning event emitted")
+						return true, nil
+					}
+				}
+				t.Logf("No warning event is emitted yet")
+				return false, nil
+			}); err != nil {
+				t.Fatalf("error waiting for BackendConfig warning event: %v", err)
+			}
+
+			testIng, err = crud.Get(s.Namespace, testIng.Name)
+			if err != nil {
+				t.Fatalf("error retrieving Ingress %q: %v", testIng.Name, err)
+			}
+			if len(testIng.Status.LoadBalancer.Ingress) > 0 {
+				t.Fatalf("Ingress should not have an IP: %+v", testIng.Status)
+			}
+		})
+	}
+}
+
+// TestBackendConfigAPI creates a backend config resource with v1 API and
+// retrieves it with the v1beta1 API clientset. Also, tests v1beta1 => v1.
+func TestBackendConfigAPI(t *testing.T) {
+	t.Parallel()
+	pstring := func(x string) *string { return &x }
+	Framework.RunWithSandbox("API conversion", t, func(t *testing.T, s *e2e.Sandbox) {
+		backendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "bc1").
+			SetSessionAffinity("GENERATED_COOKIE").SetAffinityCookieTtlSec(60).
+			EnableCDN(true).
+			SetCachePolicy(&backendconfigv1.CacheKeyPolicy{
+				IncludeHost:        true,
+				IncludeProtocol:    false,
+				IncludeQueryString: true,
+			}).
+			AddCustomRequestHeader("X-Client-Geo-Location:{client_region},{client_city}").
+			SetConnectionDrainingTimeout(60).
+			SetIAPConfig(true, "bar").
+			SetSecurityPolicy("secpol1").SetTimeout(42).Build()
+		backendConfig.Spec.HealthCheck = &backendconfigv1.HealthCheckConfig{
+			CheckIntervalSec:   test.Int64ToPtr(7),
+			TimeoutSec:         test.Int64ToPtr(3),
+			HealthyThreshold:   test.Int64ToPtr(3),
+			UnhealthyThreshold: test.Int64ToPtr(5),
+			Port:               test.Int64ToPtr(8080),
+			RequestPath:        pstring("/my-path"),
+		}
+		bcKey := fmt.Sprintf("%s/%s", backendConfig.Namespace, backendConfig.Name)
+		bcData, err := json.Marshal(backendConfig)
+		if err != nil {
+			t.Fatalf("Failed to marshall backendconfig %s: %v", bcKey, err)
+		}
+		v1beta1BackendConfig := &backendconfigv1beta1.BackendConfig{}
+		if err := json.Unmarshal(bcData, v1beta1BackendConfig); err != nil {
+			t.Fatalf("Failed to unmarshal backendconfig %s into v1beta1: %v", bcKey, err)
+		}
+
+		// Create BackendConfig using v1 API and retrieve it using v1beta1 API.
+		v1BcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		if _, err := v1BcCRUD.Create(backendConfig); err != nil {
+			t.Fatalf("Error creating v1 backendconfig %s: %v", bcKey, err)
+		}
+		t.Logf("BackendConfig %s created using V1 API", bcKey)
+		gotV1beta1BC, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(backendConfig.Namespace).
+			Get(context.Background(), backendConfig.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error getting v1beta1 backendconfig %s: %v", bcKey, err)
+		}
+
+		if diff := cmp.Diff(v1beta1BackendConfig.Spec, gotV1beta1BC.Spec); diff != "" {
+			t.Fatalf("Unexpected v1beta1 backendconfig spec (-want +got):\n%s", diff)
+		}
+		// Create BackendConfig using v1beta1 API and retrieve it using v1 API.
+		backendConfig.Name = "bc2"
+		v1beta1BackendConfig.Name = backendConfig.Name
+		bcKey = fmt.Sprintf("%s/%s", backendConfig.Namespace, backendConfig.Name)
+		if _, err := Framework.BackendConfigClient.CloudV1beta1().BackendConfigs(v1beta1BackendConfig.Namespace).
+			Create(context.Background(), v1beta1BackendConfig, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Error creating v1beta1 backendconfig %s: %v", bcKey, err)
+		}
+		gotV1BC, err := v1BcCRUD.Get(backendConfig.Namespace, backendConfig.Name)
+		if err != nil {
+			t.Fatalf("Error getting v1 backendconfig %s: %v", bcKey, err)
+		}
+		if diff := cmp.Diff(backendConfig.Spec, gotV1BC.Spec); diff != "" {
+			t.Fatalf("Unexpected v1 backendconfig spec (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestRegionalXLBBackendConfigNegatives(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc           string
+		svcAnnotations map[string]string
+		backendConfig  *backendconfigv1.BackendConfig
+		expectedMsg    string
+	}{
+		{
+			desc: "backend config not exist",
+			svcAnnotations: map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			},
+			expectedMsg: "no BackendConfig",
+		},
+		{
+			desc: "invalid format in backend config annotation",
+			svcAnnotations: map[string]string{
+				annotations.BackendConfigKey: `invalid`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			},
+			expectedMsg: fmt.Sprintf("%v", annotations.ErrBackendConfigInvalidJSON),
+		},
+		{
+			desc: "enable IAP in backend config",
+			svcAnnotations: map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			},
+			backendConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetIAPConfig(true, "bar").
+				Build(),
+			expectedMsg: "IAP configuration is not supported in TPC Environment",
+		},
+		{
+			desc: "enable CDN in backend config",
+			svcAnnotations: map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			},
+			backendConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				EnableCDN(true).
+				Build(),
+			expectedMsg: "CDN configuration is not supported in TPC Environment",
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			if tc.backendConfig != nil {
+				tc.backendConfig.Namespace = s.Namespace
+				bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+				if _, err := bcCRUD.Create(tc.backendConfig); err != nil {
+					t.Fatalf("Error creating backend config: %v", err)
+				}
+				t.Logf("Backend config %s/%s created", s.Namespace, tc.backendConfig.Name)
+			}
+
+			if _, err := e2e.CreateEchoService(s, "service-1", tc.svcAnnotations); err != nil {
+				t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", tc.svcAnnotations, err)
+			}
+
+			port80 := networkingv1.ServiceBackendPort{Number: 80}
+			testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", port80).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			testIng, err := crud.Create(testIng)
+			if err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
+
+			t.Logf("Waiting %v for warning event to be emitted", eventPollTimeout)
+			if err := wait.Poll(eventPollInterval, eventPollTimeout, func() (bool, error) {
+				events, err := Framework.Clientset.CoreV1().Events(s.Namespace).List(context.TODO(), metav1.ListOptions{})
+				if err != nil {
+					return false, fmt.Errorf("error in listing events: %s", err)
+				}
+				for _, event := range events.Items {
+					if event.InvolvedObject.Kind != "Ingress" ||
+						event.InvolvedObject.Name != "ingress-1" ||
+						event.Type != v1.EventTypeWarning {
+						continue
+					}
+					if strings.Contains(event.Message, tc.expectedMsg) {
+						t.Logf("Warning event emitted")
+						return true, nil
+					}
+				}
+				t.Logf("No warning event is emitted yet")
+				return false, nil
+			}); err != nil {
+				t.Fatalf("error waiting for BackendConfig warning event: %v", err)
+			}
+
+			testIng, err = crud.Get(s.Namespace, testIng.Name)
+			if err != nil {
+				t.Fatalf("error retrieving Ingress %q: %v", testIng.Name, err)
+			}
+			if len(testIng.Status.LoadBalancer.Ingress) > 0 {
+				t.Fatalf("Ingress should not have an IP: %+v", testIng.Status)
+			}
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/basic_https_test.go
+++ b/cmd/ingress-controller-e2e-test/basic_https_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestBasicHTTPS(t *testing.T) {
+	t.Parallel()
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc       string
+		ingBuilder *fuzz.IngressBuilder
+		hosts      []string
+		certType   e2e.CertType
+	}{
+		{
+			desc: "http(s) one path via pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				AddPath("test.com", "/", "service-1", port80),
+			hosts:    []string{"test.com"},
+			certType: e2e.GCPCert,
+		},
+		{
+			desc: "http(s) multi-path multi-TLS",
+			ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				AddPath("foo.com", "/", "service-1", port80).
+				AddPath("bar.com", "/", "service-1", port80).
+				AddPath("baz.com", "/", "service-1", port80),
+			hosts:    []string{"foo.com", "bar.com", "baz.com"},
+			certType: e2e.K8sCert,
+		},
+		{
+			desc:  "http(s) multi-path multi-pre-shared cert",
+			hosts: []string{"foo.com", "bar.com", "baz.com"},
+			ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				AddPath("foo.com", "/", "service-1", port80).
+				AddPath("bar.com", "/", "service-1", port80).
+				AddPath("baz.com", "/", "service-1", port80),
+			certType: e2e.GCPCert,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			for i, h := range tc.hosts {
+				name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+				cert, err := e2e.NewCert(name, h, tc.certType, false)
+				if err != nil {
+					t.Fatalf("Error initializing cert: %v", err)
+				}
+				if err := cert.Create(s); err != nil {
+					t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+				}
+				defer cert.Delete(s)
+
+				if tc.certType == e2e.K8sCert {
+					tc.ingBuilder.AddTLS([]string{}, cert.Name)
+				} else {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+			}
+			ing := tc.ingBuilder.Build()
+			ing.Namespace = s.Namespace // namespace depends on sandbox
+
+			_, err := e2e.CreateEchoService(s, "service-1", nil)
+			if err != nil {
+				t.Fatalf("Error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+func TestRegionalXLBHTTPS(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing2-"
+	serviceName := "svc-2"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc       string
+		ingBuilder *fuzz.IngressBuilder
+		hosts      []string
+		certType   e2e.CertType
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "https RXLB one path, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https RXLB one path, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https RXLB multiple paths, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForRegionalXLB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+		{
+			desc: "https RXLB multiple paths, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForRegionalXLB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+
+			for i, h := range tc.hosts {
+				name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+				cert, err := e2e.NewCert(name, h, tc.certType, true)
+				if err != nil {
+					t.Fatalf("Error initializing cert: %v", err)
+				}
+				if err := cert.Create(s); err != nil {
+					t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+				}
+				defer cert.Delete(s)
+
+				if tc.certType == e2e.K8sCert {
+					tc.ingBuilder.AddTLS([]string{}, cert.Name)
+				} else {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+			}
+			ing := tc.ingBuilder.Build()
+			ing.Namespace = s.Namespace // namespace depends on sandbox
+
+			t.Logf("Ingress = %s", ing.String())
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: false,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/basic_test.go
+++ b/cmd/ingress-controller-e2e-test/basic_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+func TestWindows(t *testing.T) {
+	testBasicOS(t, e2e.Windows)
+}
+
+func TestBasic(t *testing.T) {
+	testBasicOS(t, e2e.Linux)
+}
+
+func testBasicOS(t *testing.T, os e2e.OS) {
+	t.Parallel()
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1.Ingress
+	}{
+		{
+			desc: "http default backend",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				DefaultBackend("service-1", port80).
+				Build(),
+		},
+		{
+			desc: "http one path",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/", "service-1", port80).
+				Build(),
+		},
+		{
+			desc: "http multiple paths",
+			ing: fuzz.NewIngressBuilder("", "ingress-1", "").
+				AddPath("test.com", "/foo", "service-1", port80).
+				AddPath("test.com", "/bar", "service-1", port80).
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			_, err := e2e.CreateEchoServiceWithOS(s, "service-1", nil, os)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
+			if _, err = crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TestBasicStaticIP tests that the static-ip annotation works as expected.
+func TestBasicStaticIP(t *testing.T) {
+	ctx := context.Background()
+	t.Parallel()
+
+	Framework.RunWithSandbox("static-ip", t, func(t *testing.T, s *e2e.Sandbox) {
+		_, err := e2e.CreateEchoService(s, "service-1", nil)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(s, service-1, nil) = _, %v; want _, nil", err)
+		}
+
+		addrName := fmt.Sprintf("test-addr-%s", s.Namespace)
+		if err := e2e.NewGCPAddress(s, addrName, ""); err != nil {
+			t.Fatalf("e2e.NewGCPAddress(..., %s) = %v, want nil", addrName, err)
+		}
+		defer e2e.DeleteGCPAddress(s, addrName, "")
+
+		testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", v1.ServiceBackendPort{Number: 80}).
+			AddStaticIP(addrName, false).
+			Build()
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		testIng, err = crud.Create(testIng)
+		if err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
+
+		testIng, err = e2e.WaitForIngress(s, testIng, nil, nil)
+		if err != nil {
+			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
+		}
+		if len(testIng.Status.LoadBalancer.Ingress) < 1 {
+			t.Fatalf("Ingress does not have an IP: %+v", testIng.Status)
+		}
+
+		vip := testIng.Status.LoadBalancer.Ingress[0].IP
+		params := &fuzz.GCLBForVIPParams{
+			VIP:        vip,
+			Validators: fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy}),
+		}
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
+		}
+
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, testIng, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", testIng.Name, err)
+		}
+	})
+
+	// TODO(rramkumar): Add transition
+}
+
+// TestEdge exercises some basic edge cases that previously have caused bugs.
+func TestEdge(t *testing.T) {
+	t.Parallel()
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1.Ingress
+	}{
+		{
+			desc: "long ingress name",
+			ing: fuzz.NewIngressBuilder("", "long-ingress-name", "").
+				DefaultBackend("service-1", port80).
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			_, err := e2e.CreateEchoService(s, "service-1", nil)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace // namespace depends on sandbox
+			if _, err = crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TestFrontendResourceDeletion asserts that unused GCP frontend resources are
+// deleted. This also tests that necessary GCP frontend resources exist.
+func TestFrontendResourceDeletion(t *testing.T) {
+	t.Parallel()
+	port80 := v1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+	host := "foo.com"
+
+	// All the test cases create an ingress with a HTTP + HTTPS load-balancer
+	// at the beginning of the test and turnoff these based on the testcase params.
+	for _, tc := range []struct {
+		desc         string
+		disableHTTP  bool
+		disableHTTPS bool
+	}{
+		// Note that disabling both HTTP & HTTPS would result in a sync error, so excluded.
+		{"http only", false, true},
+		{"https only", true, false},
+	} {
+		tc := tc
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			_, err := e2e.CreateEchoService(s, svcName, nil)
+			if err != nil {
+				t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+			// Create SSL certificate.
+			certName := "cert-1"
+			cert, err := e2e.NewCert(certName, host, e2e.K8sCert, false)
+			if err != nil {
+				t.Fatalf("e2e.NewCert(%q, %q, _, %t) = %v, want nil", certName, host, false, err)
+			}
+			if err := cert.Create(s); err != nil {
+				t.Fatalf("cert.Create(_) = %v, want nil, error creating cert %s", err, cert.Name)
+			}
+			t.Logf("Cert created %s", certName)
+			defer cert.Delete(s)
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ing1", "").
+				AddPath(host, "/", svcName, port80).AddTLS([]string{}, cert.Name).Build()
+			ingKey := common.NamespacedName(ing)
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("crud.Create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+			}
+			t.Logf("Ingress created (%s)", ingKey)
+			if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+				t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+			}
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s, ...)= %v, want nil", ingKey, err)
+			}
+
+			// Update ingress with desired frontend resource configuration.
+			ingBuilder := fuzz.NewIngressBuilderFromExisting(ing)
+			if tc.disableHTTP {
+				ingBuilder = ingBuilder.SetAllowHttp(false)
+			}
+			if tc.disableHTTPS {
+				ingBuilder = ingBuilder.SetTLS(nil)
+			}
+			newIng := ingBuilder.Build()
+
+			if _, err := crud.Patch(ing, newIng); err != nil {
+				t.Fatalf("Patch(%s) = %v, want nil; current ingress: %+v new ingress: %+v", ingKey, err, ing, newIng)
+			}
+			t.Logf("Ingress patched (%s)", ingKey)
+			if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+				t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend:          true,
+				CheckHttpFrontendResources:  tc.disableHTTP,
+				CheckHttpsFrontendResources: tc.disableHTTPS,
+			}
+			// Wait for unused frontend resources to be deleted.
+			if err := e2e.WaitForFrontendResourceDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForFrontendResourceDeletion(..., %q, _) = %v, want nil", ingKey, err)
+			}
+			if _, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s); err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+			}
+
+			expectedVIP := ing.Status.LoadBalancer.Ingress[0].IP
+			// Re-enable http/https and verify that the ingress uses same VIP.
+			if ing, err = crud.Get(ing.Namespace, ing.Name); err != nil {
+				t.Fatalf("crud.Get(%s) = %v, want nil", ingKey, err)
+			}
+			ingBuilder = fuzz.NewIngressBuilderFromExisting(ing)
+			if tc.disableHTTP {
+				ingBuilder = ingBuilder.SetAllowHttp(true)
+			}
+			if tc.disableHTTPS {
+				ingBuilder.SetTLS([]v1.IngressTLS{
+					{
+						Hosts:      []string{},
+						SecretName: cert.Name,
+					},
+				})
+			}
+			newIng = ingBuilder.Build()
+			if _, err := crud.Patch(ing, newIng); err != nil {
+				t.Fatalf("Patch(%s) = %v, want nil; current ingress: %+v new ingress %+v", ingKey, err, ing, newIng)
+			}
+			t.Logf("Ingress patched (%s)", ingKey)
+			if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+				t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+			}
+			if ing, err = e2e.WaitForHTTPResourceAnnotations(s, ing); err != nil {
+				t.Fatalf("error waiting for http annotations on Ingress %s: %v", ingKey, err)
+			}
+
+			gclb, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s, ...)= %v, want nil", ingKey, err)
+			}
+			// Verify that ingress VIP is retained.
+			gotVIP := ing.Status.LoadBalancer.Ingress[0].IP
+			if expectedVIP != gotVIP {
+				t.Fatalf("Two separate VIPs are created. expected %s, got %s", expectedVIP, gotVIP)
+			}
+
+			deleteOptions = &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, _) = %v, want nil", ingKey, err)
+			}
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/cdn_test.go
+++ b/cmd/ingress-controller-e2e-test/cdn_test.go
@@ -1,0 +1,1071 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kr/pretty"
+	"google.golang.org/api/compute/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+const cdnTestPollTimeout = 30 * time.Minute
+
+// TestCDN is for ingress versions before the CDN config was expanded
+func TestCDN(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http one path w/ CDN.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				EnableCDN(true).
+				Build(),
+		},
+		{
+			desc: "http one path w/ CDN & cache policies.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				EnableCDN(true).
+				SetCachePolicy(&backendconfig.CacheKeyPolicy{
+					IncludeHost:        true,
+					IncludeProtocol:    false,
+					IncludeQueryString: true,
+				}).
+				Build(),
+		},
+		{
+			desc: "http one path w/ no CDN.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				EnableCDN(false).
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", networkingv1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// If needed, verify the cache policies were applied.
+			if tc.beConfig.Spec.Cdn.CachePolicy != nil {
+				verifyCachePolicies(t, gclb, s.Namespace, "service-1", tc.beConfig.Spec.Cdn.CachePolicy)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestCdnEnable(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN enabled/disabled tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "cdn disabled",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: false,
+					}).Build(),
+				expected: nil,
+			},
+			{
+				desc: "cdn re-enabled",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+			// disable cdn when backend config is removed is not supported for now
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnCacheMode(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	var (
+		cacheAllStatic   string = "CACHE_ALL_STATIC"
+		useOriginHeaders string = "USE_ORIGIN_HEADERS"
+		forceCacheAll    string = "FORCE_CACHE_ALL"
+	)
+
+	Framework.RunWithSandbox("CDN cache mode tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "update TTLs",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:    true,
+						ClientTtl:  createInt64(1234),
+						DefaultTtl: createInt64(1234),
+						MaxTtl:     createInt64(1234),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = cacheAllStatic
+					cdn.ClientTtl = 1234
+					cdn.DefaultTtl = 1234
+					cdn.MaxTtl = 1234
+				}).build(),
+			},
+			{
+				desc: "update TTLs to zero",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:    true,
+						ClientTtl:  createInt64(0),
+						DefaultTtl: createInt64(0),
+						MaxTtl:     createInt64(0),
+					}).Build(),
+				expected: newBSBuilder().
+					setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+						cdn.CacheMode = cacheAllStatic
+						cdn.ClientTtl = 0
+						cdn.DefaultTtl = 0
+						cdn.MaxTtl = 0
+					}).build(),
+			},
+			{
+				desc: "Update cache mode to,from CACHE_ALL_STATIC to USE_ORIGIN_HEADERS",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &useOriginHeaders,
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = useOriginHeaders
+					cdn.ClientTtl = 0
+					cdn.DefaultTtl = 0
+					cdn.MaxTtl = 0
+				}).build(),
+			},
+			{
+				desc: "Update cache mode to,from USE_ORIGIN_HEADERS to FORCE_CACHE_ALL",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &forceCacheAll,
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = forceCacheAll
+					cdn.MaxTtl = 0
+				}).build(),
+			},
+			{
+				desc: "Update cache mode to,from FORCE_CACHE_ALL to USE_ORIGIN_HEADERS",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &useOriginHeaders,
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = useOriginHeaders
+					cdn.ClientTtl = 0
+					cdn.DefaultTtl = 0
+					cdn.MaxTtl = 0
+				}).build(),
+			},
+			{
+				desc: "Update cache mode to,from USE_ORIGIN_HEADERS to CACHE_ALL_STATIC",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &cacheAllStatic,
+					}).Build(),
+				expected: newBSBuilder().
+					setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+						cdn.CacheMode = cacheAllStatic
+					}).build(),
+			},
+			{
+				desc: "Update cache mode to, from CACHE_ALL_STATIC to FORCE_CACHE_ALL",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &forceCacheAll,
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = forceCacheAll
+					cdn.MaxTtl = 0
+				}).build(),
+			},
+			{
+				desc: "FORCE_CACHE_ALL update TTLs, set to zero",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:    true,
+						CacheMode:  &forceCacheAll,
+						ClientTtl:  createInt64(0),
+						DefaultTtl: createInt64(0),
+						MaxTtl:     createInt64(0),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = forceCacheAll
+					cdn.ClientTtl = 0
+					cdn.DefaultTtl = 0
+					cdn.MaxTtl = 0
+				}).build(),
+			},
+			{
+				desc: "Update cache mode to, from FORCE_CACHE_ALL to CACHE_ALL_STATIC",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:   true,
+						CacheMode: &cacheAllStatic,
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheMode = cacheAllStatic
+				}).build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnCacheKeyPolicy(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN cache key policy tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "custom cache key",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						CachePolicy: &backendconfig.CacheKeyPolicy{
+							IncludeHost:        false,
+							IncludeProtocol:    false,
+							IncludeQueryString: false,
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheKeyPolicy.IncludeHost = false
+					cdn.CacheKeyPolicy.IncludeProtocol = false
+					cdn.CacheKeyPolicy.IncludeQueryString = false
+				}).build(),
+			},
+			{
+				desc: "set white list",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						CachePolicy: &backendconfig.CacheKeyPolicy{
+							IncludeHost:          true,
+							IncludeProtocol:      false,
+							IncludeQueryString:   true,
+							QueryStringWhitelist: []string{"query1", "query2"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheKeyPolicy.IncludeHost = true
+					cdn.CacheKeyPolicy.IncludeProtocol = false
+					cdn.CacheKeyPolicy.IncludeQueryString = true
+					cdn.CacheKeyPolicy.QueryStringWhitelist = []string{"query1", "query2"}
+				}).build(),
+			},
+			{
+				desc: "set black list",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						CachePolicy: &backendconfig.CacheKeyPolicy{
+							IncludeHost:          true,
+							IncludeProtocol:      false,
+							IncludeQueryString:   true,
+							QueryStringBlacklist: []string{"query3", "query4"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheKeyPolicy.IncludeHost = true
+					cdn.CacheKeyPolicy.IncludeProtocol = false
+					cdn.CacheKeyPolicy.IncludeQueryString = true
+					cdn.CacheKeyPolicy.QueryStringBlacklist = []string{"query3", "query4"}
+				}).build(),
+			},
+			{
+				desc: "set IncludeQueryString to false, white list",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						CachePolicy: &backendconfig.CacheKeyPolicy{
+							IncludeHost:          true,
+							IncludeProtocol:      false,
+							IncludeQueryString:   false,
+							QueryStringWhitelist: []string{"query1", "query2"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheKeyPolicy.IncludeHost = true
+					cdn.CacheKeyPolicy.IncludeProtocol = false
+					cdn.CacheKeyPolicy.IncludeQueryString = false
+				}).build(),
+			},
+			{
+				desc: "set IncludeQueryString to false, black list",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						CachePolicy: &backendconfig.CacheKeyPolicy{
+							IncludeHost:          true,
+							IncludeProtocol:      false,
+							IncludeQueryString:   false,
+							QueryStringBlacklist: []string{"query3", "query4"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.CacheKeyPolicy.IncludeHost = true
+					cdn.CacheKeyPolicy.IncludeProtocol = false
+					cdn.CacheKeyPolicy.IncludeQueryString = false
+				}).build(),
+			},
+			{
+				desc: "restore defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnNegativeCaching(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN negative caching tests", t, func(t *testing.T, s *e2e.Sandbox) {
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "negative caching,defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:         true,
+						NegativeCaching: createBool(true),
+						NegativeCachingPolicy: []*backendconfig.NegativeCachingPolicy{
+							{Code: 301, Ttl: 600},
+							{Code: 404, Ttl: 1800},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.NegativeCaching = true
+					cdn.NegativeCachingPolicy = []*compute.BackendServiceCdnPolicyNegativeCachingPolicy{
+						{Code: 301, Ttl: 600},
+						{Code: 404, Ttl: 1800},
+					}
+				}).build(),
+			},
+			{
+				desc: "negative caching,disable",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:         true,
+						NegativeCaching: createBool(false),
+						NegativeCachingPolicy: []*backendconfig.NegativeCachingPolicy{
+							{Code: 301, Ttl: 600},
+							{Code: 404, Ttl: 1800},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.NegativeCaching = false
+				}).build(),
+			},
+			{
+				desc: "negative caching, restore to defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+			})
+		}
+	})
+}
+
+func TestCdnBypassCache(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN bypass cache on request headers tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "bypass cache, set headers",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						BypassCacheOnRequestHeaders: []*backendconfig.BypassCacheOnRequestHeader{
+							{HeaderName: "X-Bypass-Cache-1"},
+							{HeaderName: "X-Bypass-Cache-2"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.BypassCacheOnRequestHeaders = []*compute.BackendServiceCdnPolicyBypassCacheOnRequestHeader{
+						{HeaderName: "X-Bypass-Cache-1"},
+						{HeaderName: "X-Bypass-Cache-2"},
+					}
+				}).build(),
+			},
+			{
+				desc: "bypass cache, update headers",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+						BypassCacheOnRequestHeaders: []*backendconfig.BypassCacheOnRequestHeader{
+							{HeaderName: "X-Bypass-Cache-3"},
+							{HeaderName: "X-Bypass-Cache-4"},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.BypassCacheOnRequestHeaders = []*compute.BackendServiceCdnPolicyBypassCacheOnRequestHeader{
+						{HeaderName: "X-Bypass-Cache-3"},
+						{HeaderName: "X-Bypass-Cache-4"},
+					}
+				}).build(),
+			},
+			{
+				desc: "bypass cache, reset to defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnServeWhileStale(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN serve while stale tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "serve while stale, set",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:         true,
+						ServeWhileStale: createInt64(1234),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.ServeWhileStale = 1234
+				}).build(),
+			},
+			{
+				desc: "serve while stale, update",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:         true,
+						ServeWhileStale: createInt64(4321),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.ServeWhileStale = 4321
+				}).build(),
+			},
+			{
+				desc: "serve while stale, reset to defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnRequestCoalescing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN request coalescing tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "request coalescing, disable",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:           true,
+						RequestCoalescing: createBool(false),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.RequestCoalescing = false
+				}).build(),
+			},
+			{
+				desc: "request coalescing, enable",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:           true,
+						RequestCoalescing: createBool(true),
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.RequestCoalescing = true
+				}).build(),
+			},
+			{
+				desc: "request coalescing, reset to defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+func TestCdnSignedUrls(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName1   = "cdn-service-1"
+		backendconfig1 = "cdn-backendconfig-1"
+		ingressName    = "cdn-ingress-1"
+	)
+
+	Framework.RunWithSandbox("CDN signed urls tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing, err := setupIngress(s, ingressName, serviceName1, backendconfig1)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, tc := range []struct {
+			desc     string
+			beConfig *backendconfig.BackendConfig
+			expected *compute.BackendServiceCdnPolicy
+		}{
+			{
+				desc: "signed url cache max age, set",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:                 true,
+						SignedUrlCacheMaxAgeSec: createInt64(1234),
+						SignedUrlKeys: []*backendconfig.SignedUrlKey{
+							{KeyName: "key1", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+							{KeyName: "key2", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+							{KeyName: "key3", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.SignedUrlCacheMaxAgeSec = 1234
+					cdn.SignedUrlKeyNames = []string{"key1", "key2", "key3"}
+				}).build(),
+			},
+			{
+				desc: "signed url cache max age, update",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled:                 true,
+						SignedUrlCacheMaxAgeSec: createInt64(3421),
+						SignedUrlKeys: []*backendconfig.SignedUrlKey{
+							{KeyName: "key4", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+							{KeyName: "key5", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+							{KeyName: "key6", KeyValue: "MH5PnJa2HCKM232GxJ3z0g=="},
+						},
+					}).Build(),
+				expected: newBSBuilder().setProp(func(cdn *compute.BackendServiceCdnPolicy) {
+					cdn.SignedUrlCacheMaxAgeSec = 3421
+					cdn.SignedUrlKeyNames = []string{"key4", "key5", "key6"}
+				}).build(),
+			},
+			{
+				desc: "signed url cache max age, reset to defaults",
+				beConfig: fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+					SetCDNConfig(&backendconfig.CDNConfig{
+						Enabled: true,
+					}).Build(),
+				expected: newBSBuilder().build(),
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				if err := updateConfigAndValidate(ing, s.Namespace, serviceName1, tc.beConfig, tc.expected); err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+
+			})
+		}
+	})
+}
+
+// helper functions
+
+func verifyCachePolicies(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedCachePolicies *backendconfig.CacheKeyPolicy) error {
+	numBsWithPolicy := 0
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		if bs.GA.CdnPolicy == nil || bs.GA.CdnPolicy.CacheKeyPolicy == nil {
+			return fmt.Errorf("backend service %q has no cache policy", bs.GA.Name)
+		}
+		cachePolicy := bs.GA.CdnPolicy.CacheKeyPolicy
+		if expectedCachePolicies.IncludeHost != cachePolicy.IncludeHost ||
+			expectedCachePolicies.IncludeProtocol != cachePolicy.IncludeProtocol ||
+			expectedCachePolicies.IncludeQueryString != cachePolicy.IncludeQueryString ||
+			!reflect.DeepEqual(expectedCachePolicies.QueryStringBlacklist, cachePolicy.QueryStringBlacklist) ||
+			!reflect.DeepEqual(expectedCachePolicies.QueryStringWhitelist, cachePolicy.QueryStringWhitelist) {
+			return fmt.Errorf("backend service %q has cache policy %v, want %v", bs.GA.Name, cachePolicy, expectedCachePolicies)
+		}
+		t.Logf("Backend service %q has expected cache policy", bs.GA.Name)
+		numBsWithPolicy = numBsWithPolicy + 1
+	}
+	if numBsWithPolicy != 1 {
+		return fmt.Errorf("unexpected number of backend service has cache policy attached: got %d, want 1", numBsWithPolicy)
+	}
+	return nil
+}
+
+func createInt64(a int64) *int64 {
+	return &a
+}
+
+func createBool(a bool) *bool {
+	return &a
+}
+
+type backendServiceBuilder struct {
+	CdnPolicy *compute.BackendServiceCdnPolicy
+}
+
+func newBSBuilder() *backendServiceBuilder {
+	return &backendServiceBuilder{
+		CdnPolicy: &compute.BackendServiceCdnPolicy{
+			CacheKeyPolicy: &compute.CacheKeyPolicy{
+				IncludeHost:        true,
+				IncludeProtocol:    true,
+				IncludeQueryString: true,
+			},
+			CacheMode:         "CACHE_ALL_STATIC",
+			ClientTtl:         3600,
+			DefaultTtl:        3600,
+			MaxTtl:            86400,
+			NegativeCaching:   true,
+			RequestCoalescing: true,
+			ServeWhileStale:   86400,
+		},
+	}
+}
+
+func (bsb *backendServiceBuilder) setProp(fn func(*compute.BackendServiceCdnPolicy)) *backendServiceBuilder {
+	fn(bsb.CdnPolicy)
+	return bsb
+}
+
+func (bsb *backendServiceBuilder) build() *compute.BackendServiceCdnPolicy {
+	return bsb.CdnPolicy
+}
+
+func setupIngress(s *e2e.Sandbox, ingressName, serviceName1, backendconfig1 string) (*networkingv1.Ingress, error) {
+
+	ingress := fuzz.NewIngressBuilder(s.Namespace, ingressName, "").
+		AddPath("", "/", serviceName1, networkingv1.ServiceBackendPort{Number: 80}).
+		Build()
+
+	serviceAnnotations := map[string]string{
+		annotations.BackendConfigKey: fmt.Sprintf(`{"%s":"%s"}`, "default", backendconfig1),
+		annotations.NEGAnnotationKey: `{"ingress": true}`,
+	}
+
+	// create the backend config with defaults
+	bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+	_, err := bcCRUD.Ensure(fuzz.NewBackendConfigBuilder(s.Namespace, backendconfig1).
+		SetCDNConfig(&backendconfig.CDNConfig{
+			Enabled: true,
+		}).Build())
+	if err != nil {
+		return nil, fmt.Errorf("error creating BackendConfig: %v", err)
+	}
+	// create the service and deployment
+	if _, err := e2e.CreateEchoService(s, serviceName1, serviceAnnotations); err != nil {
+		return nil, fmt.Errorf("error creating echo service: %v", err)
+	}
+	// create the ingress
+	ing, err := e2e.EnsureIngress(s, ingress)
+	if err != nil {
+		return nil, fmt.Errorf("error ensuring Ingress spec: %v", err)
+	}
+	// wait for ingress to stabilize
+	ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for Ingress to stabilize: %v", err)
+	}
+	// validate the default cdn setup
+	err = validateBackend(ing, s.Namespace, serviceName1, newBSBuilder().build())
+	if err != nil {
+		return nil, fmt.Errorf("error validate backend: %v", err)
+	}
+
+	return ing, nil
+}
+
+func updateConfigAndValidate(
+	ing *networkingv1.Ingress,
+	namespace,
+	serviceName string,
+	beConfig *backendconfig.BackendConfig,
+	expected *compute.BackendServiceCdnPolicy) error {
+
+	// update the backend configuration
+	bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+	_, err := bcCRUD.Ensure(beConfig)
+	if err != nil {
+		return fmt.Errorf("error creating BackendConfig: %v", err)
+	}
+
+	// wait and validate the changes
+	var lastError error
+	waitErr := wait.Poll(transitionPollInterval, cdnTestPollTimeout, func() (bool, error) {
+		lastError = validateBackend(ing, namespace, serviceName, expected)
+		if lastError == nil {
+			return true, nil
+		}
+		klog.V(2).Infof("Retry backend validation for %s/%s", namespace, serviceName)
+		return false, nil
+	})
+	if waitErr != nil {
+		return lastError
+	}
+	return nil
+}
+
+func validateBackend(ing *networkingv1.Ingress, namespace, serviceName string, expected *compute.BackendServiceCdnPolicy) error {
+
+	klog.V(2).Infof("Begin backend validation for %s/%s", namespace, serviceName)
+
+	vip := ing.Status.LoadBalancer.Ingress[0].IP
+	params := &fuzz.GCLBForVIPParams{
+		VIP:        vip,
+		Validators: fuzz.FeatureValidators(features.All),
+	}
+	gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+	if err != nil {
+		return fmt.Errorf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+	}
+
+	numBsWithPolicy := 0
+	for _, bs := range gclb.BackendService {
+		// find our backend service
+		bcdesc := utils.DescriptionFromString(bs.GA.Description)
+		if bcdesc.ServiceName != fmt.Sprintf("%s/%s", namespace, serviceName) {
+			continue
+		}
+		numBsWithPolicy++
+
+		if expected == nil {
+			if bs.GA.EnableCDN {
+				return fmt.Errorf("CDN enabled on service %s/%s expected not", namespace, serviceName)
+			}
+			return nil
+		}
+
+		if !bs.GA.EnableCDN {
+			return fmt.Errorf("CDN not enabled on service %s/%s", namespace, serviceName)
+		}
+
+		if bs.GA.CdnPolicy == nil {
+			return fmt.Errorf("backend service %q has no CdnPolicy", bs.GA.Name)
+		}
+
+		// we need deep copy here because we will alter the objects
+		expCdnPolicy := deepCopyCdnPolicy(expected)
+		bsCdnPolicy := deepCopyCdnPolicy(bs.GA.CdnPolicy)
+
+		if sliceEqual(expCdnPolicy.NegativeCachingPolicy, bsCdnPolicy.NegativeCachingPolicy) {
+			expCdnPolicy.NegativeCachingPolicy = nil
+			bsCdnPolicy.NegativeCachingPolicy = nil
+		}
+
+		if !reflect.DeepEqual(expCdnPolicy, bsCdnPolicy) {
+			return fmt.Errorf("expected %s, but got %s",
+				pretty.Sprint(expected), // use the original values for error reporting
+				pretty.Sprint(bs.GA.CdnPolicy))
+		}
+	}
+
+	if numBsWithPolicy != 1 {
+		return fmt.Errorf("unexpected number of backend service has cache policy attached: got %d, want 1", numBsWithPolicy)
+	}
+	return nil
+}
+
+func sliceEqual(x, y []*compute.BackendServiceCdnPolicyNegativeCachingPolicy) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	xMap := map[int64]int64{}
+	yMap := map[int64]int64{}
+	for _, v := range x {
+		xMap[v.Code] = v.Ttl
+	}
+	for _, v := range y {
+		yMap[v.Code] = v.Ttl
+	}
+	return reflect.DeepEqual(xMap, yMap)
+}
+
+func copyViaJSON(dst, src interface{}) error {
+	var err error
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bytes, dst)
+}
+
+func deepCopyCdnPolicy(src *compute.BackendServiceCdnPolicy) *compute.BackendServiceCdnPolicy {
+	dst := &compute.BackendServiceCdnPolicy{}
+	if err := copyViaJSON(dst, src); err != nil {
+		panic(err)
+	}
+	return dst
+}

--- a/cmd/ingress-controller-e2e-test/customrequestheaders_test.go
+++ b/cmd/ingress-controller-e2e-test/customrequestheaders_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// TODO(rramkumar): Add transition test.
+
+func TestCustomRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+		Build()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http one path w/ Custom header.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				AddCustomRequestHeader("X-Client-Geo-Location:{client_region},{client_city}").
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing.Namespace = s.Namespace
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if tc.beConfig.Spec.CustomRequestHeaders != nil {
+				verifyHeaders(t, gclb, s.Namespace, "service-1", tc.beConfig.Spec.CustomRequestHeaders)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyHeaders(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedCustomRequestHeaders *backendconfig.CustomRequestHeadersConfig) error {
+	numBsWithCRH := 0
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		headers := bs.GA.CustomRequestHeaders
+		if !reflect.DeepEqual(headers, expectedCustomRequestHeaders.Headers) {
+			return fmt.Errorf("backend service %q has custom request headers %v, want %v", bs.GA.Name, headers, expectedCustomRequestHeaders.Headers)
+		}
+
+		t.Logf("Backend service %q has expected custom request headers", bs.GA.Name)
+		numBsWithCRH = numBsWithCRH + 1
+	}
+	if numBsWithCRH != 1 {
+		return fmt.Errorf("unexpected number of backend service has custom request headers: got %d, want 1", numBsWithCRH)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/customresponseheaders_test.go
+++ b/cmd/ingress-controller-e2e-test/customresponseheaders_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+func TestCustomResponseHeaders(t *testing.T) {
+	t.Parallel()
+
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+		Build()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http one path w/ Custom Response header.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				AddCustomResponseHeader("X-Test-Header: test").
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf(appendDesc(tc.desc, "error creating BackendConfig: %v"), err)
+			}
+			t.Logf(appendDesc(tc.desc, "BackendConfig created (%s/%s) "), s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf(appendDesc(tc.desc, "error creating echo service: %v"), err)
+			}
+			t.Logf(appendDesc(tc.desc, "Echo service created (%s/%s)"), s.Namespace, "service-1")
+
+			ing.Namespace = s.Namespace
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf(appendDesc(tc.desc, "error creating Ingress spec: %v"), err)
+			}
+			t.Logf(appendDesc(tc.desc, "Ingress created (%s/%s)"), s.Namespace, ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf(appendDesc(tc.desc, "error waiting for Ingress to stabilize: %v"), err)
+			}
+			t.Logf(appendDesc(tc.desc, "GCLB resources created (%s/%s)"), s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf(appendDesc(tc.desc, "Ingress %s/%s VIP = %s"), s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf(appendDesc(tc.desc, "Error getting GCP resources for LB with IP = %q: %v"), vip, err)
+			}
+			if tc.beConfig.Spec.CustomResponseHeaders != nil {
+				verifyResponseHeaders(t, gclb, s.Namespace, "service-1", tc.beConfig.Spec.CustomResponseHeaders, tc.desc)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
+				t.Errorf(appendDesc(tc.desc, "Delete(%q) = %v, want nil"), ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf(appendDesc(tc.desc, "Waiting for GCLB resources to be deleted (%s/%s)"), s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf(appendDesc(tc.desc, "GCLB resources deleted (%s/%s)"), s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyResponseHeaders(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedCustomResponseHeaders *backendconfig.CustomResponseHeadersConfig, testDesc string) error {
+	numBsWithCRH := 0
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		headers := bs.GA.CustomResponseHeaders
+		if !reflect.DeepEqual(headers, expectedCustomResponseHeaders.Headers) {
+			return fmt.Errorf("backend service %q has custom response headers %v, want %v", bs.GA.Name, headers, expectedCustomResponseHeaders.Headers)
+		}
+
+		t.Logf(appendDesc(testDesc, "Backend service %q has expected custom response headers"), bs.GA.Name)
+		numBsWithCRH = numBsWithCRH + 1
+	}
+	if numBsWithCRH != 1 {
+		return fmt.Errorf("unexpected number of backend service has custom response headers: got %d, want 1", numBsWithCRH)
+	}
+	return nil
+}
+
+// Append test description to the log for debugging
+func appendDesc(desc string, format string) string {
+	return fmt.Sprintf("[%s]: %s", desc, format)
+}

--- a/cmd/ingress-controller-e2e-test/draining_test.go
+++ b/cmd/ingress-controller-e2e-test/draining_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	drainingTransitionPollTimeout  = 15 * time.Minute
+	drainingTransitionPollInterval = 30 * time.Second
+)
+
+func TestDraining(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc         string
+		beConfig     *backendconfig.BackendConfig
+		transitionTo int64
+	}{
+		{
+			desc: "http with 60s draining timeout",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetConnectionDrainingTimeout(60).
+				Build(),
+			transitionTo: 30,
+		},
+		{
+			desc: "http no draining defined",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				Build(),
+			transitionTo: 60,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			timeout := int64(0)
+			if tc.beConfig.Spec.ConnectionDraining != nil {
+				timeout = tc.beConfig.Spec.ConnectionDraining.DrainingTimeoutSec
+			}
+
+			// Check conformity
+			if err := verifyConnectionDrainingTimeout(t, gclb, s.Namespace, "service-1", timeout); err != nil {
+				t.Errorf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", timeout, err)
+			}
+
+			// Test modifications/transitions
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				if bc.Spec.ConnectionDraining == nil {
+					bc.Spec.ConnectionDraining = &backendconfig.ConnectionDrainingConfig{}
+				}
+				bc.Spec.ConnectionDraining.DrainingTimeoutSec = tc.transitionTo
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("Failed to update BackendConfig ConnectionDraining settings for %s: %v", t.Name(), err)
+			}
+
+			if err := wait.Poll(drainingTransitionPollInterval, drainingTransitionPollTimeout, func() (bool, error) {
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyConnectionDrainingTimeout(t, gclb, s.Namespace, "service-1", tc.transitionTo); err != nil {
+					t.Logf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", tc.transitionTo, err)
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Errorf("error waiting for BackendConfig ConnectionDraining transition propagation to GCLB: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestRegionalXLBDrain(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc         string
+		beConfig     *backendconfig.BackendConfig
+		transitionTo int64
+	}{
+		{
+			desc: "http with 60s draining timeout",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetConnectionDrainingTimeout(60).
+				Build(),
+			transitionTo: 30,
+		},
+		{
+			desc: "http no draining defined",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				Build(),
+			transitionTo: 60,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey:     negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			timeout := int64(0)
+			if tc.beConfig.Spec.ConnectionDraining != nil {
+				timeout = tc.beConfig.Spec.ConnectionDraining.DrainingTimeoutSec
+			}
+
+			// Check conformity
+			if err := verifyConnectionDrainingTimeout(t, gclb, s.Namespace, "service-1", timeout); err != nil {
+				t.Errorf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", timeout, err)
+			}
+
+			// Test modifications/transitions
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				if bc.Spec.ConnectionDraining == nil {
+					bc.Spec.ConnectionDraining = &backendconfig.ConnectionDrainingConfig{}
+				}
+				bc.Spec.ConnectionDraining.DrainingTimeoutSec = tc.transitionTo
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Errorf("Failed to update BackendConfig ConnectionDraining settings for %s: %v", t.Name(), err)
+			}
+
+			if err := wait.Poll(drainingTransitionPollInterval, drainingTransitionPollTimeout, func() (bool, error) {
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("error getting GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyConnectionDrainingTimeout(t, gclb, s.Namespace, "service-1", tc.transitionTo); err != nil {
+					t.Logf("verifyConnectionDrainingTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", tc.transitionTo, err)
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Errorf("error waiting for BackendConfig ConnectionDraining transition propagation to GCLB: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyConnectionDrainingTimeout(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedTimeout int64) error {
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		if bs.GA.ConnectionDraining == nil {
+			return fmt.Errorf("backend service %q has no draining configuration", bs.GA.Name)
+		}
+		if bs.GA.ConnectionDraining.DrainingTimeoutSec != expectedTimeout {
+			return fmt.Errorf("backend service %q has draining timeout %d, want %d", bs.GA.Name,
+				bs.GA.ConnectionDraining.DrainingTimeoutSec, expectedTimeout)
+		}
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/e2e-test.yaml
+++ b/cmd/ingress-controller-e2e-test/e2e-test.yaml
@@ -1,0 +1,70 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# To run the containerized e2e test in your own cluster:
+#
+# $ kubectl apply -f e2e-test.yaml
+#
+# You will nee to first enable creating RBAC rules on the GKE cluster:
+#
+# $ kubectl create clusterrolebinding cluster-admin-binding \
+#   --clusterrole cluster-admin \
+#   --user $(gcloud config get-value account) \
+#   clusterrolebinding "cluster-admin-binding"
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ingress-e2e-test
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-e2e-test
+rules:
+   - apiGroups: ["*"]
+     resources: ["*"]
+     verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-e2e-test
+subjects:
+  - kind: ServiceAccount
+    name: ingress-e2e-test
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: ingress-e2e-test
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ingress-e2e
+  namespace: default
+spec:
+  containers:
+  - name: ingress-e2e
+    image: gcr.io/k8s-ingress-image-push/ingress-controller-e2e-test:master
+    imagePullPolicy: Always
+  restartPolicy: Never
+  serviceAccount: ingress-e2e-test
+  tolerations:
+  - key: kubernetes.io/arch
+    operator: Equal
+    value: arm64
+    effect: NoSchedule

--- a/cmd/ingress-controller-e2e-test/finalizer_test.go
+++ b/cmd/ingress-controller-e2e-test/finalizer_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+// TestFinalizer asserts that finalizer is added/ removed appropriately during the life cycle
+// of an ingress resource.
+func TestFinalizer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	port80 := v1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		AddPath("foo.com", "/", svcName, port80).
+		SetIngressClass("gce").
+		Build()
+
+	Framework.RunWithSandbox("finalizer", t, func(t *testing.T, s *e2e.Sandbox) {
+		_, err := e2e.CreateEchoService(s, svcName, nil)
+		if err != nil {
+			t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		ing.Namespace = s.Namespace
+		ingKey := common.NamespacedName(ing)
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+		}
+		t.Logf("Ingress created (%s)", ingKey)
+
+		ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+		if err != nil {
+			t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+		}
+
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
+		}
+
+		// Perform whitebox testing.
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+		if err != nil {
+			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ingKey, err)
+		}
+	})
+}
+
+// TestFinalizerIngressClassChange asserts that finalizer is removed from ingress after its
+// associated resources are cleaned up when ingress class is updated to a non glbc type.
+func TestFinalizerIngressClassChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	port80 := v1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		AddPath("foo.com", "/", svcName, port80).
+		SetIngressClass("gce").
+		Build()
+
+	Framework.RunWithSandbox("finalizer-ingress-class-change", t, func(t *testing.T, s *e2e.Sandbox) {
+		_, err := e2e.CreateEchoService(s, svcName, nil)
+		if err != nil {
+			t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		ing.Namespace = s.Namespace
+		ingKey := common.NamespacedName(ing)
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+		}
+		t.Logf("Ingress created (%s)", ingKey)
+		ing, err := e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+		if err != nil {
+			t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+		}
+
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
+		}
+
+		// Perform whitebox testing.
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+		if err != nil {
+			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+		}
+
+		// Change Ingress class
+		newIngClass := "nginx"
+		newIng := fuzz.NewIngressBuilderFromExisting(ing).SetIngressClass(newIngClass).Build()
+
+		if _, err := crud.Patch(ing, newIng); err != nil {
+			t.Fatalf("Patch(%s) = %v, want nil; current ingress: %+v new ingress %+v", ingKey, err, ing, newIng)
+		}
+		t.Logf("Ingress (%s) class changed to %s", ingKey, newIngClass)
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForFinalizerDeletion(ctx, gclb, s, ing.Name, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForFinalizerDeletion(..., %q, _) = %v, want nil", ing.Name, err)
+		}
+		t.Logf("Finalizer for Ingress (%s) deleted", ingKey)
+	})
+}
+
+// TestFinalizerIngressesWithSharedResources asserts that sync does not return error with finalizer
+// when multiple ingresses with shared resources are created or deleted.
+func TestFinalizerIngressesWithSharedResources(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	port80 := v1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+	ing := fuzz.NewIngressBuilder("", "ingress-1", "").
+		AddPath("foo.com", "/", svcName, port80).
+		SetIngressClass("gce").
+		Build()
+	otherIng := fuzz.NewIngressBuilder("", "ingress-2", "").
+		AddPath("foo.com", "/", svcName, port80).
+		SetIngressClass("gce").
+		Build()
+
+	Framework.RunWithSandbox("finalizer-ingress-class-change", t, func(t *testing.T, s *e2e.Sandbox) {
+		_, err := e2e.CreateEchoService(s, svcName, nil)
+		if err != nil {
+			t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+		}
+		t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		ing.Namespace = s.Namespace
+		ingKey := common.NamespacedName(ing)
+		if _, err := crud.Create(ing); err != nil {
+			t.Fatalf("create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+		}
+		t.Logf("Ingress created (%s)", ingKey)
+
+		otherIng.Namespace = s.Namespace
+		otherIngKey := common.NamespacedName(ing)
+		if _, err := crud.Create(otherIng); err != nil {
+			t.Fatalf("create(%s) = %v, want nil; Ingress: %v", otherIngKey, err, otherIng)
+		}
+		t.Logf("Ingress created (%s)", otherIngKey)
+
+		if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+			t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+		}
+		if otherIng, err = e2e.WaitForIngress(s, otherIng, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+			t.Fatalf("error waiting for Ingress %s to stabilize: %v", otherIngKey, err)
+		}
+
+		if err := e2e.CheckForAnyFinalizer(ing); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", ingKey, err)
+		}
+		if err := e2e.CheckForAnyFinalizer(otherIng); err != nil {
+			t.Fatalf("CheckForAnyFinalizer(%s) = %v, want nil", otherIngKey, err)
+		}
+
+		// Perform whitebox testing.
+		gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+		if err != nil {
+			t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+		}
+		otherGclb, err := e2e.WhiteboxTest(otherIng, nil, Framework.Cloud, "", s)
+		if err != nil {
+			t.Fatalf("e2e.WhiteboxTest(%s)", otherIngKey)
+		}
+
+		// SkipBackends ensure that we dont wait on deletion of shared backends.
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+			SkipBackends:       true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ingKey, err)
+		}
+		deleteOptions = &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, otherGclb, s, otherIng, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", otherIngKey, err)
+		}
+	})
+}

--- a/cmd/ingress-controller-e2e-test/healthcheck_test.go
+++ b/cmd/ingress-controller-e2e-test/healthcheck_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+func TestHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	pint64 := func(x int64) *int64 { return &x }
+	pstring := func(x string) *string { return &x }
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+		want     *backendconfig.HealthCheckConfig
+	}{
+		{
+			desc:     "override healthcheck with IG",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			want: &backendconfig.HealthCheckConfig{
+				CheckIntervalSec:   pint64(7),
+				TimeoutSec:         pint64(3),
+				HealthyThreshold:   pint64(3),
+				UnhealthyThreshold: pint64(5),
+				RequestPath:        pstring("/my-path"),
+			},
+		},
+		{
+			desc:     "override healthcheck and port with NEG",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			want: &backendconfig.HealthCheckConfig{
+				RequestPath: pstring("/my-path"),
+				Port:        pint64(9000), // Purposely does not match deployment, we verify it separately
+			},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+			tc.beConfig.Spec.HealthCheck = tc.want
+
+			becrud := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := becrud.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			svc, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			// Update service for NEG
+			if tc.want.Port != nil {
+				svc.Annotations[annotations.NEGAnnotationKey] = `{"ingress":true}`
+				if _, err := Framework.Clientset.CoreV1().Services(s.Namespace).Update(ctx, svc, v1.UpdateOptions{}); err != nil {
+					t.Fatalf("error updating port on svc: %v", err)
+				}
+			}
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", networkingv1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			// If health check port does not match deployment, then the deployment will be unreachable
+			if tc.want.Port != nil {
+				options := &e2e.WaitForIngressOptions{ExpectUnreachable: true}
+				ing, _ = e2e.WaitForIngress(s, ing, nil, options)
+			} else {
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+				}
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+			if err := verifyHealthCheck(t, gclb, tc.want); err != nil {
+				t.Fatal(err)
+			}
+
+			// Change the configuration and wait for stabilization.
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				newBEConfig, err := becrud.Get(s.Namespace, tc.beConfig.Name)
+				if err != nil {
+					t.Fatalf("becrud.Get(%q, %q) = %v, want nil", s.Namespace, tc.beConfig.Name, err)
+				}
+				newBEConfig.Spec.HealthCheck.RequestPath = pstring("/other-path")
+				if _, err := becrud.Update(newBEConfig); err != nil {
+					return err
+				}
+				t.Logf("BackendConfig updated (%s/%s) ", s.Namespace, tc.beConfig.Name)
+				return nil
+			}); err != nil {
+				t.Fatalf("error updating BackendConfig %s/%s: %v", s.Namespace, tc.beConfig.Name, err)
+			}
+
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				err := verifyHealthCheck(t, gclb, tc.want)
+				if err == nil {
+					return true, nil
+				}
+				t.Logf("Waiting for healthcheck to be updated: %v", err)
+				return false, nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func TestRegionalXLBHC(t *testing.T) {
+	t.Parallel()
+
+	pint64 := func(x int64) *int64 { return &x }
+	pstring := func(x string) *string { return &x }
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+		want     *backendconfig.HealthCheckConfig
+	}{
+		{
+			desc:     "override healthcheck configs",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").Build(),
+			want: &backendconfig.HealthCheckConfig{
+				CheckIntervalSec:   pint64(7),
+				TimeoutSec:         pint64(3),
+				HealthyThreshold:   pint64(3),
+				UnhealthyThreshold: pint64(5),
+				RequestPath:        pstring("/my-path"),
+				Port:               pint64(9000), // Purposely does not match deployment, we verify it separately
+			},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			}
+			tc.beConfig.Spec.HealthCheck = tc.want
+
+			becrud := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := becrud.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				DefaultBackend("service-1", networkingv1.ServiceBackendPort{Number: 80}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			// If health check port does not match deployment, then the deployment will be unreachable
+			options := &e2e.WaitForIngressOptions{
+				ExpectUnreachable: true,
+			}
+			ing, _ = e2e.WaitForIngress(s, ing, nil, options)
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+			if err := verifyHealthCheck(t, gclb, tc.want); err != nil {
+				t.Fatal(err)
+			}
+
+			// Change the configuration and wait for stabilization.
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				newBEConfig, err := becrud.Get(s.Namespace, tc.beConfig.Name)
+				if err != nil {
+					t.Fatalf("becrud.Get(%q, %q) = %v, want nil", s.Namespace, tc.beConfig.Name, err)
+				}
+				newBEConfig.Spec.HealthCheck.RequestPath = pstring("/other-path")
+				if _, err := becrud.Update(newBEConfig); err != nil {
+					return err
+				}
+				t.Logf("BackendConfig updated (%s/%s) ", s.Namespace, tc.beConfig.Name)
+				return nil
+			}); err != nil {
+				t.Fatalf("error updating BackendConfig %s/%s: %v", s.Namespace, tc.beConfig.Name, err)
+			}
+
+			if err := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				err := verifyHealthCheck(t, gclb, tc.want)
+				if err == nil {
+					return true, nil
+				}
+				t.Logf("Waiting for healthcheck to be updated: %v", err)
+				return false, nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyHealthCheck(t *testing.T, gclb *fuzz.GCLB, want *backendconfig.HealthCheckConfig) error {
+	// We assume there is a single service for now. The logic will have to be
+	// changed if there is more than one backend service.
+	for _, bs := range gclb.BackendService {
+		for _, hcURL := range bs.GA.HealthChecks {
+			rID, err := cloud.ParseResourceURL(hcURL)
+			if err != nil {
+				t.Fatalf("cloud.ParseResourceURL(%q) = _, %v; want _, nil", hcURL, err)
+			}
+			hc, ok := gclb.HealthCheck[*rID.Key]
+			if !ok {
+				t.Fatalf("HealthCheck %s not found in BackendService %+v", rID.Key, bs)
+			}
+
+			// Pull out the field that are in common among the different
+			// healthchecks per protocol.
+			common := struct {
+				port        int64
+				requestPath string
+			}{}
+			switch {
+			case hc.GA.Http2HealthCheck != nil:
+				common.port = hc.GA.Http2HealthCheck.Port
+				common.requestPath = hc.GA.Http2HealthCheck.RequestPath
+			case hc.GA.HttpHealthCheck != nil:
+				common.port = hc.GA.HttpHealthCheck.Port
+				common.requestPath = hc.GA.HttpHealthCheck.RequestPath
+			case hc.GA.HttpsHealthCheck != nil:
+				common.port = hc.GA.HttpsHealthCheck.Port
+				common.requestPath = hc.GA.HttpsHealthCheck.RequestPath
+			}
+
+			if want.CheckIntervalSec != nil && hc.GA.CheckIntervalSec != *want.CheckIntervalSec {
+				return fmt.Errorf("HealthCheck %v checkIntervalSec = %d, want %d", rID.Key, hc.GA.CheckIntervalSec, *want.CheckIntervalSec)
+			}
+			if want.TimeoutSec != nil && hc.GA.TimeoutSec != *want.TimeoutSec {
+				return fmt.Errorf("HealthCheck %v timeoutSec = %d, want %d", rID.Key, hc.GA.TimeoutSec, *want.TimeoutSec)
+			}
+			if want.HealthyThreshold != nil && hc.GA.HealthyThreshold != *want.HealthyThreshold {
+				return fmt.Errorf("HealthCheck %v healthyThreshold = %d, want %d", rID.Key, hc.GA.HealthyThreshold, *want.HealthyThreshold)
+			}
+			if want.UnhealthyThreshold != nil && hc.GA.UnhealthyThreshold != *want.UnhealthyThreshold {
+				return fmt.Errorf("HealthCheck %v unhealthThreshold = %d, want %d", rID.Key, hc.GA.UnhealthyThreshold, *want.UnhealthyThreshold)
+			}
+			if want.Type != nil {
+				return fmt.Errorf("HealthCheck %v type = %s, want %s", rID.Key, hc.GA.Type, *want.Type)
+			}
+			if want.Port != nil && common.port != *want.Port {
+				return fmt.Errorf("HealthCheck %v port = %d, want %d", rID.Key, common.port, *want.Port)
+			}
+			if want.RequestPath != nil && common.requestPath != *want.RequestPath {
+				return fmt.Errorf("HealthCheck %v requestPath = %q, want %q", rID.Key, common.requestPath, *want.RequestPath)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/iap_test.go
+++ b/cmd/ingress-controller-e2e-test/iap_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+// TODO(rramkumar): Add transition test.
+
+// TODO(rramkumar): Add test for positive case.
+
+func TestIAP(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http one path w/ IAP.",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetIAPConfig(false, "").
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(ing.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/ilb_test.go
+++ b/cmd/ingress-controller-e2e-test/ilb_test.go
@@ -1,0 +1,877 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+var (
+	negVal        = annotations.NegAnnotation{Ingress: true}
+	negAnnotation = map[string]string{
+		annotations.NEGAnnotationKey: negVal.String()}
+)
+
+func TestILB(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing1-"
+	serviceName := "svc-1"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1.Ingress
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "http ILB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc: "http ILB one path",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+		{
+			desc: "http ILB multiple paths",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			t.Logf("Ingress = %s", tc.ing.String())
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			tc.ing.Namespace = s.Namespace
+			if _, err := crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+			if !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+			}
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TestILBStaticIP is a transition test:
+// 1) static IP disabled
+// 2) static IP enabled
+// 3) static IP disabled
+func TestILBStaticIP(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("ilb-static-ip", t, func(t *testing.T, s *e2e.Sandbox) {
+		if Framework.CreateILBSubnet {
+			if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+				t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+			}
+		}
+
+		_, err := e2e.CreateEchoService(s, "service-1", negAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(s, service-1, nil) = _, %v; want _, nil", err)
+		}
+
+		addrName := fmt.Sprintf("test-addr-%s", s.Namespace)
+		if err := e2e.NewGCPAddress(s, addrName, Framework.Region); err != nil {
+			t.Fatalf("e2e.NewGCPAddress(..., %s) = %v, want nil", addrName, err)
+		}
+		defer e2e.DeleteGCPAddress(s, addrName, Framework.Region)
+
+		testIngEnabled := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", v1.ServiceBackendPort{Number: 80}).
+			ConfigureForILB().
+			AddStaticIP(addrName, true).
+			Build()
+		testIngDisabled := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", v1.ServiceBackendPort{Number: 80}).
+			ConfigureForILB().
+			Build()
+
+		// Create original ingress
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		ing, err := crud.Create(testIngDisabled)
+		if err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress %s/%s created", s.Namespace, ing.Name)
+
+		var gclb *fuzz.GCLB
+		for i, testIng := range []*v1.Ingress{testIngDisabled, testIngEnabled, testIngDisabled} {
+			t.Run(fmt.Sprintf("Transition-%d", i), func(t *testing.T) {
+				ing, err = e2e.EnsureIngress(s, testIng)
+				if err != nil {
+					t.Fatalf("error patching Ingress spec: %v", err)
+				}
+				t.Logf("Ingress %s/%s updated", s.Namespace, testIng.Name)
+
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
+				}
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+			})
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+func TestILBHttps(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing2-"
+	serviceName := "svc-2"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc       string
+		ingBuilder *fuzz.IngressBuilder
+		hosts      []string
+		certType   e2e.CertType
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "https ILB one path, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				SetAllowHttp(false),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https ILB one path, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				SetAllowHttp(false),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https ILB multiple paths, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForILB().
+				SetAllowHttp(false),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+		{
+			desc: "https ILB multiple paths, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForILB().
+				SetAllowHttp(false),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			for i, h := range tc.hosts {
+				name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+				cert, err := e2e.NewCert(name, h, tc.certType, true)
+				if err != nil {
+					t.Fatalf("Error initializing cert: %v", err)
+				}
+				if err := cert.Create(s); err != nil {
+					t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+				}
+				defer cert.Delete(s)
+
+				if tc.certType == e2e.K8sCert {
+					tc.ingBuilder.AddTLS([]string{}, cert.Name)
+				} else {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+			}
+			ing := tc.ingBuilder.Build()
+			ing.Namespace = s.Namespace // namespace depends on sandbox
+
+			t.Logf("Ingress = %s", ing.String())
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			if !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+			}
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: false,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TestILBSharedVIP test the support of HTTPS and HTTP on the same LB when static IP is provided
+func TestILBSharedVIP(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing2-"
+	serviceName := "svc-2"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc       string
+		ingBuilder *fuzz.IngressBuilder
+		hosts      []string
+		certType   e2e.CertType
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "https ILB one path, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https ILB one path, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com"},
+		},
+		{
+			desc: "https ILB multiple paths, pre-shared cert",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForILB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.GCPCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+		{
+			desc: "https ILB multiple paths, tls",
+			ingBuilder: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("baz.com", "/bar", serviceName, port80).
+				ConfigureForILB(),
+			numForwardingRules: 2,
+			numBackendServices: 2,
+			certType:           e2e.K8sCert,
+			hosts:              []string{"test.com", "baz.com"},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			addrName := fmt.Sprintf("test-addr-%s", s.Namespace)
+			if err := e2e.NewGCPAddress(s, addrName, Framework.Region); err != nil {
+				t.Fatalf("e2e.NewGCPAddress(..., %s) = %v, want nil", addrName, err)
+			}
+			defer e2e.DeleteGCPAddress(s, addrName, Framework.Region)
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			for i, h := range tc.hosts {
+				name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+				cert, err := e2e.NewCert(name, h, tc.certType, true)
+				if err != nil {
+					t.Fatalf("Error initializing cert: %v", err)
+				}
+				if err := cert.Create(s); err != nil {
+					t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+				}
+				defer cert.Delete(s)
+
+				if tc.certType == e2e.K8sCert {
+					tc.ingBuilder.AddTLS([]string{}, cert.Name)
+				} else {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+			}
+			ing := tc.ingBuilder.AddStaticIP(addrName, true).Build()
+			ing.Namespace = s.Namespace // namespace depends on sandbox
+
+			t.Logf("Ingress = %s", ing.String())
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources createdd (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			if !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+			}
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: false,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// Test Updating ILB and transitioning between ILB/ELB
+func TestILBUpdate(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing3-"
+	serviceName := "svc-3"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc      string
+		ing       *v1.Ingress
+		ingUpdate *v1.Ingress
+
+		numForwardingRules       int
+		numBackendServices       int
+		numForwardingRulesUpdate int
+		numBackendServicesUpdate int
+	}{
+		{
+			desc: "http ILB default backend to one path",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 2,
+		},
+		{
+			desc: "http ILB one path to default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+		{
+			desc: "http ILB default backend to ELB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				DefaultBackend(serviceName, port80).
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+		{
+			desc: "ELB default backend to ILB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				DefaultBackend(serviceName, port80).
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			t.Logf("Ingress = %s", tc.ing.String())
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace
+			if _, err := crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+
+			if utils.IsGCEL7ILBIngress(ing) && !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+			}
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			tc.ingUpdate.Namespace = s.Namespace
+			// Perform update
+			if _, err := crud.Update(tc.ingUpdate); err != nil {
+				t.Fatalf("error updating ingress spec: %v", err)
+			}
+
+			// Verify everything works
+			ing, err = e2e.WaitForIngress(s, tc.ingUpdate, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ingUpdate.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip = ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ingUpdate.Name, vip)
+			if utils.IsGCEL7ILBIngress(ing) && !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TODO(shance): Add unsupported features here
+func TestILBError(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing4-"
+	serviceName := "svc-4"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc           string
+		ing            *v1.Ingress
+		svcAnnotations map[string]string
+	}{
+		{
+			desc: "No neg annotation",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			svcAnnotations: map[string]string{},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			t.Logf("Ingress = %s", tc.ing.String())
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, tc.svcAnnotations)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			tc.ing.Namespace = s.Namespace
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Retrieve service NEG annotation
+			// TODO(freehan): remove this once NEG is default for all qualified cluster versions
+			svc, err := Framework.Clientset.CoreV1().Services(s.Namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("expect err = nil, but got %v", err)
+			}
+			svcAnnotation := annotations.FromService(svc)
+			negAnnotation, ok, err := svcAnnotation.NEGAnnotation()
+			if err != nil {
+				t.Fatalf("expect err = nil, but got %v", err)
+			}
+
+			// Proceed with error expectation according to NEG annotation
+			// TODO(freehan): remove this once NEG is default for all qualified cluster versions
+			expectError := true
+			if ok && negAnnotation.Ingress {
+				expectError = false
+			}
+
+			_, err = e2e.WaitForIngress(s, tc.ing, nil, nil)
+
+			if expectError && err == nil {
+				t.Fatalf("want err, got nil")
+			}
+
+			if !expectError && err != nil {
+				t.Fatalf("want err nil, got err %v", err)
+			}
+		})
+	}
+}
+
+// Test ILB and ELB sharing same service
+func TestILBShared(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing5-"
+	serviceName := "svc-5"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc               string
+		ilbIng             *v1.Ingress
+		elbIng             *v1.Ingress
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "default backend",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			elbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-1", "").
+				DefaultBackend(serviceName, port80).
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc: "one path",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			elbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+		{
+			desc: "multiple paths",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			elbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			var gclb *fuzz.GCLB
+			for _, ing := range []*v1.Ingress{tc.ilbIng, tc.elbIng} {
+
+				t.Logf("Ingress = %s", ing.String())
+
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				ing.Namespace = s.Namespace
+				if _, err := crud.Create(ing); err != nil {
+					t.Fatalf("error creating Ingress spec: %v", err)
+				}
+				t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+				ing, err := e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Perform whitebox testing.
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+				if utils.IsGCEL7ILBIngress(ing) && !e2e.IsRfc1918Addr(vip) {
+					t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+				}
+
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+
+				if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/logging_test.go
+++ b/cmd/ingress-controller-e2e-test/logging_test.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/test"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+type logging struct {
+	// whether logging is enabled.
+	enabled bool
+	// log sampling rate, takes a value between 0.0 and 1.0.
+	sampleRate float64
+}
+
+func TestLogging(t *testing.T) {
+	t.Parallel()
+	const svcName = "service1"
+
+	for _, tc := range []struct {
+		desc       string
+		beConfig   *backendconfig.BackendConfig
+		expect     logging
+		transition logging
+	}{
+		{
+			desc: "nil logging config",
+			beConfig: fuzz.NewBackendConfigBuilder("", "nil-log-config-beconfig").
+				Build(),
+			// Logging is expected to be on by default when it is not configured.
+			expect: logging{
+				enabled:    true,
+				sampleRate: 1.0,
+			},
+			transition: logging{
+				enabled: false,
+			},
+		},
+		{
+			desc: "logging disabled",
+			beConfig: fuzz.NewBackendConfigBuilder("", "logging-disabled-beconfig").
+				EnableLogging(false).
+				Build(),
+			expect: logging{
+				enabled: false,
+			},
+			transition: logging{
+				enabled:    true,
+				sampleRate: 0.5,
+			},
+		},
+		{
+			desc: "update sample rate",
+			beConfig: fuzz.NewBackendConfigBuilder("", "sample-rate-beconfig").
+				EnableLogging(true).SetSampleRate(test.Float64ToPtr(0.5)).
+				Build(),
+			expect: logging{
+				enabled:    true,
+				sampleRate: 0.5,
+			},
+			transition: logging{
+				enabled:    true,
+				sampleRate: 0.75,
+			},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BackendConfigKey: fmt.Sprintf(`{"default":"%s"}`, tc.beConfig.Name),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("Failed to create BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, svcName, backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("Failed to create echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", svcName, v1.ServiceBackendPort{Number: 80}).
+				Build()
+			ingKey := common.NamespacedName(ing)
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("crud.Create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+			}
+			t.Logf("Ingress created (%s)", ingKey)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress %s to stabilize: %v", ingKey, err)
+			}
+			t.Logf("GCLB resources created (%s)", ingKey)
+
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress %s does not have a VIP: %+v", ingKey, ing.Status)
+			}
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Failed to get GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Verify logging configuration.
+			if err := verifyLogging(t, gclb, s.Namespace, svcName, tc.expect); err != nil {
+				t.Error(err)
+			}
+
+			// Test transitions.
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				// Update backend config.
+				bc = fuzz.NewBackendConfigBuilderFromExisting(bc).
+					EnableLogging(tc.transition.enabled).
+					SetSampleRate(&tc.transition.sampleRate).Build()
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Fatalf("Failed to update BackendConfig logging settings: %v", err)
+			}
+
+			// Wait for transition settings to be propagated.
+			if waitErr := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("Failed to GCP resources for LB with IP = %q: %v", vip, err)
+					err = fmt.Errorf("failed to GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err = verifyLogging(t, gclb, s.Namespace, svcName, tc.transition); err != nil {
+					err = fmt.Errorf("failed to verify logging for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				return true, nil
+			}); waitErr != nil {
+				t.Errorf("Timeout waiting for BackendConfig logging transition propagation to GCLB, last seen error: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ingKey, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s)", ingKey)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(_, _, %q, _) = %v, want nil", vip, err)
+			}
+			t.Logf("GCLB resources deleted (%s)", ingKey)
+		})
+	}
+}
+
+func TestRegionalXLBLog(t *testing.T) {
+	t.Parallel()
+	const svcName = "service1"
+
+	for _, tc := range []struct {
+		desc       string
+		beConfig   *backendconfig.BackendConfig
+		expect     logging
+		transition logging
+	}{
+		{
+			desc: "nil logging config",
+			beConfig: fuzz.NewBackendConfigBuilder("", "nil-log-config-beconfig").
+				Build(),
+			// Logging is expected to be on by default when it is not configured.
+			expect: logging{
+				enabled:    true,
+				sampleRate: 1.0,
+			},
+			transition: logging{
+				enabled: false,
+			},
+		},
+		{
+			desc: "logging disabled",
+			beConfig: fuzz.NewBackendConfigBuilder("", "logging-disabled-beconfig").
+				EnableLogging(false).
+				Build(),
+			expect: logging{
+				enabled: false,
+			},
+			transition: logging{
+				enabled:    true,
+				sampleRate: 0.5,
+			},
+		},
+		{
+			desc: "update sample rate",
+			beConfig: fuzz.NewBackendConfigBuilder("", "sample-rate-beconfig").
+				EnableLogging(true).SetSampleRate(test.Float64ToPtr(0.5)).
+				Build(),
+			expect: logging{
+				enabled:    true,
+				sampleRate: 0.5,
+			},
+			transition: logging{
+				enabled:    true,
+				sampleRate: 0.75,
+			},
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BackendConfigKey: fmt.Sprintf(`{"default":"%s"}`, tc.beConfig.Name),
+				annotations.NEGAnnotationKey: negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("Failed to create BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, svcName, backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("Failed to create echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", svcName, v1.ServiceBackendPort{Number: 80}).
+				ConfigureForRegionalXLB().
+				Build()
+			ingKey := common.NamespacedName(ing)
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("crud.Create(%s) = %v, want nil; Ingress: %v", ingKey, err, ing)
+			}
+			t.Logf("Ingress created (%s)", ingKey)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("Error waiting for Ingress %s to stabilize: %v", ingKey, err)
+			}
+			t.Logf("GCLB resources created (%s)", ingKey)
+
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress %s does not have a VIP: %+v", ingKey, ing.Status)
+			}
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Failed to get GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			// Verify logging configuration.
+			if err := verifyLogging(t, gclb, s.Namespace, svcName, tc.expect); err != nil {
+				t.Error(err)
+			}
+
+			// Test transitions.
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				bc, err := bcCRUD.Get(tc.beConfig.Namespace, tc.beConfig.Name)
+				if err != nil {
+					return err
+				}
+				// Update backend config.
+				bc = fuzz.NewBackendConfigBuilderFromExisting(bc).
+					EnableLogging(tc.transition.enabled).
+					SetSampleRate(&tc.transition.sampleRate).Build()
+				_, err = bcCRUD.Update(bc)
+				return err
+			}); err != nil {
+				t.Fatalf("Failed to update BackendConfig logging settings: %v", err)
+			}
+
+			// Wait for transition settings to be propagated.
+			if waitErr := wait.Poll(transitionPollInterval, transitionPollTimeout, func() (bool, error) {
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Logf("Failed to GCP resources for LB with IP = %q: %v", vip, err)
+					return false, nil
+				}
+				if err := verifyLogging(t, gclb, s.Namespace, svcName, tc.transition); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); waitErr != nil {
+				t.Errorf("Timeout waiting for BackendConfig logging transition propagation to GCLB, last seen error: %v", err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ingKey, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s)", ingKey)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(_, _, %q, _) = %v, want nil", vip, err)
+			}
+			t.Logf("GCLB resources deleted (%s)", ingKey)
+		})
+	}
+}
+
+func verifyLogging(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedLogConfig logging) error {
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		logConfig := bs.GA.LogConfig
+		if logConfig.Enable != expectedLogConfig.enabled {
+			return fmt.Errorf("expected logging to be %t but got %t for backend service %q", expectedLogConfig.enabled, logConfig.Enable, bs.GA.Name)
+		}
+		// Verify sample rate only if logging is enabled.
+		if logConfig.Enable && logConfig.SampleRate != expectedLogConfig.sampleRate {
+			return fmt.Errorf("expected sample rate %f but got %f for backend service %q", expectedLogConfig.sampleRate, logConfig.SampleRate, bs.GA.Name)
+		}
+		t.Logf("Backend service %q has expected logging configuration", bs.GA.Name)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/main_test.go
+++ b/cmd/ingress-controller-e2e-test/main_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kr/pretty"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/ingress-gce/pkg/e2e"
+	_ "k8s.io/ingress-gce/pkg/klog"
+	"k8s.io/ingress-gce/pkg/version"
+	"k8s.io/klog/v2"
+
+	// Pull in the auth library for GCP.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+var (
+	flags struct {
+		run                 bool
+		inCluster           bool
+		kubeconfig          string
+		project             string
+		region              string
+		network             string
+		subnet              string
+		seed                int64
+		destroySandboxes    bool
+		handleSIGINT        bool
+		gceEndpointOverride string
+		createILBSubnet     bool
+	}
+
+	Framework *e2e.Framework
+)
+
+func init() {
+	home := os.Getenv("HOME")
+	if home != "" {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.BoolVar(&flags.run, "run", false, "set to true to run tests (suppresses test suite from 'go test ./...')")
+	flag.BoolVar(&flags.inCluster, "inCluster", false, "set to true if running in the cluster")
+	flag.StringVar(&flags.project, "project", "", "GCP project")
+	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
+	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default)")
+	flag.StringVar(&flags.subnet, "subnet", "", "Optional GCP subnet name.  Parsed from custom metadata key 'cluster-subnet'")
+	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
+	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
+	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
+	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/")
+	flag.BoolVar(&flags.createILBSubnet, "createILBSubnet", false, "If set, creates a proxy subnet for the L7 ILB")
+}
+
+// TestMain is the entrypoint for the end-to-end test suite. This is where
+// global resource setup should be done.
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	fmt.Fprintf(os.Stderr, "Flags:\n%s\n", pretty.Sprint(flags))
+
+	if !flags.inCluster && !flags.run {
+		fmt.Fprintln(os.Stderr, "Set -run to run the tests.")
+		// Return 0 here so 'go test ./...' will succeed.
+		os.Exit(0)
+	}
+	if flags.project == "" {
+		fmt.Fprintln(os.Stderr, "-project must be set to the Google Cloud test project")
+		os.Exit(1)
+	}
+	if flags.region == "" {
+		fmt.Println("-region must be set to the region of the cluster")
+		os.Exit(1)
+	}
+	if flags.network == "" {
+		fmt.Fprintln(os.Stderr, "-network must be set to the network of the cluster")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Version: %q, Commit: %q\n", version.Version, version.GitCommit)
+
+	var err error
+	var kubeconfig *rest.Config
+
+	if flags.inCluster {
+		kubeconfig, err = rest.InClusterConfig()
+		if err != nil {
+			klog.Fatalf("Error creating InClusterConfig(): %v", err)
+		}
+	} else {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfig)
+		if err != nil {
+			klog.Fatalf("Error creating kubernetes clientset from %q: %v", flags.kubeconfig, err)
+		}
+	}
+
+	if flags.seed == -1 {
+		flags.seed = time.Now().UnixNano()
+	}
+	klog.Infof("Using random seed = %d", flags.seed)
+
+	Framework = e2e.NewFramework(kubeconfig, e2e.Options{
+		Project:             flags.project,
+		Region:              flags.region,
+		Network:             flags.network,
+		Subnet:              flags.subnet,
+		Seed:                flags.seed,
+		DestroySandboxes:    flags.destroySandboxes,
+		GceEndpointOverride: flags.gceEndpointOverride,
+		CreateILBSubnet:     flags.createILBSubnet,
+	})
+	if flags.handleSIGINT {
+		Framework.CatchSIGINT()
+	}
+	if err := Framework.SanityCheck(); err != nil {
+		klog.Fatalf("Framework sanity check failed: %v", err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/cmd/ingress-controller-e2e-test/readme.md
+++ b/cmd/ingress-controller-e2e-test/readme.md
@@ -1,0 +1,105 @@
+# End-to-end tests
+
+The executable built here (`ingress-controller-e2e-test`) is intended to be run manually by a
+developer using a cluster and GCP credentials as well as in a container from
+within a cluster that has the right service account credentials.
+
+Tests should be written using the standard Golang unit test framework.
+`basic_test.go` is an example of a simple test that creates an Ingress,
+validates the configuration, deletes the Ingress and waits for the associated
+cloud resources to be removed.
+
+Tests have access to the global variable `Framework` that contains a k8s
+clientset, GCP Cloud client to interact with the environment under test. Per
+namespace sandboxes should be created with `Framework.RunWithSandbox()`. This
+is similar in behavior to `t.Run()` but includes creation of the sandbox:
+
+```go
+Framework.RunWithSandbox("my test", t, func(t*testing.T, s *e2e.Sandbox) {
+  t.Parallel()
+  // Do your test here.
+})
+```
+
+As GCLB provisioning may take some time, it is important to perform your tests
+in parallel as much as possible. The easiest way to do this is to put a
+`t.Parallel()` invocation at the start of the `func TestFoo(t *testing.T)` and
+immediately within each call to `RunWithSandbox()`.
+
+## Running the tests
+
+### Building the tests
+
+For Linux users, the `ingress-controller-e2e-test` binary will be built in a container using the
+build make target:
+
+```console
+make build
+```
+
+For Mac Users, or to build the tests locally:
+```console
+go test -c -o bin/amd64/ingress-controller-e2e-test k8s.io/ingress-gce/cmd/ingress-controller-e2e-test
+```
+
+### From the command line
+
+Run tests against your cluster and GCP environment. This uses your default
+cluster credentials. `-v` and `-logtostderr` will enable verbose logging:
+
+```go
+$ bin/amd64/ingress-controller-e2e-test -run -project my-project -v 2 -logtostderr -region my-region -network my-network
+
+Version: "v1.1.0-183-gfaefb0f2", Commit: "faefb0f257a6c591d19a4768e3a8bc776ad14d33"
+I0618 23:51:03.023843   62186 main_test.go:101] Using random seed = 1529391063023834550
+I0618 23:51:03.024330   62186 framework.go:104] Catching SIGINT
+I0618 23:51:03.024411   62186 framework.go:79] Checking connectivity with Kubernetes API
+I0618 23:51:03.464677   62186 framework.go:84] Checking connectivity with Google Cloud API (get project "my-project")
+I0618 23:51:04.068408   62186 framework.go:89] Checking external Internet connectivity
+...
+```
+
+To run a specific test case, you can use something similar to the command below:
+
+```bash
+# Ref https://golang.org/cmd/go/#hdr-Testing_flags.
+$ bin/amd64/ingress-controller-e2e-test -run -project my-project -v 2 -logtostderr -region my-region -network my-network -test.run=TestIAP
+```
+
+Note that killing the test with `CTRL-C` will cause the existing namespace
+sandboxes to be deleted, hopefully reducing the amount of cleanup necessary on
+an aborted test run:
+
+```text
+^C
+W0618 23:51:04.157786   62186 framework.go:120] SIGINT received, cleaning up sandboxes (disable with -handleSIGINT=false)
+E0618 23:51:04.157869   62186 framework.go:129] Exiting due to SIGINT
+```
+
+To prevent the test from cleaning up the namespace sandboxes (for debugging purposes), use the flag `-destroySandboxes=false`.
+
+### Within a cluster
+
+The YAML resource definition `cmd/ingress-controller-e2e-test/e2e-test.yaml` will create RBAC
+bindings and a pod built with the end-to-end test binary. Build and push the
+image to your own registry:
+
+```shell
+$ REGISTRY=gcr.io/my-reg make push
+$ sed 's/k8s-ingress-image-push/my-reg/g' cmd/ingress-controller-e2e-test/e2e-test.yaml > my-e2e-test.yaml
+$ kubectl apply -f my-e2e-test.yaml
+
+# Check the test results:
+$ kubectl logs -n default ingress-e2e
+```
+
+Note: e2e-test.yaml assumes your image is build from the tip of `master` branch.  If you are using a different tag or version, update the image tag in e2e-test.yaml accordingly.
+
+## Limitations
+
+The tests in [`ilb_test.go`](ilb_test.go) cannot be run from your local machine because they need access to the Internal HTTP(S) Load Balancer VIP provisioned by the test.  There are two ways to run these tests:
+
+1) Run the e2e-test pod in the cluster
+2) Run the e2e-test binary from a VM located inside the same VPC and Region as the [ILB Proxy-Only Subnet](https://cloud.google.com/load-balancing/docs/proxy-only-subnets)
+
+If your VPC and Region does not already have a proxy-only subnet, the test binary can create one with the flag `createILBSubnet=true`

--- a/cmd/ingress-controller-e2e-test/redirects_test.go
+++ b/cmd/ingress-controller-e2e-test/redirects_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	frontendconfig "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+)
+
+// Does not run in parallel since this is a transition test
+func TestHttpsRedirects(t *testing.T) {
+	ctx := context.Background()
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	// Run all test cases in the same sandbox to share certs
+	Framework.RunWithSandbox("https redirects transition_e2e", t, func(t *testing.T, s *e2e.Sandbox) {
+		// Setup Certificates
+		hosts := []string{"test.com"}
+		var certs []*e2e.Cert
+		for i, h := range hosts {
+			name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+			cert, err := e2e.NewCert(name, h, e2e.GCPCert, false)
+			if err != nil {
+				t.Fatalf("Error initializing cert: %v", err)
+			}
+			if err := cert.Create(s); err != nil {
+				t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+			}
+			certs = append(certs, cert)
+
+			defer cert.Delete(s)
+		}
+
+		// Each test is a transition on the original ingress
+		var gclb *fuzz.GCLB
+		var ing *v1.Ingress
+		for _, tc := range []struct {
+			desc       string
+			ingBuilder *fuzz.IngressBuilder
+			config     *frontendconfig.HttpsRedirectConfig
+		}{
+			{
+				desc: "Ingress with no redirects",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80),
+			},
+			{
+				desc: "Enable Https Redirects and response code name",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80),
+				config: &frontendconfig.HttpsRedirectConfig{Enabled: true, ResponseCodeName: "FOUND"},
+			},
+			{
+				desc: "Disable Https Redirects and response code name",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80),
+				config: &frontendconfig.HttpsRedirectConfig{Enabled: false},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				for _, cert := range certs {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+
+				// FrontendConfig Ensure
+				var feConfig *frontendconfig.FrontendConfig
+				if tc.config != nil {
+					tc.ingBuilder.SetFrontendConfig("e2e-test")
+					feConfig = &frontendconfig.FrontendConfig{ObjectMeta: metav1.ObjectMeta{Name: "e2e-test"}, Spec: frontendconfig.FrontendConfigSpec{RedirectToHttps: tc.config}}
+					if _, err := e2e.EnsureFrontendConfig(s, feConfig); err != nil {
+						t.Fatalf("Error ensuring frontendconfig: %v", err)
+					}
+				}
+
+				ing = tc.ingBuilder.Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
+
+				_, err := e2e.CreateEchoService(s, "service-1", nil)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
+					} else {
+						t.Fatalf("Error Creating Ingress: %v", err)
+					}
+				}
+
+				ing, err = e2e.WaitForIngress(s, ing, feConfig, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Check just for URL map deletion.  This URL map should have been created in another transition test case
+				// TODO(shance): uncomment this once GC has been fixed
+				//if tc.config != nil && !tc.config.Enabled {
+				//	if err := e2e.WaitForRedirectURLMapDeletion(ctx, Framework.Cloud, gclb); err != nil {
+				//		t.Errorf("WaitForRedirectURLMapDeletion(%v) = %v", gclb, err)
+				//	}
+				//}
+
+				// Perform whitebox testing.
+				gclb, err = e2e.WhiteboxTest(ing, feConfig, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+				}
+			})
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+// Does not run in parallel since this is a transition test
+func TestRegionalXLBHttpsRedirects(t *testing.T) {
+	ctx := context.Background()
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	// Run all test cases in the same sandbox to share certs
+	Framework.RunWithSandbox("rxlb https redirects transition_e2e", t, func(t *testing.T, s *e2e.Sandbox) {
+		// Setup Certificates
+		hosts := []string{"test.com"}
+		var certs []*e2e.Cert
+		for i, h := range hosts {
+			name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+			cert, err := e2e.NewCert(name, h, e2e.GCPCert, true)
+			if err != nil {
+				t.Fatalf("Error initializing cert: %v", err)
+			}
+			if err := cert.Create(s); err != nil {
+				t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+			}
+			certs = append(certs, cert)
+
+			defer cert.Delete(s)
+		}
+
+		// Each test is a transition on the original ingress
+		var gclb *fuzz.GCLB
+		var ing *v1.Ingress
+		for _, tc := range []struct {
+			desc       string
+			ingBuilder *fuzz.IngressBuilder
+			config     *frontendconfig.HttpsRedirectConfig
+		}{
+			{
+				desc: "Ingress with no redirects",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80).
+					ConfigureForRegionalXLB(),
+			},
+			{
+				desc: "Enable Https Redirects and response code name",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80).
+					ConfigureForRegionalXLB(),
+				config: &frontendconfig.HttpsRedirectConfig{Enabled: true, ResponseCodeName: "FOUND"},
+			},
+			{
+				desc: "Disable Https Redirects and response code name",
+				ingBuilder: fuzz.NewIngressBuilder("", "ingress-1", "").
+					DefaultBackend("service-1", port80).
+					AddPath("test.com", "/", "service-1", port80).
+					ConfigureForRegionalXLB(),
+				config: &frontendconfig.HttpsRedirectConfig{Enabled: false},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				for _, cert := range certs {
+					tc.ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+
+				// FrontendConfig Ensure
+				var feConfig *frontendconfig.FrontendConfig
+				if tc.config != nil {
+					tc.ingBuilder.SetFrontendConfig("e2e-test")
+					feConfig = &frontendconfig.FrontendConfig{ObjectMeta: metav1.ObjectMeta{Name: "e2e-test"}, Spec: frontendconfig.FrontendConfigSpec{RedirectToHttps: tc.config}}
+					if _, err := e2e.EnsureFrontendConfig(s, feConfig); err != nil {
+						t.Fatalf("Error ensuring frontendconfig: %v", err)
+					}
+				}
+
+				ing = tc.ingBuilder.Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
+
+				_, err := e2e.CreateEchoService(s, "service-1", negAnnotation)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
+					} else {
+						t.Fatalf("Error Creating Ingress: %v", err)
+					}
+				}
+
+				ing, err = e2e.WaitForIngress(s, ing, feConfig, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Check just for URL map deletion.  This URL map should have been created in another transition test case
+				if tc.config != nil && !tc.config.Enabled {
+					if err := e2e.WaitForRedirectURLMapDeletion(ctx, Framework.Cloud, gclb); err != nil {
+						t.Errorf("WaitForRedirectURLMapDeletion(%v) = %v", gclb, err)
+					}
+				}
+
+				// Perform whitebox testing.
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				t.Logf("Ingress %s/%s VIP = %s", ing.Namespace, ing.Name, vip)
+
+				params := &fuzz.GCLBForVIPParams{
+					VIP:              vip,
+					Validators:       fuzz.FeatureValidators(features.All),
+					Region:           Framework.Region,
+					Network:          Framework.Network,
+					IsForRegionalXLB: true,
+				}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+			})
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}

--- a/cmd/ingress-controller-e2e-test/regional_xlb_test.go
+++ b/cmd/ingress-controller-e2e-test/regional_xlb_test.go
@@ -1,0 +1,502 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+// TestRegionalXLB simple test that creates and deletes gce-regional-external
+// ingress. Should be run only when ingress-gce has
+// --enable-ingress-regional-external flag enabled.
+func TestRegionalXLB(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing1-"
+	serviceName := "svc-1"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc string
+		ing  *v1.Ingress
+
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "http Regional XLB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc: "http Regional XLB one path",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+		{
+			desc: "http Regional XLB multiple paths",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			t.Logf("Ingress = %s", tc.ing.String())
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			tc.ing.Namespace = s.Namespace
+			if _, err := crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+			}
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Error(err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+// TestRegionalXLBStaticIP is a transition test:
+// 1) static IP disabled
+// 2) static IP enabled
+// 3) static IP disabled
+func TestRegionalXLBStaticIP(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("rxlb-static-ip", t, func(t *testing.T, s *e2e.Sandbox) {
+		_, err := e2e.CreateEchoService(s, "service-1", negAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(s, service-1, nil) = _, %v; want _, nil", err)
+		}
+
+		addrName := fmt.Sprintf("test-addr-%s", s.Namespace)
+		if err := e2e.NewGCPRegionalExternalAddress(s, addrName, Framework.Region); err != nil {
+			t.Fatalf("e2e.NewGCPRegionalExternalAddress(..., %s) = %v, want nil", addrName, err)
+		}
+		defer e2e.DeleteGCPAddress(s, addrName, Framework.Region)
+
+		testIngEnabled := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", v1.ServiceBackendPort{Number: 80}).
+			ConfigureForRegionalXLB().
+			AddStaticIP(addrName, true).
+			Build()
+		testIngDisabled := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", v1.ServiceBackendPort{Number: 80}).
+			ConfigureForRegionalXLB().
+			Build()
+
+		// Create original ingress
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		ing, err := crud.Create(testIngDisabled)
+		if err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress %s/%s created", s.Namespace, ing.Name)
+
+		var gclb *fuzz.GCLB
+		for i, testIng := range []*v1.Ingress{testIngDisabled, testIngEnabled, testIngDisabled} {
+			t.Run(fmt.Sprintf("Transition-%d", i), func(t *testing.T) {
+				ing, err = e2e.EnsureIngress(s, testIng)
+				if err != nil {
+					t.Fatalf("error patching Ingress spec: %v", err)
+				}
+				t.Logf("Ingress %s/%s updated", s.Namespace, testIng.Name)
+
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
+				}
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+			})
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+// Test RXLB and ILB sharing same service
+func TestRegionalXLBILBShared(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing5-"
+	serviceName := "svc-5"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc               string
+		ilbIng             *v1.Ingress
+		rxlbIng            *v1.Ingress
+		numForwardingRules int
+		numBackendServices int
+	}{
+		{
+			desc: "default backend",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			rxlbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+		},
+		{
+			desc: "one path",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			rxlbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+		{
+			desc: "multiple paths",
+			ilbIng: fuzz.NewIngressBuilder("", ingressPrefix+"i-3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			rxlbIng: fuzz.NewIngressBuilder("", ingressPrefix+"e-3", "").
+				AddPath("test.com", "/foo", serviceName, port80).
+				AddPath("test.com", "/bar", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			var gclb *fuzz.GCLB
+			for _, ing := range []*v1.Ingress{tc.ilbIng, tc.rxlbIng} {
+
+				t.Logf("Ingress = %s", ing.String())
+
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				ing.Namespace = s.Namespace
+				if _, err := crud.Create(ing); err != nil {
+					t.Fatalf("error creating Ingress spec: %v", err)
+				}
+				t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+				ing, err := e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Perform whitebox testing.
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+				if utils.IsGCEL7ILBIngress(ing) && !e2e.IsRfc1918Addr(vip) {
+					t.Fatalf("got %v, want RFC1918 address, ing: %v", vip, ing)
+				}
+
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+
+				if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}
+
+// Test Updating RXLB and transitioning between ILB/RXLB
+func TestRegionalXLBILBTransition(t *testing.T) {
+	t.Parallel()
+
+	// These names are useful when reading the debug logs
+	ingressPrefix := "ing3-"
+	serviceName := "svc-3"
+
+	port80 := v1.ServiceBackendPort{Number: 80}
+
+	for _, tc := range []struct {
+		desc      string
+		ing       *v1.Ingress
+		ingUpdate *v1.Ingress
+
+		numForwardingRules       int
+		numBackendServices       int
+		numForwardingRulesUpdate int
+		numBackendServicesUpdate int
+	}{
+		{
+			desc: "http RXLB default backend to one path",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"1", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 2,
+		},
+		{
+			desc: "http RXLB one path to default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				AddPath("test.com", "/", serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 2,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"2", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+		{
+			desc: "http ILB default backend to ELB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"3", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+		{
+			desc: "RXLB default backend to ILB default backend",
+			ing: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForRegionalXLB().
+				Build(),
+			numForwardingRules: 1,
+			numBackendServices: 1,
+			ingUpdate: fuzz.NewIngressBuilder("", ingressPrefix+"4", "").
+				DefaultBackend(serviceName, port80).
+				ConfigureForILB().
+				Build(),
+			numForwardingRulesUpdate: 1,
+			numBackendServicesUpdate: 1,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			t.Logf("Ingress = %s", tc.ing.String())
+
+			if Framework.CreateILBSubnet {
+				if err := e2e.CreateILBSubnet(s); err != nil && err != e2e.ErrSubnetExists {
+					t.Fatalf("e2e.CreateILBSubnet(%+v) = %v", s, err)
+				}
+			}
+
+			_, err := e2e.CreateEchoService(s, serviceName, negAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, serviceName)
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			tc.ing.Namespace = s.Namespace
+			if _, err := crud.Create(tc.ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			ing1, err := e2e.WaitForIngress(s, tc.ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ing.Name)
+
+			// Perform whitebox testing.
+			if len(ing1.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing1.Status)
+			}
+
+			vip := ing1.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ing.Name, vip)
+
+			if utils.IsGCEL7ILBIngress(ing1) && !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing1: %v", vip, ing1)
+			}
+
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Region: Framework.Region, Network: Framework.Network, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb, tc.numForwardingRules, tc.numBackendServices); err != nil {
+				t.Errorf("e2e.CheckGCLB(%v, %d, %d) returned error for ingress %s/%s after transition: %v", gclb, tc.numForwardingRules, tc.numBackendServices, ing1.Namespace, tc.ing.Name, err)
+			}
+
+			tc.ingUpdate.Namespace = s.Namespace
+			// Perform update
+			if _, err := crud.Update(tc.ingUpdate); err != nil {
+				t.Fatalf("error updating ingress spec: %v", err)
+			}
+
+			// Sleep to ensure that the ingress is updated. WaitForIngress is not checking
+			// that address was changed from External IP to Internal IP.
+			time.Sleep(10 * time.Minute)
+			// Verify everything works
+			ing2, err := e2e.WaitForIngress(s, tc.ingUpdate, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, tc.ingUpdate.Name)
+
+			if len(ing2.Status.LoadBalancer.Ingress) < 1 {
+				t.Fatalf("Ingress does not have an IP: %+v", ing2.Status)
+			}
+
+			vip = ing2.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, tc.ingUpdate.Name, vip)
+			if utils.IsGCEL7ILBIngress(ing2) && !e2e.IsRfc1918Addr(vip) {
+				t.Fatalf("got %v, want RFC1918 address, ing1: %v", vip, ing2)
+			}
+
+			params.VIP = vip
+			gclb2, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			if err = e2e.CheckGCLB(gclb2, tc.numForwardingRulesUpdate, tc.numBackendServicesUpdate); err != nil {
+				t.Errorf("e2e.CheckGCLB(%v, %d, %d) returned error for ingress %s/%s after transition: %v", gclb2, tc.numForwardingRulesUpdate, tc.numBackendServicesUpdate, s.Namespace, tc.ingUpdate.Name, err)
+			}
+
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb, s, ing1, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing1.Name, err)
+			}
+			if err := e2e.WaitForIngressDeletion(context.Background(), gclb2, s, ing2, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing2.Name, err)
+			}
+		})
+	}
+}

--- a/cmd/ingress-controller-e2e-test/run.sh
+++ b/cmd/ingress-controller-e2e-test/run.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# run.sh manages the settings required for running containerized in a
+# Kubernetes cluster.
+echo '--- BEGIN ---'
+
+for ATTEMPT in $(seq 60); do
+  PROJECT=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null)
+  if [[ -n "$PROJECT" ]]; then
+    break
+  fi
+  echo "Warning: could not get Compute project name from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: could not get Compute project name from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+
+for ATTEMPT in $(seq 60); do
+  ZONE_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/zone)
+  if [[ -n "${ZONE_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get zone from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${ZONE_INFO}" ]]; then
+  echo "Error: could not get zone info from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+echo "ZONE_INFO: ${ZONE_INFO}"
+
+# Get Region information from zone info
+ZONE=$(echo ${ZONE_INFO} | sed 's+projects/.*/zones/++')
+REGION=$(echo ${ZONE} | sed 's/-[a-z]$//')
+
+if [[ -z "${REGION}" ]]; then
+  echo "Error: could not parse region from zone info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Region: ${REGION}"
+
+# Get network information
+for ATTEMPT in $(seq 60); do
+  NETWORK_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/network)
+  if [[ -n "${NETWORK_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get network from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+NETWORK=$(echo ${NETWORK_INFO} | sed 's+projects/.*/networks/++')
+
+if [[ -z "${NETWORK}" ]]; then
+  echo "Error: could not parse network from network info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Network: ${NETWORK}"
+
+# Get subnet  information
+# We expect the custom metadata field 'cluster-subnet' on all VMs.
+for ATTEMPT in $(seq 60); do
+  SUBNET=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-subnet)
+  if [[ -n "${SUBNET}" ]]; then
+    break
+  fi
+  echo "Error: could not get subnet from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${SUBNET}" ]]; then
+  echo "Error: could not get subnet"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Subnet: ${SUBNET}"
+
+
+echo
+echo ==============================================================================
+echo "PROJECT: ${PROJECT}"
+CMD="/ingress-controller-e2e-test -test.v -test.parallel=100 -run -project ${PROJECT} -region ${REGION} -network ${NETWORK} -subnet ${SUBNET} -logtostderr -inCluster -v=2"
+echo "CMD: ${CMD}" $@
+echo
+
+echo ==============================================================================
+echo E2E TEST
+echo
+${CMD} "$@" 2>&1
+RESULT=$?
+echo
+
+if [[ "${DUMP_RESOURCES:-}" == "true" ]]; then
+  GCLOUD=/google-cloud-sdk/bin/gcloud
+  RESOURCES="forwarding-rules target-http-proxies target-https-proxies url-maps backend-services"
+  for RES in ${RESOURCES}; do
+    echo ==============================================================================
+    echo "GCP RESOURCE: ${RES}"
+    ${GCLOUD} compute ${RES} list --quiet --project ${PROJECT} --format yaml 2>&1
+  done
+fi
+
+echo ==============================================================================
+echo "RESULT: $RESULT"
+echo '--- END ---'

--- a/cmd/ingress-controller-e2e-test/security_policy_test.go
+++ b/cmd/ingress-controller-e2e-test/security_policy_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	computebeta "google.golang.org/api/compute/v0.beta"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	policyUpdateInterval = 15 * time.Second
+	policyUpdateTimeout  = 10 * time.Minute
+)
+
+var deleteOptions = &fuzz.GCLBDeleteOptions{
+	SkipDefaultBackend: true,
+}
+
+func buildPolicyAllowAll(name string) *computebeta.SecurityPolicy {
+	return &computebeta.SecurityPolicy{
+		Name: name,
+	}
+}
+
+func buildPolicyDisallowAll(name string) *computebeta.SecurityPolicy {
+	return &computebeta.SecurityPolicy{
+		Name: name,
+		Rules: []*computebeta.SecurityPolicyRule{
+			{
+				Action: "deny(403)",
+				Match: &computebeta.SecurityPolicyRuleMatcher{
+					Config: &computebeta.SecurityPolicyRuleMatcherConfig{
+						SrcIpRanges: []string{"*"},
+					},
+					VersionedExpr: "SRC_IPS_V1",
+				},
+				Priority: 2147483647,
+			},
+		},
+	}
+}
+
+func TestSecurityPolicyEnable(t *testing.T) {
+	ctx := context.Background()
+	t.Parallel()
+
+	Framework.RunWithSandbox("Security Policy Enable", t, func(t *testing.T, s *e2e.Sandbox) {
+		policies := []*computebeta.SecurityPolicy{
+			buildPolicyAllowAll(fmt.Sprintf("enable-test-allow-all-%s", s.Namespace)),
+		}
+		defer func() {
+			if err := cleanupSecurityPolicies(ctx, t, Framework.Cloud, policies); err != nil {
+				t.Errorf("cleanupSecurityPolicies(...) =  %v, want nil", err)
+			}
+		}()
+		policies, err := createSecurityPolicies(ctx, t, Framework.Cloud, policies)
+		if err != nil {
+			t.Fatalf("createSecurityPolicies(...) = _, %v, want _, nil", err)
+		}
+		// Re-assign to get the populated self-link.
+		testSecurityPolicy := policies[0]
+
+		testBackendConfigAnnotation := map[string]string{
+			annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+		}
+		testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
+		}
+
+		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicy.Name).Build()
+		bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
+		if err != nil {
+			t.Fatalf("Error creating test backend config: %v", err)
+		}
+		t.Logf("Backend config %s/%s created", s.Namespace, testBackendConfig.Name)
+
+		port80 := v1.ServiceBackendPort{Number: 80}
+		testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			AddPath("test.com", "/", "service-1", port80).
+			Build()
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		testIng, err = crud.Create(testIng)
+		if err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
+
+		t.Logf("Checking on relevant backend service whether security policy is properly attached")
+
+		testIng, err = e2e.WaitForIngress(s, testIng, nil, nil)
+		if err != nil {
+			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
+		}
+		if len(testIng.Status.LoadBalancer.Ingress) < 1 {
+			t.Fatalf("Ingress does not have an IP: %+v", testIng.Status)
+		}
+
+		vip := testIng.Status.LoadBalancer.Ingress[0].IP
+		params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators([]fuzz.Feature{features.SecurityPolicy})}
+		gclb, err := fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
+		if err != nil {
+			t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
+		}
+
+		if err := verifySecurityPolicy(t, gclb, s.Namespace, testSvc.Name, testSecurityPolicy.SelfLink); err != nil {
+			t.Errorf("verifySecurityPolicy(..., %q, %q, %q) = %v, want nil", s.Namespace, testSvc.Name, testSecurityPolicy.SelfLink, err)
+		}
+
+		t.Logf("Cleaning up test")
+
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, testIng, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", testIng.Name, err)
+		}
+	})
+}
+
+func TestSecurityPolicyTransition(t *testing.T) {
+	ctx := context.Background()
+	t.Parallel()
+
+	Framework.RunWithSandbox("Security Policy Transition", t, func(t *testing.T, s *e2e.Sandbox) {
+		policies := []*computebeta.SecurityPolicy{
+			buildPolicyAllowAll(fmt.Sprintf("transition-test-allow-all-%s", s.Namespace)),
+			buildPolicyDisallowAll(fmt.Sprintf("transition-test-disallow-all-%s", s.Namespace)),
+		}
+		defer func() {
+			if err := cleanupSecurityPolicies(ctx, t, Framework.Cloud, policies); err != nil {
+				t.Errorf("cleanupSecurityPolicies(...) = %v, want nil", err)
+			}
+		}()
+		policies, err := createSecurityPolicies(ctx, t, Framework.Cloud, policies)
+		if err != nil {
+			t.Fatalf("createSecurityPolicies(...) = _, %v, want _, nil", err)
+		}
+		// Re-assign to get the populated self-link.
+		testSecurityPolicyAllow, testSecurityPolicyDisallow := policies[0], policies[1]
+
+		testBackendConfigAnnotation := map[string]string{
+			annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+		}
+		testSvc, err := e2e.CreateEchoService(s, "service-1", testBackendConfigAnnotation)
+		if err != nil {
+			t.Fatalf("e2e.CreateEchoService(s, service-1, %q) = _, _, %v, want _, _, nil", testBackendConfigAnnotation, err)
+		}
+
+		testBackendConfig := fuzz.NewBackendConfigBuilder(s.Namespace, "backendconfig-1").SetSecurityPolicy(testSecurityPolicyAllow.Name).Build()
+		bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+		testBackendConfig, err = bcCRUD.Create(testBackendConfig)
+		if err != nil {
+			t.Fatalf("Error creating test backend config: %v", err)
+		}
+		t.Logf("Backend config %s/%s created", s.Namespace, testBackendConfig.Name)
+
+		port80 := v1.ServiceBackendPort{Number: 80}
+		testIng := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			AddPath("test.com", "/", "service-1", port80).
+			Build()
+		crud := adapter.IngressCRUD{C: Framework.Clientset}
+		testIng, err = crud.Create(testIng)
+		if err != nil {
+			t.Fatalf("error creating Ingress spec: %v", err)
+		}
+		t.Logf("Ingress %s/%s created", s.Namespace, testIng.Name)
+
+		ing, err := e2e.WaitForIngress(s, testIng, nil, nil)
+		if err != nil {
+			t.Fatalf("e2e.WaitForIngress(s, %q) = _, %v; want _, nil", testIng.Name, err)
+		}
+		if len(ing.Status.LoadBalancer.Ingress) < 1 {
+			t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+		}
+
+		vip := ing.Status.LoadBalancer.Ingress[0].IP
+		var gclb *fuzz.GCLB
+
+		steps := []struct {
+			desc                string
+			securityPolicyToSet string
+			expectedpolicyLink  string
+		}{
+			{
+				desc:                "update to use policy that disallows all",
+				securityPolicyToSet: testSecurityPolicyDisallow.Name,
+				expectedpolicyLink:  testSecurityPolicyDisallow.SelfLink,
+			},
+			{
+				desc:                "detach policy",
+				securityPolicyToSet: "",
+				expectedpolicyLink:  "",
+			},
+		}
+
+		for _, step := range steps {
+			t.Run(step.desc, func(t *testing.T) {
+				testBackendConfig.Spec.SecurityPolicy.Name = step.securityPolicyToSet
+				bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+				testBackendConfig, err = bcCRUD.Update(testBackendConfig)
+				if err != nil {
+					t.Fatalf("Error updating test backend config: %v", err)
+				}
+				t.Logf("Backend config %s/%s updated", testBackendConfig.Name, s.Namespace)
+
+				t.Logf("Waiting %v for security policy to be updated on relevant backend service", policyUpdateTimeout)
+				if err := wait.Poll(policyUpdateInterval, policyUpdateTimeout, func() (bool, error) {
+					params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+					gclb, err = fuzz.GCLBForVIP(ctx, Framework.Cloud, params)
+					if err != nil {
+						t.Fatalf("fuzz.GCLBForVIP(..., %q, %q) = _, %v; want _, nil", vip, features.SecurityPolicy, err)
+					}
+
+					if err := verifySecurityPolicy(t, gclb, s.Namespace, testSvc.Name, step.expectedpolicyLink); err != nil {
+						t.Logf("verifySecurityPolicy(..., %q, %q, %q) = %v, want nil", s.Namespace, testSvc.Name, step.expectedpolicyLink, err)
+						return false, nil
+					}
+					return true, nil
+				}); err != nil {
+					t.Errorf("Failed to wait for security policy updated: %v", err)
+				}
+			})
+		}
+
+		t.Logf("Cleaning up test")
+
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+func createSecurityPolicies(ctx context.Context, t *testing.T, c cloud.Cloud, policies []*computebeta.SecurityPolicy) ([]*computebeta.SecurityPolicy, error) {
+	t.Logf("Creating security policies...")
+	createdPolicies := []*computebeta.SecurityPolicy{}
+	for _, policy := range policies {
+		if err := c.BetaSecurityPolicies().Insert(ctx, meta.GlobalKey(policy.Name), policy); err != nil {
+			return nil, fmt.Errorf("error creating security policy %q: %v", policy.Name, err)
+		}
+		t.Logf("Security policy %q created", policy.Name)
+		policy, err := c.BetaSecurityPolicies().Get(ctx, meta.GlobalKey(policy.Name))
+		if err != nil {
+			return nil, fmt.Errorf("error getting security policy %q: %v", policy.Name, err)
+		}
+		createdPolicies = append(createdPolicies, policy)
+	}
+	return createdPolicies, nil
+}
+
+func cleanupSecurityPolicies(ctx context.Context, t *testing.T, c cloud.Cloud, policies []*computebeta.SecurityPolicy) error {
+	t.Logf("Deleting security policies...")
+	var errs []string
+	for _, policy := range policies {
+		if err := c.BetaSecurityPolicies().Delete(ctx, meta.GlobalKey(policy.Name)); err != nil {
+			errs = append(errs, err.Error())
+		}
+		t.Logf("Security policy %q deleted", policy.Name)
+	}
+	if len(errs) != 0 {
+		return fmt.Errorf("failed to delete security policies: %s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func verifySecurityPolicy(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName, policyLink string) error {
+	numBsWithPolicy := 0
+	for _, bs := range gclb.BackendService {
+		// Check on relevant backend services.
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+
+		if bs.Beta == nil {
+			return fmt.Errorf("beta BackendService resource not found: %v", bs)
+		}
+		if bs.Beta.SecurityPolicy != policyLink {
+			return fmt.Errorf("backend service %q has security policy %q, want %q", bs.Beta.Name, bs.Beta.SecurityPolicy, policyLink)
+		}
+		t.Logf("Backend service %q has the expected security policy %q attached", bs.Beta.Name, bs.Beta.SecurityPolicy)
+		numBsWithPolicy = numBsWithPolicy + 1
+	}
+	if numBsWithPolicy != 1 {
+		return fmt.Errorf("unexpected number of backend service has security policy attached: got %d, want 1", numBsWithPolicy)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/sslpolicy_test.go
+++ b/cmd/ingress-controller-e2e-test/sslpolicy_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"google.golang.org/api/compute/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const policyName = "e2e-ssl-policy"
+
+// TestSSLPolicy is a transition test
+func TestSSLPolicy(t *testing.T) {
+	ctx := context.Background()
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+
+	// Run all test cases in the same sandbox to share certs
+	Framework.RunWithSandbox("sslpolicy_e2e", t, func(t *testing.T, s *e2e.Sandbox) {
+		// Shared amongst all tests
+		sslPolicy := &compute.SslPolicy{Name: policyName, MinTlsVersion: "TLS_1_0", Profile: "COMPATIBLE"}
+		ingBuilder := fuzz.NewIngressBuilder("", "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			AddPath("test.com", "/", "service-1", port80)
+
+		// Setup Certificates
+		hosts := []string{"test.com"}
+		var certs []*e2e.Cert
+		for i, h := range hosts {
+			name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+			cert, err := e2e.NewCert(name, h, e2e.GCPCert, false)
+			if err != nil {
+				t.Fatalf("Error initializing cert: %v", err)
+			}
+			if err := cert.Create(s); err != nil {
+				t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+			}
+			certs = append(certs, cert)
+
+			defer cert.Delete(s)
+		}
+
+		var gclb *fuzz.GCLB
+		var ing *networkingv1.Ingress
+		for _, tc := range []struct {
+			desc             string
+			configPolicyName string
+		}{
+			{
+				desc:             "Set SslPolicy",
+				configPolicyName: policyName,
+			},
+			{
+				desc:             "Remove SslPolicy",
+				configPolicyName: "",
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				for _, cert := range certs {
+					ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+
+				// Ensure Ssl Policy exists, we re-use it for all e2e tests that run in the same project.
+				err := Framework.Cloud.SslPolicies().Insert(ctx, meta.GlobalKey(policyName), sslPolicy)
+				if err != nil {
+					if !utils.IsHTTPErrorCode(err, http.StatusConflict) {
+						t.Errorf("SslPolicies().Insert(%v, %v) = %v, want nil", meta.GlobalKey(policyName), sslPolicy, err)
+					}
+				} else {
+					t.Logf("SslPolicy %q Created", policyName)
+				}
+
+				// Ensure FrontendConfig
+				feConfig, err := e2e.EnsureFrontendConfig(s, fuzz.NewFrontendConfigBuilder(s.Namespace, "e2e-feconfig").SetSslPolicy(tc.configPolicyName).Build())
+				if err != nil {
+					t.Errorf("EnsureFrontendConfig(%v) = %v, want nil", feConfig, err)
+				}
+
+				ing = ingBuilder.SetFrontendConfig(feConfig.Name).Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
+
+				_, err = e2e.CreateEchoService(s, "service-1", nil)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
+					} else {
+						t.Fatalf("Error Creating Ingress: %v", err)
+					}
+				}
+
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Perform whitebox testing.
+				gclb, err = e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+				}
+
+				// Check that SslPolicy is added to Target Proxy
+				if len(gclb.TargetHTTPSProxy) == 0 {
+					t.Errorf("No target https proxy found")
+				}
+
+				for _, tps := range gclb.TargetHTTPSProxy {
+					if tps.GA.SslPolicy != "" {
+						resourceID, err := cloud.ParseResourceURL(tps.GA.SslPolicy)
+						if err != nil {
+							t.Fatalf("ParseResourceURL(%q) = %v, want nil", tps.GA.SslPolicy, err)
+						}
+
+						if resourceID.Key == nil || resourceID.Key.Name != tc.configPolicyName {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, tc.configPolicyName)
+						}
+					} else {
+						if tc.configPolicyName != "" {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, tc.configPolicyName)
+						}
+					}
+				}
+			})
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}
+
+// TestRegionalXLBsslPolicy is a transition test
+func TestRegionalXLBsslPolicy(t *testing.T) {
+	ctx := context.Background()
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+
+	// Run all test cases in the same sandbox to share certs
+	Framework.RunWithSandbox("sslpolicy_e2e", t, func(t *testing.T, s *e2e.Sandbox) {
+		// Shared amongst all tests
+		sslPolicy := &compute.SslPolicy{Name: policyName, MinTlsVersion: "TLS_1_0", Profile: "COMPATIBLE"}
+		ingBuilder := fuzz.NewIngressBuilder("", "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			ConfigureForRegionalXLB().
+			AddPath("test.com", "/", "service-1", port80)
+
+		// Setup Certificates
+		hosts := []string{"test.com"}
+		var certs []*e2e.Cert
+		for i, h := range hosts {
+			name := fmt.Sprintf("cert%d--%s", i, s.Namespace)
+			cert, err := e2e.NewCert(name, h, e2e.GCPCert, true)
+			if err != nil {
+				t.Fatalf("Error initializing cert: %v", err)
+			}
+			if err := cert.Create(s); err != nil {
+				t.Fatalf("Error creating cert %s: %v", cert.Name, err)
+			}
+			certs = append(certs, cert)
+
+			defer cert.Delete(s)
+		}
+
+		var gclb *fuzz.GCLB
+		var ing *networkingv1.Ingress
+		for _, tc := range []struct {
+			desc             string
+			configPolicyName string
+		}{
+			{
+				desc:             "Set SslPolicy",
+				configPolicyName: policyName,
+			},
+			{
+				desc:             "Remove SslPolicy",
+				configPolicyName: "",
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				t.Logf("Running %s", tc.desc)
+				for _, cert := range certs {
+					ingBuilder.AddPresharedCerts([]string{cert.Name})
+				}
+
+				// Ensure Ssl Policy exists, we re-use it for all e2e tests that run in the same project.
+				err := Framework.Cloud.RegionSslPolicies().Insert(ctx, meta.RegionalKey(policyName, Framework.Region), sslPolicy)
+				if err != nil {
+					if !utils.IsHTTPErrorCode(err, http.StatusConflict) {
+						t.Errorf("RegionSslPolicies().Insert(%v, %v) = %v, want nil", meta.RegionalKey(policyName, Framework.Region), sslPolicy, err)
+					}
+				} else {
+					t.Logf("RegionSslPolicies %q Created", policyName)
+				}
+
+				// Ensure FrontendConfig
+				feConfig, err := e2e.EnsureFrontendConfig(s, fuzz.NewFrontendConfigBuilder(s.Namespace, "e2e-feconfig").SetSslPolicy(tc.configPolicyName).Build())
+				if err != nil {
+					t.Errorf("EnsureFrontendConfig(%v) = %v, want nil", feConfig, err)
+				}
+
+				ing = ingBuilder.SetFrontendConfig(feConfig.Name).Build()
+				ing.Namespace = s.Namespace // namespace depends on sandbox
+
+				_, err = e2e.CreateEchoService(s, "service-1", negAnnotation)
+				if err != nil {
+					t.Fatalf("Error creating echo service: %v", err)
+				}
+				t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+				// Ensure Ingress
+				crud := adapter.IngressCRUD{C: Framework.Clientset}
+				_, err = crud.Create(ing)
+				if err != nil {
+					if errors.IsAlreadyExists(err) {
+						if _, err := crud.Update(ing); err != nil {
+							t.Fatalf("Error updating Ingress: %v", err)
+						}
+					} else {
+						t.Fatalf("Error Creating Ingress: %v", err)
+					}
+				}
+
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("Error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				if len(ing.Status.LoadBalancer.Ingress) < 1 {
+					t.Fatalf("Ingress does not have an IP: %+v", ing.Status)
+				}
+
+				if tc.configPolicyName == "" {
+					//time.Sleep(20 * time.Minute)
+				}
+				vip := ing.Status.LoadBalancer.Ingress[0].IP
+				params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region, Network: Framework.Network}
+				gclb, err = fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+				if err != nil {
+					t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+				}
+
+				// Check that SslPolicy is added to Target Proxy
+				if len(gclb.TargetHTTPSProxy) == 0 {
+					t.Errorf("No target https proxy found")
+				}
+
+				for _, tps := range gclb.TargetHTTPSProxy {
+					t.Logf("%+v", tps.Beta.SslPolicy)
+					if tps.Beta.SslPolicy != "" {
+						resourceID, err := cloud.ParseResourceURL(tps.Beta.SslPolicy)
+						if err != nil {
+							t.Fatalf("ParseResourceURL(%q) = %v, want nil", tps.Beta.SslPolicy, err)
+						}
+
+						if resourceID.Key == nil || resourceID.Key.Name != tc.configPolicyName {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.Beta.SslPolicy, tc.configPolicyName)
+						}
+					} else {
+						if tc.configPolicyName != "" {
+							t.Errorf("Incorrect SslPolicy set for TargetHttpsProxy: %q, want %q", tps.GA.SslPolicy, tc.configPolicyName)
+						}
+					}
+				}
+			})
+		}
+
+		deleteOptions := &fuzz.GCLBDeleteOptions{
+			SkipDefaultBackend: true,
+		}
+		if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, deleteOptions); err != nil {
+			t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+		}
+	})
+}

--- a/cmd/ingress-controller-e2e-test/timeout_test.go
+++ b/cmd/ingress-controller-e2e-test/timeout_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	backendconfig "k8s.io/ingress-gce/pkg/apis/backendconfig/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/fuzz/features"
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const GLBDefaultTimeout int64 = 30
+
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http with 60s timeout",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetTimeout(42).
+				Build(),
+		},
+		{
+			desc: "http no timeout defined",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All)}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			var timeout int64
+			if tc.beConfig.Spec.TimeoutSec == nil {
+				timeout = GLBDefaultTimeout
+			} else {
+				timeout = *tc.beConfig.Spec.TimeoutSec
+			}
+
+			if err := verifyTimeout(t, gclb, s.Namespace, "service-1", timeout); err != nil {
+				t.Errorf("verifyTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", timeout, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+// Test Connection Timeout feature with L7-ILB
+// Named specifically to avoid using "Timeout" so that we don't run this accidentally
+func TestILBCT(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http with 60s timeout",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetTimeout(42).
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			svcAnnotation := map[string]string{
+				annotations.BetaBackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey:     negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", svcAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				ConfigureForILB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			var timeout int64
+			if tc.beConfig.Spec.TimeoutSec == nil {
+				timeout = GLBDefaultTimeout
+			} else {
+				timeout = *tc.beConfig.Spec.TimeoutSec
+			}
+
+			if err := verifyTimeout(t, gclb, s.Namespace, "service-1", timeout); err != nil {
+				t.Errorf("verifyTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", timeout, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+// TODO(slavik): rename to TestRegionalXLBTimeout.
+func TestRegionalXLBCT(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc     string
+		beConfig *backendconfig.BackendConfig
+	}{
+		{
+			desc: "http with 60s timeout",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				SetTimeout(42).
+				Build(),
+		},
+		{
+			desc: "http no timeout defined",
+			beConfig: fuzz.NewBackendConfigBuilder("", "backendconfig-1").
+				Build(),
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			backendConfigAnnotation := map[string]string{
+				annotations.BackendConfigKey: `{"default":"backendconfig-1"}`,
+				annotations.NEGAnnotationKey: negVal.String(),
+			}
+
+			bcCRUD := adapter.BackendConfigCRUD{C: Framework.BackendConfigClient}
+			tc.beConfig.Namespace = s.Namespace
+			if _, err := bcCRUD.Create(tc.beConfig); err != nil {
+				t.Fatalf("error creating BackendConfig: %v", err)
+			}
+			t.Logf("BackendConfig created (%s/%s) ", s.Namespace, tc.beConfig.Name)
+
+			_, err := e2e.CreateEchoService(s, "service-1", backendConfigAnnotation)
+			if err != nil {
+				t.Fatalf("error creating echo service: %v", err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, "service-1")
+
+			ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+				AddPath("test.com", "/", "service-1", v1.ServiceBackendPort{Number: 80}).
+				ConfigureForRegionalXLB().
+				Build()
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			if _, err := crud.Create(ing); err != nil {
+				t.Fatalf("error creating Ingress spec: %v", err)
+			}
+			t.Logf("Ingress created (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			vip := ing.Status.LoadBalancer.Ingress[0].IP
+			t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+			params := &fuzz.GCLBForVIPParams{VIP: vip, Validators: fuzz.FeatureValidators(features.All), Region: Framework.Region}
+			gclb, err := fuzz.GCLBForVIP(context.Background(), Framework.Cloud, params)
+			if err != nil {
+				t.Fatalf("Error getting GCP resources for LB with IP = %q: %v", vip, err)
+			}
+
+			var timeout int64
+			if tc.beConfig.Spec.TimeoutSec == nil {
+				timeout = GLBDefaultTimeout
+			} else {
+				timeout = *tc.beConfig.Spec.TimeoutSec
+			}
+
+			if err := verifyTimeout(t, gclb, s.Namespace, "service-1", timeout); err != nil {
+				t.Errorf("verifyTimeout(..., %q, %q, %d) = %v, want nil", s.Namespace, "service-1", timeout, err)
+			}
+
+			// Wait for GCLB resources to be deleted.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			if err := crud.Delete(s.Namespace, ing.Name); err != nil {
+				t.Errorf("Delete(%q) = %v, want nil", ing.Name, err)
+			}
+			t.Logf("Waiting for GCLB resources to be deleted (%s/%s)", s.Namespace, ing.Name)
+			if err := e2e.WaitForGCLBDeletion(ctx, Framework.Cloud, gclb, deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForGCLBDeletion(...) = %v, want nil", err)
+			}
+			t.Logf("GCLB resources deleted (%s/%s)", s.Namespace, ing.Name)
+		})
+	}
+}
+
+func verifyTimeout(t *testing.T, gclb *fuzz.GCLB, svcNamespace, svcName string, expectedTimeout int64) error {
+	for _, bs := range gclb.BackendService {
+		desc := utils.DescriptionFromString(bs.GA.Description)
+		if desc.ServiceName != fmt.Sprintf("%s/%s", svcNamespace, svcName) {
+			continue
+		}
+		if bs.GA.TimeoutSec != expectedTimeout {
+			return fmt.Errorf("backend service %q has timeout %d, want %d", bs.GA.Name,
+				bs.GA.ConnectionDraining.DrainingTimeoutSec, expectedTimeout)
+		}
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/upgrade/basic_http.go
+++ b/cmd/ingress-controller-e2e-test/upgrade/basic_http.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+var (
+	port80  = v1.ServiceBackendPort{Number: 80}
+	ingName = "ing1"
+)
+
+// Finalizer implements e2e.UpgradeTest interface.
+type BasicHTTP struct {
+	t         *testing.T
+	s         *e2e.Sandbox
+	framework *e2e.Framework
+	crud      adapter.IngressCRUD
+	ing       *v1.Ingress
+}
+
+// NewBasicHTTPUpgradeTest returns an upgrade test that tests the basic behavior
+// of an ingress with http load-balancer.
+func NewBasicHTTPUpgradeTest() e2e.UpgradeTest {
+	return &BasicHTTP{}
+}
+
+// Name implements e2e.UpgradeTest.Init.
+func (bh *BasicHTTP) Name() string {
+	return "BasicHTTPUpgrade"
+}
+
+// Init implements e2e.UpgradeTest.Init.
+func (bh *BasicHTTP) Init(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework) error {
+	bh.t = t
+	bh.s = s
+	bh.framework = framework
+	return nil
+}
+
+// PreUpgrade implements e2e.UpgradeTest.PreUpgrade.
+func (bh *BasicHTTP) PreUpgrade() error {
+	_, err := e2e.CreateEchoService(bh.s, svcName, nil)
+	if err != nil {
+		bh.t.Fatalf("error creating echo service: %v", err)
+	}
+	bh.t.Logf("Echo service created (%s/%s)", bh.s.Namespace, svcName)
+
+	bh.ing = fuzz.NewIngressBuilder(bh.s.Namespace, ingName, "").
+		AddPath("foo.com", "/", svcName, port80).
+		Build()
+	ingKey := common.NamespacedName(bh.ing)
+	bh.crud = adapter.IngressCRUD{C: bh.framework.Clientset}
+	if _, err := bh.crud.Create(bh.ing); err != nil {
+		bh.t.Fatalf("error creating Ingress %s: %v", ingKey, err)
+	}
+	bh.t.Logf("Ingress created (%s)", ingKey)
+
+	ing, err := e2e.UpgradeTestWaitForIngress(bh.s, bh.ing, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+	if err != nil {
+		bh.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+	}
+	bh.t.Logf("GCLB resources created (%s)", ingKey)
+
+	if _, err := e2e.WhiteboxTest(ing, nil, bh.framework.Cloud, "", bh.s); err != nil {
+		bh.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+	return nil
+}
+
+// DuringUpgrade implements e2e.UpgradeTest.DuringUpgrade.
+func (bh *BasicHTTP) DuringUpgrade() error {
+	return nil
+}
+
+// PostUpgrade implements e2e.UpgradeTest.PostUpgrade
+func (bh *BasicHTTP) PostUpgrade() error {
+	// Force ingress update by adding a new path.
+	newIng := fuzz.NewIngressBuilderFromExisting(bh.ing).
+		AddPath("bar.com", "/", svcName, port80).
+		Build()
+	ingKey := common.NamespacedName(newIng)
+	// TODO: does the path need to be different for each upgrade
+	if _, err := bh.crud.Patch(bh.ing, newIng); err != nil {
+		bh.t.Fatalf("error patching Ingress %s: %v; current ingress %+v new ingress %+v", ingKey, err, bh.ing, newIng)
+	} else {
+		// If Ingress upgrade succeeds, we update the status on this Ingress
+		// to Unstable. It is set back to Stable after UpgradeTestWaitForIngress
+		// below finishes successfully.
+		bh.s.PutStatus(e2e.Unstable)
+	}
+
+	// Verify the Ingress has stabilized after the master upgrade.
+	ing, err := e2e.UpgradeTestWaitForIngress(bh.s, bh.ing, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+	if err != nil {
+		bh.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+	}
+	bh.t.Logf("GCLB is stable (%s)", ingKey)
+	gclb, err := e2e.WhiteboxTest(ing, nil, bh.framework.Cloud, "", bh.s)
+	if err != nil {
+		bh.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+
+	// If the Master has upgraded and the Ingress is stable,
+	// we delete the Ingress and exit out of the loop to indicate that
+	// the test is done.
+	deleteOptions := &fuzz.GCLBDeleteOptions{
+		SkipDefaultBackend: true,
+	}
+
+	if err := e2e.WaitForIngressDeletion(context.Background(), gclb, bh.s, ing, deleteOptions); err != nil { // Sometimes times out waiting
+		bh.t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ingKey, err)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/upgrade/finalizer.go
+++ b/cmd/ingress-controller-e2e-test/upgrade/finalizer.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+// Finalizer implements e2e.UpgradeTest interface.
+type Finalizer struct {
+	t         *testing.T
+	s         *e2e.Sandbox
+	framework *e2e.Framework
+	crud      adapter.IngressCRUD
+	ing       *v1.Ingress
+}
+
+// NewFinalizerUpgradeTest returns an upgrade test that asserts that finalizer
+// is added to an ingress when upgraded from a version without finalizer to v1.7.0.
+// Also, verifies that ingress is deleted with finalizer enabled.
+func NewFinalizerUpgradeTest() e2e.UpgradeTest {
+	return &Finalizer{}
+}
+
+// Name implements e2e.UpgradeTest.Init.
+func (fr *Finalizer) Name() string {
+	return "FinalizerUpgrade"
+}
+
+// Init implements e2e.UpgradeTest.Init.
+func (fr *Finalizer) Init(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework) error {
+	fr.t = t
+	fr.s = s
+	fr.framework = framework
+	return nil
+}
+
+// PreUpgrade implements e2e.UpgradeTest.PreUpgrade.
+func (fr *Finalizer) PreUpgrade() error {
+	_, err := e2e.CreateEchoService(fr.s, svcName, nil)
+	if err != nil {
+		fr.t.Fatalf("error creating echo service: %v", err)
+	}
+	fr.t.Logf("Echo service created (%s/%s)", fr.s.Namespace, svcName)
+
+	ing := fuzz.NewIngressBuilder(fr.s.Namespace, ingName, "").
+		AddPath("foo.com", "/", svcName, port80).
+		Build()
+	ingKey := common.NamespacedName(ing)
+	fr.crud = adapter.IngressCRUD{C: fr.framework.Clientset}
+	if _, err := fr.crud.Create(ing); err != nil {
+		fr.t.Fatalf("error creating Ingress %s: %v", ingKey, err)
+	}
+	fr.t.Logf("Ingress created (%s)", ingKey)
+
+	if fr.ing, err = e2e.UpgradeTestWaitForIngress(fr.s, ing, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+		fr.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+	}
+
+	fr.t.Logf("GCLB resources created (%s)", ingKey)
+
+	// Check that finalizer is not added in old version in which finalizer add is not enabled.
+	ingFinalizers := fr.ing.GetFinalizers()
+	if l := len(ingFinalizers); l != 0 {
+		fr.t.Fatalf("len(GetFinalizers()) = %d, want 0", l)
+	}
+
+	if _, err := e2e.WhiteboxTest(fr.ing, nil, fr.framework.Cloud, "", fr.s); err != nil {
+		fr.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+	return nil
+}
+
+// DuringUpgrade implements e2e.UpgradeTest.DuringUpgrade.
+func (fr *Finalizer) DuringUpgrade() error {
+	return nil
+}
+
+// PostUpgrade implements e2e.UpgradeTest.PostUpgrade
+func (fr *Finalizer) PostUpgrade() error {
+	ingKey := common.NamespacedName(fr.ing)
+	// A finalizer is expected to be added on the ingress after master upgrade.
+	// Ingress status is updated to unstable, which would be set back to stable
+	// after WaitForFinalizer below finishes successfully.
+	fr.s.PutStatus(e2e.Unstable)
+	// Wait for an ingress finalizer to be added on the ingress after the upgrade.
+	ing, err := e2e.WaitForFinalizer(fr.s, fr.ing)
+	if err != nil {
+		fr.t.Fatalf("e2e.WaitForFinalizer(_, %q) = _, %v, want nil", ingKey, err)
+	}
+	// Assert that v1 finalizer is added.
+	if err := e2e.CheckV1Finalizer(ing); err != nil {
+		fr.t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
+	}
+	gclb, err := e2e.WhiteboxTest(ing, nil, fr.framework.Cloud, "", fr.s)
+	if err != nil {
+		fr.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+
+	// If the Master has upgraded and the Ingress is stable,
+	// we delete the Ingress and exit out of the loop to indicate that
+	// the test is done.
+	deleteOptions := &fuzz.GCLBDeleteOptions{
+		SkipDefaultBackend: true,
+	}
+
+	if err := e2e.WaitForIngressDeletion(context.Background(), gclb, fr.s, fr.ing, deleteOptions); err != nil {
+		fr.t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ingKey, err)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/upgrade/v2frontendnamer.go
+++ b/cmd/ingress-controller-e2e-test/upgrade/v2frontendnamer.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+// V2FrontendNamer implements e2e.UpgradeTest interface.
+type V2FrontendNamer struct {
+	t         *testing.T
+	s         *e2e.Sandbox
+	framework *e2e.Framework
+	crud      adapter.IngressCRUD
+	ing       *v1.Ingress
+}
+
+// NewV2FrontendNamerTest returns upgrade test for v2 frontend namer.
+// This test asserts that v1 finalizer is retained/attached and ingress continues
+// to use v1 naming scheme when master is upgraded to a gke version that use v1.8.
+func NewV2FrontendNamerTest() e2e.UpgradeTest {
+	return &V2FrontendNamer{}
+}
+
+// Name implements e2e.UpgradeTest.Init.
+func (vf *V2FrontendNamer) Name() string {
+	return "V2FrontendNamerUpgrade"
+}
+
+// Init implements e2e.UpgradeTest.Init.
+func (vf *V2FrontendNamer) Init(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework) error {
+	vf.t = t
+	vf.s = s
+	vf.framework = framework
+	return nil
+}
+
+// PreUpgrade implements e2e.UpgradeTest.PreUpgrade.
+func (vf *V2FrontendNamer) PreUpgrade() error {
+	if _, err := e2e.CreateEchoService(vf.s, svcName, nil); err != nil {
+		vf.t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+	}
+	vf.t.Logf("Echo service created (%s/%s)", vf.s.Namespace, svcName)
+
+	vf.ing = fuzz.NewIngressBuilder(vf.s.Namespace, ingName, "").
+		AddPath("foo.com", "/", svcName, port80).
+		SetIngressClass("gce").
+		Build()
+	ingKey := common.NamespacedName(vf.ing)
+	vf.crud = adapter.IngressCRUD{C: vf.framework.Clientset}
+
+	if _, err := vf.crud.Create(vf.ing); err != nil {
+		vf.t.Fatalf("Create(%s) = %v, want nil; Ingress: %v", ingKey, err, vf.ing)
+	}
+	vf.t.Logf("Ingress created (%s)", ingKey)
+	ing, err := e2e.UpgradeTestWaitForIngress(vf.s, vf.ing, &e2e.WaitForIngressOptions{ExpectUnreachable: true})
+	if err != nil {
+		vf.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+	}
+
+	// Assert that v1 finalizer is added.
+	if err := e2e.CheckV1Finalizer(ing); err != nil {
+		vf.t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
+	}
+
+	// Perform whitebox testing.
+	if _, err := e2e.WhiteboxTest(ing, nil, vf.framework.Cloud, "", vf.s); err != nil {
+		vf.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+	return nil
+}
+
+// DuringUpgrade implements e2e.UpgradeTest.DuringUpgrade.
+func (vf *V2FrontendNamer) DuringUpgrade() error {
+	return nil
+}
+
+// PostUpgrade implements e2e.UpgradeTest.PostUpgrade
+func (vf *V2FrontendNamer) PostUpgrade() error {
+	// Force ingress update by adding a new path and mark sandbox unstable.
+	newIng := fuzz.NewIngressBuilderFromExisting(vf.ing).
+		AddPath("bar.com", "/", svcName, port80).
+		Build()
+	ingKey := common.NamespacedName(newIng)
+	if _, err := vf.crud.Patch(vf.ing, newIng); err != nil {
+		vf.t.Fatalf("error patching ingress %s: %v; current ingress: %+v new ingress: %+v", ingKey, err, vf.ing, newIng)
+	} else {
+		// If Ingress upgrade succeeds, we update the status on this Ingress
+		// to Unstable. It is set back to Stable after WaitForFinalizer below
+		// finishes successfully.
+		vf.s.PutStatus(e2e.Unstable)
+	}
+	// Wait for ingress to stabilize after the master upgrade.
+	if _, err := e2e.WaitForIngress(vf.s, vf.ing, nil, nil); err != nil {
+		vf.t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+	}
+	// Wait for an ingress finalizer to be added.
+	ing, err := e2e.WaitForFinalizer(vf.s, vf.ing)
+	if err != nil {
+		vf.t.Fatalf("e2e.WaitForFinalizer(_, %q) = _, %v, want nil", ingKey, err)
+	}
+
+	// Assert that v1 finalizer is retained.
+	if err := e2e.CheckV1Finalizer(ing); err != nil {
+		vf.t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
+	}
+
+	// Perform whitebox testing.
+	gclb, err := e2e.WhiteboxTest(ing, nil, vf.framework.Cloud, "", vf.s)
+	if err != nil {
+		vf.t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+	}
+
+	// If the Master has upgraded and the Ingress is stable,
+	// we delete the Ingress and exit out of the loop to indicate that
+	// the test is done.
+	deleteOptions := &fuzz.GCLBDeleteOptions{
+		SkipDefaultBackend: true,
+	}
+	if err := e2e.WaitForIngressDeletion(context.Background(), gclb, vf.s, ing, deleteOptions); err != nil {
+		vf.t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+	}
+	return nil
+}

--- a/cmd/ingress-controller-e2e-test/upgrade_test.go
+++ b/cmd/ingress-controller-e2e-test/upgrade_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/ingress-gce/cmd/e2e-test/upgrade"
+	"k8s.io/ingress-gce/pkg/e2e"
+)
+
+func TestGenericUpgrade(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []e2e.UpgradeTest{
+		upgrade.NewBasicHTTPUpgradeTest(),
+		upgrade.NewStandaloneNEGWithSvcNEGUpgradeTest(),
+	} {
+		test := test // Capture test as we are running this in parallel.
+		runUpgradeTest(t, test)
+	}
+}
+
+// TestUpgradeToV1dot7 runs upgrade tests for features that are introduced in v1.7.0.
+// Note that this test runs only when an upgrade results in enabling these features.
+func TestUpgradeToV1dot7(t *testing.T) {
+	runUpgradeTest(t, upgrade.NewFinalizerUpgradeTest())
+}
+
+// TestUpgradeToV1dot8 runs upgrade tests for features that are introduced in v1.8.0.
+// Note that this test runs only when an upgrade results in enabling these features.
+func TestUpgradeToV1dot8(t *testing.T) {
+	runUpgradeTest(t, upgrade.NewV2FrontendNamerTest())
+}
+
+// TestUpgradeToV1dot15 runs upgrade tests for features that are introduced in v1.15.0.
+// Note that this test runs only when an upgrade results in enabling these features.
+func TestUpgradeToV1dot15(t *testing.T) {
+	runUpgradeTest(t, upgrade.NewPSCUpgradeTest())
+}
+
+func runUpgradeTest(t *testing.T, test e2e.UpgradeTest) {
+	desc := test.Name()
+	Framework.RunWithSandbox(desc, t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+
+		t.Logf("Running upgrade test %v", desc)
+		if err := test.Init(t, s, Framework); err != nil {
+			t.Fatalf("For upgrade test %v, step Init failed due to %v", desc, err)
+		}
+
+		s.PutStatus(e2e.Unstable)
+		func() {
+			// always mark the test as stable in order to unblock other upgrade tests.
+			defer s.PutStatus(e2e.Stable)
+			if err := test.PreUpgrade(); err != nil {
+				t.Fatalf("For upgrade test %v, step PreUpgrade failed due to %v", desc, err)
+			}
+		}()
+
+		for {
+			// While k8s master is upgrading, it will return a connection refused
+			// error for any k8s resource we try to hit. We loop until the
+			// master upgrade has finished.
+			if s.MasterUpgrading() {
+				if err := test.DuringUpgrade(); err != nil {
+					t.Fatalf("For upgrade test %v, step DuringUpgrade failed due to %v", desc, err)
+				}
+				continue
+			}
+
+			if s.MasterUpgraded() {
+				t.Logf("Detected master upgrade, continuing upgrade test %v", desc)
+				break
+			}
+		}
+		if err := test.PostUpgrade(); err != nil {
+			t.Fatalf("For upgrade test %v, step PostUpgrade failed due to %v", desc, err)
+		}
+	})
+}

--- a/cmd/ingress-controller-e2e-test/v2frontendnamer_test.go
+++ b/cmd/ingress-controller-e2e-test/v2frontendnamer_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/e2e/adapter"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+// TestV2FrontendNamer tests basic lifecycle of an ingress with v1/v2 frontend naming scheme
+// when v2 naming policy is enabled. This test adds v1 finalizer manually to generate an ingress
+// with  v1 naming scheme.
+func TestV2FrontendNamer(t *testing.T) {
+	t.Parallel()
+	port80 := v1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+	v1Ing := fuzz.NewIngressBuilder("", "ing-v1", "").
+		AddPath("foo.com", "/", svcName, port80).
+		Build()
+	v1Ing.SetFinalizers([]string{common.FinalizerKey})
+	v2Ing := fuzz.NewIngressBuilder("", "ing-v2", "").
+		AddPath("foo.com", "/", svcName, port80).
+		Build()
+
+	for _, tc := range []struct {
+		desc string
+		ings []*v1.Ingress
+	}{
+		{"v2 only", []*v1.Ingress{v2Ing}},
+		{"v1 only", []*v1.Ingress{v1Ing}},
+		// The following test cases create ingresses with both naming schemes. These
+		// test cases assert that GC of v1 naming scheme does not affect ingress with
+		// v2 naming scheme and vice-versa.
+		// Note that the first element in the list of ingresses is deleted first,
+		// which tests that GC of the naming scheme for first ingress does not affect
+		// other naming scheme.
+		{"both v1 and v2, delete v1 first", []*v1.Ingress{v1Ing, v2Ing}},
+		{"both v1 and v2, delete v2 first", []*v1.Ingress{v2Ing, v1Ing}},
+	} {
+		tc := tc
+		desc := fmt.Sprintf("v2 frontend namer %s", tc.desc)
+		Framework.RunWithSandbox(desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			if _, err := e2e.CreateEchoService(s, svcName, nil); err != nil {
+				t.Fatalf("CreateEchoService(_, %q, nil): %v, want nil", svcName, err)
+			}
+			t.Logf("Echo service created (%s/%s)", s.Namespace, svcName)
+
+			crud := adapter.IngressCRUD{C: Framework.Clientset}
+			var gclbs []*fuzz.GCLB
+			var updatedIngs []*v1.Ingress
+
+			// Create Ingresses.
+			for _, ing := range tc.ings {
+				ing = ing.DeepCopy()
+				ing.Namespace = s.Namespace
+				if _, err := crud.Create(ing); err != nil {
+					t.Fatalf("create(%s/%s) = %v, want nil; Ingress: %v", ing.Namespace, ing.Name, err, ing)
+				}
+				t.Logf("Ingress created (%s/%s)", ing.Namespace, ing.Name)
+			}
+			// Wait for ingress to stabilize and perform whitebox testing.
+			for _, ing := range tc.ings {
+				ingKey := fmt.Sprintf("%s/%s", s.Namespace, ing.Name)
+				// Determine the expected finalizer after ingress creation.
+				isV1Finalizer := false
+				if len(ing.GetFinalizers()) > 0 {
+					isV1Finalizer = true
+				}
+				var err error
+				if ing, err = e2e.WaitForIngress(s, ing, nil, &e2e.WaitForIngressOptions{ExpectUnreachable: true}); err != nil {
+					t.Fatalf("error waiting for Ingress %s to stabilize: %v", ingKey, err)
+				}
+				if isV1Finalizer {
+					// Assert that v1 finalizer is added.
+					if err := e2e.CheckV1Finalizer(ing); err != nil {
+						t.Fatalf("CheckV1Finalizer(%s) = %v, want nil", ingKey, err)
+					}
+				} else {
+					// Assert that v2 finalizer is added.
+					if err := e2e.CheckV2Finalizer(ing); err != nil {
+						t.Fatalf("CheckV2Finalizer(%s) = %v, want nil", ingKey, err)
+					}
+				}
+				// Perform whitebox testing. This also tests naming scheme.
+				gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+				}
+				gclbs = append(gclbs, gclb)
+				updatedIngs = append(updatedIngs, ing)
+			}
+			// Return immediately if there are no ingresses.
+			if updatedIngs == nil || len(updatedIngs) == 0 {
+				return
+			}
+			ingCount := len(updatedIngs)
+
+			// Delete the first ingress. After deleting the first ingress, assert that
+			// the resources of remaining ingress are unaffected.
+			deleteOptions := &fuzz.GCLBDeleteOptions{
+				SkipDefaultBackend: true,
+			}
+			// Skip checking deletion for backends of first ingress as backends are shared.
+			if ingCount > 1 {
+				deleteOptions.SkipBackends = true
+			}
+			// Wait for Ingress and GCLB resources to be deleted for first ingress.
+			if err := e2e.WaitForIngressDeletion(ctx, gclbs[0], s, updatedIngs[0], deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", common.NamespacedName(updatedIngs[0]), err)
+			}
+			// Return if there are no more ingresses to check.
+			if ingCount < 2 {
+				return
+			}
+			ingKey := common.NamespacedName(updatedIngs[1])
+			// Verify that GCLB resources of second ingress are intact.
+			gclb, err := e2e.WhiteboxTest(updatedIngs[1], nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s, ...) = %v, want nil", ingKey, err)
+			}
+			// Delete the second ingress.
+			deleteOptions.SkipBackends = false
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, updatedIngs[1], deleteOptions); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ingKey, err)
+			}
+		})
+	}
+}

--- a/cmd/neg-e2e-test/main_test.go
+++ b/cmd/neg-e2e-test/main_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kr/pretty"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/ingress-gce/pkg/e2e"
+	_ "k8s.io/ingress-gce/pkg/klog"
+	"k8s.io/ingress-gce/pkg/version"
+	"k8s.io/klog/v2"
+
+	// Pull in the auth library for GCP.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+var (
+	flags struct {
+		run                 bool
+		inCluster           bool
+		kubeconfig          string
+		project             string
+		region              string
+		network             string
+		subnet              string
+		seed                int64
+		destroySandboxes    bool
+		handleSIGINT        bool
+		gceEndpointOverride string
+		createILBSubnet     bool
+	}
+
+	Framework *e2e.Framework
+)
+
+func init() {
+	home := os.Getenv("HOME")
+	if home != "" {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.BoolVar(&flags.run, "run", false, "set to true to run tests (suppresses test suite from 'go test ./...')")
+	flag.BoolVar(&flags.inCluster, "inCluster", false, "set to true if running in the cluster")
+	flag.StringVar(&flags.project, "project", "", "GCP project")
+	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
+	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default)")
+	flag.StringVar(&flags.subnet, "subnet", "", "Optional GCP subnet name.  Parsed from custom metadata key 'cluster-subnet'")
+	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
+	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
+	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
+	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/")
+	flag.BoolVar(&flags.createILBSubnet, "createILBSubnet", false, "If set, creates a proxy subnet for the L7 ILB")
+}
+
+// TestMain is the entrypoint for the end-to-end test suite. This is where
+// global resource setup should be done.
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	fmt.Fprintf(os.Stderr, "Flags:\n%s\n", pretty.Sprint(flags))
+
+	if !flags.inCluster && !flags.run {
+		fmt.Fprintln(os.Stderr, "Set -run to run the tests.")
+		// Return 0 here so 'go test ./...' will succeed.
+		os.Exit(0)
+	}
+	if flags.project == "" {
+		fmt.Fprintln(os.Stderr, "-project must be set to the Google Cloud test project")
+		os.Exit(1)
+	}
+	if flags.region == "" {
+		fmt.Println("-region must be set to the region of the cluster")
+		os.Exit(1)
+	}
+	if flags.network == "" {
+		fmt.Fprintln(os.Stderr, "-network must be set to the network of the cluster")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Version: %q, Commit: %q\n", version.Version, version.GitCommit)
+
+	var err error
+	var kubeconfig *rest.Config
+
+	if flags.inCluster {
+		kubeconfig, err = rest.InClusterConfig()
+		if err != nil {
+			klog.Fatalf("Error creating InClusterConfig(): %v", err)
+		}
+	} else {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfig)
+		if err != nil {
+			klog.Fatalf("Error creating kubernetes clientset from %q: %v", flags.kubeconfig, err)
+		}
+	}
+
+	if flags.seed == -1 {
+		flags.seed = time.Now().UnixNano()
+	}
+	klog.Infof("Using random seed = %d", flags.seed)
+
+	Framework = e2e.NewFramework(kubeconfig, e2e.Options{
+		Project:             flags.project,
+		Region:              flags.region,
+		Network:             flags.network,
+		Subnet:              flags.subnet,
+		Seed:                flags.seed,
+		DestroySandboxes:    flags.destroySandboxes,
+		GceEndpointOverride: flags.gceEndpointOverride,
+		CreateILBSubnet:     flags.createILBSubnet,
+	})
+	if flags.handleSIGINT {
+		Framework.CatchSIGINT()
+	}
+	if err := Framework.SanityCheck(); err != nil {
+		klog.Fatalf("Framework sanity check failed: %v", err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/cmd/neg-e2e-test/neg_test.go
+++ b/cmd/neg-e2e-test/neg_test.go
@@ -1,0 +1,1074 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+	"k8s.io/ingress-gce/pkg/fuzz"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/utils/common"
+)
+
+func TestNEG(t *testing.T) {
+	testNEGOS(t, e2e.Linux)
+}
+
+func TestWindowsNEG(t *testing.T) {
+	testNEGOS(t, e2e.Windows)
+}
+
+func testNEGOS(t *testing.T, os e2e.OS) {
+	t.Parallel()
+	const (
+		numForwardingRules = 1
+		serviceName1       = "neg-service1"
+		serviceName2       = "neg-service2"
+		ingressName        = "neg-ingress1"
+		replicas           = 2
+	)
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+
+	type serviceAttr struct {
+		annotations annotations.NegAnnotation
+		svcType     v1.ServiceType
+	}
+
+	for _, tc := range []struct {
+		desc             string
+		ingress          *networkingv1.Ingress
+		services         map[string]serviceAttr
+		expectNegBackend bool
+		expectIgBackend  bool
+	}{
+		{
+			desc:    "Create a ingress with 2 NEG services of different types",
+			ingress: fuzz.NewIngressBuilder("", ingressName, "").DefaultBackend(serviceName1, port80).AddPath("foo.com", "/foo", serviceName2, port80).Build(),
+			services: map[string]serviceAttr{
+				serviceName1: {
+					annotations: annotations.NegAnnotation{Ingress: true},
+					svcType:     v1.ServiceTypeClusterIP,
+				},
+				serviceName2: {
+					annotations: annotations.NegAnnotation{Ingress: true},
+					svcType:     v1.ServiceTypeNodePort,
+				},
+			},
+			expectNegBackend: true,
+			expectIgBackend:  false,
+		},
+		{
+			desc:    "Create a ingress with 1 NEG service and 1 non-NEG service with default backend",
+			ingress: fuzz.NewIngressBuilder("", ingressName, "").AddPath("foo.com", "/foo", serviceName1, port80).AddPath("bar.com", "/bar", serviceName2, port80).Build(),
+			services: map[string]serviceAttr{
+				serviceName1: {
+					annotations: annotations.NegAnnotation{Ingress: false},
+					svcType:     v1.ServiceTypeNodePort,
+				},
+				serviceName2: {
+					annotations: annotations.NegAnnotation{Ingress: true},
+					svcType:     v1.ServiceTypeClusterIP,
+				},
+			},
+			expectNegBackend: true,
+			expectIgBackend:  true,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			for name, attr := range tc.services {
+				_, err := e2e.EnsureEchoServiceOS(s, name, map[string]string{
+					annotations.NEGAnnotationKey: attr.annotations.String()}, attr.svcType, replicas, os)
+				if err != nil {
+					t.Fatalf("error ensuring echo service: %v", err)
+				}
+				t.Logf("Echo service ensured (%s/%s)", s.Namespace, name)
+			}
+			ing := tc.ingress
+			ing.Namespace = s.Namespace
+			ing, err := e2e.EnsureIngress(s, ing)
+			if err != nil {
+				t.Fatalf("error ensuring Ingress spec: %v", err)
+			}
+			t.Logf("Ingress ensured (%s/%s)", s.Namespace, ing.Name)
+
+			ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+			if err != nil {
+				t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+			}
+			t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+			// Perform whitebox testing.
+			gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+			if err != nil {
+				t.Fatalf("e2e.WhiteboxTest(%s/%s, ...) = %v, want nil", ing.Namespace, ing.Name, err)
+			}
+
+			// TODO(mixia): The below checks should be merged into PerformWhiteboxTests().
+			if (len(gclb.NetworkEndpointGroup) > 0) != tc.expectNegBackend {
+				t.Errorf("Error: expectNegBackend = %v, %d negs found for gclb %v", tc.expectNegBackend, len(gclb.NetworkEndpointGroup), gclb)
+			}
+
+			if (len(gclb.InstanceGroup) > 0) != tc.expectIgBackend {
+				t.Errorf("Error: expectNegBackend = %v, %d negs found for gclb %v", tc.expectNegBackend, len(gclb.NetworkEndpointGroup), gclb)
+			}
+
+			if err := e2e.WaitForIngressDeletion(ctx, gclb, s, ing, &fuzz.GCLBDeleteOptions{}); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		})
+	}
+}
+
+func TestNEGTransition(t *testing.T) {
+	testNEGTransitionOS(t, e2e.Linux)
+}
+
+func TestWindowsNEGTransition(t *testing.T) {
+	testNEGTransitionOS(t, e2e.Windows)
+}
+
+func testNEGTransitionOS(t *testing.T, os e2e.OS) {
+	t.Parallel()
+
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("NEG State Transition Tests", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+			DefaultBackend("service-1", port80).
+			Build()
+
+		var previousGCLBState *fuzz.GCLB
+
+		for _, tc := range []struct {
+			desc        string
+			annotations *annotations.NegAnnotation
+			// negGC is true if a NEG should be garbage collected after applying the annotations
+			negGC bool
+		}{
+			{
+				desc:        "Using ingress only",
+				annotations: &annotations.NegAnnotation{Ingress: true},
+				negGC:       false,
+			},
+			{
+				desc:        "Disable NEG for ingress",
+				annotations: &annotations.NegAnnotation{Ingress: false},
+				negGC:       true,
+			},
+			{
+				desc:        "Re-enable NEG for ingress",
+				annotations: &annotations.NegAnnotation{Ingress: true},
+				negGC:       false,
+			},
+			{
+				desc:        "No annotations",
+				annotations: nil,
+				negGC:       true,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				svcAnnotations := map[string]string{}
+				if tc.annotations != nil {
+					svcAnnotations[annotations.NEGAnnotationKey] = tc.annotations.String()
+				}
+				// First create the echo service, we will be adapting it throughout the basic tests
+				_, err := e2e.EnsureEchoServiceOS(s, "service-1", svcAnnotations, v1.ServiceTypeNodePort, 1, os)
+
+				if err != nil {
+					t.Fatalf("error ensuring echo service: %v", err)
+				}
+				t.Logf("Echo service ensured (%s/%s)", s.Namespace, "service-1")
+
+				ing.Namespace = s.Namespace
+				// Create the ingress
+				ing, err = e2e.EnsureIngress(s, ing)
+				if err != nil {
+					t.Fatalf("error ensuring Ingress spec: %v", err)
+				}
+				t.Logf("Ingress ensured (%s/%s)", s.Namespace, ing.Name)
+
+				ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+				if err != nil {
+					t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+				}
+				t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+
+				// Perform whitebox testing.
+				gclb, err := e2e.WhiteboxTest(ing, nil, Framework.Cloud, "", s)
+				if err != nil {
+					t.Fatalf("e2e.WhiteboxTest(%s/%s, ...)", ing.Namespace, ing.Name)
+				}
+
+				if tc.negGC {
+					if len(gclb.NetworkEndpointGroup) != 0 {
+						t.Errorf("NegGC = true, expected 0 negs for gclb %v, got %d", gclb, len(gclb.NetworkEndpointGroup))
+					}
+					if err = e2e.WaitForNEGDeletion(ctx, s.ValidatorEnv.Cloud(), previousGCLBState, nil); err != nil {
+						t.Errorf("Error waiting for NEGDeletion: %v", err)
+					}
+				} else {
+					if len(gclb.NetworkEndpointGroup) < 1 {
+						t.Errorf("Error, no NEGS associated with gclb %v, expected at least one", gclb)
+					}
+				}
+				previousGCLBState = gclb
+			})
+		}
+
+		if ing != nil && previousGCLBState != nil {
+			if err := e2e.WaitForIngressDeletion(ctx, previousGCLBState, s, ing, &fuzz.GCLBDeleteOptions{}); err != nil {
+				t.Errorf("e2e.WaitForIngressDeletion(..., %q, nil) = %v, want nil", ing.Name, err)
+			}
+		}
+	})
+}
+
+func TestNEGSyncEndpoints(t *testing.T) {
+	testNEGSyncEndpoints(t, e2e.Linux)
+}
+
+func TestWindowsNEGSyncEndpoints(t *testing.T) {
+	testNEGSyncEndpoints(t, e2e.Windows)
+}
+
+func testNEGSyncEndpoints(t *testing.T, os e2e.OS) {
+	t.Parallel()
+
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+	svcName := "service-1"
+
+	for _, tc := range []struct {
+		desc                     string
+		annotations              annotations.NegAnnotation
+		expectServicePort        sets.String
+		expectHealthyServicePort sets.String
+		checkBackendReachability bool
+	}{
+		{
+			desc:                     "Ingress NEG only",
+			annotations:              annotations.NegAnnotation{Ingress: true},
+			expectServicePort:        sets.NewString("80"),
+			expectHealthyServicePort: sets.NewString("80"),
+			checkBackendReachability: true,
+		},
+		{
+			desc: "Both standalone NEGs and Ingress NEG enabled",
+			annotations: annotations.NegAnnotation{
+				Ingress: true,
+				ExposedPorts: map[int32]annotations.NegAttributes{
+					int32(443): {},
+				},
+			},
+			expectServicePort:        sets.NewString("80", "443"),
+			expectHealthyServicePort: sets.NewString("80"),
+			checkBackendReachability: true,
+		},
+		{
+			desc: "Standalone NEGs only",
+			annotations: annotations.NegAnnotation{
+				Ingress: false,
+				ExposedPorts: map[int32]annotations.NegAttributes{
+					int32(443): {},
+					int32(80):  {},
+				},
+			},
+			expectServicePort:        sets.NewString("80", "443"),
+			expectHealthyServicePort: sets.NewString(),
+			checkBackendReachability: false,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			svcAnnotations := map[string]string{annotations.NEGAnnotationKey: tc.annotations.String()}
+			_, err := e2e.EnsureEchoServiceOS(s, svcName, svcAnnotations, v1.ServiceTypeClusterIP, 0, os)
+
+			if err != nil {
+				t.Fatalf("error ensuring echo service: %v", err)
+			}
+			t.Logf("Echo service ensured (%s/%s)", s.Namespace, "service-1")
+
+			scaleAndValidate := func(replicas int32) {
+				t.Logf("Scaling echo deployment to %v replicas", replicas)
+				// The deployment is created with pod anti affinity rules trying to spread the pods across zones.
+				// GCLB only creates the underlying infrastructure in each zone when there is at least one backend.
+				// Since this test tries to validate by sending traffic, it is essential that the LB backends are fully
+				// instantiated in all zones so that the new endpoints can show up faster before test timeout occur.
+				// If the LB backend need to be freshly setup when a new pod is scheduled to the zone, this may lead to
+				// test timeout as it takes more time for the pod to respond to traffic
+				// However, the anti affinity rule may not fully solve this problem in the case where there
+				// is no capacity left in all nodes in a zone. Hence, it may still cause all pods to be scheduled into
+				// other zones. A pod started later may get scheduled to a zone when capacity freed up.
+				if err := e2e.EnsureEchoDeploymentOS(s, svcName, replicas, e2e.SpreadPodAcrossZones, os); err != nil {
+					t.Fatalf("error ensuring echo deployment: %v", err)
+				}
+
+				if err := e2e.WaitForEchoDeploymentStable(s, svcName); err != nil {
+					t.Fatalf("Echo deployment failed to become stable: %v", err)
+				}
+
+				// validate via sending traffic
+				if tc.checkBackendReachability {
+					// only ensure ingress if we check reachability
+					ing := fuzz.NewIngressBuilder(s.Namespace, "ingress-1", "").
+						DefaultBackend(svcName, port80).
+						Build()
+					ing, err = e2e.EnsureIngress(s, ing)
+					if err != nil {
+						t.Fatalf("error ensuring Ingress spec: %v", err)
+					}
+					t.Logf("Ingress ensured (%s/%s)", s.Namespace, ing.Name)
+
+					ing, err = e2e.WaitForIngress(s, ing, nil, nil)
+					if err != nil {
+						t.Fatalf("error waiting for Ingress to stabilize: %v", err)
+					}
+					t.Logf("GCLB resources created (%s/%s)", s.Namespace, ing.Name)
+					vip := ing.Status.LoadBalancer.Ingress[0].IP
+					t.Logf("Ingress %s/%s VIP = %s", s.Namespace, ing.Name, vip)
+					if err = e2e.WaitForDistinctHosts(ctx, vip, int(replicas), true); err != nil {
+						t.Errorf("error waiting for Ingress to response from %v backends: %v", replicas, err)
+					}
+				}
+
+				// validate neg status
+				negStatus, err := e2e.WaitForNegStatus(s, svcName, tc.expectServicePort.List(), false)
+				if err != nil {
+					t.Fatalf("error waiting for NEG status to update: %v", err)
+				}
+
+				// validate neg configurations
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					if tc.expectHealthyServicePort.Has(port) {
+						e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, true, int(replicas))
+					} else if tc.expectServicePort.Has(port) {
+						e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, int(replicas))
+					} else {
+						t.Errorf("Unexpected port %v and NEG %q in NEG Status %v", port, negName, negStatus)
+					}
+				}
+			}
+
+			// This test rescales test backend and validate if NEG controller is able to handle it correctly.
+			// Following validation is performed:
+			// 1. validate if expected number of network endpoint is in NEGs
+			// 2. validate if the network endpoint is healthy
+			// 3. validate by sending traffic to LB VIP and check if expected number of backends can be reached.
+			// First scale up the pods to 5 replicas to try to cover all zones where the cluster spans.
+			scaleAndValidate(5)
+			scaleAndValidate(3)
+			scaleAndValidate(1)
+			scaleAndValidate(4)
+			scaleAndValidate(2)
+		})
+	}
+}
+
+func TestReadinessReflector(t *testing.T) {
+	t.Parallel()
+	Framework.RunWithSandbox("Readiness reflector should handle pods that are not behind NEG but with NEG readiness gate", t, func(t *testing.T, s *e2e.Sandbox) {
+		name := "deployment1"
+		// create deployment with NEG readiness gate
+		if err := e2e.EnsureEchoDeployment(s, name, 3, func(deployment *apps.Deployment) {
+			deployment.Spec.Template.Spec.ReadinessGates = []v1.PodReadinessGate{{ConditionType: shared.NegReadinessGate}}
+		}); err != nil {
+			t.Errorf("Failed to ensure echo deployment: %v", err)
+		}
+
+		if err := e2e.WaitForEchoDeploymentStable(s, name); err != nil {
+			t.Errorf("Echo deployment failed to become stable: %v", err)
+		}
+	})
+}
+
+func TestNegCRDTransitions(t *testing.T) {
+	t.Parallel()
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+	port443 := networkingv1.ServiceBackendPort{Number: 443}
+	serviceName := "neg-service"
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("NEGs with custom names", t, func(t *testing.T, s *e2e.Sandbox) {
+		var previousNegStatus annotations.NegStatus
+		expectedNEGName := fmt.Sprintf("test-neg-name-%x", s.RandInt)
+
+		for _, tc := range []struct {
+			desc               string
+			annotations        annotations.NegAnnotation
+			replicas           int32
+			expectedNegAttrs   map[string]string
+			expectedGCNegPorts []string
+		}{
+			{desc: "one NEG with custom name, one neg with generated name",
+				annotations: annotations.NegAnnotation{
+					Ingress: false,
+					ExposedPorts: map[int32]annotations.NegAttributes{
+						port80.Number:  annotations.NegAttributes{Name: expectedNEGName},
+						port443.Number: annotations.NegAttributes{},
+					}},
+				replicas:         2,
+				expectedNegAttrs: map[string]string{strconv.Itoa(int(port80.Number)): expectedNEGName, strconv.Itoa(int(port443.Number)): ""},
+			},
+			{desc: "remove custom name",
+				annotations: annotations.NegAnnotation{
+					Ingress: false,
+					ExposedPorts: map[int32]annotations.NegAttributes{
+						port80.Number:  annotations.NegAttributes{},
+						port443.Number: annotations.NegAttributes{},
+					}},
+				replicas:           2,
+				expectedNegAttrs:   map[string]string{strconv.Itoa(int(port80.Number)): "", strconv.Itoa(int(port443.Number)): ""},
+				expectedGCNegPorts: []string{strconv.Itoa(int(port80.Number))},
+			},
+			{desc: "add custom name",
+				annotations: annotations.NegAnnotation{
+					Ingress: false,
+					ExposedPorts: map[int32]annotations.NegAttributes{
+						port80.Number:  annotations.NegAttributes{},
+						port443.Number: annotations.NegAttributes{Name: expectedNEGName},
+					}},
+				replicas:           2,
+				expectedNegAttrs:   map[string]string{strconv.Itoa(int(port80.Number)): "", strconv.Itoa(int(port443.Number)): expectedNEGName},
+				expectedGCNegPorts: []string{strconv.Itoa(int(port443.Number))},
+			},
+			{desc: "no NEGs",
+				annotations: annotations.NegAnnotation{
+					Ingress:      false,
+					ExposedPorts: map[int32]annotations.NegAttributes{}},
+				replicas:           2,
+				expectedGCNegPorts: []string{strconv.Itoa(int(port80.Number)), strconv.Itoa(int(port443.Number))},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				_, err := e2e.EnsureEchoService(s, serviceName, map[string]string{
+					annotations.NEGAnnotationKey: tc.annotations.String()}, v1.ServiceTypeClusterIP, tc.replicas)
+				if err != nil {
+					t.Fatalf("error ensuring echo service: %v", err)
+				}
+				t.Logf("Echo service ensured (%s/%s)", s.Namespace, serviceName)
+
+				if len(tc.expectedGCNegPorts) > 0 {
+					for _, port := range tc.expectedGCNegPorts {
+						if err = e2e.WaitForStandaloneNegDeletion(ctx, s.ValidatorEnv.Cloud(), s, port, previousNegStatus); err != nil {
+							t.Errorf("Error waiting for NEGDeletion: %v", err)
+						}
+					}
+				}
+
+				negStatus, err := e2e.WaitForNegCRs(s, serviceName, tc.expectedNegAttrs)
+				if err != nil {
+					t.Fatalf("Error: e2e.WaitForNegCRs(%s,%+v) = %s, want nil", serviceName, tc.expectedNegAttrs, err)
+				}
+
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					err := e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, int(tc.replicas))
+					if err != nil {
+						t.Fatalf("Error: e2e.WaitForNegs service %s/%s neg port/name %s/%s", serviceName, s.Namespace, port, negName)
+					}
+				}
+				previousNegStatus = negStatus
+			})
+		}
+	})
+}
+
+func TestNegCRDErrorEvents(t *testing.T) {
+	t.Parallel()
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+	svc1 := "svc1"
+	svc2 := "svc2"
+	replicas := int32(2)
+	ctx := context.Background()
+
+	Framework.RunWithSandbox("two services, same neg name", t, func(t *testing.T, s *e2e.Sandbox) {
+		expectedNEGName := fmt.Sprintf("test-neg-name-%x", s.RandInt)
+		annotation := annotations.NegAnnotation{
+			Ingress: true,
+			ExposedPorts: map[int32]annotations.NegAttributes{
+				port80.Number: annotations.NegAttributes{Name: expectedNEGName},
+			},
+		}
+
+		_, err := e2e.EnsureEchoService(s, svc1, map[string]string{
+			annotations.NEGAnnotationKey: annotation.String()}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring echo service: %v", err)
+		}
+
+		// Ingress true with a custom name should cause an event
+		if err = e2e.WaitForSvcNegErrorEvents(s, svc1, []string{"custom neg name cannot be used with ingress enabled"}); err != nil {
+			t.Errorf("error waiting for error events: %s", err)
+		}
+
+		// Ensure service with ingress true and wait for neg to be created
+		annotation.Ingress = false
+		_, err = e2e.EnsureEchoService(s, svc1, map[string]string{
+			annotations.NEGAnnotationKey: annotation.String()}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring echo service: %v", err)
+		}
+		t.Logf("Echo service ensured (%s/%s)", s.Namespace, svc1)
+
+		expectedNegAttrs := map[string]string{strconv.Itoa(int(port80.Number)): expectedNEGName}
+		negStatus, err := e2e.WaitForNegCRs(s, svc1, expectedNegAttrs)
+		if err != nil {
+			t.Fatalf("Error: e2e.WaitForNegCRs(%s,%+v) = %s, want nil", svc1, expectedNegAttrs, err)
+		}
+
+		for port, negName := range negStatus.NetworkEndpointGroups {
+			err := e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, int(replicas))
+			if err != nil {
+				t.Fatalf("Error: e2e.WaitForNegs service %s/%s neg port/name %s/%s", svc1, s.Namespace, port, negName)
+			}
+		}
+
+		// Ensure a second service requesting the same neg name
+		_, err = e2e.EnsureEchoService(s, svc2, map[string]string{
+			annotations.NEGAnnotationKey: annotation.String()}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring echo service: %v", err)
+		}
+
+		// Requesting the same neg name should cause an error event on the second service
+		if err = e2e.WaitForSvcNegErrorEvents(s, svc2, []string{"Neg already exists", "Please remove previous neg before creating this configuration"}); err != nil {
+			t.Errorf("error waiting for error events: %s", err)
+		}
+
+		// GC existing negs
+		_, err = e2e.EnsureEchoService(s, svc1, map[string]string{}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring echo service: %v", err)
+		}
+
+		_, err = e2e.EnsureEchoService(s, svc2, map[string]string{}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring echo service: %v", err)
+		}
+
+		e2e.WaitForStandaloneNegDeletion(ctx, Framework.Cloud, s, strconv.Itoa(int(port80.Number)), negStatus)
+	})
+}
+
+func TestNegDisruptive(t *testing.T) {
+	t.Parallel()
+	port80 := networkingv1.ServiceBackendPort{Number: 80}
+	replicas := int32(2)
+	serviceName := "disruptive-neg-service"
+	// gcSvcName is the name of the service used to determine if GC has finished
+	gcSvcName := "gc-service"
+	ctx := context.Background()
+
+	annotation := annotations.NegAnnotation{
+		ExposedPorts: map[int32]annotations.NegAttributes{
+			port80.Number: annotations.NegAttributes{},
+		},
+	}
+
+	ensureGCService := func(s *e2e.Sandbox) annotations.NegStatus {
+		// use gc-service as a way to track if GC has completed or not
+		_, err := e2e.EnsureEchoService(s, "gc-service", map[string]string{
+			annotations.NEGAnnotationKey: annotation.String()}, v1.ServiceTypeClusterIP, replicas)
+		if err != nil {
+			t.Fatalf("error ensuring gc service: %v", err)
+		}
+		t.Logf("GC service ensured (%s/%s)", s.Namespace, gcSvcName)
+
+		expectedNegAttrs := map[string]string{strconv.Itoa(int(port80.Number)): ""}
+		negStatus, err := e2e.WaitForNegCRs(s, gcSvcName, expectedNegAttrs)
+		if err != nil {
+			t.Fatalf("Error: e2e.WaitForNegCRs(%s,%+v) = %s, want nil", gcSvcName, expectedNegAttrs, err)
+		}
+		for port, negName := range negStatus.NetworkEndpointGroups {
+			err := e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, int(replicas))
+			if err != nil {
+				t.Fatalf("Error: e2e.WaitForNegs service %s/%s neg port/name %s/%s", gcSvcName, s.Namespace, port, negName)
+			}
+		}
+		return negStatus
+	}
+
+	waitForGCSvcDeletion := func(s *e2e.Sandbox, negStatus annotations.NegStatus) {
+		if err := e2e.DeleteService(s, gcSvcName); err != nil {
+			t.Fatalf("Error: e2e.DeleteService %s: %q", gcSvcName, err)
+		}
+		t.Logf("GC service deleted (%s/%s)", s.Namespace, gcSvcName)
+
+		if err := e2e.WaitForStandaloneNegDeletion(ctx, s.ValidatorEnv.Cloud(), s, strconv.Itoa(int(port80.Number)), negStatus); err != nil {
+			t.Fatalf("Error waiting for NEGDeletion: %v", err)
+		}
+	}
+
+	Framework.RunWithSandbox("Disruptive Service Recreations", t, func(t *testing.T, s *e2e.Sandbox) {
+
+		testcases := []struct {
+			desc string
+			// waitForGC waits until the NEG controller finished GC. It will wait at the beginning of the testcase
+			// before processing any service changes
+			waitForGC bool
+			// waitForNeg will occur at the end of the testcase after any deletion and creation is processed
+			waitForNeg bool
+			// waitForNegGC waits to see that the NEG has been deleted
+			waitForNegGC bool
+			// deleteService will delete the service will run be run before createService
+			deleteService bool
+			// createService will create the service will run be run after deleteService
+			createService bool
+			// checkForErrorEvents checks to see that no processing error events have occurred
+			checkErrorEvents bool
+		}{
+			{
+				desc:          "create service and wait for neg creations",
+				createService: true,
+				waitForNeg:    true,
+			},
+			{
+				desc:          "delete service and recreate first time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:          "delete service and recreate second time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:          "delete service and recreate third time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:       "check that neg still exists",
+				waitForNeg: true,
+			},
+			//waitForGC is to ensure that GC doesn't occur after deletion and before the recreation
+			{
+				desc:          "waitForGC, delete service and recreate fourth time",
+				waitForGC:     true,
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:          "delete service and recreate fifth time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:          "delete service and recreate sixth time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:             "check neg still exists and no processing error events",
+				waitForNeg:       true,
+				checkErrorEvents: true,
+			},
+			{
+				desc:          "delete service and recreate seventh time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:          "delete service and recreate eight time",
+				deleteService: true,
+				createService: true,
+			},
+			{
+				desc:       "check that neg still exists",
+				waitForNeg: true,
+			},
+			{
+				desc:          "delete service",
+				deleteService: true,
+			},
+			{
+				desc:         "waitForGC to properly delete",
+				waitForNegGC: true,
+			},
+		}
+
+		var previousNegStatus annotations.NegStatus
+		for _, tc := range testcases {
+			t.Log(tc.desc)
+			if tc.waitForGC {
+				negStatus := ensureGCService(s)
+				waitForGCSvcDeletion(s, negStatus)
+			}
+
+			if tc.deleteService {
+				if err := e2e.DeleteService(s, serviceName); err != nil {
+					t.Fatalf("Error: e2e.DeleteService %s: %q", serviceName, err)
+				}
+				t.Logf("Echo service deleted (%s/%s)", s.Namespace, serviceName)
+			}
+
+			if tc.createService {
+				_, err := e2e.EnsureEchoService(s, serviceName, map[string]string{
+					annotations.NEGAnnotationKey: annotation.String()}, v1.ServiceTypeClusterIP, replicas)
+				if err != nil {
+					t.Fatalf("error ensuring echo service: %v", err)
+				}
+				t.Logf("Echo service ensured (%s/%s)", s.Namespace, serviceName)
+			}
+
+			if tc.waitForNeg {
+				expectedNegAttrs := map[string]string{strconv.Itoa(int(port80.Number)): ""}
+				negStatus, err := e2e.WaitForNegCRs(s, serviceName, expectedNegAttrs)
+				if err != nil {
+					t.Fatalf("Error: e2e.WaitForNegCRs(%s,%+v) = %s, want nil", serviceName, expectedNegAttrs, err)
+				}
+
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					err := e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, int(replicas))
+					if err != nil {
+						t.Fatalf("Error: e2e.WaitForNegs service %s/%s neg port/name %s/%s", serviceName, s.Namespace, port, negName)
+					}
+				}
+				previousNegStatus = negStatus
+			}
+
+			if tc.checkErrorEvents {
+				// check for "error processing service" events that do not include "is shutting down" or "not found"
+				// Error events that are due to syncers shutting down or service not found (due to out of date cache)
+				// are temporary and can be ignored
+				foundEvents, err := e2e.CheckSvcEvents(s, serviceName, v1.EventTypeWarning, "error processing service", "is shutting down", "not found")
+				if err != nil {
+					t.Fatalf("errored querying for service events: %q", err)
+				}
+				if foundEvents {
+					t.Fatalf("found error events when none were expected")
+				}
+			}
+
+			if tc.waitForNegGC {
+				if err := e2e.WaitForStandaloneNegDeletion(ctx, s.ValidatorEnv.Cloud(), s, strconv.Itoa(int(port80.Number)), previousNegStatus); err != nil {
+					t.Fatalf("Error waiting for NEGDeletion: %v", err)
+				}
+			}
+		}
+	})
+}
+
+func TestLabelPropagation(t *testing.T) {
+	t.Parallel()
+
+	svcName := "label-propagation-service"
+
+	for _, tc := range []struct {
+		desc              string
+		podLabels         map[string]string
+		expectAnnotations map[string]string
+	}{
+		{
+			desc:              "no labels on the pod",
+			podLabels:         map[string]string{},
+			expectAnnotations: nil,
+		},
+		{
+			desc: "tlsMode with value istio",
+			podLabels: map[string]string{
+				"security.istio.io/tlsMode": "istio",
+			},
+			expectAnnotations: map[string]string{
+				"itls": "istio",
+			},
+		},
+		{
+			desc: "tlsMode with value disabled",
+			podLabels: map[string]string{
+				"security.istio.io/tlsMode": "disabled",
+			},
+			expectAnnotations: map[string]string{
+				"itls": "disabled",
+			},
+		},
+		{
+			// Only support a total label size of 15 for security.istio.io/tlsMode
+			desc: "truncated label value",
+			podLabels: map[string]string{
+				"security.istio.io/tlsMode": "something-very-long",
+			},
+			expectAnnotations: map[string]string{
+				"itls": "something-v",
+			},
+		},
+		{
+			desc: "invalid label key",
+			podLabels: map[string]string{
+				"security.istio.io/something-else": "istio",
+			},
+			expectAnnotations: nil,
+		},
+	} {
+		tc := tc // Capture tc as we are running this in parallel.
+		Framework.RunWithSandbox(tc.desc, t, func(t *testing.T, s *e2e.Sandbox) {
+			t.Parallel()
+			ctx := context.Background()
+
+			annotation := annotations.NegAnnotation{
+				Ingress: false,
+				ExposedPorts: map[int32]annotations.NegAttributes{
+					int32(443): {},
+					int32(80):  {},
+				},
+			}
+
+			svcAnnotations := map[string]string{annotations.NEGAnnotationKey: annotation.String()}
+			_, err := e2e.EnsureEchoServiceWithPodLabels(s, svcName, svcAnnotations, v1.ServiceTypeClusterIP, 3, tc.podLabels)
+
+			if err != nil {
+				t.Fatalf("Error ensuring echo service: %v", err)
+			}
+			t.Logf("Echo service ensured (%s/%s)", s.Namespace, svcName)
+
+			if err := e2e.WaitForEchoDeploymentStable(s, svcName); err != nil {
+				t.Fatalf("Echo deployment failed to become stable: %v", err)
+			}
+
+			negStatus, err := e2e.WaitForNegStatus(s, svcName, []string{"80", "443"}, false)
+			if err != nil {
+				t.Fatalf("Error waiting for NEG status to update: %v", err)
+			}
+
+			for _, negName := range negStatus.NetworkEndpointGroups {
+				e2e.WaitForNegs(ctx, Framework.Cloud, negName, negStatus.Zones, false, 3)
+			}
+			for _, negName := range negStatus.NetworkEndpointGroups {
+				negs, err := fuzz.NetworkEndpointsInNegs(ctx, Framework.Cloud, negName, negStatus.Zones)
+				if err != nil {
+					t.Fatalf("Failed to retrieve NEG %s: %v", negName, err)
+				}
+				if err := e2e.CheckNegAnnotations(negs, tc.expectAnnotations); err != nil {
+					t.Errorf("Check Neg Annotations failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDegradedMode(t *testing.T) {
+	t.Parallel()
+
+	const (
+		customEPSName     = "custom-endpointslice"
+		replicas          = 2
+		endpointAttach    = 2
+		replicasScaleDown = 1
+	)
+
+	ctx := context.Background()
+	Framework.RunWithSandbox("Degraded Mode", t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+		// Create a CustomEPS deployment.
+		// It has labels not matched to the service,
+		// so it won't be used by the service endpoint slice.
+		if err := e2e.EnsureEchoDeployment(s, customEPSName, endpointAttach, e2e.NoopModify); err != nil {
+			t.Fatalf("Error: e2e.EnsureEchoDeployment(%s, %d) = %v, want nil", customEPSName, endpointAttach, err)
+		}
+		if err := e2e.WaitForEchoDeploymentStable(s, customEPSName); err != nil {
+			t.Fatalf("Echo deployment failed to become stable: %v", err)
+		}
+
+		// Get pods from the CustomEPS deployment.
+		// EnsureEchoDeployment() creates pods with label
+		//    ["app"] = DeploymentName
+		podList, err := e2e.ListPods(s)
+		if err != nil {
+			t.Fatalf("Error: e2e.ListPods() = %v, want nil", err)
+		}
+		var pods []v1.Pod
+		var podIPs []string
+		for _, pod := range podList.Items {
+			if pod.ObjectMeta.Labels["app"] != customEPSName {
+				continue
+			}
+			pods = append(pods, pod)
+			podIPs = append(podIPs, pod.Status.PodIP)
+		}
+
+		for _, tc := range []struct {
+			desc string
+			// modify makes changes to the custom endpoint slice to trigger
+			// error state
+			modify func(endpointslice *discoveryv1.EndpointSlice)
+			// epInNEGFromCustomEPS are endpoints IPs expected to be in
+			// the NEG after endpoints in the custom endpoint slice are
+			// successfully attached.
+			// This is dependent on the behavior of modify()
+			epInNEGFromCustomEPS []string
+		}{
+			{
+				desc: "create a custom endpoint slice with one endpoint with missing nodeName",
+				modify: func(endpointslice *discoveryv1.EndpointSlice) {
+					endpointslice.Endpoints[0].NodeName = nil
+				},
+				epInNEGFromCustomEPS: podIPs, // Endpoint's NodeName will be corrected and attached.
+			},
+			{
+				desc: "create a custom endpoint slice with one endpoint corresponds to non-existent node",
+				modify: func(endpointslice *discoveryv1.EndpointSlice) {
+					nonExistentNode := "foo"
+					endpointslice.Endpoints[0].NodeName = &nonExistentNode
+				},
+				epInNEGFromCustomEPS: podIPs, // Endpoint's NodeName will be corrected and attached.
+			},
+			{
+				desc: "create a custom endpoint slice with one endpoint is missing pod information",
+				modify: func(endpointslice *discoveryv1.EndpointSlice) {
+					endpointslice.Endpoints[0].TargetRef = nil
+				},
+				epInNEGFromCustomEPS: podIPs[1:], // Endpoints without pod information won't be attached.
+			},
+			{
+				desc: "create a custom endpoint slice with one endpoint doesn't correspond to a existing pod",
+				modify: func(endpointslice *discoveryv1.EndpointSlice) {
+					endpointslice.Endpoints[0].TargetRef.Name = "foo"
+				},
+				epInNEGFromCustomEPS: podIPs[1:], // Endpoints from non-existing pod won't be attached.
+			},
+			{
+				desc: "create a custom endpoint slice with one endpoint has IP doesn't correspond to any PodIP",
+				modify: func(endpointslice *discoveryv1.EndpointSlice) {
+					endpointslice.Endpoints[0].Addresses[0] = "1.1.1.1"
+				},
+				epInNEGFromCustomEPS: podIPs[1:], // Endpoints with IPs not matched to pods won't be attached.
+			},
+		} {
+			tc := tc
+			svcName := fmt.Sprintf("service-%s", common.ContentHash(tc.desc, 8))
+			t.Run(tc.desc, func(t *testing.T) {
+				// Setup Standalone NEG.
+				annotation := annotations.NegAnnotation{
+					Ingress: false,
+					ExposedPorts: map[int32]annotations.NegAttributes{
+						int32(443): {},
+						int32(80):  {},
+					},
+				}
+				svcAnnotations := map[string]string{annotations.NEGAnnotationKey: annotation.String()}
+				svc, err := e2e.EnsureEchoService(s, svcName, svcAnnotations, v1.ServiceTypeClusterIP, replicas)
+				if err != nil {
+					t.Fatalf("Error ensuring echo service: %v", err)
+				}
+				t.Logf("Echo service ensured (%s/%s).\n", s.Namespace, svcName)
+				if err := e2e.WaitForEchoDeploymentStable(s, svcName); err != nil {
+					t.Fatalf("Echo deployment failed to become stable: %v", err)
+				}
+
+				// Verify endpoint IPs by ensuring NEG endpoints are from
+				// the service deployment.
+				podList, err := e2e.ListPods(s)
+				if err != nil {
+					t.Fatalf("Error: e2e.ListPods() = %v, want nil", err)
+				}
+				var epInNEGFromSvcDeployment []string
+				// Only select podIPs from service deployment pods.
+				for _, pod := range podList.Items {
+					if pod.ObjectMeta.Labels["app"] != svcName {
+						continue
+					}
+					epInNEGFromSvcDeployment = append(epInNEGFromSvcDeployment, pod.Status.PodIP)
+				}
+
+				// Verify endpoint IPs before attaching custom endpoint slice.
+				exposedPorts := sets.NewString("80", "443")
+				negStatus, err := e2e.WaitForNegStatus(s, svcName, exposedPorts.List(), false)
+				if err != nil {
+					t.Fatalf("Error waiting for NEG status to update: %v", err)
+				}
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					err = e2e.CheckNEGEndpointIPs(ctx, Framework.Cloud, negName, negStatus.Zones, epInNEGFromSvcDeployment)
+					if err != nil {
+						t.Fatalf("Error: e2e.CheckNEGEndpointIPs service %s/%s neg port/name %s/%s: %v", svcName, s.Namespace, port, negName, err)
+					}
+				}
+
+				// Create and add a custom endpoint slice.
+				// modify() injects invalid information to the endpoint slice,
+				// which would trigger error state.
+				// Valid endpoints will be attached, and invalid endpoints will be
+				// attached or ignored based on the type of invalid information.
+				customEPS, err := e2e.EnsureCustomEndpointSlice(s, svc, customEPSName, pods, tc.modify)
+				if err != nil {
+					t.Fatalf("Error: e2e.EnsureCustomEndpointSlice() = %v, want nil", err)
+				}
+				t.Logf("Create custom endpoint slice: %v.\n", customEPS)
+
+				// Verify endpoint IPs after the custom endpoint slice is added.
+				expectEndpoints := append(tc.epInNEGFromCustomEPS, epInNEGFromSvcDeployment...)
+				negStatus, err = e2e.WaitForNegStatus(s, svcName, exposedPorts.List(), false)
+				if err != nil {
+					t.Fatalf("Error waiting for NEG status to update: %v", err)
+				}
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					err = e2e.CheckNEGEndpointIPs(ctx, Framework.Cloud, negName, negStatus.Zones, expectEndpoints)
+					if err != nil {
+						t.Fatalf("Error: e2e.CheckNEGEndpointIPs service %s/%s neg port/name %s/%s: %v", svcName, s.Namespace, port, negName, err)
+					}
+				}
+
+				// Scale down service deployment to verify if the controller
+				// still works properly and detach removed endpoints.
+				if err := e2e.EnsureEchoDeployment(s, svcName, replicasScaleDown, func(deployment *apps.Deployment) {}); err != nil {
+					t.Fatalf("Error ensuring echo deployment: %v", err)
+				}
+				if err := e2e.WaitForEchoDeploymentStable(s, svcName); err != nil {
+					t.Fatalf("Echo deployment failed to become stable: %v", err)
+				}
+				// Get updated podIPs from service deployment.
+				podList, err = e2e.ListPods(s)
+				if err != nil {
+					t.Fatalf("Error: e2e.ListPods() = %v, want nil", err)
+				}
+				var epInNEGFromSvcDeploymentAfterScaleDown []string
+				for _, pod := range podList.Items {
+					if pod.ObjectMeta.Labels["app"] != svcName {
+						continue
+					}
+					epInNEGFromSvcDeploymentAfterScaleDown = append(epInNEGFromSvcDeploymentAfterScaleDown, pod.Status.PodIP)
+				}
+
+				// Verify endpoint IPs after service deployment is scaled down.
+				expectEndpointsAfterScaleDown := append(epInNEGFromSvcDeploymentAfterScaleDown, tc.epInNEGFromCustomEPS...)
+				for port, negName := range negStatus.NetworkEndpointGroups {
+					err = e2e.CheckNEGEndpointIPs(ctx, Framework.Cloud, negName, negStatus.Zones, expectEndpointsAfterScaleDown)
+					if err != nil {
+						t.Fatalf("Error: e2e.CheckNEGEndpointIPs service %s/%s neg port/name %s/%s: %v", svcName, s.Namespace, port, negName, err)
+					}
+				}
+			})
+		}
+	})
+}

--- a/cmd/neg-e2e-test/run.sh
+++ b/cmd/neg-e2e-test/run.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# run.sh manages the settings required for running containerized in a
+# Kubernetes cluster.
+echo '--- BEGIN ---'
+
+for ATTEMPT in $(seq 60); do
+  PROJECT=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null)
+  if [[ -n "$PROJECT" ]]; then
+    break
+  fi
+  echo "Warning: could not get Compute project name from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: could not get Compute project name from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+
+for ATTEMPT in $(seq 60); do
+  ZONE_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/zone)
+  if [[ -n "${ZONE_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get zone from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${ZONE_INFO}" ]]; then
+  echo "Error: could not get zone info from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+echo "ZONE_INFO: ${ZONE_INFO}"
+
+# Get Region information from zone info
+ZONE=$(echo ${ZONE_INFO} | sed 's+projects/.*/zones/++')
+REGION=$(echo ${ZONE} | sed 's/-[a-z]$//')
+
+if [[ -z "${REGION}" ]]; then
+  echo "Error: could not parse region from zone info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Region: ${REGION}"
+
+# Get network information
+for ATTEMPT in $(seq 60); do
+  NETWORK_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/network)
+  if [[ -n "${NETWORK_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get network from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+NETWORK=$(echo ${NETWORK_INFO} | sed 's+projects/.*/networks/++')
+
+if [[ -z "${NETWORK}" ]]; then
+  echo "Error: could not parse network from network info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Network: ${NETWORK}"
+
+# Get subnet  information
+# We expect the custom metadata field 'cluster-subnet' on all VMs.
+for ATTEMPT in $(seq 60); do
+  SUBNET=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-subnet)
+  if [[ -n "${SUBNET}" ]]; then
+    break
+  fi
+  echo "Error: could not get subnet from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${SUBNET}" ]]; then
+  echo "Error: could not get subnet"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Subnet: ${SUBNET}"
+
+
+echo
+echo ==============================================================================
+echo "PROJECT: ${PROJECT}"
+CMD="/neg-e2e-test -test.v -test.parallel=100 -project ${PROJECT} -region ${REGION} -network ${NETWORK} -subnet ${SUBNET} -logtostderr -inCluster -v=2"
+echo "CMD: ${CMD}" $@
+echo
+
+echo ==============================================================================
+echo E2E TEST
+echo
+${CMD} "$@" 2>&1
+RESULT=$?
+echo
+
+if [[ "${DUMP_RESOURCES:-}" == "true" ]]; then
+  GCLOUD=/google-cloud-sdk/bin/gcloud
+  RESOURCES="forwarding-rules target-http-proxies target-https-proxies url-maps backend-services"
+  for RES in ${RESOURCES}; do
+    echo ==============================================================================
+    echo "GCP RESOURCE: ${RES}"
+    ${GCLOUD} compute ${RES} list --quiet --project ${PROJECT} --format yaml 2>&1
+  done
+fi
+
+echo ==============================================================================
+echo "RESULT: $RESULT"
+echo '--- END ---'

--- a/cmd/neg-e2e-test/upgrade/neg.go
+++ b/cmd/neg-e2e-test/upgrade/neg.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/annotations"
+	"k8s.io/ingress-gce/pkg/e2e"
+)
+
+var (
+	svcName       = "svc1"
+	negAnnotation = annotations.NegAnnotation{
+		Ingress: false,
+		ExposedPorts: map[int32]annotations.NegAttributes{
+			int32(443): {},
+			int32(80):  {},
+		},
+	}
+	expectServicePort = []string{"80", "443"}
+	expectedNegAttrs  = map[string]string{"80": "", "443": ""}
+)
+
+// StandaloneNEGWithSvcNEG implements e2e.UpgradeTest interface
+type StandaloneNEGWithSvcNEG struct {
+	t         *testing.T
+	s         *e2e.Sandbox
+	framework *e2e.Framework
+}
+
+func NewStandaloneNEGWithSvcNEGUpgradeTest() e2e.UpgradeTest {
+	return &StandaloneNEGWithSvcNEG{}
+}
+
+// Name implements e2e.UpgradeTest.Init.
+func (n *StandaloneNEGWithSvcNEG) Name() string {
+	return "StandaloneNEGWithSvcNEGUpgrade"
+}
+
+// Init implements e2e.UpgradeTest.Init.
+func (n *StandaloneNEGWithSvcNEG) Init(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework) error {
+	n.t = t
+	n.s = s
+	n.framework = framework
+	return nil
+}
+
+// PreUpgrade implements e2e.UpgradeTest.PreUpgrade.
+func (n *StandaloneNEGWithSvcNEG) PreUpgrade() error {
+	svcAnnotations := map[string]string{
+		annotations.NEGAnnotationKey: negAnnotation.String(),
+	}
+	_, err := e2e.EnsureEchoService(n.s, svcName, svcAnnotations, v1.ServiceTypeClusterIP, 0)
+
+	if err != nil {
+		n.t.Fatalf("error ensuring echo service: %v", err)
+	}
+	n.t.Logf("Echo service ensured with neg annotation (%s/%s)", n.s.Namespace, svcName)
+
+	negScaleAndValidate(n.t, n.s, n.framework, 1)
+	return nil
+}
+
+// DuringUpgrade implements e2e.UpgradeTest.DuringUpgrade.
+func (n *StandaloneNEGWithSvcNEG) DuringUpgrade() error {
+	return nil
+}
+
+// PostUpgrade implements e2e.UpgradeTest.PostUpgrade
+func (n *StandaloneNEGWithSvcNEG) PostUpgrade() error {
+	negValidate(n.t, n.s, n.framework, 1)
+
+	negStatus, err := e2e.WaitForNegCRs(n.s, svcName, expectedNegAttrs)
+	if err != nil {
+		n.t.Fatalf("error waiting for Neg CRs")
+	}
+	negScaleAndValidate(n.t, n.s, n.framework, 3)
+
+	_, err = e2e.EnsureEchoService(n.s, svcName, map[string]string{}, v1.ServiceTypeClusterIP, 0)
+	if err != nil {
+		n.t.Fatalf("error ensuring echo service: %v", err)
+	}
+
+	n.t.Logf("Echo service ensured with no annotation (%s/%s)", n.s.Namespace, svcName)
+
+	// Test that garbage collection works properly after upgrade
+	for _, port := range expectServicePort {
+		if err = e2e.WaitForStandaloneNegDeletion(context.Background(), n.s.ValidatorEnv.Cloud(), n.s, port, negStatus); err != nil {
+			n.t.Errorf("error waiting for NEGDeletion: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// negScaleAndValidate scales the deployment and validate if NEGs are reflected.
+func negScaleAndValidate(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework, replicas int32) {
+	t.Logf("Scaling echo deployment to %v replicas", replicas)
+	if err := e2e.EnsureEchoDeployment(s, svcName, replicas, e2e.NoopModify); err != nil {
+		t.Fatalf("Error ensuring echo deployment: %v", err)
+	}
+	if err := e2e.WaitForEchoDeploymentStable(s, svcName); err != nil {
+		t.Errorf("Echo deployment failed to become stable: %v", err)
+	}
+	negValidate(t, s, framework, replicas)
+}
+
+// negValidate check if the NEG status annotation and the corresponding NEGs are correctly configured.
+func negValidate(t *testing.T, s *e2e.Sandbox, framework *e2e.Framework, replicas int32) {
+	// validate neg status
+	negStatus, err := e2e.WaitForNegCRs(s, svcName, expectedNegAttrs)
+	if err != nil {
+		t.Fatalf("error waiting for NEG CRs to update: %v", err)
+	}
+
+	// validate neg configurations
+	for port, negName := range negStatus.NetworkEndpointGroups {
+		ctx := context.Background()
+		if err := e2e.WaitForNegs(ctx, framework.Cloud, negName, negStatus.Zones, false, int(replicas)); err != nil {
+			t.Errorf("Unexpected port %v and NEG %q in NEG Status %v", port, negName, negStatus)
+		}
+	}
+}

--- a/cmd/neg-e2e-test/upgrade_test.go
+++ b/cmd/neg-e2e-test/upgrade_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	upgrade "k8s.io/ingress-gce/cmd/neg-e2e-test/upgrade"
+	"k8s.io/ingress-gce/pkg/e2e"
+)
+
+func TestGenericUpgrade(t *testing.T) {
+	t.Parallel()
+	// Only run the NEG-related upgrade test.
+	runUpgradeTest(t, upgrade.NewStandaloneNEGWithSvcNEGUpgradeTest())
+}
+
+func runUpgradeTest(t *testing.T, test e2e.UpgradeTest) {
+	desc := test.Name()
+	Framework.RunWithSandbox(desc, t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+
+		t.Logf("Running upgrade test %v", desc)
+		if err := test.Init(t, s, Framework); err != nil {
+			t.Fatalf("For upgrade test %v, step Init failed due to %v", desc, err)
+		}
+
+		s.PutStatus(e2e.Unstable)
+		func() {
+			// always mark the test as stable in order to unblock other upgrade tests.
+			defer s.PutStatus(e2e.Stable)
+			if err := test.PreUpgrade(); err != nil {
+				t.Fatalf("For upgrade test %v, step PreUpgrade failed due to %v", desc, err)
+			}
+		}()
+
+		for {
+			// While k8s master is upgrading, it will return a connection refused
+			// error for any k8s resource we try to hit. We loop until the
+			// master upgrade has finished.
+			if s.MasterUpgrading() {
+				if err := test.DuringUpgrade(); err != nil {
+					t.Fatalf("For upgrade test %v, step DuringUpgrade failed due to %v", desc, err)
+				}
+				continue
+			}
+
+			if s.MasterUpgraded() {
+				t.Logf("Detected master upgrade, continuing upgrade test %v", desc)
+				break
+			}
+		}
+		if err := test.PostUpgrade(); err != nil {
+			t.Fatalf("For upgrade test %v, step PostUpgrade failed due to %v", desc, err)
+		}
+	})
+}

--- a/cmd/psc-e2e-test/main_test.go
+++ b/cmd/psc-e2e-test/main_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kr/pretty"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/ingress-gce/pkg/e2e"
+	_ "k8s.io/ingress-gce/pkg/klog"
+	"k8s.io/ingress-gce/pkg/version"
+	"k8s.io/klog/v2"
+
+	// Pull in the auth library for GCP.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+var (
+	flags struct {
+		run                 bool
+		inCluster           bool
+		kubeconfig          string
+		project             string
+		region              string
+		network             string
+		subnet              string
+		seed                int64
+		destroySandboxes    bool
+		handleSIGINT        bool
+		gceEndpointOverride string
+		createILBSubnet     bool
+	}
+
+	Framework *e2e.Framework
+)
+
+func init() {
+	home := os.Getenv("HOME")
+	if home != "" {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		flag.StringVar(&flags.kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.BoolVar(&flags.run, "run", false, "set to true to run tests (suppresses test suite from 'go test ./...')")
+	flag.BoolVar(&flags.inCluster, "inCluster", false, "set to true if running in the cluster")
+	flag.StringVar(&flags.project, "project", "", "GCP project")
+	flag.StringVar(&flags.region, "region", "", "GCP Region (e.g. us-central1)")
+	flag.StringVar(&flags.network, "network", "", "GCP network name (e.g. default)")
+	flag.StringVar(&flags.subnet, "subnet", "", "Optional GCP subnet name.  Parsed from custom metadata key 'cluster-subnet'")
+	flag.Int64Var(&flags.seed, "seed", -1, "random seed")
+	flag.BoolVar(&flags.destroySandboxes, "destroySandboxes", true, "set to false to leave sandboxed resources for debugging")
+	flag.BoolVar(&flags.handleSIGINT, "handleSIGINT", true, "catch SIGINT to perform clean")
+	flag.StringVar(&flags.gceEndpointOverride, "gce-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/")
+	flag.BoolVar(&flags.createILBSubnet, "createILBSubnet", false, "If set, creates a proxy subnet for the L7 ILB")
+}
+
+// TestMain is the entrypoint for the end-to-end test suite. This is where
+// global resource setup should be done.
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	fmt.Fprintf(os.Stderr, "Flags:\n%s\n", pretty.Sprint(flags))
+
+	if !flags.inCluster && !flags.run {
+		fmt.Fprintln(os.Stderr, "Set -run to run the tests.")
+		// Return 0 here so 'go test ./...' will succeed.
+		os.Exit(0)
+	}
+	if flags.project == "" {
+		fmt.Fprintln(os.Stderr, "-project must be set to the Google Cloud test project")
+		os.Exit(1)
+	}
+	if flags.region == "" {
+		fmt.Println("-region must be set to the region of the cluster")
+		os.Exit(1)
+	}
+	if flags.network == "" {
+		fmt.Fprintln(os.Stderr, "-network must be set to the network of the cluster")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Version: %q, Commit: %q\n", version.Version, version.GitCommit)
+
+	var err error
+	var kubeconfig *rest.Config
+
+	if flags.inCluster {
+		kubeconfig, err = rest.InClusterConfig()
+		if err != nil {
+			klog.Fatalf("Error creating InClusterConfig(): %v", err)
+		}
+	} else {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfig)
+		if err != nil {
+			klog.Fatalf("Error creating kubernetes clientset from %q: %v", flags.kubeconfig, err)
+		}
+	}
+
+	if flags.seed == -1 {
+		flags.seed = time.Now().UnixNano()
+	}
+	klog.Infof("Using random seed = %d", flags.seed)
+
+	Framework = e2e.NewFramework(kubeconfig, e2e.Options{
+		Project:             flags.project,
+		Region:              flags.region,
+		Network:             flags.network,
+		Subnet:              flags.subnet,
+		Seed:                flags.seed,
+		DestroySandboxes:    flags.destroySandboxes,
+		GceEndpointOverride: flags.gceEndpointOverride,
+		CreateILBSubnet:     flags.createILBSubnet,
+	})
+	if flags.handleSIGINT {
+		Framework.CatchSIGINT()
+	}
+	if err := Framework.SanityCheck(); err != nil {
+		klog.Fatalf("Framework sanity check failed: %v", err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/cmd/psc-e2e-test/psc_test.go
+++ b/cmd/psc-e2e-test/psc_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/e2e"
+)
+
+func TestPSCLifecycle(t *testing.T) {
+	t.Parallel()
+
+	Framework.RunWithSandbox("PSC Lifecycle", t, func(t *testing.T, s *e2e.Sandbox) {
+		svcName := fmt.Sprintf("ilb-service-e2e-%x", s.RandInt)
+		saName := fmt.Sprintf("service-attachment-e2e-%x", s.RandInt)
+
+		// PSC requires subnet to have purpose PRIVATE_SERVICE_CONNECT
+		err := e2e.CreateSubnet(s, e2e.PSCSubnetName, e2e.PSCSubnetPurpose)
+		defer e2e.DeleteSubnet(s, e2e.PSCSubnetName)
+		if err != nil {
+			// Subnet Creation could fail because of a leaked subnet from a previous run.
+			// Instead of failing the test, attempt to reuse subnet.
+			t.Logf("error creating subnet %s: %q", e2e.PSCSubnetName, err)
+		} else {
+			t.Logf("created subnet for PSC")
+		}
+
+		l4ILBAnnotation := map[string]string{gce.ServiceAnnotationLoadBalancerType: "Internal"}
+		if _, err := e2e.EnsureEchoService(s, svcName, l4ILBAnnotation, v1.ServiceTypeLoadBalancer, 1); err != nil {
+			t.Fatalf("error ensuring echo service %s/%s: %q", s.Namespace, svcName, err)
+		}
+		t.Logf("ensured echo service %s/%s", s.Namespace, svcName)
+
+		if _, err := e2e.EnsureServiceAttachment(s, saName, svcName, e2e.PSCSubnetName); err != nil {
+			t.Fatalf("error creating service attachment cr %s/%s: %q", s.Namespace, saName, err)
+		}
+
+		gceSAURL, err := e2e.WaitForServiceAttachment(s, saName)
+		if err != nil {
+			t.Fatalf("failed waiting for service attachment: %q", err)
+		}
+
+		if err := e2e.DeleteServiceAttachment(s, saName); err != nil {
+			t.Fatalf("failed deleting service attachment %s/%s: %q", s.Namespace, saName, err)
+		}
+
+		if err := e2e.WaitForServiceAttachmentDeletion(s, saName, gceSAURL); err != nil {
+			t.Fatalf("failed while waiting for service attachment deletion")
+		}
+	})
+}

--- a/cmd/psc-e2e-test/run.sh
+++ b/cmd/psc-e2e-test/run.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# run.sh manages the settings required for running containerized in a
+# Kubernetes cluster.
+echo '--- BEGIN ---'
+
+for ATTEMPT in $(seq 60); do
+  PROJECT=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null)
+  if [[ -n "$PROJECT" ]]; then
+    break
+  fi
+  echo "Warning: could not get Compute project name from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: could not get Compute project name from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+
+for ATTEMPT in $(seq 60); do
+  ZONE_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/zone)
+  if [[ -n "${ZONE_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get zone from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${ZONE_INFO}" ]]; then
+  echo "Error: could not get zone info from the metadata server"
+  echo "RESULT: 2"
+  echo '--- END ---'
+  exit
+fi
+echo "ZONE_INFO: ${ZONE_INFO}"
+
+# Get Region information from zone info
+ZONE=$(echo ${ZONE_INFO} | sed 's+projects/.*/zones/++')
+REGION=$(echo ${ZONE} | sed 's/-[a-z]$//')
+
+if [[ -z "${REGION}" ]]; then
+  echo "Error: could not parse region from zone info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Region: ${REGION}"
+
+# Get network information
+for ATTEMPT in $(seq 60); do
+  NETWORK_INFO=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/network)
+  if [[ -n "${NETWORK_INFO}" ]]; then
+    break
+  fi
+  echo "Error: could not get network from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+NETWORK=$(echo ${NETWORK_INFO} | sed 's+projects/.*/networks/++')
+
+if [[ -z "${NETWORK}" ]]; then
+  echo "Error: could not parse network from network info"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Network: ${NETWORK}"
+
+# Get subnet  information
+# We expect the custom metadata field 'cluster-subnet' on all VMs.
+for ATTEMPT in $(seq 60); do
+  SUBNET=$(curl -H'Metadata-Flavor:Google' metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-subnet)
+  if [[ -n "${SUBNET}" ]]; then
+    break
+  fi
+  echo "Error: could not get subnet from the metadata server (attempt ${ATTEMPT})"
+  sleep 1
+done
+
+if [[ -z "${SUBNET}" ]]; then
+  echo "Error: could not get subnet"
+  echo "Result: 2"
+  exit
+fi
+echo "Using Subnet: ${SUBNET}"
+
+
+echo
+echo ==============================================================================
+echo "PROJECT: ${PROJECT}"
+CMD="/psc-e2e-test -test.v -test.parallel=100 -project ${PROJECT} -region ${REGION} -network ${NETWORK} -subnet ${SUBNET} -logtostderr -inCluster -v=2"
+echo "CMD: ${CMD}" $@
+echo
+
+echo ==============================================================================
+echo E2E TEST
+echo
+${CMD} "$@" 2>&1
+RESULT=$?
+echo
+
+if [[ "${DUMP_RESOURCES:-}" == "true" ]]; then
+  GCLOUD=/google-cloud-sdk/bin/gcloud
+  RESOURCES="forwarding-rules target-http-proxies target-https-proxies url-maps backend-services"
+  for RES in ${RESOURCES}; do
+    echo ==============================================================================
+    echo "GCP RESOURCE: ${RES}"
+    ${GCLOUD} compute ${RES} list --quiet --project ${PROJECT} --format yaml 2>&1
+  done
+fi
+
+echo ==============================================================================
+echo "RESULT: $RESULT"
+echo '--- END ---'

--- a/cmd/psc-e2e-test/upgrade_test.go
+++ b/cmd/psc-e2e-test/upgrade_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	upgrade "k8s.io/ingress-gce/cmd/psc-e2e-test/upgrade"
+	"k8s.io/ingress-gce/pkg/e2e"
+)
+
+func TestGenericUpgrade(t *testing.T) {
+	t.Parallel()
+	// Only run the PSC-related upgrade test.
+	runUpgradeTest(t, upgrade.NewPSCUpgradeTest())
+}
+
+func runUpgradeTest(t *testing.T, test e2e.UpgradeTest) {
+	desc := test.Name()
+	Framework.RunWithSandbox(desc, t, func(t *testing.T, s *e2e.Sandbox) {
+		t.Parallel()
+
+		t.Logf("Running upgrade test %v", desc)
+		if err := test.Init(t, s, Framework); err != nil {
+			t.Fatalf("For upgrade test %v, step Init failed due to %v", desc, err)
+		}
+
+		s.PutStatus(e2e.Unstable)
+		func() {
+			// always mark the test as stable in order to unblock other upgrade tests.
+			defer s.PutStatus(e2e.Stable)
+			if err := test.PreUpgrade(); err != nil {
+				t.Fatalf("For upgrade test %v, step PreUpgrade failed due to %v", desc, err)
+			}
+		}()
+
+		for {
+			// While k8s master is upgrading, it will return a connection refused
+			// error for any k8s resource we try to hit. We loop until the
+			// master upgrade has finished.
+			if s.MasterUpgrading() {
+				if err := test.DuringUpgrade(); err != nil {
+					t.Fatalf("For upgrade test %v, step DuringUpgrade failed due to %v", desc, err)
+				}
+				continue
+			}
+
+			if s.MasterUpgraded() {
+				t.Logf("Detected master upgrade, continuing upgrade test %v", desc)
+				break
+			}
+		}
+		if err := test.PostUpgrade(); err != nil {
+			t.Fatalf("For upgrade test %v, step PostUpgrade failed due to %v", desc, err)
+		}
+	})
+}


### PR DESCRIPTION
The purpose is to create three new binaries that willl be subsituting the monolithic binary that existed until today (e2e-test). The new binaries are ingress-controller-e2e-test, neg-e2e-test, and psc-e2e-test.

In particular each new folder hosts: the code of the specific tests for the respective controller; an entry point for the container/binary; an upgrade folder with the targets for the upgrade_test.go.

In addition three new Docker templates are introduced to build the three images.

Finally Makefile is updated with the new binaries.

The old e2e is preserveed and it will be deleted later once the new images are tested and proven to work correctly within the CI/CD pipeline.