### PR TITLE
[Cherry-pick #2938 to 1.36] Reduce zone_getter log spam by adjusting log levels

### DIFF
--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -102,7 +102,7 @@ func (z *ZoneGetter) ZoneAndSubnetForNode(name string, logger klog.Logger) (stri
 	// In non-gcp mode, the subnet will be empty, so it matches the behavior
 	// for non-gcp NEGs since their SubnetworkURL is empty.
 	if z.mode == NonGCP {
-		logger.Info("ZoneGetter in non-gcp mode, return the single stored zone", "zone", z.singleStoredZone)
+		logger.V(4).Info("ZoneGetter in non-gcp mode, return the single stored zone", "zone", z.singleStoredZone)
 		return z.singleStoredZone, "", nil
 	}
 
@@ -137,7 +137,7 @@ func (z *ZoneGetter) ZoneAndSubnetForNode(name string, logger klog.Logger) (stri
 
 	nodeTopologySynced := z.nodeTopologyHasSynced()
 	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
-		logger.Info("Falling back to only using default subnet when getting subnet for node", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+		logger.V(4).Info("Falling back to only using default subnet when getting subnet for node", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
 
 		defaultSubnet, err := utils.KeyName(z.defaultSubnetURL)
 		if err != nil {
@@ -154,7 +154,7 @@ func (z *ZoneGetter) ZoneAndSubnetForNode(name string, logger klog.Logger) (stri
 // ListNodes returns a list of nodes that satisfy the given node filtering mode.
 func (z *ZoneGetter) ListNodes(filter Filter, logger klog.Logger) ([]*api_v1.Node, error) {
 	filterLogger := logger.WithValues("filter", filter)
-	filterLogger.Info("Listing nodes")
+	filterLogger.V(2).Info("Listing nodes")
 
 	nodes, err := listers.NewNodeLister(z.nodeLister).List(labels.Everything())
 	if err != nil {
@@ -173,7 +173,7 @@ func (z *ZoneGetter) ListNodes(filter Filter, logger klog.Logger) ([]*api_v1.Nod
 		}
 	}
 	if len(filteredOut) <= 50 {
-		filterLogger.Info("Filtered out nodes when listing node zones", "nodes", filteredOut)
+		filterLogger.V(3).Info("Filtered out nodes when listing node zones", "nodes", filteredOut)
 	}
 
 	return selected, nil
@@ -187,7 +187,7 @@ func (z *ZoneGetter) ListNodesInDefaultSubnet(filter Filter, logger klog.Logger)
 		return z.ListNodes(filter, logger)
 	}
 	filterLogger := logger.WithValues("filter", filter)
-	filterLogger.Info("Listing nodes")
+	filterLogger.V(2).Info("Listing nodes")
 
 	nodes, err := listers.NewNodeLister(z.nodeLister).List(labels.Everything())
 	if err != nil {
@@ -211,7 +211,7 @@ func (z *ZoneGetter) ListNodesInDefaultSubnet(filter Filter, logger klog.Logger)
 		}
 	}
 	if len(filteredOut) <= 50 {
-		filterLogger.Info("Filtered out nodes when listing node zones", "nodes", filteredOut)
+		filterLogger.V(3).Info("Filtered out nodes when listing node zones", "nodes", filteredOut)
 	}
 
 	return selected, nil
@@ -231,11 +231,11 @@ func (z *ZoneGetter) ListZonesInDefaultSubnet(filter Filter, logger klog.Logger)
 
 func (z *ZoneGetter) listZones(filter Filter, defaultSubnetOnly bool, logger klog.Logger) ([]string, error) {
 	if z.mode == NonGCP {
-		logger.Info("ZoneGetter in non-gcp mode, return the single stored zone", "zone", z.singleStoredZone)
+		logger.V(4).Info("ZoneGetter in non-gcp mode, return the single stored zone", "zone", z.singleStoredZone)
 		return []string{z.singleStoredZone}, nil
 	}
 	filterLogger := logger.WithValues("filter", filter)
-	filterLogger.Info("Listing zones")
+	filterLogger.V(2).Info("Listing zones")
 	var nodes []*api_v1.Node
 	var err error
 	if !defaultSubnetOnly {
@@ -265,14 +265,14 @@ func (z *ZoneGetter) listZones(filter Filter, defaultSubnetOnly bool, logger klo
 // default subnet.
 func (z *ZoneGetter) ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConfig {
 	if z.mode == Legacy {
-		logger.Info("ListSubnets is being called with legacy zone getter. Returning empty list of subnets")
+		logger.V(4).Info("ListSubnets is being called with legacy zone getter. Returning empty list of subnets")
 		return nil
 	}
 
 	nodeTopologyCRName := flags.F.NodeTopologyCRName
 	nodeTopologySynced := z.nodeTopologyHasSynced()
 	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
-		logger.Info("Falling back to only using default subnet when listing subnets", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+		logger.V(4).Info("Falling back to only using default subnet when listing subnets", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
 		return []nodetopologyv1.SubnetConfig{z.defaultSubnetConfig}
 	}
 
@@ -282,7 +282,7 @@ func (z *ZoneGetter) ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConf
 		return []nodetopologyv1.SubnetConfig{z.defaultSubnetConfig}
 	}
 	if !exists {
-		logger.Info("Unable to find node topology CR in the store", "nodeTopologyCRName", nodeTopologyCRName)
+		logger.V(2).Info("Unable to find node topology CR in the store", "nodeTopologyCRName", nodeTopologyCRName)
 		return []nodetopologyv1.SubnetConfig{z.defaultSubnetConfig}
 	}
 	nodeTopologyCR, ok := n.(*nodetopologyv1.NodeTopology)
@@ -291,7 +291,7 @@ func (z *ZoneGetter) ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConf
 		return []nodetopologyv1.SubnetConfig{z.defaultSubnetConfig}
 	}
 	if len(nodeTopologyCR.Status.Subnets) == 0 {
-		logger.Info("NodeTopology resource has no subnets; assuming that it has atleast the default subnet", "nodeTopologyCRName", nodeTopologyCRName)
+		logger.V(2).Info("NodeTopology resource has no subnets; assuming that it has atleast the default subnet", "nodeTopologyCRName", nodeTopologyCRName)
 		return []nodetopologyv1.SubnetConfig{z.defaultSubnetConfig}
 	}
 	return nodeTopologyCR.Status.Subnets
@@ -333,7 +333,7 @@ func (z *ZoneGetter) allNodesPredicate(node *api_v1.Node, nodeLogger klog.Logger
 	nodeTopologySynced := z.nodeTopologyHasSynced()
 
 	if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
-		nodeLogger.Info("Falling back to only using default subnet when listing all nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+		nodeLogger.V(4).Info("Falling back to only using default subnet when listing all nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
 
 		isInDefaultSubnet, err := z.isNodeInDefaultSubnet(node, nodeLogger)
 		if err != nil {
@@ -365,7 +365,7 @@ func (z *ZoneGetter) nodePredicateInternal(node *api_v1.Node, includeUnreadyNode
 	if z.mode != Legacy {
 		nodeTopologySynced := z.nodeTopologyHasSynced()
 		if z.onlyIncludeDefaultSubnetNodes || !nodeTopologySynced {
-			nodeAndFilterLogger.Info("Falling back to only using default subnet when listing nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
+			nodeAndFilterLogger.V(4).Info("Falling back to only using default subnet when listing nodes", "z.onlyIncludeDefaultSubnetNodes", z.onlyIncludeDefaultSubnetNodes, "nodeTopologySynced", nodeTopologySynced)
 
 			isInDefaultSubnet, err := z.isNodeInDefaultSubnet(node, nodeAndFilterLogger)
 			if err != nil {
@@ -433,7 +433,7 @@ func (z *ZoneGetter) nodePredicateInternal(node *api_v1.Node, includeUnreadyNode
 // subnet.
 func (z *ZoneGetter) isNodeInDefaultSubnet(node *api_v1.Node, nodeLogger klog.Logger) (bool, error) {
 	if z.mode == Legacy {
-		nodeLogger.Info("IsDefaultSubnetNode is being called with legacy zone getter. Returning true.")
+		nodeLogger.V(4).Info("IsDefaultSubnetNode is being called with legacy zone getter. Returning true.")
 		return true, nil
 	}
 	nodeSubnet, err := getSubnet(node, z.defaultSubnetURL)


### PR DESCRIPTION
Changed logger.Info calls to use appropriate verbosity levels (V(2), V(3), V(4)) to prevent excessive logging that can overflow disk space in large clusters with thousands of services and nodes.

- V(4): Debug-level logs for frequently called operations (per service/node)
- V(3): Verbose logs for filtered node summaries
- V(2): Info-level logs for listing operations and error conditions

This prevents disk space issues while maintaining debug capability with --v flags.


/assign @gauravkghildiyal @mmamczur 