### PR TITLE
Shut down controller on leadership loss

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -406,7 +406,13 @@ func main() {
 			if err != nil {
 				klog.Fatalf("makeNEGLeaderElectionConfig()=%v, want nil", err)
 			}
-			leaderelection.RunOrDie(context.Background(), *negRunner)
+			// Use a cancelable context so the lease is released on shutdown.
+			leCtx, cancel := context.WithCancel(context.Background())
+			go func() {
+				<-rOption.stopCh
+				cancel()
+			}()
+			leaderelection.RunOrDie(leCtx, *negRunner)
 			logger.Info("NEG Controller exited.")
 		}
 		runIngress = func() {
@@ -418,7 +424,13 @@ func main() {
 			if err != nil {
 				klog.Fatalf("makeLeaderElectionConfig()=%v, want nil", err)
 			}
-			leaderelection.RunOrDie(context.Background(), *ingressRunner)
+			// Use a cancelable context so the lease is released on shutdown.
+			leCtx, cancel := context.WithCancel(context.Background())
+			go func() {
+				<-rOption.stopCh
+				cancel()
+			}()
+			leaderelection.RunOrDie(leCtx, *ingressRunner)
 		}
 		if !flags.F.GateL4ByLock {
 			klog.Fatalf("--gate-l4-by-lock must be true when --leader-elect=true")
@@ -435,7 +447,13 @@ func main() {
 			if err != nil {
 				klog.Fatalf("makeLeaderElectionConfig()=%v, want nil", err)
 			}
-			leaderelection.RunOrDie(context.Background(), *l4Runner)
+			// Use a cancelable context so the lease is released on shutdown.
+			leCtx, cancel := context.WithCancel(context.Background())
+			go func() {
+				<-rOption.stopCh
+				cancel()
+			}()
+			leaderelection.RunOrDie(leCtx, *l4Runner)
 		}
 
 	}
@@ -489,7 +507,9 @@ func makeNEGRunnerWithLeaderElection(
 			}
 		},
 		func() {
-			logger.Info("Stop running NEG Leader election")
+			// When leadership is lost, initiate a graceful shutdown of all controllers.
+			logger.Info("NEG controller: Leadership lost, initiating process-wide shutdown")
+			runOption.closeStopCh()
 		},
 	)
 }
@@ -508,7 +528,9 @@ func makeIngressRunnerWithLeaderElection(
 			runIngressControllers(ctx, systemHealth, runOption, leOption, logger)
 		},
 		func() {
-			logger.Info("lost master")
+			// When leadership is lost, initiate a graceful shutdown of all controllers.
+			logger.Info("Ingress controller: Leadership lost, initiating process-wide shutdown")
+			runOption.closeStopCh()
 		},
 	)
 }
@@ -529,7 +551,9 @@ func makeL4RunnerWithLeaderElection(
 			runL4Controllers(ctx, systemHealth, runOption, leOption, logger)
 		},
 		func() {
-			lockLogger.Info("lost master")
+			// When leadership is lost for L4 gate, initiate a graceful shutdown
+			lockLogger.Info("L4 controller: Leadership lost, initiating process-wide shutdown")
+			runOption.closeStopCh()
 		},
 	)
 }
@@ -556,10 +580,11 @@ func makeRunnerWithLeaderElection(
 	}
 
 	return &leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: flags.F.LeaderElection.LeaseDuration.Duration,
-		RenewDeadline: flags.F.LeaderElection.RenewDeadline.Duration,
-		RetryPeriod:   flags.F.LeaderElection.RetryPeriod.Duration,
+		Lock:            rl,
+		LeaseDuration:   flags.F.LeaderElection.LeaseDuration.Duration,
+		RenewDeadline:   flags.F.LeaderElection.RenewDeadline.Duration,
+		RetryPeriod:     flags.F.LeaderElection.RetryPeriod.Duration,
+		ReleaseOnCancel: true, // release the lease when context (tied to stopCh) is canceled to speed failover
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: onStartedLeading,
 			OnStoppedLeading: onStoppedLeading,

--- a/cmd/glbc/main_test.go
+++ b/cmd/glbc/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/record"
+
+	ingctx "k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/systemhealth"
+	"k8s.io/klog/v2"
+)
+
+// TestOnStoppedLeadingClosesRootStop verifies that both electors invoke a
+// process-wide graceful shutdown by calling closeStopCh.
+func TestOnStoppedLeadingClosesRootStop(t *testing.T) {
+	t.Parallel()
+
+	client := kubefake.NewSimpleClientset()
+	broadcaster := record.NewBroadcaster()
+	t.Cleanup(broadcaster.Shutdown)
+	rec := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "glbc-test"})
+
+	le := leaderElectionOption{
+		client:   client,
+		recorder: rec,
+		id:       "test-id",
+	}
+
+	baseRunOption := runOption{
+		stopCh:      make(chan struct{}),
+		wg:          &sync.WaitGroup{},
+		closeStopCh: func() {},
+	}
+
+	cases := []struct {
+		name        string
+		buildRunner func(runOption) (*leaderelection.LeaderElectionConfig, error)
+	}{
+		{
+			name: "neg_elector",
+			buildRunner: func(ro runOption) (*leaderelection.LeaderElectionConfig, error) {
+				var ctx *ingctx.ControllerContext
+				var sh *systemhealth.SystemHealth
+				return makeNEGRunnerWithLeaderElection(ctx, sh, ro, le, klog.TODO())
+			},
+		},
+		{
+			name: "ingress_elector",
+			buildRunner: func(ro runOption) (*leaderelection.LeaderElectionConfig, error) {
+				var ctx *ingctx.ControllerContext
+				var sh *systemhealth.SystemHealth
+				return makeIngressRunnerWithLeaderElection(ctx, sh, ro, le, klog.TODO())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runOption := baseRunOption
+			closed := make(chan struct{})
+			runOption.closeStopCh = func() {
+				select {
+				case <-closed:
+				default:
+					close(closed)
+				}
+			}
+
+			cfg, err := tc.buildRunner(runOption)
+			if err != nil {
+				t.Fatalf("build leader election config: %v", err)
+			}
+			if cfg == nil || cfg.Callbacks.OnStoppedLeading == nil {
+				t.Fatalf("invalid cfg or nil OnStoppedLeading")
+			}
+			if !cfg.ReleaseOnCancel {
+				t.Fatalf("ReleaseOnCancel = false, want true")
+			}
+
+			// Simulate loss of leadership.
+			cfg.Callbacks.OnStoppedLeading()
+
+			select {
+			case <-closed:
+				// ok
+			case <-time.After(500 * time.Millisecond):
+				t.Fatalf("expected closeStopCh to be called by OnStoppedLeading")
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Close root stopCh in OnStoppedLeading for Ingress, NEG, and L4 gate
* Use cancelable leader-election context; enable ReleaseOnCancel to free lease
* Ensure idempotent shutdown with once-guarded stop channel
* Add unit tests verifying OnStoppedLeading triggers graceful shutdown

/assign @swetharepakula @gauravkghildiyal 