### PR TITLE
Let ReactionChain continue in EmulateProviderConfigLabelingWebhook

### DIFF
--- a/pkg/multiproject/start/start_test.go
+++ b/pkg/multiproject/start/start_test.go
@@ -207,7 +207,7 @@ func TestStartProviderConfigIntegration(t *testing.T) {
 
 			// This simulates the automatic labeling that the real environment does.
 			// ProviderConfig name label is set to the namespace of the object.
-			testutil.EmulateProviderConfigLabelingWebhook(svcNegClient.Tracker(), &svcNegClient.Fake, "servicenetworkendpointgroups")
+			testutil.EmulateProviderConfigLabelingWebhook(&svcNegClient.Fake, "servicenetworkendpointgroups")
 
 			logger := klog.TODO()
 			gceCreator := multiprojectgce.NewGCEFake()
@@ -326,7 +326,7 @@ func TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking(t *testing.T) {
 	nodeTopoClient := nodetopologyfake.NewSimpleClientset()
 
 	// Simulate webhook: label SvcNEGs with provider-config name == namespace.
-	testutil.EmulateProviderConfigLabelingWebhook(svcNegClient.Tracker(), &svcNegClient.Fake, "servicenetworkendpointgroups")
+	testutil.EmulateProviderConfigLabelingWebhook(&svcNegClient.Fake, "servicenetworkendpointgroups")
 
 	informersFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, flags.F.ResyncPeriod)
 	svcNegFactory := informersvcneg.NewSharedInformerFactoryWithOptions(svcNegClient, flags.F.ResyncPeriod)
@@ -936,7 +936,7 @@ func TestProviderConfigErrorCases(t *testing.T) {
 			networkClient := networkfake.NewSimpleClientset()
 			nodeTopologyClient := nodetopologyfake.NewSimpleClientset()
 
-			testutil.EmulateProviderConfigLabelingWebhook(svcNegClient.Tracker(), &svcNegClient.Fake, "servicenetworkendpointgroups")
+			testutil.EmulateProviderConfigLabelingWebhook(&svcNegClient.Fake, "servicenetworkendpointgroups")
 
 			logger := klog.TODO()
 			gceCreator := multiprojectgce.NewGCEFake()

--- a/pkg/multiproject/testutil/providerconfigwebhook.go
+++ b/pkg/multiproject/testutil/providerconfigwebhook.go
@@ -8,10 +8,6 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-type FakeTracker interface {
-	Add(obj runtime.Object) error
-}
-
 // EmulateProviderConfigLabelingWebhook is a helper function that emulates the behaviour
 // of the providerconfig webhook.
 // It will set the providerconfig name label on the object, on creation.
@@ -22,19 +18,32 @@ type FakeTracker interface {
 // However, in the real world, multiple namespaces can have the same providerconfig name.
 //
 // The function takes a fake client and the name of the CRD.
-func EmulateProviderConfigLabelingWebhook(tracker FakeTracker, fake *testing.Fake, crName string) {
+func EmulateProviderConfigLabelingWebhook(fake *testing.Fake, crName string) {
 	fake.PrependReactor("create", crName, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-		createAction := action.(testing.CreateAction)
-		obj := createAction.GetObject()
-		pc := obj.(metav1.Object)
-		pc.GetLabels()[flags.F.ProviderConfigNameLabelKey] = pc.GetNamespace()
-
-		err = tracker.Add(obj)
-		if err != nil {
-			klog.Errorf("Failed to add object to tracker: %v", err)
+		createAction, ok := action.(testing.CreateAction)
+		if !ok {
+			return false, nil, nil
 		}
 
+		obj := createAction.GetObject()
+		pc, ok := obj.(metav1.Object)
+		if !ok {
+			klog.Errorf("EmulateProviderConfigWebhook: object does not implement metav1.Object: %T", obj)
+			return false, nil, nil
+		}
+
+		labels := pc.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[flags.F.ProviderConfigNameLabelKey] = pc.GetNamespace()
+		pc.SetLabels(labels)
+
 		klog.Infof("EmulateProviderConfigWebhook: %s/%s", pc.GetNamespace(), pc.GetName())
-		return true, obj, nil
+
+		// Returning false means the ReactionChain will continue and the object will be
+		// stored by the standard fake reactors after we mutated it. If we returned true,
+		// the reaction chain would stop here.
+		return false, nil, nil
 	})
 }


### PR DESCRIPTION
Previously, the reactor manually called tracker.Add and returned handled=true, short-circuiting the chain and sometimes causing double-add/AlreadyExists. Now we only label the object and return handled=false so the default ObjectReaction persists it, reducing flakes.

Also initialize the labels map and remove the unused FakeTracker parameter.

### This change affects tests only, EmulateProviderConfigLabelingWebhook is a testing helper