### PR TITLE
Fix multi-project tests bookmark fixtures

### DIFF
--- a/pkg/multiproject/framework/controller_test.go
+++ b/pkg/multiproject/framework/controller_test.go
@@ -314,6 +314,9 @@ func (f *fakePanickingManager) getPanicCount() int {
 func TestPanicRecovery(t *testing.T) {
 	pcClient := fakeproviderconfigclient.NewSimpleClientset()
 	panicManager := &fakePanickingManager{}
+	test.PrependBookmarkReactor(&pcClient.Fake, pcClient.Tracker(), "*", &providerconfigv1.ProviderConfig{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
 	providerConfigInformer := providerconfiginformers.NewSharedInformerFactory(pcClient, 0).Cloud().V1().ProviderConfigs().Informer()
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/multiproject/neg/informerset/informerset_test.go
+++ b/pkg/multiproject/neg/informerset/informerset_test.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	svcnegv1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/test"
 )
 
@@ -254,6 +255,9 @@ func TestFilterByProviderConfig_WrappingAndState(t *testing.T) {
 	for _, r := range resources {
 		test.PrependBookmarkReactor(&kubeClient.Fake, kubeClient.Tracker(), r.res, r.obj)
 	}
+	test.PrependBookmarkReactor(&svcClient.Fake, svcClient.Tracker(), "servicenetworkendpointgroups", &svcnegv1.ServiceNetworkEndpointGroup{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
 
 	inf := NewInformerSet(kubeClient, svcClient, nil, nil, metav1.Duration{Duration: 0})
 

--- a/pkg/multiproject/neg/neg_test.go
+++ b/pkg/multiproject/neg/neg_test.go
@@ -12,6 +12,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	providerconfig "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
+	svcnegv1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	multiprojectgce "k8s.io/ingress-gce/pkg/multiproject/common/gce"
 	multiprojectinformers "k8s.io/ingress-gce/pkg/multiproject/neg/informerset"
 	"k8s.io/ingress-gce/pkg/neg"
@@ -21,6 +22,7 @@ import (
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	svcnegfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
+	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
@@ -34,7 +36,16 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 
 	logger, _ := ktesting.NewTestContext(t)
 	kubeClient := k8sfake.NewSimpleClientset()
-	informers := multiprojectinformers.NewInformerSet(kubeClient, svcnegfake.NewSimpleClientset(), networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
+	svcNegClient := svcnegfake.NewSimpleClientset()
+
+	test.PrependBookmarkReactor(&kubeClient.Fake, kubeClient.Tracker(), "*", &providerconfig.ProviderConfig{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
+	test.PrependBookmarkReactor(&svcNegClient.Fake, svcNegClient.Tracker(), "*", &svcnegv1.ServiceNetworkEndpointGroup{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
+
+	informers := multiprojectinformers.NewInformerSet(kubeClient, svcNegClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
 
 	// Start base informers; they are not strictly required by our stubbed controller,
 	// but mirrors real startup flow and ensures CombinedHasSynced would be true if used.


### PR DESCRIPTION
In a recent client-go update(bumped to version v0.35.3 ), the WatchList streaming feature became enabled by default. This update corresponds to the Kubernetes 1.35 release cycle. 

When mock tests lack standard initial-events bookmarks, WaitForCacheSync hangs indefinitely. (see for example: [this](https://github.com/kubernetes/kubernetes/issues/135895))

This PR extends the work introduced by [PR_3042](https://github.com/kubernetes/ingress-gce/pull/3042).

There are three specific tests (TestPanicRecovery, TestStartNEGController_StopJoin, and TestFilterByProviderConfig_WrappingAndState) that call `clientfake.NewSimpleClientset()` directly inline, bypassing the shared helper utilities (like newTestProviderConfigController). Consequently, when the client-go dependency bumped, they were the only ones left behind to not to have the fix of using the `PrependBookmarkReactor`.