### PR TITLE
fix(neg): correct 'occured' -> 'occurred' in label-propagation doc comments

### DIFF
--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -337,7 +337,7 @@ func (m *NegMetrics) PublishNegControllerErrorCountMetrics(err error, isIgnored 
 	NegControllerErrorCount.WithLabelValues(getErrorLabel(err, isIgnored)).Inc()
 }
 
-// PublishLabelPropagationError publishes error occured during label propagation.
+// PublishLabelPropagationError publishes error occurred during label propagation.
 func PublishLabelPropagationError(errType string) {
 	LabelPropagationError.WithLabelValues(errType).Inc()
 }

--- a/pkg/neg/syncers/labels/labels.go
+++ b/pkg/neg/syncers/labels/labels.go
@@ -90,7 +90,7 @@ func GetPodLabelMap(pod *v1.Pod, lpConfig PodLabelPropagationConfig) (PodLabelMa
 	return labelMap, nil
 }
 
-// publishLabelPropagationTruncationMetrics publishes errors occured during
+// publishLabelPropagationTruncationMetrics publishes errors occurred during
 // label truncation.
 func publishLabelPropagationTruncationMetrics(err error) {
 	if errors.Is(err, ErrLabelTruncated) {


### PR DESCRIPTION
Two doc comments in `pkg/neg` used `occured` instead of `occurred`:

- `pkg/neg/metrics/metrics.go:340` — `PublishLabelPropagationError`
- `pkg/neg/syncers/labels/labels.go:93` — `publishLabelPropagationTruncationMetrics`

Both are doc-only changes. `go build ./pkg/neg/...` stays clean against current `master`.