### PR TITLE
feat(l4): Add support for enabling L4 NetLB Regional Backend Services by default

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -357,6 +357,7 @@ func main() {
 		EnableL4DenyFirewallsRollbackCleanup: flags.F.EnableL4DenyFirewallRollbackCleanup,
 		EnableL4ILBZonalAffinity:             flags.F.EnableL4ILBZonalAffinity,
 		ReadOnlyMode:                         flags.F.ReadOnlyMode,
+		EnableL4NetLBRBSByDefault:            flags.F.EnableL4NetLBRBSByDefault,
 	}
 	ctx, err := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, l4LBConfigClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	if err != nil {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -143,6 +143,7 @@ type ControllerContextConfig struct {
 	EnableL3ForNetLBMixedProtocol        bool
 	EnableL4DenyFirewalls                bool
 	EnableL4DenyFirewallsRollbackCleanup bool
+	EnableL4NetLBRBSByDefault            bool
 }
 
 // NewControllerContext returns a new shared set of informers.

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -156,6 +156,7 @@ var F = struct {
 	EnableL4NEGLocalIncludeDrainNodes           bool
 	// EnableL4DenyFirewallExplicitlySet will be set to true if the argument was explicitly set by the user.
 	EnableL4DenyFirewallExplicitlySet bool
+	EnableL4NetLBRBSByDefault         bool
 	// ===============================
 	// DEPRECATED FLAGS
 	// ===============================
@@ -373,6 +374,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NEGDetachCancel, "enable-l4-neg-detach-cancel", false, "Enable cancelling NEG detach when endpoints need to be re-attached.")
 	flag.BoolVar(&F.EnablePSCReconcileConnections, "enable-psc-reconcile-connections", false, "Enable support for PSC ServiceAttachment reconcile connections field")
 	flag.BoolVar(&F.EnableL4NEGLocalIncludeDrainNodes, "enable-l4-neg-local-include-drain-nodes", false, "For L4 LB NEGs with externalTrafficPolicy=Local, keep nodes carrying the GKE drain label in the NEG as long as they still host a backing pod. Unready-node behavior is unchanged.")
+	flag.BoolVar(&F.EnableL4NetLBRBSByDefault, "enable-l4-netlb-rbs-by-default", false, "Enable L4 NetLB Regional Backend Services by default for new L4 NetLB services.")
 }
 
 func Validate() {

--- a/pkg/l4/annotations/service_test.go
+++ b/pkg/l4/annotations/service_test.go
@@ -328,6 +328,20 @@ func TestWantsL4NetLB(t *testing.T) {
 			want: false,
 		},
 		{
+			desc: "LoadBalancer with explicit External annotation wants NetLB",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cloud.google.com/load-balancer-type": "External",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			},
+			want: true,
+		},
+		{
 			desc: "LoadBalancer with Regional Internal Class does not wants NetLB",
 			svc: &v1.Service{
 				Spec: v1.ServiceSpec{

--- a/pkg/l4/controllers/l4netlbcontroller.go
+++ b/pkg/l4/controllers/l4netlbcontroller.go
@@ -87,6 +87,7 @@ type L4NetLBController struct {
 	serviceVersions             *serviceVersionsTracker
 	enableNEGSupport            bool
 	enableNEGAsDefault          bool
+	enableRBSDefault            bool
 
 	hasSynced func() bool
 
@@ -122,6 +123,7 @@ func NewL4NetLBController(
 		serviceVersions:             NewServiceVersionsTracker(),
 		logger:                      logger,
 		hasSynced:                   ctx.HasSynced,
+		enableRBSDefault:            ctx.EnableL4NetLBRBSByDefault,
 	}
 	var networkLister cache.Indexer
 	if ctx.NetworkInformer != nil {
@@ -359,6 +361,7 @@ func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service, sv
 	warnL4FinalizerRemoved(lc.ctx, oldSvc, newSvc)
 
 	if !lc.isRBSBasedService(newSvc, svcLogger) && !lc.isRBSBasedService(oldSvc, svcLogger) {
+		svcLogger.V(4).Info("Ignoring non RBS based NetLB service")
 		return false, false
 	}
 
@@ -391,27 +394,65 @@ func (lc *L4NetLBController) isRBSBasedService(svc *v1.Service, svcLogger klog.L
 	// Check if the type=LoadBalancer, so we don't execute API calls o non-LB services
 	// this call is nil-safe
 	if !utils.IsLoadBalancerServiceType(svc) {
+		svcLogger.V(4).Info("Service is not of type LoadBalancer")
 		return false
 	}
 	if svc.Spec.LoadBalancerClass != nil {
+		svcLogger.V(4).Info("Service has LoadBalancerClass annotation", "loadBalancerClass", *svc.Spec.LoadBalancerClass)
 		return annotations.HasLoadBalancerClass(svc, annotations.RegionalExternalLoadBalancerClass)
 	}
-	return annotations.HasRBSAnnotation(svc) || utils.HasL4NetLBFinalizerV2(svc) || utils.HasL4NetLBFinalizerV3(svc) || lc.hasRBSForwardingRule(svc, svcLogger)
+	if utils.HasL4NetLBFinalizerV2(svc) || utils.HasL4NetLBFinalizerV3(svc) {
+		svcLogger.V(4).Info("Service has L4 NetLB RBS finalizer")
+		return true
+	}
+	if annotations.HasRBSAnnotation(svc) {
+		svcLogger.V(4).Info("Service has RBS annotation")
+		return true
+	}
+	if lc.hasLegacyControllerOwnership(svc, svcLogger) {
+		svcLogger.V(4).Info("Service has legacy controller ownership")
+		return false
+	}
+	if lc.enableRBSDefault {
+		svcLogger.V(4).Info("RBS is enabled by default, treating service as RBS based")
+		return true
+	}
+	if lc.hasRBSForwardingRule(svc, svcLogger) {
+		svcLogger.V(4).Info("Service has RBS forwarding rule")
+		return true
+	}
+	return false
+}
+
+func (lc *L4NetLBController) hasLegacyControllerOwnership(svc *v1.Service, svcLogger klog.Logger) bool {
+	// Check for legacy finalizer
+	if utils.HasL4NetLBFinalizerV1(svc) {
+		svcLogger.V(4).Info("Service has Legacy L4 NetLB finalizer", "finalizers", svc.ObjectMeta.Finalizers)
+		return true
+	}
+
+	// Check if forwarding rule points to a target pool
+	return lc.hasTargetPoolForwardingRule(svc, svcLogger)
 }
 
 func (lc *L4NetLBController) preventLegacyServiceHandling(service *v1.Service, key string, svcLogger klog.Logger) (bool, error) {
-	if (annotations.HasRBSAnnotation(service) || annotations.HasLoadBalancerClass(service, annotations.RegionalExternalLoadBalancerClass)) && lc.hasTargetPoolForwardingRule(service, svcLogger) {
-		if utils.HasL4NetLBFinalizerV2(service) || utils.HasL4NetLBFinalizerV3(service) {
+	svcLogger.Info("Checking for legacy target pool service with RBS annotation or finalizers", "finalizers", service.ObjectMeta.Finalizers)
+	if lc.hasLegacyControllerOwnership(service, svcLogger) {
+		if utils.HasL4NetLBRBSFinalizers(service) {
 			// If we found that RBS finalizer was attached to service, it means that RBS controller
 			// had a race condition on Service creation with Legacy Controller.
 			// It should only happen during service creation, and we should clean up RBS resources
+			svcLogger.Info("Detected Target Pool on RBS service with RBS finalizer. Cleaning up RBS resources to prevent race condition.", "finalizers", service.ObjectMeta.Finalizers)
 			return true, lc.preventTargetPoolRaceWithRBSOnCreation(service, key, svcLogger)
-		} else {
+		} else if annotations.HasRBSAnnotation(service) {
 			// Target Pool to RBS migration is NOT yet supported and causes service to break (for now).
 			// If we detect RBS annotation on legacy service, we remove RBS annotation,
 			// so service stays with Legacy Target Pool implementation
+			svcLogger.Info("Detected Target Pool on service with RBS annotation. Removing RBS annotation to prevent unsupported migration.", "finalizers", service.ObjectMeta.Finalizers)
 			return true, lc.preventExistingTargetPoolToRBSMigration(service, svcLogger)
 		}
+		svcLogger.Info("Service is legacy Target Pool based service. No action needed.", "finalizers", service.ObjectMeta.Finalizers)
+		return true, nil
 	}
 	return false, nil
 }
@@ -419,6 +460,7 @@ func (lc *L4NetLBController) preventLegacyServiceHandling(service *v1.Service, k
 func (lc *L4NetLBController) hasTargetPoolForwardingRule(service *v1.Service, svcLogger klog.Logger) bool {
 	frName := utils.LegacyForwardingRuleName(service)
 	if lc.hasForwardingRuleAnnotation(service, frName) {
+		svcLogger.V(4).Info("Service does not have Target Pool forwarding rule annotation", "forwardingRule", frName)
 		return false
 	}
 
@@ -428,8 +470,10 @@ func (lc *L4NetLBController) hasTargetPoolForwardingRule(service *v1.Service, sv
 		return false
 	}
 	if existingFR != nil && existingFR.Target != "" {
+		svcLogger.V(4).Info("Service has Target Pool forwarding rule", "forwardingRule", frName, "targetPool", strings.Split(existingFR.Target, "/")[len(strings.Split(existingFR.Target, "/"))-1])
 		return true
 	}
+	svcLogger.V(4).Info("Service does not have Target Pool forwarding rule", "forwardingRule", frName)
 	return false
 }
 

--- a/pkg/l4/controllers/l4netlbcontroller_test.go
+++ b/pkg/l4/controllers/l4netlbcontroller_test.go
@@ -312,7 +312,7 @@ func getFakeGCECloud(vals gce.TestClusterValues) *gce.Cloud {
 	return fakeGCE
 }
 
-func buildContext(vals gce.TestClusterValues, readOnlyMode bool) (*ingctx.ControllerContext, error) {
+func buildContext(vals gce.TestClusterValues, readOnlyMode bool, isRBSdefault bool) (*ingctx.ControllerContext, error) {
 	fakeGCE := getFakeGCECloud(vals)
 	kubeClient := fake.NewSimpleClientset()
 	networkClient := netfake.NewSimpleClientset()
@@ -321,24 +321,33 @@ func buildContext(vals gce.TestClusterValues, readOnlyMode bool) (*ingctx.Contro
 	namer := namer.NewNamer(clusterUID, "", klog.TODO())
 
 	ctxConfig := ingctx.ControllerContextConfig{
-		Namespace:              v1.NamespaceAll,
-		ResyncPeriod:           1 * time.Minute,
-		NumL4NetLBWorkers:      5,
-		MaxIGSize:              1000,
-		ReadOnlyMode:           readOnlyMode,
-		EnableL4ILBDualStack:   true,
-		EnableL4NetLBDualStack: true,
+		Namespace:                 v1.NamespaceAll,
+		ResyncPeriod:              1 * time.Minute,
+		NumL4NetLBWorkers:         5,
+		MaxIGSize:                 1000,
+		ReadOnlyMode:              readOnlyMode,
+		EnableL4ILBDualStack:      true,
+		EnableL4NetLBDualStack:    true,
+		EnableL4NetLBRBSByDefault: isRBSdefault,
 	}
 	return ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, networkClient, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 }
 
 func newL4NetLBServiceController() *L4NetLBController {
-	return createL4NetLBServiceController(test.DefaultTestClusterValues(), false)
+	return createL4NetLBServiceController(test.DefaultTestClusterValues(), false, false)
 }
 
-func createL4NetLBServiceController(vals gce.TestClusterValues, readOnlyMode bool) *L4NetLBController {
+func newL4NetLBServiceControllerReadOnlyMode(readOnlyMode bool) *L4NetLBController {
+	return createL4NetLBServiceController(test.DefaultTestClusterValues(), readOnlyMode, false)
+}
+
+func newL4NetLBServiceControllerRBSDefault(isRBSdefault bool) *L4NetLBController {
+	return createL4NetLBServiceController(test.DefaultTestClusterValues(), false, isRBSdefault)
+}
+
+func createL4NetLBServiceController(vals gce.TestClusterValues, readOnlyMode bool, isRBSdefault bool) *L4NetLBController {
 	stopCh := make(chan struct{})
-	ctx, err := buildContext(vals, readOnlyMode)
+	ctx, err := buildContext(vals, readOnlyMode, isRBSdefault)
 	if err != nil {
 		klog.Fatalf("Failed to build context: %v", err)
 	}
@@ -1668,6 +1677,7 @@ func TestIsRBSBasedService(t *testing.T) {
 		finalizers       []string
 		annotations      map[string]string
 		frHook           getForwardingRuleHook
+		isRBSDefault     bool
 		expectRBSService bool
 	}{
 		{
@@ -1704,13 +1714,30 @@ func TestIsRBSBasedService(t *testing.T) {
 			frHook:           test.GetLegacyForwardingRule,
 			expectRBSService: false,
 		},
+		{
+			desc:             "Should detect RBS by default",
+			isRBSDefault:     true,
+			expectRBSService: true,
+		},
+		{
+			desc:             "Should not detect RBS by forwarding rule pointed to target pool, even if RBS is default",
+			frHook:           test.GetLegacyForwardingRule,
+			isRBSDefault:     true,
+			expectRBSService: false,
+		},
+		{
+			desc:             "Legacy service should not be marked as RBS, even if RBS is default",
+			finalizers:       []string{common.NetLBFinalizerV1},
+			isRBSDefault:     true,
+			expectRBSService: false,
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.desc, func(t *testing.T) {
 			// Setup
 			svc := test.NewL4LegacyNetLBService(8080, 30234)
-			controller := newL4NetLBServiceController()
+			controller := newL4NetLBServiceControllerRBSDefault(testCase.isRBSDefault)
 			svc.Annotations = testCase.annotations
 			svc.ObjectMeta.Finalizers = testCase.finalizers
 			controller.ctx.Cloud.Compute().(*cloud.MockGCE).MockForwardingRules.GetHook = testCase.frHook
@@ -2319,7 +2346,7 @@ func TestEnsureExternalLoadBalancerClass(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			lc := createL4NetLBServiceController(test.DefaultTestClusterValues(), false)
+			lc := newL4NetLBServiceController()
 
 			svc := test.NewL4LBServiceWithLoadBalancerClass(tc.loadBalancerClass)
 			if tc.loadBalancerClass == "" {
@@ -2422,7 +2449,7 @@ func TestEnsureReadOnlyModeDoesNotProvision(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			lc := createL4NetLBServiceController(test.DefaultTestClusterValues(), tc.readOnlyModeEnabled)
+			lc := newL4NetLBServiceControllerReadOnlyMode(tc.readOnlyModeEnabled)
 
 			svc := test.NewL4LBServiceWithLoadBalancerClass(tc.loadBalancerClass)
 			if tc.loadBalancerClass == "" {

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -40,6 +40,8 @@ const (
 	ILBFinalizerV2 = "gke.networking.io/l4-ilb-v2"
 	// NegFinalizerKey is the finalizer used by neg controller to ensure NEG CRs are deleted after corresponding negs are deleted
 	NegFinalizerKey = "networking.gke.io/neg-finalizer"
+	// NetLBFinalizerV1 is the finalizer used by legacy cloud controller manager that manage L4 External LoadBalancer services.
+	NetLBFinalizerV1 = "gke.networking.io/l4-netlb-v1"
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
 	// NetLBFinalizerV3 is the finalizer used by the NEG backed variant of the L4 External LoadBalancer services.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -792,6 +792,16 @@ func HasL4ILBFinalizerV2(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.ILBFinalizerV2, nil)
 }
 
+// HasL4NetLBFinalizerV1 returns true if the given Service has NetLBFinalizerV1
+func HasL4NetLBFinalizerV1(svc *api_v1.Service) bool {
+	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV1, nil)
+}
+
+// HasL4NetLBRBSFinalizers returns true if the given Service has any of the NetLBRBS finalizers v2 or v3
+func HasL4NetLBRBSFinalizers(svc *api_v1.Service) bool {
+	return HasL4NetLBFinalizerV2(svc) || HasL4NetLBFinalizerV3(svc)
+}
+
 // HasL4NetLBFinalizerV2 returns true if the given Service has NetLBFinalizerV2
 func HasL4NetLBFinalizerV2(svc *api_v1.Service) bool {
 	return slice.ContainsString(svc.ObjectMeta.Finalizers, common.NetLBFinalizerV2, nil)


### PR DESCRIPTION
feat(l4): Enable L4 NetLB Regional Backend Services by default

This change introduces a feature flag `--enable-l4-netlb-rbs-by-default` to enable the use of L4 NetLB Regional Backend Services (RBS) by default for newly created L4 NetLB services, instead of relying on CCM as default implementation.

**Changes:**

*   Added `EnableL4NetLBRBSByDefault` field to `ControllerContextConfig` in `pkg/context/context.go`.
*   Added the `--enable-l4-netlb-rbs-by-default` boolean flag in `pkg/flags/flags.go`, defaulting to `false`.
*   Updated `L4NetLBController` in `pkg/l4lb/l4netlbcontroller.go` to use the `EnableL4NetLBRBSByDefault` setting from the context.
*   Modified `isRBSBasedService` logic to return `true` if the `enableRBSDefault` flag is set, in addition to existing checks (annotations, finalizers, existing FR).
*   Updated unit tests in `pkg/l4/l4netlbcontroller_test.go` to test the new default behavior.

This change allows clusters to default to using the more modern RBS for L4 NetLBs, while still allowing individual services to use the legacy instance-based backend services if explicitly setting the LoadBalancerClass spec in the Service.

#L4NetLB #RBS