### PR TITLE
Ensure Ingress CRDS only when Ingress ctrl is enabled

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -128,32 +128,34 @@ func main() {
 		klog.Fatalf("Failed to create kubernetes client config: %v", err)
 	}
 
-	var backendConfigClient backendconfigclient.Interface
 	crdClient, err := crdclient.NewForConfig(kubeConfig)
 	if err != nil {
 		klog.Fatalf("Failed to create kubernetes CRD client: %v", err)
 	}
 	// TODO(rramkumar): Reuse this CRD handler for other CRD's coming.
 	crdHandler := crd.NewCRDHandler(crdClient, rootLogger)
-	backendConfigCRDMeta := backendconfig.CRDMeta()
-	if _, err := crdHandler.EnsureCRD(backendConfigCRDMeta, true); err != nil {
-		klog.Fatalf("Failed to ensure BackendConfig CRD: %v", err)
-	}
-
-	backendConfigClient, err = backendconfigclient.NewForConfig(kubeConfig)
-	if err != nil {
-		klog.Fatalf("Failed to create BackendConfig client: %v", err)
-	}
-
 	var frontendConfigClient frontendconfigclient.Interface
-	frontendConfigCRDMeta := frontendconfig.CRDMeta()
-	if _, err := crdHandler.EnsureCRD(frontendConfigCRDMeta, true); err != nil {
-		klog.Fatalf("Failed to ensure FrontendConfig CRD: %v", err)
-	}
+	var backendConfigClient backendconfigclient.Interface
+	if flags.F.RunIngressController {
+		backendConfigCRDMeta := backendconfig.CRDMeta()
+		if _, err := crdHandler.EnsureCRD(backendConfigCRDMeta, true); err != nil {
+			klog.Fatalf("Failed to ensure BackendConfig CRD: %v", err)
+		}
 
-	frontendConfigClient, err = frontendconfigclient.NewForConfig(kubeConfig)
-	if err != nil {
-		klog.Fatalf("Failed to create FrontendConfig client: %v", err)
+		backendConfigClient, err = backendconfigclient.NewForConfig(kubeConfig)
+		if err != nil {
+			klog.Fatalf("Failed to create BackendConfig client: %v", err)
+		}
+
+		frontendConfigCRDMeta := frontendconfig.CRDMeta()
+		if _, err := crdHandler.EnsureCRD(frontendConfigCRDMeta, true); err != nil {
+			klog.Fatalf("Failed to ensure FrontendConfig CRD: %v", err)
+		}
+
+		frontendConfigClient, err = frontendconfigclient.NewForConfig(kubeConfig)
+		if err != nil {
+			klog.Fatalf("Failed to create FrontendConfig client: %v", err)
+		}
 	}
 
 	var firewallCRClient firewallcrclient.Interface

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/events"
 	"k8s.io/ingress-gce/pkg/flags"
+	frontendconfigclient "k8s.io/ingress-gce/pkg/frontendconfig/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
@@ -71,6 +72,7 @@ var (
 func newLoadBalancerController() (*LoadBalancerController, error) {
 	kubeClient := fake.NewSimpleClientset()
 	backendConfigClient := backendconfigclient.NewSimpleClientset()
+	frontendConfigClient := frontendconfigclient.NewSimpleClientset()
 	svcNegClient := svcnegclient.NewSimpleClientset()
 	vals := gce.DefaultTestClusterValues()
 	vals.SubnetworkURL = defaultTestSubnetURL
@@ -93,7 +95,7 @@ func newLoadBalancerController() (*LoadBalancerController, error) {
 		HealthCheckPath:               "/",
 		EnableIngressRegionalExternal: true,
 	}
-	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, nil, nil, svcNegClient, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, nil, svcNegClient, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controller context")
 	}


### PR DESCRIPTION
 * BackendConfig and FrontendConfig are only used by Ingress and do not need to be ensured by other controllers.

/assign @gauravkghildiyal 