### PR TITLE
Remove .metadata from CRD

### DIFF
--- a/pkg/crd/validation_test.go
+++ b/pkg/crd/validation_test.go
@@ -155,4 +155,21 @@ func TestCondenseSchema(t *testing.T) {
 	if !tsProp.SchemaProps.Nullable {
 		t.Errorf("Expected Foo's ts property to be Nullable")
 	}
+
+	// Verify that metadata is removed.
+	schemaWithMetadata := spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Properties: map[string]spec.Schema{
+				"metadata": {},
+				"spec":     {},
+			},
+		},
+	}
+	condensedSchemaWithMetadata := condenseSchema(schemaWithMetadata, openapiSpec)
+	if _, exists := condensedSchemaWithMetadata.Properties["metadata"]; exists {
+		t.Errorf("condenseSchema should have removed 'metadata' property, but it still exists")
+	}
+	if _, exists := condensedSchemaWithMetadata.Properties["spec"]; !exists {
+		t.Errorf("condenseSchema should not have removed 'spec' property, but it is gone")
+	}
 }


### PR DESCRIPTION
New codegen CRDs include metadata, these must be removed to pass 
validation. See Kubernetes commit d74a9a9da658e1cb9ae23ae0622089fe09d65564.

This fixes the reverted PR: https://github.com/kubernetes/ingress-gce/pull/2957