### PR TITLE
Implement a legacy mode for the zonegetter

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -247,8 +247,18 @@ func NewControllerContext(
 		context.EnableIngressRegionalExternal,
 		logger,
 	)
+
 	// The subnet specified in gce.conf is considered as the default subnet.
-	context.ZoneGetter = zonegetter.NewZoneGetter(context.NodeInformer, context.Cloud.SubnetworkURL())
+	subnet := context.Cloud.SubnetworkURL()
+	if subnet != "" {
+		logger.Info("Detected a non-empty subnet, using regular zoneGetter", "subnetURL", subnet)
+
+		context.ZoneGetter = zonegetter.NewZoneGetter(context.NodeInformer, context.Cloud.SubnetworkURL())
+	} else {
+		logger.Info("Detected a Legacy Network Cluster, using legacy zoneGetter", "subnetURL", subnet)
+		context.ZoneGetter = zonegetter.NewLegacyZoneGetter(context.NodeInformer)
+	}
+
 	context.InstancePool = instancegroups.NewManager(&instancegroups.ManagerConfig{
 		Cloud:      context.Cloud,
 		Namer:      context.ClusterNamer,

--- a/pkg/utils/zonegetter/README.md
+++ b/pkg/utils/zonegetter/README.md
@@ -1,0 +1,23 @@
+The `pkg/utils/zonegetter` package provides a `ZoneGetter` utility for determining the zones and subnets of Kubernetes nodes. It is designed to work in two distinct modes: GCP and NonGCP.
+
+### GCP Mode
+
+In its primary GCP mode, the `ZoneGetter` interacts with the Kubernetes API to retrieve node information. Its key functionalities include:
+
+*   **Zone and Subnet Discovery:** It determines a node's zone by parsing the `providerID` field in the node's specification, which for GCP has the format `gce://<project-id>/<zone>/<instance-name>`. It can also identify the node's subnet.
+*   **Node Filtering:** The `ZoneGetter` can list nodes based on different filtering criteria:
+    *   `AllNodesFilter`: Returns all nodes.
+    *   `CandidateNodesFilter`: Returns only nodes that are considered eligible for load balancing (i.e., are in a "Ready" state and do not have labels that exclude them from load balancers).
+    *   `CandidateAndUnreadyNodesFilter`: A slightly more relaxed filter that includes unready nodes but excludes nodes that are in the process of being upgraded.
+*   **Zone Listing:** It can provide a list of all unique zones that contain nodes, subject to the same filtering logic as node listing.
+*   **Multi-Subnet Awareness:** The `ZoneGetter` includes logic to handle multi-subnet clusters, with the capability to filter nodes to include only those belonging to the cluster's default subnet.
+
+### Legacy Network Mode
+
+A special mode for handling GCE legacy networks where a subnetwork URL is not specified. When enabled, the `ZoneGetter` assumes all nodes belong to a single, default network. This prevents errors from attempting to parse an empty subnet URL and ensures that all nodes are correctly considered for load balancing. In this mode, subnet-related checks are short-circuited to reflect the simpler network topology.
+
+### NonGCP Mode
+
+For environments not running on GCP, the `ZoneGetter` can be configured in a simplified `NonGCP` mode. In this mode, it is initialized with a single, predetermined zone and will always return that zone when queried, without interacting with the Kubernetes API for node information.
+
+In essence, the `zonegetter` is a crucial component for the ingress controller to make topology-aware decisions, such as configuring regional load balancer backends, by accurately identifying the location of nodes within the GCP environment.


### PR DESCRIPTION
Legacy networks do not have the concept of subnets and naturally are not compatible with the multi subnet feature. Therefore zonegetter must be able to handle legacy networks and not error out. Legacy mode zonegetter still validates that the Nodes have the pod cidr and the provider ID set before using it for any calculation

Legacy Network Assumptions:
* All Nodes are considered part of the default network
* The subnetwork is always empty

Adds a readme on what the zonegetter does at a high level

/assign @gauravkghildiyal 