### PR TITLE
PSC Controller: avoid odd patch requests

### DIFF
--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -699,6 +699,10 @@ func needsUpdate(existingSA, desiredSA *ga.ServiceAttachment) (bool, error) {
 	// Set region to avoid selflink mismatches
 	desiredCopy.Region = existingSA.Region
 
+	// convertRejectList should be a nil (but not empty list) if there is no data
+	if len(desiredCopy.ConsumerRejectLists) == 0 {
+		desiredCopy.ConsumerRejectLists = nil
+	}
 	return !reflect.DeepEqual(desiredCopy, existingSA), nil
 }
 


### PR DESCRIPTION
ConsumerRejectLists should be set to nil for needsUpdate() if there is no data to avoid odd patch requests.

When needUpdate() compare gceSvcAttachment and existingSA, ConsumerRejectLists fields are different:
 nil != [] 
 
 so it caused odd Patch request for PSC SA.