### PR TITLE
[cherrypick #2923 to release-1.36] Add handler functions for watching…

### DIFF
--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	l4metrics "k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
@@ -177,6 +178,17 @@ func NewILBController(ctx *context.ControllerContext, stopCh <-chan struct{}, lo
 			}
 		},
 	})
+
+	enableMultiSubnetClusterPhase1 := flags.F.EnableMultiSubnetClusterPhase1
+	if enableMultiSubnetClusterPhase1 {
+		ctx.SvcNegInformer.AddEventHandler(&svcNEGEventHandler{
+			ServiceInformer: ctx.ServiceInformer,
+			svcQueue:        l4c.svcQueue,
+			svcFilterFunc:   isSubsettingILBService,
+			logger:          logger,
+		})
+		logger.V(3).Info("set up SvcNegInformer event handlers")
+	}
 
 	return l4c
 }

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/instancegroups"
 	l4metrics "k8s.io/ingress-gce/pkg/l4lb/metrics"
@@ -172,6 +173,17 @@ func NewL4NetLBController(
 			}
 		},
 	})
+
+	enableMultiSubnetClusterPhase1 := flags.F.EnableMultiSubnetClusterPhase1
+	if l4netLBc.enableNEGSupport && enableMultiSubnetClusterPhase1 {
+		ctx.SvcNegInformer.AddEventHandler(&svcNEGEventHandler{
+			ServiceInformer: ctx.ServiceInformer,
+			svcQueue:        l4netLBc.svcQueue,
+			svcFilterFunc:   isRBSNetLBServiceWithNEGs,
+			logger:          logger,
+		})
+		logger.V(3).Info("set up SvcNegInformer event handlers")
+	}
 
 	return l4netLBc
 }

--- a/pkg/l4lb/svcnegeventhandler.go
+++ b/pkg/l4lb/svcnegeventhandler.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package l4lb
+
+import (
+	"reflect"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/annotations"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+// svcNEGEventHandler is a handler used to trigger service processing on update
+// of a related ServiceNetworkEndpointGroup.
+// It should be added as an event handler to the ServiceNetworkEndpointGroup informer.
+// Then it will enqueue a matching service to a given queue, if the service is matched by the svcFilterFunc.
+type svcNEGEventHandler struct {
+	logger          klog.Logger
+	ServiceInformer cache.SharedIndexInformer
+	svcQueue        utils.TaskQueue
+	svcFilterFunc   func(*v1.Service) bool
+}
+
+func (s *svcNEGEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
+	// This function is directly executed by the event handler routine,
+	// it should not do heavy computation but rather focus on short checks and enqueuing.
+	svcNEG, ok := obj.(*negv1beta1.ServiceNetworkEndpointGroup)
+	if !ok {
+		s.logger.Error(nil, "ServiceNetworkEndpointGroup invalid type, got %+v", obj)
+		return
+	}
+	svcKeys := getSvcOwnersOfSvcNEG(svcNEG, s.logger)
+	for _, svcKey := range svcKeys {
+		svcObj, exists, err := s.ServiceInformer.GetStore().GetByKey(svcKey)
+		if err != nil {
+			s.logger.Error(err, "ServiceNetworkEndpointGroup getting owner service", "svcKey", svcKey, "svcNeg", klog.KObj(svcNEG))
+			continue
+		}
+		if !exists {
+			s.logger.V(3).Info("ServiceNetworkEndpointGroup owner service not found", "svcKey", svcKey, "svcNeg", klog.KObj(svcNEG))
+			continue
+		}
+		svc, ok := svcObj.(*v1.Service)
+		if !ok {
+			continue
+		}
+		isHandledByTheL4Controller := s.svcFilterFunc(svc)
+		if !isHandledByTheL4Controller {
+			continue
+		}
+		svcLogger := s.logger.WithValues("serviceKey", svcKey)
+		svcLogger.V(3).Info("NEGs added for service, triggering resync")
+		s.svcQueue.Enqueue(svc)
+	}
+}
+func (s *svcNEGEventHandler) OnUpdate(old, cur interface{}) {
+	// This function is directly executed by the event handler routine,
+	// it should not do heavy computation but rather focus on short checks and enqueuing.
+	curSvcNEG, ok := cur.(*negv1beta1.ServiceNetworkEndpointGroup)
+	if !ok {
+		s.logger.Error(nil, "ServiceNetworkEndpointGroup invalid type, got %+v", cur)
+		return
+	}
+	oldSvcNEG, ok := old.(*negv1beta1.ServiceNetworkEndpointGroup)
+	if !ok {
+		s.logger.V(3).Info("ServiceNetworkEndpointGroup invalid type, got %+v", old)
+		return
+	}
+	svcKeys := getSvcOwnersOfSvcNEG(curSvcNEG, s.logger)
+	for _, svcKey := range svcKeys {
+		obj, exists, err := s.ServiceInformer.GetStore().GetByKey(svcKey)
+		if err != nil {
+			s.logger.Error(err, "ServiceNetworkEndpointGroup getting owner service", "svcKey", svcKey, "svcNeg", klog.KObj(curSvcNEG))
+			continue
+		}
+		if !exists {
+			s.logger.Error(nil, "ServiceNetworkEndpointGroup owner service not found", "svcKey", svcKey, "svcNeg", klog.KObj(curSvcNEG))
+			continue
+		}
+		svc, ok := obj.(*v1.Service)
+		if !ok {
+			continue
+		}
+		isHandledByTheL4Controller := s.svcFilterFunc(svc)
+		if !isHandledByTheL4Controller {
+			continue
+		}
+
+		oldNEGs := negReferenceListToMap(oldSvcNEG.Status.NetworkEndpointGroups)
+		curNEGs := negReferenceListToMap(curSvcNEG.Status.NetworkEndpointGroups)
+		if !reflect.DeepEqual(oldNEGs, curNEGs) {
+			svcLogger := s.logger.WithValues("serviceKey", svcKey)
+			svcLogger.V(3).Info("NEGs changed for service, triggering resync")
+			s.svcQueue.Enqueue(svc)
+		}
+	}
+}
+func (s *svcNEGEventHandler) OnDelete(obj interface{}) {
+	// no need for any action. The service is likely being deleted anyway.
+}
+
+func getSvcOwnersOfSvcNEG(svcNEG *negv1beta1.ServiceNetworkEndpointGroup, logger klog.Logger) []string {
+	logger.V(3).Info("getSvcOwnerOfSvcNEG", "ownersLen", len(svcNEG.OwnerReferences))
+	var resultKeys []string
+	for _, ownersRef := range svcNEG.OwnerReferences {
+		if ownersRef.Kind != "Service" {
+			continue
+		}
+		svcName := ownersRef.Name
+		svcNamespace := svcNEG.Namespace
+		if svcNamespace == "" {
+			svcNamespace = metav1.NamespaceDefault
+		}
+		svcKey := utils.ServiceKeyFunc(svcNamespace, svcName)
+		resultKeys = append(resultKeys, svcKey)
+	}
+	return resultKeys
+}
+
+func isSubsettingILBService(svc *v1.Service) bool {
+	needsILB, _ := annotations.WantsL4ILB(svc)
+	return needsILB && utils.IsSubsettingL4ILBService(svc)
+}
+
+func isRBSNetLBServiceWithNEGs(svc *v1.Service) bool {
+	needsNetLB, _ := annotations.WantsL4NetLB(svc)
+	return needsNetLB && utils.HasL4NetLBFinalizerV3(svc)
+}
+
+func negReferenceListToMap(refs []negv1beta1.NegObjectReference) map[string]*negv1beta1.NegObjectReference {
+	negRefsMap := make(map[string]*negv1beta1.NegObjectReference)
+	for _, svcNEG := range refs {
+		negRefsMap[svcNEG.Id] = &svcNEG
+	}
+	return negRefsMap
+}

--- a/pkg/l4lb/svcnegeventhandler_test.go
+++ b/pkg/l4lb/svcnegeventhandler_test.go
@@ -1,0 +1,680 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package l4lb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	informerv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/ingress-gce/pkg/annotations"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/common"
+	"k8s.io/klog/v2"
+)
+
+func TestAddSvcNEGEnqueuesService(t *testing.T) {
+	subsettingILBService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testService",
+			Namespace: "testNamespace",
+			Annotations: map[string]string{
+				annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+			},
+			Finalizers: []string{
+				common.ILBFinalizerV2,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		svcNEG         *negv1beta1.ServiceNetworkEndpointGroup
+		services       []*v1.Service
+		expectEnqueues int
+	}{
+		{
+			name: "Enqueue_service",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 1,
+		},
+		{
+			name: "Dont_enqueue_not_existent",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testOtherService"},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name: "Dont_enqueue_owner_of_kind_other_than_service",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Ingress", Name: "testService"},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name: "Dont_enqueue_not_handled_service",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+			},
+			services: []*v1.Service{
+				{ // legacy ILB
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testService",
+						Namespace: "testNamespace",
+						Annotations: map[string]string{
+							annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+						},
+						Finalizers: []string{
+							common.LegacyILBFinalizer,
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+				},
+			},
+			expectEnqueues: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := fake.NewClientset()
+			serviceInformer := informerv1.NewServiceInformer(kubeClient, metav1.NamespaceAll, 10*time.Minute, utils.NewNamespaceIndexer())
+
+			queue := utils.NewPeriodicTaskQueueWithMultipleWorkers("l4netLB", "services", 1, func(s string) error {
+				return nil
+			}, klog.TODO())
+
+			handler := &svcNEGEventHandler{
+				logger:          klog.TODO(),
+				ServiceInformer: serviceInformer,
+				svcQueue:        queue,
+				svcFilterFunc:   isSubsettingILBService,
+			}
+			for _, svc := range tc.services {
+				serviceInformer.GetIndexer().Add(svc)
+			}
+
+			handler.OnAdd(tc.svcNEG, false)
+
+			if queue.Len() != tc.expectEnqueues {
+				t.Errorf("unexpected number of enqueues want=%d got=%d", tc.expectEnqueues, queue.Len())
+			}
+		})
+	}
+}
+
+func TestUpdateSvcNEGEnqueuesService(t *testing.T) {
+	subsettingILBService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testService",
+			Namespace: "testNamespace",
+			Annotations: map[string]string{
+				annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+			},
+			Finalizers: []string{
+				common.ILBFinalizerV2,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+		},
+	}
+	testSvcNEG := &negv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSvcNEG",
+			Namespace: "testNamespace",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Service", Name: "testService"},
+			},
+		},
+		Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+			NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+				{
+					Id:                  "1",
+					SelfLink:            "networkEndpointGroups/1",
+					SubnetURL:           "subnet1",
+					NetworkEndpointType: "GCE_VM_IP",
+					State:               "ACTIVE",
+				},
+			},
+		},
+	}
+	emptyTestSvcNEG := &negv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSvcNEG",
+			Namespace: "testNamespace",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Service", Name: "testService"},
+			},
+		},
+		Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+			NetworkEndpointGroups: []negv1beta1.NegObjectReference{},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		svcNEG         *negv1beta1.ServiceNetworkEndpointGroup
+		oldSvcNEG      *negv1beta1.ServiceNetworkEndpointGroup
+		services       []*v1.Service
+		expectEnqueues int
+	}{
+		{
+			name:   "SvcNEG_unchanged_dont_enqueue",
+			svcNEG: testSvcNEG,
+			oldSvcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name:      "SvcNEG_changed_enqueue",
+			svcNEG:    testSvcNEG,
+			oldSvcNEG: emptyTestSvcNEG,
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 1,
+		},
+		{
+			name: "SvcNEG_order_changes_but_is_the_same_dont_enqueue",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+						{
+							Id:                  "2",
+							SelfLink:            "networkEndpointGroups/2",
+							SubnetURL:           "subnet2",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+					},
+				},
+			},
+			oldSvcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "2",
+							SelfLink:            "networkEndpointGroups/2",
+							SubnetURL:           "subnet2",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name: "Dont_enqueue_not_existent_svc",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testOtherService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+					},
+				},
+			},
+			oldSvcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testOtherService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name:      "Dont_enqueue_not_handled_service",
+			svcNEG:    testSvcNEG,
+			oldSvcNEG: emptyTestSvcNEG,
+			services: []*v1.Service{
+				{ // legacy ILB
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testService",
+						Namespace: "testNamespace",
+						Annotations: map[string]string{
+							annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+						},
+						Finalizers: []string{
+							common.LegacyILBFinalizer,
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+				},
+			},
+			expectEnqueues: 0,
+		},
+		{
+			name:   "Enqueue_on_NEG_status_change",
+			svcNEG: testSvcNEG,
+			oldSvcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "INACTIVE",
+						},
+					},
+				},
+			},
+			services: []*v1.Service{
+				subsettingILBService,
+			},
+			expectEnqueues: 1,
+		},
+		// this case should not be happening really, since we don't expect the SvcNEG to have multiple owners,
+		// but to make code more resilient, we include this case
+		{
+			name: "Enqueue multiple services",
+			svcNEG: &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testSvcNEG",
+					Namespace: "testNamespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Service", Name: "testService"},
+						{Kind: "Service", Name: "testOtherService"},
+					},
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+						{
+							Id:                  "1",
+							SelfLink:            "networkEndpointGroups/1",
+							SubnetURL:           "subnet1",
+							NetworkEndpointType: "GCE_VM_IP",
+							State:               "ACTIVE",
+						},
+					},
+				},
+			},
+			oldSvcNEG: emptyTestSvcNEG,
+			services: []*v1.Service{
+				subsettingILBService,
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testOtherService",
+						Namespace: "testNamespace",
+						Annotations: map[string]string{
+							annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+						},
+						Finalizers: []string{
+							common.ILBFinalizerV2,
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+				},
+			},
+			expectEnqueues: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := fake.NewClientset()
+			serviceInformer := informerv1.NewServiceInformer(kubeClient, metav1.NamespaceAll, 10*time.Minute, utils.NewNamespaceIndexer())
+
+			queue := utils.NewPeriodicTaskQueueWithMultipleWorkers("l4netLB", "services", 1, func(s string) error {
+				return nil
+			}, klog.TODO())
+
+			handler := &svcNEGEventHandler{
+				logger:          klog.TODO(),
+				ServiceInformer: serviceInformer,
+				svcQueue:        queue,
+				svcFilterFunc:   isSubsettingILBService,
+			}
+			for _, svc := range tc.services {
+				serviceInformer.GetIndexer().Add(svc)
+			}
+
+			handler.OnUpdate(tc.oldSvcNEG, tc.svcNEG)
+
+			if queue.Len() != tc.expectEnqueues {
+				t.Errorf("unexpected number of enqueues want=%d got=%d", tc.expectEnqueues, queue.Len())
+			}
+		})
+	}
+}
+
+func TestGetSvcOwnersOfSvcNEG(t *testing.T) {
+	svcNEG := &negv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testSvcNEG",
+			Namespace: "testNamespace",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Service", Name: "testService"},
+				{Kind: "Ingress", Name: "testIngress"},
+				{Kind: "Service", Name: "testService2"},
+			},
+		},
+	}
+	svcKeys := getSvcOwnersOfSvcNEG(svcNEG, klog.TODO())
+
+	want := []string{
+		"testNamespace/testService",
+		"testNamespace/testService2",
+	}
+	if diff := cmp.Diff(want, svcKeys); diff != "" {
+		t.Errorf("getSvcOwnersOfSvcNEG() invalid result, diff=%s (want-, got+)", diff)
+	}
+
+}
+
+func TestIsSubsettingILBService(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    *v1.Service
+		wantResult bool
+	}{
+		{
+			name: "Match_ILB_with_V2_finalizer",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testSubsetting",
+					Annotations: map[string]string{
+						annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+					},
+					Finalizers: []string{
+						common.ILBFinalizerV2,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "Dont_match_ILB_with_V1_finalizer",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testSubsetting",
+					Annotations: map[string]string{
+						annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+					},
+					Finalizers: []string{
+						common.LegacyILBFinalizer,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: false,
+		},
+		{
+			name: "Dont_match_NetLB",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testSubsetting",
+					Annotations: map[string]string{
+						annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeExternal),
+					},
+					Finalizers: []string{
+						common.ILBFinalizerV2,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: false,
+		},
+		{
+			name: "Dont_match_non_LB",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testSubsetting",
+					Annotations: map[string]string{
+						annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+					},
+					Finalizers: []string{
+						common.ILBFinalizerV2,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeClusterIP,
+				},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isSubsettingILBService(tc.service)
+			if result != tc.wantResult {
+				t.Errorf("isSubsettingILBService() unexpected result, want=%v, got=%v, svc=%+v", tc.wantResult, result, tc.service)
+			}
+		})
+	}
+}
+
+func TestIsRBSNetLBServiceWithNEGs(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    *v1.Service
+		wantResult bool
+	}{
+		{
+			name: "Match_NetLB_with_V2_finalizer",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Finalizers: []string{
+						common.NetLBFinalizerV3,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "Dont_match_NetLB_with_V2_finalizer",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Finalizers: []string{
+						common.NetLBFinalizerV2,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: false,
+		},
+		{
+			name: "Dont_match_ILB",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						annotations.ServiceAnnotationLoadBalancerType: string(annotations.LBTypeInternal),
+					},
+					Finalizers: []string{
+						common.NetLBFinalizerV2,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantResult: false,
+		},
+		{
+			name: "Dont_match_non_LB",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Finalizers: []string{
+						common.NetLBFinalizerV3,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeClusterIP,
+				},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isRBSNetLBServiceWithNEGs(tc.service)
+			if result != tc.wantResult {
+				t.Errorf("isRBSNetLBServiceWithNEGs() unexpected result, want=%v, got=%v, svc=%+v", tc.wantResult, result, tc.service)
+			}
+		})
+	}
+}


### PR DESCRIPTION
… updates to ServiceNetworkEndpointGroup CR for L4 services.

Whenever the ServiceNetworkEndpointGroup CR changes it's referred NEGs a resync for related services should be triggered.

(cherry picked from commit 0a79fae7ecba274d970a8d313d01ba096d60e08c)