### PR TITLE
L4 Multi-Networking services - use a per service health check firewal…

### DIFF
--- a/pkg/l4/healthchecks/healthchecksl4.go
+++ b/pkg/l4/healthchecks/healthchecksl4.go
@@ -150,14 +150,19 @@ func (l4hc *l4HealthChecks) EnsureHealthCheckWithDualStackFirewalls(svc *corev1.
 		WasUpdated: wasUpdate,
 	}
 
+	isSharedFirewall := sharedHC
+	if !svcNetwork.IsDefault {
+		isSharedFirewall = false
+	}
+
 	if needsIPv4 {
 		hcLogger.V(3).Info("Ensuring IPv4 firewall rule for health check for service")
-		l4hc.ensureIPv4Firewall(svc, namer, hcPort, sharedHC, nodeNames, hcResult, svcNetwork, hcLogger)
+		l4hc.ensureIPv4Firewall(svc, namer, hcPort, isSharedFirewall, nodeNames, hcResult, svcNetwork, hcLogger)
 	}
 
 	if needsIPv6 {
 		hcLogger.V(3).Info("Ensuring IPv6 firewall rule for health check for service")
-		l4hc.ensureIPv6Firewall(svc, namer, hcPort, sharedHC, nodeNames, l4Type, hcResult, svcNetwork, hcLogger)
+		l4hc.ensureIPv6Firewall(svc, namer, hcPort, isSharedFirewall, nodeNames, l4Type, hcResult, svcNetwork, hcLogger)
 	}
 
 	return hcResult

--- a/pkg/l4/healthchecks/healthchecksl4_test.go
+++ b/pkg/l4/healthchecks/healthchecksl4_test.go
@@ -18,10 +18,12 @@ package healthchecks
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
@@ -549,6 +551,9 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 			HealthCheckNodePort:   1234,
 		},
 	}
+	svcETPCluster := svc.DeepCopy()
+	svcETPCluster.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
+	svcETPCluster.Spec.HealthCheckNodePort = 0
 	namespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	fwDescription, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(svc.Namespace, svc.Name), "", meta.VersionGA, false)
 	if err != nil {
@@ -582,12 +587,47 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 		},
 		Priority: 999,
 	}
+	fwSharedDescription, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(svc.Namespace, svc.Name), "", meta.VersionGA, true)
+	if err != nil {
+		t.Errorf("utils.MakeL4LBFirewallDescription() err=%v", err)
+	}
+	expectedSharedFw := &compute.Firewall{
+		Name:         l4Namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, true),
+		Description:  fwSharedDescription,
+		Network:      testClusterValues.NetworkURL,
+		SourceRanges: gce.L4LoadBalancerSrcRanges(),
+		TargetTags:   []string{"k8s-test"},
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "TCP",
+				Ports:      []string{strconv.Itoa(int(gce.GetNodesHealthCheckPort()))},
+			},
+		},
+		Priority: 999,
+	}
+
+	secondaryNetwork := &network.NetworkInfo{IsDefault: false, K8sNetwork: "secondary", NetworkURL: "secondaryNetworkURL", SubnetworkURL: "secondarySubnetworkURL"}
+	expectedMultinetFw := &compute.Firewall{
+		Name:         l4Namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, false),
+		Description:  fwDescription,
+		Network:      secondaryNetwork.NetworkURL,
+		SourceRanges: gce.L4LoadBalancerSrcRanges(),
+		TargetTags:   []string{"k8s-test"},
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "TCP",
+				Ports:      []string{strconv.Itoa(int(gce.GetNodesHealthCheckPort()))},
+			},
+		},
+		Priority: 999,
+	}
 
 	testCases := []struct {
 		desc             string
 		existingHC       *composite.HealthCheck
 		existingFirewall *compute.Firewall
 		svc              *corev1.Service
+		svcNetwork       *network.NetworkInfo
 		wantHC           *composite.HealthCheck
 		wantFirewall     *compute.Firewall
 		needIPv6         bool
@@ -599,6 +639,23 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 			svc:          svc,
 			wantHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, false), namespacedName, false, hcDefaultPath, 1234, utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
 			wantFirewall: expectedFw,
+			wantUpdate:   utils.ResourceUpdate,
+			wantUpdateFw: utils.ResourceUpdate,
+		},
+		{
+			desc:         "create cluster mode",
+			svc:          svcETPCluster,
+			wantHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, true), namespacedName, true, hcDefaultPath, gce.GetNodesHealthCheckPort(), utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall: expectedSharedFw,
+			wantUpdate:   utils.ResourceUpdate,
+			wantUpdateFw: utils.ResourceUpdate,
+		},
+		{
+			desc:         "create cluster mode multinet",
+			svc:          svcETPCluster,
+			svcNetwork:   secondaryNetwork,
+			wantHC:       newL4HealthCheck(l4Namer.L4HealthCheck(svc.Namespace, svc.Name, true), namespacedName, true, hcDefaultPath, gce.GetNodesHealthCheckPort(), utils.XLB, meta.Global, testClusterValues.Region, klog.TODO()),
+			wantFirewall: expectedMultinetFw,
 			wantUpdate:   utils.ResourceUpdate,
 			wantUpdateFw: utils.ResourceUpdate,
 		},
@@ -663,7 +720,10 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 			fakeGCE := gce.NewFakeGCECloud(testClusterValues)
 			nodeNames := []string{"k8s-test-node"}
 			createVMInstanceWithTag(t, fakeGCE, "k8s-test")
-			defaultNetwork := network.DefaultNetwork(fakeGCE)
+			svcNetwork := tc.svcNetwork
+			if svcNetwork == nil {
+				svcNetwork = network.DefaultNetwork(fakeGCE)
+			}
 			hcs := NewL4HealthChecks(fakeGCE, &record.FakeRecorder{}, klog.TODO(), true)
 			if tc.existingHC != nil {
 				err := hcs.hcProvider.Create(tc.existingHC)
@@ -677,7 +737,8 @@ func TestEnsureHealthCheckWithDualStackFirewalls(t *testing.T) {
 			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
 			mockGCE.MockFirewalls.PatchHook = mock.UpdateFirewallHook
 
-			result := hcs.EnsureHealthCheckWithDualStackFirewalls(svc, l4Namer, false, meta.Global, utils.XLB, nodeNames, true, tc.needIPv6, *defaultNetwork, klog.TODO())
+			sharedHC := !helpers.RequestsOnlyLocalTraffic(tc.svc)
+			result := hcs.EnsureHealthCheckWithDualStackFirewalls(svc, l4Namer, sharedHC, meta.Global, utils.XLB, nodeNames, true, tc.needIPv6, *svcNetwork, klog.TODO())
 			if result.Err != nil {
 				t.Errorf("hcs.EnsureHealthCheckWithDualStackFirewalls() err=%v", result.Err)
 			}

--- a/pkg/l4/resources/l4_test.go
+++ b/pkg/l4/resources/l4_test.go
@@ -2917,6 +2917,7 @@ func assertDualStackILBResourcesWithCustomSubnet(t *testing.T, l4 *L4, nodeNames
 
 func buildExpectedAnnotations(l4 *L4) map[string]string {
 	isSharedHC := !servicehelper.RequestsOnlyLocalTraffic(l4.Service)
+	sharedHCFW := isSharedHC && l4.network.IsDefault
 	proto := utils.GetProtocol(l4.Service.Spec.Ports)
 
 	backendName := l4.namer.L4Backend(l4.Service.Namespace, l4.Service.Name)
@@ -2928,7 +2929,7 @@ func buildExpectedAnnotations(l4 *L4) map[string]string {
 	}
 
 	if utils.NeedsIPv4(l4.Service) {
-		hcFwName := l4.namer.L4HealthCheckFirewall(l4.Service.Namespace, l4.Service.Name, isSharedHC)
+		hcFwName := l4.namer.L4HealthCheckFirewall(l4.Service.Namespace, l4.Service.Name, sharedHCFW)
 
 		expectedAnnotations[annotations.FirewallRuleForHealthcheckKey] = hcFwName
 		expectedAnnotations[annotations.FirewallRuleKey] = backendName
@@ -2941,7 +2942,7 @@ func buildExpectedAnnotations(l4 *L4) map[string]string {
 		}
 	}
 	if utils.NeedsIPv6(l4.Service) {
-		ipv6hcFwName := l4.namer.L4IPv6HealthCheckFirewall(l4.Service.Namespace, l4.Service.Name, isSharedHC)
+		ipv6hcFwName := l4.namer.L4IPv6HealthCheckFirewall(l4.Service.Namespace, l4.Service.Name, sharedHCFW)
 		ipv6FirewallName := l4.namer.L4IPv6Firewall(l4.Service.Namespace, l4.Service.Name)
 
 		expectedAnnotations[annotations.FirewallRuleForHealthcheckIPv6Key] = ipv6hcFwName
@@ -3090,7 +3091,7 @@ func verifyILBIPv6NodesFirewall(l4 *L4, nodeNames []string) error {
 }
 
 func verifyILBIPv4HealthCheckFirewall(l4 *L4, nodeNames []string) error {
-	isSharedHC := !servicehelper.RequestsOnlyLocalTraffic(l4.Service)
+	isSharedHC := !servicehelper.RequestsOnlyLocalTraffic(l4.Service) && l4.network.IsDefault
 
 	hcFwName := l4.namer.L4HealthCheckFirewall(l4.Service.Namespace, l4.Service.Name, isSharedHC)
 	hcFwDesc, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(l4.Service.Namespace, l4.Service.Name), "", meta.VersionGA, isSharedHC)

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -1792,7 +1792,7 @@ func verifyNetLBIPv6NodesFirewall(l4netlb *L4NetLB, nodeNames []string) error {
 }
 
 func verifyNetLBIPv4HealthCheckFirewall(l4netlb *L4NetLB, nodeNames []string) error {
-	isSharedHC := !servicehelper.RequestsOnlyLocalTraffic(l4netlb.Service)
+	isSharedHC := !servicehelper.RequestsOnlyLocalTraffic(l4netlb.Service) && l4netlb.networkInfo.IsDefault
 
 	hcFwName := l4netlb.namer.L4HealthCheckFirewall(l4netlb.Service.Namespace, l4netlb.Service.Name, isSharedHC)
 	hcFwDesc, err := utils.MakeL4LBFirewallDescription(utils.ServiceKeyFunc(l4netlb.Service.Namespace, l4netlb.Service.Name), "", meta.VersionGA, isSharedHC)
@@ -1968,8 +1968,9 @@ func buildExpectedNetLBAnnotations(l4netlb *L4NetLB) map[string]string {
 		annotations.HealthcheckKey:    hcName,
 	}
 
+	isSharedHCFW := isSharedHC && l4netlb.networkInfo.IsDefault
 	if utils.NeedsIPv4(l4netlb.Service) {
-		hcFwName := l4netlb.namer.L4HealthCheckFirewall(l4netlb.Service.Namespace, l4netlb.Service.Name, isSharedHC)
+		hcFwName := l4netlb.namer.L4HealthCheckFirewall(l4netlb.Service.Namespace, l4netlb.Service.Name, isSharedHCFW)
 
 		expectedAnnotations[annotations.FirewallRuleForHealthcheckKey] = hcFwName
 		expectedAnnotations[annotations.FirewallRuleKey] = backendName
@@ -1982,7 +1983,7 @@ func buildExpectedNetLBAnnotations(l4netlb *L4NetLB) map[string]string {
 		}
 	}
 	if utils.NeedsIPv6(l4netlb.Service) {
-		ipv6hcFwName := l4netlb.namer.L4IPv6HealthCheckFirewall(l4netlb.Service.Namespace, l4netlb.Service.Name, isSharedHC)
+		ipv6hcFwName := l4netlb.namer.L4IPv6HealthCheckFirewall(l4netlb.Service.Namespace, l4netlb.Service.Name, isSharedHCFW)
 		ipv6FirewallName := l4netlb.namer.L4IPv6Firewall(l4netlb.Service.Namespace, l4netlb.Service.Name)
 
 		expectedAnnotations[annotations.FirewallRuleForHealthcheckIPv6Key] = ipv6hcFwName


### PR DESCRIPTION
…l even if the service is externalTrafficPolicy: Cluster.

These services are in non default VPC, they can't use the shared health check. Use a per service setup to allow for easier cleanup and resource-to-service attribution.