### PR TITLE
filter out inactive negs in isZoneChange

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -843,6 +843,11 @@ func (s *transactionSyncer) isZoneChange() bool {
 
 	existingZones := sets.NewString()
 	for _, ref := range negCR.Status.NetworkEndpointGroups {
+		// For backward compatibility, an empty state is considered active.
+		if ref.State != "" && ref.State != negv1beta1.ActiveState {
+			continue
+		}
+
 		id, err := cloud.ParseResourceURL(ref.SelfLink)
 		if err != nil {
 			s.logger.Error(err, "unable to parse selflink", "selfLink", ref.SelfLink)

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -2728,6 +2728,7 @@ func TestIsZoneChange(t *testing.T) {
 		zoneDeleted                    bool
 		zoneAdded                      bool
 		nodeWithNoProviderIDAdded      bool
+		negCRStateInactive             bool
 		nodeWithInvalidProviderIDAdded bool
 		expectedResult                 bool
 	}{
@@ -2761,6 +2762,11 @@ func TestIsZoneChange(t *testing.T) {
 			desc:           "no zone change occurred",
 			expectedResult: false,
 		},
+		{
+			desc:               "neg cr state is inactive",
+			negCRStateInactive: true,
+			expectedResult:     true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2792,6 +2798,9 @@ func TestIsZoneChange(t *testing.T) {
 			var refs []negv1beta1.NegObjectReference
 			for _, neg := range negRefMap {
 				refs = append(refs, neg)
+			}
+			if tc.negCRStateInactive {
+				refs[0].State = negv1beta1.InactiveState
 			}
 			negCR := createNegCR(syncer.NegName, metav1.Now(), true, true, refs)
 			if err = syncer.svcNegLister.Add(negCR); err != nil {


### PR DESCRIPTION

1. Upgrade Starts: The E2E test triggers the cluster upgrade. The node in us-central1-a is cordoned and becomes temporarily NotReady.
2. Controller Restarts: The NEG controller pod is rescheduled onto the new, upgraded master.
3. The Race Condition: The new controller starts up and immediately runs a sync loop. Crucially, this happens in the small time window when the node is still NotReady.
4. Incorrect State Detection: The controller's syncInternal() logic queries for the current state of the cluster. Since the only node is NotReady, the zoneGetter reports that there are zero active nodes in us-central1-a.
5. NEG Marked INACTIVE: The controller compares the current state (zero active nodes) with the pre-upgrade state (one active NEG in us-central1-a). It concludes that the zone is no longer active and correctly, based on this limited information, patches the ServiceNetworkEndpointGroup CR to set the NEG's state to INACTIVE.
6. Node Becomes Ready: A moment later, the node finishes its upgrade and becomes Ready.
7. The Bug is Exposed: On the next sync, the controller should see that us-central1-a is active again and switch the NEG back to ACTIVE. This is where it fails. The isZoneChange() function, which is supposed to detect this, has a flaw. It checks the zones of all NEGs in the CR status, including INACTIVE ones.
- existingZones from the CR status is {"us-central1-a"} (from the INACTIVE NEG).
- currZones from the now-ready node is {"us-central1-a"}.
The function sees no difference ({"us-central1-a"} == {"us-central1-a"}) and returns false.
8. Stuck State: Because isZoneChange() returns false, the controller doesn't trigger the reconciliation logic needed to switch the NEG back to ACTIVE. The test waits for an active NEG, which never happens, and times out.


Solution

This is why the proposed change to isZoneChange is so critical. By making it ignore INACTIVE NEGs, it can correctly detect the transition from "no active zones" to "one active zone," triggering the necessary reconciliation to bring the NEG back to an ACTIVE state and fix the load balancer.

