### PR TITLE
metrics: Rename logging_control_enabled label to logging_enabled

### DIFF
--- a/pkg/l4/metrics/ipv4_metrics.go
+++ b/pkg/l4/metrics/ipv4_metrics.go
@@ -35,7 +35,7 @@ const (
 	l4LabelZonalAffinity         = "zonal_affinity"
 	l4LabelBackendType           = "backend_type"
 	l4LabelProtocol              = "protocol" // Either "TCP", "UDP", or "MIXED". The default "" means that there is an error.
-	l4LabelLoggingControlEnabled = "logging_control_enabled"
+	l4LabelLoggingControlEnabled = "logging_enabled"
 	labelDenyFirewall            = "deny_firewall"
 )
 

--- a/pkg/l4/metrics/metrics_test.go
+++ b/pkg/l4/metrics/metrics_test.go
@@ -84,13 +84,13 @@ func TestPublishILBSyncMetrics(t *testing.T) {
 		},
 		{
 			labels: prometheus.Labels{
-				"logging_control_enabled": "true",
+				"logging_enabled": "true",
 			},
 			count: 3,
 		},
 		{
 			labels: prometheus.Labels{
-				"logging_control_enabled": "false",
+				"logging_enabled": "false",
 			},
 			count: 5,
 		},
@@ -239,13 +239,13 @@ func TestPublishNetLBSyncMetrics(t *testing.T) {
 		},
 		{
 			labels: prometheus.Labels{
-				"logging_control_enabled": "true",
+				"logging_enabled": "true",
 			},
 			count: 2,
 		},
 		{
 			labels: prometheus.Labels{
-				"logging_control_enabled": "false",
+				"logging_enabled": "false",
 			},
 			count: 6,
 		},


### PR DESCRIPTION
## Description
This PR renames the Prometheus metric label `logging_control_enabled` to `logging_enabled` in the L4 IPv4 metrics implementation. This makes the label name more concise.

## Changes
*   `pkg/l4/metrics/ipv4_metrics.go`: Updated the value of the `l4LabelLoggingControlEnabled` constant from `"logging_control_enabled"` to `"logging_enabled"`.
*   `pkg/l4/metrics/metrics_test.go`: Updated the corresponding test cases to use the new label name `"logging_enabled"`.

## Verification
*   The unit tests in `pkg/l4/metrics/metrics_test.go` were updated to reflect this change.
