### PR TITLE
Add Logging Enabled label to existing COUNT metrics

### DIFF
--- a/pkg/l4lb/metrics/ipv4_metrics.go
+++ b/pkg/l4lb/metrics/ipv4_metrics.go
@@ -35,6 +35,7 @@ const (
 	l4LabelZonalAffinity         = "zonal_affinity"
 	l4LabelBackendType           = "backend_type"
 	l4LabelProtocol              = "protocol" // Either "TCP", "UDP", or "MIXED". The default "" means that there is an error.
+	l4LabelLoggingEnabled        = "logging_enabled"
 )
 
 var (
@@ -43,7 +44,7 @@ var (
 			Name: "l4_ilbs_count",
 			Help: "Metric containing the number of ILBs that can be filtered by feature labels and status",
 		},
-		[]string{l4LabelStatus, l4LabelMultinet, l4LabelWeightedLBPodsPerNode, l4LabelZonalAffinity, l4LabelProtocol},
+		[]string{l4LabelStatus, l4LabelMultinet, l4LabelWeightedLBPodsPerNode, l4LabelZonalAffinity, l4LabelProtocol, l4LabelLoggingEnabled},
 	)
 
 	l4NetLBCount = prometheus.NewGaugeVec(
@@ -51,7 +52,7 @@ var (
 			Name: "l4_netlbs_count",
 			Help: "Metric containing the number of NetLBs that can be filtered by feature labels and status",
 		},
-		[]string{l4LabelStatus, l4LabelMultinet, l4LabelStrongSessionAffinity, l4LabelWeightedLBPodsPerNode, l4LabelBackendType, l4LabelProtocol},
+		[]string{l4LabelStatus, l4LabelMultinet, l4LabelStrongSessionAffinity, l4LabelWeightedLBPodsPerNode, l4LabelBackendType, l4LabelProtocol, l4LabelLoggingEnabled},
 	)
 )
 
@@ -167,6 +168,7 @@ func (c *Collector) exportL4ILBsMetrics() {
 			l4LabelWeightedLBPodsPerNode: strconv.FormatBool(svcState.WeightedLBPodsPerNode),
 			l4LabelZonalAffinity:         strconv.FormatBool(svcState.ZonalAffinity),
 			l4LabelProtocol:              string(svcState.Protocol),
+			l4LabelLoggingEnabled:        strconv.FormatBool(svcState.LoggingEnabled),
 		}).Inc()
 	}
 	c.logger.V(3).Info("L4 ILB usage metrics exported")
@@ -185,6 +187,7 @@ func (c *Collector) exportL4NetLBsMetrics() {
 			l4LabelWeightedLBPodsPerNode: strconv.FormatBool(svcState.WeightedLBPodsPerNode),
 			l4LabelBackendType:           string(svcState.BackendType),
 			l4LabelProtocol:              string(svcState.Protocol),
+			l4LabelLoggingEnabled:        strconv.FormatBool(svcState.LoggingEnabled),
 		}).Inc()
 	}
 	c.logger.V(3).Info("L4 NetLB usage metrics exported")

--- a/pkg/l4lb/metrics/types.go
+++ b/pkg/l4lb/metrics/types.go
@@ -71,6 +71,8 @@ type L4FeaturesServiceLabels struct {
 	ZonalAffinity bool
 	// Protocol should be either "TCP", "UDP" or when both are present - "MIXED". The default value is "" empty string, but shouldn't be used.
 	Protocol L4ProtocolType
+	// LoggingEnabled is true if logging is configured to be enabled on the Backend Service
+	LoggingEnabled bool
 }
 
 // L4ServiceState tracks the state of an L4 service. It includes data needed to fill various L4 metrics plus the status of the service.

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -584,6 +584,9 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 		return result
 	}
 	result.Annotations[annotations.BackendServiceKey] = bsName
+	if bs.LogConfig != nil {
+		result.MetricsState.LoggingEnabled = bs.LogConfig.Enable
+	}
 
 	if l4.enableDualStack {
 		l4.ensureDualStackResources(result, nodeNames, options, bs, existingIPv4FR, existingIPv6FR, subnetworkURL, ipv4AddressToUse, ipv6AddrToUse)

--- a/pkg/loadbalancers/l4netlb.go
+++ b/pkg/loadbalancers/l4netlb.go
@@ -402,6 +402,10 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 	}
 
 	syncResult.Annotations[annotations.BackendServiceKey] = bsName
+	if bs.LogConfig != nil {
+		syncResult.MetricsState.LoggingEnabled = bs.LogConfig.Enable
+	}
+
 	return bs.SelfLink
 }
 


### PR DESCRIPTION
Allows to monitor number of services, which have Backend Service logging enabled.