### PR TITLE
Fix invalid YAML syntax in default-http-backend image placeholder

### DIFF
--- a/docs/deploy/gce/README.md
+++ b/docs/deploy/gce/README.md
@@ -39,7 +39,7 @@ Apply [rbac.yaml](../resources/rbac.yaml).
 > [!NOTE]
 > This is only needed if you're deploying the L7 controller for Ingress.
 
-Replace `IMAGE_URL` with your `ingress-gce-404-server-with-metrics-amd64` image (for example, `gcr.io/my-project/ingress-gce-404-server-with-metrics-amd64:latest`) and apply [default-http-backend.yaml](../resources/default-http-backend.yaml).
+Replace the `"IMAGE_URL"` placeholder with your own `ingress-gce-404-server-with-metrics-amd64` image (for example, `gcr.io/my-project/ingress-gce-404-server-with-metrics-amd64:latest`) and apply [default-http-backend.yaml](../resources/default-http-backend.yaml). The ingress-gce project no longer publishes a default multi-arch backend image, so you must build and provide your own.
 
 ## Create Google Service Account and generate a key
 

--- a/docs/deploy/resources/default-http-backend.yaml
+++ b/docs/deploy/resources/default-http-backend.yaml
@@ -36,7 +36,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: [IMAGE_URL]
+        image: "IMAGE_URL"
         securityContext:
           # go/gke-components/integration-guide#run-containers-as-non-root
           runAsUser: 1000


### PR DESCRIPTION
The `[IMAGE_URL]` placeholder in `default-http-backend.yaml` was causing `kubectl apply` to fail with a syntax error during local development (`hack/run-local-glbc.sh`).

The PR also updates the README to explicitly inform users that they must build and provide their own multi-arch backend image, as the project no longer publishes a default one (https://github.com/kubernetes/ingress-gce/issues/1719).