### PR TITLE
Gracefully handle empty default backend service

### DIFF
--- a/cmd/glbc/app/init.go
+++ b/cmd/glbc/app/init.go
@@ -35,6 +35,11 @@ import (
 // DefaultBackendServicePort returns the ServicePort which will be
 // used as the default backend for load balancers.
 func DefaultBackendServicePort(kubeClient kubernetes.Interface, logger klog.Logger) utils.ServicePort {
+	if !flags.F.RunIngressController && !flags.F.EnableNEGsForIngress {
+		noDefaultBackendServicePort := utils.ServicePort{}
+		return noDefaultBackendServicePort
+	}
+
 	if flags.F.DefaultSvc == "" {
 		klog.Fatalf("Please specify --default-backend-service")
 	}

--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -689,6 +689,7 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 		ctx.EnableIngressRegionalExternal,
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
+		flags.F.EnableNEGsForIngress,
 		stopCh,
 		logger,
 	)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -146,6 +146,7 @@ var F = struct {
 	MultiProjectOwnerLabelKey                 string
 	OverrideHealthCheckSourceCIDRs            string
 	ManageL4LBLogging                         bool
+	EnableNEGsForIngress                      bool
 
 	// ===============================
 	// DEPRECATED FLAGS
@@ -356,6 +357,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.StringVar(&F.OverrideHealthCheckSourceCIDRs, "override-health-check-src-cidrs", "", "Overrides the default source IP ranges used when configuring firewall rules to allow health check probes for L7 load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-health-check-src-cidrs=130.211.0.0/22,35.191.0.0/16")
 	flag.BoolVar(&F.ManageL4LBLogging, "manage-l4lb-logging", false, "Manage L4 ILB/NetLB logging.")
 	flag.BoolVar(&F.ReadOnlyMode, "read-only-controllers", false, "When enabled, this flag runs the IG, NEG, L4 ILB, and L4 NetLB controllers in a read-only mode. This prevents them from executing any mutating API calls (e.g., create, update, delete), allowing you to safely observe controller behavior without modifying resources. The Ingress controller is exempt from this mode.")
+	flag.BoolVar(&F.EnableNEGsForIngress, "enable-negs-for-ingress", true, "Allow the NEG controller to create NEGs for Ingress services.")
 }
 
 func Validate() {

--- a/pkg/multiproject/neg/neg.go
+++ b/pkg/multiproject/neg/neg.go
@@ -305,6 +305,7 @@ func createNEGController(
 		flags.F.EnableIngressRegionalExternal,
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
+		flags.F.EnableNEGsForIngress,
 		stopCh,
 		logger,
 	)


### PR DESCRIPTION
This commit prevents controllers initialization from crashing and controllers performing unnecessary work by ensuring the DefaultBackendServicePort function returns an empty utils.ServicePort when the Ingress controller is disabled. This change modifies the core behavior of the DefaultBackendServicePort function, making it resilient to cases where the default backend service does not exist when the Ingress controller is not running. It also ensures that all controllers that rely on this function are now able to gracefully handle the empty utils.ServicePort, preventing panics and redundant processing.