### PR TITLE
Enable IPv6-only L4 LoadBalancer 

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -147,8 +147,8 @@ var F = struct {
 	OverrideHealthCheckSourceCIDRs            string
 	ManageL4LBLogging                         bool
 	EnableNEGsForIngress                      bool
-	EnableIPv6OnlyL4                          bool
 	L4ILBLegacyHeadStartTime                  time.Duration
+	EnableIPv6NodeNEGEndpoints                bool
 
 	// ===============================
 	// DEPRECATED FLAGS
@@ -360,8 +360,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.ManageL4LBLogging, "manage-l4lb-logging", false, "Manage L4 ILB/NetLB logging.")
 	flag.BoolVar(&F.ReadOnlyMode, "read-only-controllers", false, "When enabled, this flag runs the IG, NEG, L4 ILB, and L4 NetLB controllers in a read-only mode. This prevents them from executing any mutating API calls (e.g., create, update, delete), allowing you to safely observe controller behavior without modifying resources. The Ingress controller is exempt from this mode.")
 	flag.BoolVar(&F.EnableNEGsForIngress, "enable-negs-for-ingress", true, "Allow the NEG controller to create NEGs for Ingress services.")
-	flag.BoolVar(&F.EnableIPv6OnlyL4, "enable-ipv6-only-l4", false, "Enables IPv6-only mode for the L4 ILB and NetLB controllers, disabling all IPv4-related logic and resource management.")
 	flag.DurationVar(&F.L4ILBLegacyHeadStartTime, "prevent-legacy-race-l4-ilb", 0*time.Second, "Delay before processing new L4 ILB services without existing finalizers. This gives the legacy controller a head start to claim the service, preventing a race condition upon service creation.")
+	flag.BoolVar(&F.EnableIPv6NodeNEGEndpoints, "enable-ipv6-node-neg-endpoints", false, "Enable populating IPv6 addresses for Node IPs in GCE_VM_IP NEGs.")
 }
 
 func Validate() {

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -77,8 +77,7 @@ type L4Controller struct {
 	syncTracker     utils.TimeTracker
 	forwardingRules ForwardingRulesGetter
 	enableDualStack bool
-
-	hasSynced func() bool
+	hasSynced       func() bool
 
 	serviceVersions *serviceVersionsTracker
 

--- a/pkg/loadbalancers/l4.go
+++ b/pkg/loadbalancers/l4.go
@@ -590,6 +590,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	} else {
 		l4.ensureIPv4Resources(result, nodeNames, options, bs, existingIPv4FR, subnetworkURL, ipv4AddressToUse)
 	}
+
 	if result.Error != nil {
 		return result
 	}
@@ -624,6 +625,7 @@ func (l4 *L4) provideHealthChecks(nodeNames []string, result *L4ILBSyncResult) s
 
 func (l4 *L4) provideDualStackHealthChecks(nodeNames []string, result *L4ILBSyncResult) string {
 	sharedHC := !helpers.RequestsOnlyLocalTraffic(l4.Service)
+
 	hcResult := l4.healthChecks.EnsureHealthCheckWithDualStackFirewalls(l4.Service, l4.namer, sharedHC, meta.Global, utils.ILB, nodeNames, utils.NeedsIPv4(l4.Service), utils.NeedsIPv6(l4.Service), l4.network, l4.svcLogger)
 	if hcResult.Err != nil {
 		result.GCEResourceInError = hcResult.GceResourceInError
@@ -633,10 +635,16 @@ func (l4 *L4) provideDualStackHealthChecks(nodeNames []string, result *L4ILBSync
 
 	if hcResult.HCFirewallRuleName != "" {
 		result.Annotations[annotations.FirewallRuleForHealthcheckKey] = hcResult.HCFirewallRuleName
+	} else {
+		delete(result.Annotations, annotations.FirewallRuleForHealthcheckKey)
 	}
+
 	if hcResult.HCFirewallRuleIPv6Name != "" {
 		result.Annotations[annotations.FirewallRuleForHealthcheckIPv6Key] = hcResult.HCFirewallRuleIPv6Name
+	} else {
+		delete(result.Annotations, annotations.FirewallRuleForHealthcheckIPv6Key)
 	}
+
 	result.Annotations[annotations.HealthcheckKey] = hcResult.HCName
 	return hcResult.HCLink
 }

--- a/pkg/neg/syncers/subsets.go
+++ b/pkg/neg/syncers/subsets.go
@@ -24,10 +24,12 @@ import (
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/ingress-gce/pkg/flags"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/net"
 )
 
 const (
@@ -222,7 +224,16 @@ func getSubsetPerZone(nodesPerZone map[string][]*nodeWithSubnet, totalLimit int,
 			if _, ok := result[egi]; !ok {
 				result[egi] = negtypes.NewNetworkEndpointSet()
 			}
-			result[egi].Insert(negtypes.NetworkEndpoint{Node: nodeAndSubnet.node.Name, IP: ip})
+
+			newEndpoint := negtypes.NetworkEndpoint{Node: nodeAndSubnet.node.Name}
+
+			if flags.F.EnableIPv6NodeNEGEndpoints && net.IsIPv6String(ip) {
+				newEndpoint.IPv6 = ip
+			} else {
+				newEndpoint.IP = ip
+			}
+
+			result[egi].Insert(newEndpoint)
 		}
 		totalLimit -= len(subset)
 		zonesRemaining--

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -756,8 +756,9 @@ func makeEndpointBatch(endpoints negtypes.NetworkEndpointSet, negType negtypes.N
 		}
 		if negType == negtypes.VmIpEndpointType {
 			endpointBatch[networkEndpoint] = &composite.NetworkEndpoint{
-				Instance:  networkEndpoint.Node,
-				IpAddress: networkEndpoint.IP,
+				Instance:    networkEndpoint.Node,
+				IpAddress:   networkEndpoint.IP,
+				Ipv6Address: networkEndpoint.IPv6,
 			}
 		} else {
 			portNum, err := strconv.Atoi(networkEndpoint.Port)

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -3478,11 +3478,13 @@ func genTestEndpoints(num int, epType negtypes.NetworkEndpointType, lpFlag bool)
 		switch epType {
 		case negtypes.VmIpEndpointType:
 			ip = numToIP(count)
-			key := negtypes.NetworkEndpoint{IP: ip, Node: instance}
+			ipv6 := fmt.Sprintf("2001:db8::%x", count)
+			key := negtypes.NetworkEndpoint{IP: ip, IPv6: ipv6, Node: instance}
 			endpointSet.Insert(key)
 			endpointMap[key] = &composite.NetworkEndpoint{
-				IpAddress: ip,
-				Instance:  instance,
+				IpAddress:   ip,
+				Ipv6Address: ipv6,
+				Instance:    instance,
 			}
 		case negtypes.VmIpPortEndpointType:
 			port++

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -87,6 +87,7 @@ const (
 	// be removed in 1.18.
 	LabelAlphaNodeRoleExcludeBalancer = "alpha.service-controller.kubernetes.io/exclude-balancer"
 	DualStackSubnetStackType          = "IPV4_IPV6"
+	IPv6SubnetStackType               = "IPV6_ONLY"
 
 	// LabelNodeSubnet specifies the subnet name of this node.
 	LabelNodeSubnet = "cloud.google.com/gke-node-pool-subnet"
@@ -861,7 +862,14 @@ func SubnetHasIPv6Range(cloud *gce.Cloud, subnetName, ipv6AccessType string) (bo
 	if err != nil {
 		return false, fmt.Errorf("failed getting subnet: %w", err)
 	}
-	return subnet.StackType == DualStackSubnetStackType && subnet.Ipv6AccessType == ipv6AccessType, nil
+
+	if subnet.Ipv6AccessType != ipv6AccessType {
+		return false, nil
+	}
+
+	isValidStackType := (subnet.StackType == DualStackSubnetStackType) || (subnet.StackType == IPv6SubnetStackType)
+
+	return isValidStackType, nil
 }
 
 // IsUnsupportedFeatureError returns true if the error has 400 number,


### PR DESCRIPTION
This change adds support to the controller to provision L4 LoadBalancers configured as IPv6-only.