### PR TITLE
Add configurable connection draining timeout for L4 LoadBalancers

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -90,17 +90,18 @@ func NewPoolWithConnectionTrackingPolicy(cloud *gce.Cloud, namer namer.BackendNa
 
 // L4BackendServiceParams encapsulates parameters for ensuring an L4 BackendService.
 type L4BackendServiceParams struct {
-	Name                     string
-	HealthCheckLink          string
-	Protocol                 string
-	SessionAffinity          string
-	Scheme                   string
-	NamespacedName           types.NamespacedName
-	NetworkInfo              *network.NetworkInfo
-	ConnectionTrackingPolicy *composite.BackendServiceConnectionTrackingPolicy
-	LocalityLbPolicy         LocalityLBPolicyType
-	EnableZonalAffinity      bool
-	LogConfig                *composite.BackendServiceLogConfig
+	Name                         string
+	HealthCheckLink              string
+	Protocol                     string
+	SessionAffinity              string
+	Scheme                       string
+	NamespacedName               types.NamespacedName
+	NetworkInfo                  *network.NetworkInfo
+	ConnectionTrackingPolicy     *composite.BackendServiceConnectionTrackingPolicy
+	LocalityLbPolicy             LocalityLBPolicyType
+	EnableZonalAffinity          bool
+	LogConfig                    *composite.BackendServiceLogConfig
+	ConnectionDrainingTimeoutSec int64 // 0 means not specified, use default
 }
 
 var versionPrecedence = map[meta.Version]int{
@@ -432,7 +433,12 @@ func (p *Pool) EnsureL4BackendService(params L4BackendServiceParams, beLogger kl
 		expectedBS.Network = params.NetworkInfo.NetworkURL
 	}
 	if params.Protocol == string(api_v1.ProtocolTCP) {
-		expectedBS.ConnectionDraining = &composite.ConnectionDraining{DrainingTimeoutSec: DefaultConnectionDrainingTimeoutSeconds}
+		// Use custom timeout if specified, otherwise use default
+		timeoutSec := int64(DefaultConnectionDrainingTimeoutSeconds)
+		if params.ConnectionDrainingTimeoutSec > 0 {
+			timeoutSec = params.ConnectionDrainingTimeoutSec
+		}
+		expectedBS.ConnectionDraining = &composite.ConnectionDraining{DrainingTimeoutSec: timeoutSec}
 	} else {
 		// This config is not supported in UDP mode, explicitly set to 0 to reset, if proto was TCP previously.
 		expectedBS.ConnectionDraining = &composite.ConnectionDraining{DrainingTimeoutSec: 0}
@@ -468,8 +474,9 @@ func (p *Pool) EnsureL4BackendService(params L4BackendServiceParams, beLogger kl
 		beLogger.V(2).Info("EnsureL4BackendService: backend service did not change, skipping update")
 		return currentBS, utils.ResourceResync, nil
 	}
-	if currentBS.ConnectionDraining != nil && currentBS.ConnectionDraining.DrainingTimeoutSec > 0 && params.Protocol == string(api_v1.ProtocolTCP) {
-		// only preserves user overridden timeout value when the protocol is TCP
+	// Preserve manually configured connection draining timeout if annotation is not set
+	if params.ConnectionDrainingTimeoutSec == 0 && currentBS.ConnectionDraining != nil && currentBS.ConnectionDraining.DrainingTimeoutSec > 0 && params.Protocol == string(api_v1.ProtocolTCP) {
+		// Only preserves user overridden timeout value when the protocol is TCP and no annotation is specified
 		expectedBS.ConnectionDraining.DrainingTimeoutSec = currentBS.ConnectionDraining.DrainingTimeoutSec
 	}
 	beLogger.V(2).Info("EnsureL4BackendService: updating backend service")
@@ -526,6 +533,10 @@ func backendSvcEqual(newBS, oldBS *composite.BackendService, compareConnectionTr
 
 	// If zonal affinity is set, needs to be equal
 	svcsEqual = svcsEqual && zonalAffinityEqual(newBS, oldBS)
+
+	// Compare connection draining timeout
+	svcsEqual = svcsEqual && connectionDrainingEqual(newBS.ConnectionDraining, oldBS.ConnectionDraining)
+
 	return svcsEqual
 }
 
@@ -580,6 +591,21 @@ func zonalAffinityEqual(a, b *composite.BackendService) bool {
 	spilloverRatioEqual := aZonalAffinity.SpilloverRatio == bZonalAffinity.SpilloverRatio
 
 	return spilloverEqual && spilloverRatioEqual
+}
+
+// connectionDrainingEqual returns true if both connection draining configs are equal
+func connectionDrainingEqual(a, b *composite.ConnectionDraining) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	// Treat nil and zero timeout as equivalent (e.g., for UDP or when unset)
+	getTimeout := func(cd *composite.ConnectionDraining) int64 {
+		if cd == nil {
+			return 0
+		}
+		return cd.DrainingTimeoutSec
+	}
+	return getTimeout(a) == getTimeout(b)
 }
 
 // connectionTrackingPolicyEqual returns true if both elements are equal

--- a/pkg/l4annotations/service.go
+++ b/pkg/l4annotations/service.go
@@ -18,8 +18,8 @@ package l4annotations
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
@@ -101,8 +101,9 @@ const (
 	// Service annotation key for specifying config map which contains logging config
 	L4LoggingConfigMapKey = "networking.gke.io/l4-logging-config-map"
 
-	// Service annotation key for specifying connection draining timeout in seconds for L4 backend services
-	ConnectionDrainingTimeoutKey = "networking.gke.io/connection-draining-timeout-sec"
+	// Service annotation key for specifying connection draining timeout for L4 backend services
+	// Supports time.Duration format (e.g., "300s", "5m", "1h")
+	ConnectionDrainingTimeoutKey = "networking.gke.io/connection-draining-timeout"
 )
 
 // Service represents Service annotations.
@@ -252,23 +253,33 @@ func (svc *Service) GetInternalLoadBalancerAnnotationSubnet() string {
 
 // GetConnectionDrainingTimeout returns the connection draining timeout in seconds.
 // Returns 0 and false if the annotation is not specified or invalid.
-// Returns the parsed value (0-3600) and true if valid.
+// Accepts time.Duration format (e.g., "300s", "5m", "1h").
+// Returns the parsed value in seconds (0-3600) and true if valid.
 // GCP supports connection draining timeout values from 0 to 3600 seconds.
+// Fractional seconds (e.g., "100ms", "1.5s") are not supported and will be rejected.
 func (svc *Service) GetConnectionDrainingTimeout() (int64, bool) {
 	val, exists := svc.v[ConnectionDrainingTimeoutKey]
 	if !exists {
 		return 0, false
 	}
 
-	timeout, err := strconv.ParseInt(val, 10, 64)
+	duration, err := time.ParseDuration(val)
 	if err != nil {
 		return 0, false
 	}
 
-	// Validate range: GCP allows 0-3600 seconds
-	if timeout < 0 || timeout > 3600 {
+	// Validate that duration is a whole number of seconds (no fractional seconds)
+	if duration%time.Second != 0 {
 		return 0, false
 	}
 
-	return timeout, true
+	// Convert to seconds
+	timeoutSec := int64(duration.Seconds())
+
+	// Validate range: GCP allows 0-3600 seconds
+	if timeoutSec < 0 || timeoutSec > 3600 {
+		return 0, false
+	}
+
+	return timeoutSec, true
 }

--- a/pkg/l4annotations/service_test.go
+++ b/pkg/l4annotations/service_test.go
@@ -294,11 +294,23 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			wantSpecified: false,
 		},
 		{
-			desc: "Connection draining timeout with valid value",
+			desc: "Connection draining timeout with valid seconds value",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ConnectionDrainingTimeoutKey: "300",
+						ConnectionDrainingTimeoutKey: "300s",
+					},
+				},
+			},
+			wantTimeout:   300,
+			wantSpecified: true,
+		},
+		{
+			desc: "Connection draining timeout with minutes value",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "5m",
 					},
 				},
 			},
@@ -310,7 +322,19 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ConnectionDrainingTimeoutKey: "3600",
+						ConnectionDrainingTimeoutKey: "3600s",
+					},
+				},
+			},
+			wantTimeout:   3600,
+			wantSpecified: true,
+		},
+		{
+			desc: "Connection draining timeout with 1 hour",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "1h",
 					},
 				},
 			},
@@ -322,7 +346,7 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ConnectionDrainingTimeoutKey: "0",
+						ConnectionDrainingTimeoutKey: "0s",
 					},
 				},
 			},
@@ -334,7 +358,19 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ConnectionDrainingTimeoutKey: "3601",
+						ConnectionDrainingTimeoutKey: "3601s",
+					},
+				},
+			},
+			wantTimeout:   0,
+			wantSpecified: false,
+		},
+		{
+			desc: "Connection draining timeout with invalid value (over 1 hour)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "2h",
 					},
 				},
 			},
@@ -346,7 +382,7 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ConnectionDrainingTimeoutKey: "-1",
+						ConnectionDrainingTimeoutKey: "-1s",
 					},
 				},
 			},
@@ -354,11 +390,47 @@ func TestGetConnectionDrainingTimeout(t *testing.T) {
 			wantSpecified: false,
 		},
 		{
-			desc: "Connection draining timeout with invalid value (non-numeric)",
+			desc: "Connection draining timeout with invalid value (no unit)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "300",
+					},
+				},
+			},
+			wantTimeout:   0,
+			wantSpecified: false,
+		},
+		{
+			desc: "Connection draining timeout with invalid value (non-duration)",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						ConnectionDrainingTimeoutKey: "invalid",
+					},
+				},
+			},
+			wantTimeout:   0,
+			wantSpecified: false,
+		},
+		{
+			desc: "Connection draining timeout with fractional seconds (milliseconds)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "500ms",
+					},
+				},
+			},
+			wantTimeout:   0,
+			wantSpecified: false,
+		},
+		{
+			desc: "Connection draining timeout with fractional seconds (1.5s)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConnectionDrainingTimeoutKey: "1.5s",
 					},
 				},
 			},

--- a/pkg/l4resources/l4.go
+++ b/pkg/l4resources/l4.go
@@ -561,18 +561,25 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 		}
 	}
 
+	// Get connection draining timeout from annotation if specified
+	var connectionDrainingTimeoutSec int64
+	if timeout, ok := l4annotations.FromService(l4.Service).GetConnectionDrainingTimeout(); ok {
+		connectionDrainingTimeoutSec = timeout
+	}
+
 	backendParams := backends.L4BackendServiceParams{
-		Name:                     bsName,
-		HealthCheckLink:          hcLink,
-		Protocol:                 backendProtocol,
-		SessionAffinity:          string(l4.Service.Spec.SessionAffinity),
-		Scheme:                   string(cloud.SchemeInternal),
-		NamespacedName:           l4.NamespacedName,
-		NetworkInfo:              &l4.network,
-		ConnectionTrackingPolicy: noConnectionTrackingPolicy,
-		EnableZonalAffinity:      enableZonalAffinity,
-		LocalityLbPolicy:         localityLbPolicy,
-		LogConfig:                logConfig,
+		Name:                         bsName,
+		HealthCheckLink:              hcLink,
+		Protocol:                     backendProtocol,
+		SessionAffinity:              string(l4.Service.Spec.SessionAffinity),
+		Scheme:                       string(cloud.SchemeInternal),
+		NamespacedName:               l4.NamespacedName,
+		NetworkInfo:                  &l4.network,
+		ConnectionTrackingPolicy:     noConnectionTrackingPolicy,
+		EnableZonalAffinity:          enableZonalAffinity,
+		LocalityLbPolicy:             localityLbPolicy,
+		LogConfig:                    logConfig,
+		ConnectionDrainingTimeoutSec: connectionDrainingTimeoutSec,
 	}
 
 	bs, bsSyncStatus, err := l4.backendPool.EnsureL4BackendService(backendParams, l4.svcLogger)

--- a/pkg/l4resources/l4netlb.go
+++ b/pkg/l4resources/l4netlb.go
@@ -385,17 +385,24 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 		}
 	}
 
+	// Get connection draining timeout from annotation if specified
+	var connectionDrainingTimeoutSec int64
+	if timeout, ok := l4annotations.FromService(l4netlb.Service).GetConnectionDrainingTimeout(); ok {
+		connectionDrainingTimeoutSec = timeout
+	}
+
 	backendParams := backends.L4BackendServiceParams{
-		Name:                     bsName,
-		HealthCheckLink:          hcLink,
-		Protocol:                 protocol,
-		SessionAffinity:          string(l4netlb.Service.Spec.SessionAffinity),
-		Scheme:                   string(cloud.SchemeExternal),
-		NamespacedName:           l4netlb.NamespacedName,
-		NetworkInfo:              network.DefaultNetwork(l4netlb.cloud),
-		ConnectionTrackingPolicy: connectionTrackingPolicy,
-		LocalityLbPolicy:         localityLbPolicy,
-		LogConfig:                logConfig,
+		Name:                         bsName,
+		HealthCheckLink:              hcLink,
+		Protocol:                     protocol,
+		SessionAffinity:              string(l4netlb.Service.Spec.SessionAffinity),
+		Scheme:                       string(cloud.SchemeExternal),
+		NamespacedName:               l4netlb.NamespacedName,
+		NetworkInfo:                  network.DefaultNetwork(l4netlb.cloud),
+		ConnectionTrackingPolicy:     connectionTrackingPolicy,
+		LocalityLbPolicy:             localityLbPolicy,
+		LogConfig:                    logConfig,
+		ConnectionDrainingTimeoutSec: connectionDrainingTimeoutSec,
 	}
 
 	bs, wasUpdate, err := l4netlb.backendPool.EnsureL4BackendService(backendParams, l4netlb.svcLogger)


### PR DESCRIPTION
Adds `networking.gke.io/connection-draining-timeout-sec` annotation to configure connection draining timeout for L4 LoadBalancers with RBS enabled.

Currently, L4 LoadBalancers use a hardcoded 30 second timeout. For workloads with long-lived connections, this is quite insufficient. GCE supports up to 3600 seconds, but there is no way to configure this in the Service definition.

Note: for disclosure, I used the assistance of Claude Code to help implement this PR, but I have reviewed everything personally to the best of my knowledge.