### PR TITLE
Disable Weighted Load Balancing by unsetting localityLBPolicy field

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -446,14 +446,6 @@ func (p *Pool) EnsureL4BackendService(params L4BackendServiceParams, beLogger kl
 		createdBS, err := composite.GetBackendService(p.cloud, key, expectedBS.Version, beLogger)
 		return createdBS, utils.ResourceUpdate, err
 	} else {
-		// TODO(FelipeYepez) remove this check once LocalityLBPolicyMaglev does not require allow lisiting
-		// Use LocalityLBPolicyMaglev instead of LocalityLBPolicyDefault if ILB already uses MAGLEV or WEIGHTEDMAGLEV
-		if expectedBS.LocalityLbPolicy == string(LocalityLBPolicyDefault) &&
-			(currentBS.LocalityLbPolicy == string(LocalityLBPolicyWeightedMaglev) || currentBS.LocalityLbPolicy == string(LocalityLBPolicyMaglev)) {
-
-			expectedBS.LocalityLbPolicy = string(LocalityLBPolicyMaglev)
-		}
-
 		// Determine the appropriate API version to use for updating the backend service
 		currentVersion := meta.VersionGA
 		var currentDesc utils.L4LBResourceDescription

--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -860,7 +860,7 @@ func TestUpdateLocalityLBPolicy(t *testing.T) {
 			desc:                       "from WEIGHTED_MAGLEV to empty",
 			existingBSLocalityLbPolicy: LocalityLBPolicyWeightedMaglev,
 			updatedBSLocalityLbPolicy:  LocalityLBPolicyDefault,
-			wantBSLocalityLbPolicy:     LocalityLBPolicyMaglev,
+			wantBSLocalityLbPolicy:     LocalityLBPolicyDefault,
 		},
 	}
 

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -812,8 +812,7 @@ func (l4 *L4) determineBackendServiceLocalityPolicy() backends.LocalityLBPolicyT
 			}
 		}
 	}
-	// If the service has weighted load balancing disabled, the default locality policy is used.
-	// If the service disables Weighted Load Balancing the logic to use MAGLEV is handled by backends.go
+	// The default unset locality lb policy is used to disable ILB Weighted Load Balancing
 	return backends.LocalityLBPolicyDefault
 }
 

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -749,7 +749,7 @@ func (l4netlb *L4NetLB) determineBackendServiceLocalityPolicy() backends.Localit
 			return backends.LocalityLBPolicyMaglev
 		}
 	}
-	// If the service has weighted load balancing disabled, the default locality policy is used.
+	// If the controller has weighted load balancing disabled, the default unset locality policy is used.
 	return backends.LocalityLBPolicyDefault
 }
 


### PR DESCRIPTION
Unset the Locality LB Policy of the backend service when an internal LoadBalancer service disables Weighted Load Balancing. Now it is possible to move from `WEIGHTEDMAGLEV` to unset ` ` instead of using `MAGLEV`.