### PR TITLE
Prevent L4 ILB controller race conditions on service creation

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -148,6 +148,7 @@ var F = struct {
 	ManageL4LBLogging                         bool
 	EnableNEGsForIngress                      bool
 	EnableIPv6OnlyL4                          bool
+	L4ILBLegacyHeadStartTime                  time.Duration
 
 	// ===============================
 	// DEPRECATED FLAGS
@@ -360,6 +361,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.ReadOnlyMode, "read-only-controllers", false, "When enabled, this flag runs the IG, NEG, L4 ILB, and L4 NetLB controllers in a read-only mode. This prevents them from executing any mutating API calls (e.g., create, update, delete), allowing you to safely observe controller behavior without modifying resources. The Ingress controller is exempt from this mode.")
 	flag.BoolVar(&F.EnableNEGsForIngress, "enable-negs-for-ingress", true, "Allow the NEG controller to create NEGs for Ingress services.")
 	flag.BoolVar(&F.EnableIPv6OnlyL4, "enable-ipv6-only-l4", false, "Enables IPv6-only mode for the L4 ILB and NetLB controllers, disabling all IPv4-related logic and resource management.")
+	flag.DurationVar(&F.L4ILBLegacyHeadStartTime, "prevent-legacy-race-l4-ilb", 0*time.Second, "Delay before processing new L4 ILB services without existing finalizers. This gives the legacy controller a head start to claim the service, preventing a race condition upon service creation.")
 }
 
 func Validate() {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -739,6 +739,11 @@ func IsLegacyL4ILBService(svc *api_v1.Service) bool {
 	if svc.Spec.LoadBalancerClass != nil {
 		return annotations.HasLoadBalancerClass(svc, annotations.LegacyRegionalInternalLoadBalancerClass)
 	}
+	return HasLegacyL4ILBFinalizerV1(svc)
+}
+
+// HasLegacyL4ILBFinalizerV1 returns true if the given Service has ILBFinalizerV1
+func HasLegacyL4ILBFinalizerV1(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.LegacyILBFinalizer, nil)
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1801,3 +1801,69 @@ func TestFilterAPIVersionFromResourcePath(t *testing.T) {
 		})
 	}
 }
+
+func TestLBBasedOnFinalizer(t *testing.T) {
+	type wants struct {
+		IsLegacyL4ILBService      bool
+		IsSubsettingL4ILBService  bool
+		HasLegacyL4ILBFinalizerV1 bool
+		HasL4ILBFinalizerV2       bool
+		HasL4NetLBFinalizerV2     bool
+		HasL4NetLBFinalizerV3     bool
+	}
+
+	testCases := []struct {
+		finalizer string
+		want      wants
+	}{
+		{
+			finalizer: common.LegacyILBFinalizer,
+			want: wants{
+				IsLegacyL4ILBService:      true,
+				HasLegacyL4ILBFinalizerV1: true,
+			},
+		},
+		{
+			finalizer: common.ILBFinalizerV2,
+			want: wants{
+				IsSubsettingL4ILBService: true,
+				HasL4ILBFinalizerV2:      true,
+			},
+		},
+		{
+			finalizer: common.NetLBFinalizerV2,
+			want: wants{
+				HasL4NetLBFinalizerV2: true,
+			},
+		},
+		{
+			finalizer: common.NetLBFinalizerV3,
+			want: wants{
+				HasL4NetLBFinalizerV3: true,
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.finalizer, func(t *testing.T) {
+			svc := &api_v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{tC.finalizer},
+				},
+			}
+
+			got := wants{
+				IsLegacyL4ILBService:      utils.IsLegacyL4ILBService(svc),
+				IsSubsettingL4ILBService:  utils.IsSubsettingL4ILBService(svc),
+				HasLegacyL4ILBFinalizerV1: utils.HasLegacyL4ILBFinalizerV1(svc),
+				HasL4ILBFinalizerV2:       utils.HasL4ILBFinalizerV2(svc),
+
+				HasL4NetLBFinalizerV2: utils.HasL4NetLBFinalizerV2(svc),
+				HasL4NetLBFinalizerV3: utils.HasL4NetLBFinalizerV3(svc),
+			}
+
+			if diff := cmp.Diff(tC.want, got); diff != "" {
+				t.Errorf("got != want, diff(-tc.want +got) = %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces a wait and re-fetch mechanism when a service has no L4 ILB finalizers (v1 or v2) through a flag `L4ILBLegacyHeadStartTime`. This prevents race conditions between controllers during initial service creation, ensuring the L4 controller processes the most recent service state and avoids conflicting operations. This to prevent race during cluster update when enabling GKE subsetting.

This will only be applied to regional clusters since zonal clusters don't have the issue. 