### PR TITLE
[Cherrypick #2999 to relese-1.37] Add a new metric that tracks the co…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/loadbalancers/features"
 	"k8s.io/ingress-gce/pkg/metrics"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	ingsync "k8s.io/ingress-gce/pkg/sync"
@@ -361,6 +362,8 @@ func (lbc *LoadBalancerController) Run() {
 		lbc.Stop()
 	}()
 	lbc.logger.Info("Starting loadbalancer controller")
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.IngressControllerLabel)
+	defer activecontrollermetrics.RecordStoppedController(activecontrollermetrics.IngressControllerLabel)
 	go lbc.ingQueue.Run()
 
 	<-lbc.stopCh

--- a/pkg/instancegroups/controller.go
+++ b/pkg/instancegroups/controller.go
@@ -22,6 +22,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
@@ -98,6 +99,8 @@ func NewController(config *ControllerConfig, logger klog.Logger) *Controller {
 // Run the queue to process updates for the controller. This must be run in a
 // separate goroutine (method will block until queue shutdown).
 func (c *Controller) Run() {
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.IGControllerLabel)
+	defer activecontrollermetrics.RecordStoppedController(activecontrollermetrics.IGControllerLabel)
 	start := time.Now()
 	for !c.hasSynced() {
 		c.logger.V(2).Info("Waiting for hasSynced", "elapsedTime", time.Now().Sub(start))

--- a/pkg/l4lb/l4controller.go
+++ b/pkg/l4lb/l4controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/ingress-gce/pkg/forwardingrules"
 	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
@@ -263,6 +264,8 @@ func (l4c *L4Controller) Run() {
 	}, l4c.stopCh)
 
 	l4c.logger.Info("Running L4 Controller", "numWorkers", l4c.numWorkers)
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.L4ILBControllerLabel)
+	defer activecontrollermetrics.RecordStoppedController(activecontrollermetrics.L4ILBControllerLabel)
 	l4c.svcQueue.Run()
 	<-l4c.stopCh
 }

--- a/pkg/l4lb/l4netlbcontroller.go
+++ b/pkg/l4lb/l4netlbcontroller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/ingress-gce/pkg/instancegroups"
 	"k8s.io/ingress-gce/pkg/l4lb/metrics"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/network"
@@ -505,6 +506,9 @@ func (lc *L4NetLBController) Run() {
 	}, lc.stopCh)
 
 	lc.logger.Info("Running L4 Net Controller", "numWorkers", lc.ctx.NumL4NetLBWorkers)
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.L4NetLBControllerLabel)
+	defer activecontrollermetrics.RecordStoppedController(activecontrollermetrics.L4NetLBControllerLabel)
+
 	lc.svcQueue.Run()
 
 	<-lc.stopCh

--- a/pkg/metrics/activecontroller/metrics.go
+++ b/pkg/metrics/activecontroller/metrics.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activecontrollermetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// runningControllerName represents a name of a running controller.
+type runningControllerName string
+
+const (
+	runningControllerValue = 1.0
+	stoppedControllerValue = 0.0
+
+	NEGControllerLabel     runningControllerName = "NEG"
+	L4ILBControllerLabel   runningControllerName = "L4ILB"
+	L4NetLBControllerLabel runningControllerName = "L4NetLB"
+	IGControllerLabel      runningControllerName = "IG"
+	PSCControllerLabel     runningControllerName = "PSC"
+	IngressControllerLabel runningControllerName = "Ingress"
+)
+
+var (
+	runningControllers = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "running_controllers",
+			Help: "Metric fthat indicates which of the the ingress-gce controllers (Ingress, NEG, L4, IG, PSC) are running in the cluster",
+		},
+		[]string{"controller"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(runningControllers)
+}
+
+// RecordRunningController records in the metric state that the given controller is running.
+func RecordRunningController(name runningControllerName) {
+	runningControllers.WithLabelValues(string(name)).Set(runningControllerValue)
+}
+
+// RecordStoppedController records in the metric state that the given controller is not running.
+func RecordStoppedController(name runningControllerName) {
+	runningControllers.WithLabelValues(string(name)).Set(stoppedControllerValue)
+}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -39,6 +39,7 @@ import (
 	svcnegv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/flags"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	metrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
@@ -389,9 +390,11 @@ func (c *Controller) Run() {
 	}, c.stopCh)
 
 	c.logger.V(2).Info("Starting network endpoint group controller")
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.NEGControllerLabel)
 	defer func() {
 		c.logger.V(2).Info("Shutting down network endpoint group controller")
 		c.stop()
+		activecontrollermetrics.RecordStoppedController(activecontrollermetrics.NEGControllerLabel)
 		c.logger.Info("Network Endpoint Group Controller Shutdown")
 	}()
 

--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/flags"
+	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	"k8s.io/ingress-gce/pkg/psc/metrics"
 	"k8s.io/ingress-gce/pkg/psc/metrics/metricscollector"
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
@@ -174,8 +175,10 @@ func (c *Controller) Run() {
 	}, c.stopCh)
 
 	c.logger.V(2).Info("Starting private service connect controller")
+	activecontrollermetrics.RecordRunningController(activecontrollermetrics.PSCControllerLabel)
 	defer func() {
 		c.logger.V(2).Info("Shutting down private service connect controller")
+		activecontrollermetrics.RecordStoppedController(activecontrollermetrics.PSCControllerLabel)
 		c.svcAttachmentQueue.ShutDown()
 	}()
 


### PR DESCRIPTION
…ntrollers running in the cluster.

This is to be able to track individual controllers: Ingress, L4ILB, L4NetLB, PSC, IG.

(cherry picked from commit 13ae861eebc2ce9c55644c2048f8358f53d09769)