### PR TITLE
Avoid odd ig nodes sync

### DIFF
--- a/pkg/instancegroups/controller_test.go
+++ b/pkg/instancegroups/controller_test.go
@@ -199,6 +199,10 @@ func (igmf *IGManagerFake) Sync(nodeNames []string, logger klog.Logger) error {
 	return nil
 }
 
+func (igmf *IGManagerFake) InstanceGroupsExist(name string, logger klog.Logger) (exist bool, err error) {
+	return len(igmf.syncedNodes) > 0, nil
+}
+
 func (igmf *IGManagerFake) EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) ([]*compute.InstanceGroup, error) {
 	igmf.syncedNodes = append(igmf.syncedNodes, []string{name})
 	return []*compute.InstanceGroup{}, nil

--- a/pkg/instancegroups/interfaces.go
+++ b/pkg/instancegroups/interfaces.go
@@ -24,6 +24,7 @@ import (
 // Manager is an interface to sync kubernetes nodes to google cloud instance groups
 // through the Provider interface. It handles zones opaquely using the zoneLister.
 type Manager interface {
+	InstanceGroupsExist(name string, logger klog.Logger) (exist bool, err error)
 	EnsureInstanceGroupsAndPorts(name string, ports []int64, logger klog.Logger) ([]*compute.InstanceGroup, error)
 	DeleteInstanceGroup(name string, logger klog.Logger) error
 


### PR DESCRIPTION
Avoid running of add if nodes sync during subsequent NetLB ensuring.

But still we keep full IG ennure precedure during initial NetLB creation when IG are not present yet.

Otherwise, during cluster scale in,  multiple NetLB tried to sync nodes and all NetLB were waiting for long time for node removal (2 .. 6 mins). 
