### PR TITLE
Updated cloudbuild.yaml to include additional e2e-test binaries

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
   - VERBOSE=1
   - HOME=/root
   - USER=root
-  - BINARIES=e2e-test
+  - BINARIES="e2e-test psc-e2e-test neg-e2e-test ingress-controller-e2e-test"
   - ADDITIONAL_TAGS=infrastructure-public-image-$_GIT_TAG
   args:
   - -c


### PR DESCRIPTION
This PR completes the work done in  #2932, #2934, and #2935. This additional change allows Prow-job to build the images from the newly introduced binaries