### PR TITLE
Add Rendezvous hashing for ILB weighted load balancing

### DIFF
--- a/pkg/loadbalancers/l4netlb_test.go
+++ b/pkg/loadbalancers/l4netlb_test.go
@@ -1260,6 +1260,11 @@ func TestWeightedNetLB(t *testing.T) {
 			if bs.LocalityLbPolicy != string(tc.wantLocalityLBPolicy) {
 				t.Errorf("Unexpected BackendService LocalityLbPolicy value, got: %v, want: %v", bs.LocalityLbPolicy, tc.wantLocalityLBPolicy)
 			}
+
+			isWeightedLBPodsPerNode := l4NetLB.isWeightedLBPodsPerNode()
+			if tc.weightedFlagEnabled && tc.addAnnotationForWeighted && tc.externalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal && !isWeightedLBPodsPerNode {
+				t.Errorf("Expected isWeightedLBPodsPerNode() to return true for Service with weighted load balancing enabled")
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change introduces WEIGHTED_GCP_RENDEZVOUS as the locality LB policy for weighted ILB services. It also adds awareness for the upcoming RENDEZVOUS default policy to prevent unnecessary backend service recreation during reconciliation.

The controller now correctly differentiates between NetLB (Maglev) and ILB (Rendezvous) policies, ensuring stability and proper configuration for weighted load balancing. This aligns the controller with backend infrastructure updates for internal load balancers.