### PR TITLE
Fix warning related to Printf like formatting that became build error…

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -809,7 +809,7 @@ func (lbc *LoadBalancerController) toRuntimeInfo(ing *v1.Ingress, urlMap *utils.
 	for _, err := range errors {
 		if apierrors.IsNotFound(err) {
 			msg := fmt.Sprintf("Could not find TLS certificate: %v", err)
-			lbc.ctx.Recorder(ing.Namespace).Eventf(ing, apiv1.EventTypeWarning, events.SyncIngress, msg)
+			lbc.ctx.Recorder(ing.Namespace).Event(ing, apiv1.EventTypeWarning, events.SyncIngress, msg)
 		} else {
 			ingLogger.Error(err, "Could not get certificates")
 			return nil, err

--- a/pkg/firewalls/controller.go
+++ b/pkg/firewalls/controller.go
@@ -317,7 +317,7 @@ func (fwc *FirewallController) sync(key string) error {
 			if annotations.FromIngress(ing).SuppressFirewallXPNError() {
 				continue
 			}
-			fwc.ctx.Recorder(ing.Namespace).Eventf(ing, apiv1.EventTypeNormal, "XPN", fwErr.Message)
+			fwc.ctx.Recorder(ing.Namespace).Event(ing, apiv1.EventTypeNormal, "XPN", fwErr.Message)
 		}
 	}
 	return nil

--- a/pkg/firewalls/firewalls_l4.go
+++ b/pkg/firewalls/firewalls_l4.go
@@ -125,7 +125,7 @@ func ensureFirewall(svc *v1.Service, shared bool, params *FirewallParams, cloud 
 	updateStatus, err := EnsureL4FirewallRule(cloud, nsName, params, shared, fwLogger)
 	if err != nil {
 		if fwErr, ok := err.(*FirewallXPNError); ok {
-			recorder.Eventf(svc, v1.EventTypeNormal, "XPN", fwErr.Message)
+			recorder.Event(svc, v1.EventTypeNormal, "XPN", fwErr.Message)
 			return updateStatus, nil
 		}
 		return updateStatus, err

--- a/pkg/l4/address/hold_test.go
+++ b/pkg/l4/address/hold_test.go
@@ -213,7 +213,7 @@ func TestHoldExternalIPv4(t *testing.T) {
 				t.Errorf("address.IPv4ToUse(_).IP = %q, want %q", got.IP, tC.want.IP)
 			}
 			if got.Managed != tC.want.Managed {
-				t.Errorf("address.IPv4ToUse(_).Managed = %q, want %q", got.Managed, tC.want.Managed)
+				t.Errorf("address.IPv4ToUse(_).Managed = %v, want %v", got.Managed, tC.want.Managed)
 			}
 
 			// Verify that address exists

--- a/pkg/l4/backends/backends_test.go
+++ b/pkg/l4/backends/backends_test.go
@@ -145,7 +145,7 @@ func TestEnsureL4BackendService(t *testing.T) {
 				t.Errorf("BackendService.LoadBalancingScheme was not populated correctly, want=%q, got=%q", tc.schemeType, bs.LoadBalancingScheme)
 			}
 			if bs.ConnectionDraining == nil || bs.ConnectionDraining.DrainingTimeoutSec != DefaultConnectionDrainingTimeoutSeconds {
-				t.Errorf("BackendService.ConnectionDraining was not populated correctly, want=connection draining with %q, got=%q", DefaultConnectionDrainingTimeoutSeconds, bs.ConnectionDraining)
+				t.Errorf("BackendService.ConnectionDraining was not populated correctly, want=connection draining with %v, got=%v", DefaultConnectionDrainingTimeoutSeconds, bs.ConnectionDraining)
 			}
 			if tc.enableStrongSessionAffinity {
 				if diff := cmp.Diff(bs.ConnectionTrackingPolicy, tc.connectionTrackingPolicy); diff != "" {

--- a/pkg/l4/controllers/l4controller.go
+++ b/pkg/l4/controllers/l4controller.go
@@ -141,7 +141,7 @@ func NewILBController(ctx *context.ControllerContext, stopCh <-chan struct{}, lo
 			// Check for deletion since updates or deletes show up as Add when controller restarts.
 			if needsILB || l4c.needsDeletion(addSvc) {
 				svcLogger.V(3).Info("ILB Service added, enqueuing")
-				l4c.ctx.Recorder(addSvc.Namespace).Eventf(addSvc, v1.EventTypeNormal, "ADD", svcKey)
+				l4c.ctx.Recorder(addSvc.Namespace).Event(addSvc, v1.EventTypeNormal, "ADD", svcKey)
 				l4c.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, svcLogger)
 				l4c.svcQueue.Enqueue(addSvc)
 				l4c.enqueueTracker.Track()

--- a/pkg/l4/controllers/l4netlbcontroller.go
+++ b/pkg/l4/controllers/l4netlbcontroller.go
@@ -151,7 +151,7 @@ func NewL4NetLBController(
 			svcLogger := logger.WithValues("serviceKey", svcKey)
 			if shouldProcess, _ := l4netLBc.shouldProcessService(addSvc, nil, svcLogger); shouldProcess {
 				svcLogger.V(3).Info("L4 External LoadBalancer Service added, enqueuing")
-				l4netLBc.ctx.Recorder(addSvc.Namespace).Eventf(addSvc, v1.EventTypeNormal, "ADD", svcKey)
+				l4netLBc.ctx.Recorder(addSvc.Namespace).Event(addSvc, v1.EventTypeNormal, "ADD", svcKey)
 				l4netLBc.serviceVersions.SetLastUpdateSeen(svcKey, addSvc.ResourceVersion, svcLogger)
 				l4netLBc.svcQueue.Enqueue(addSvc)
 				l4netLBc.enqueueTracker.Track()
@@ -348,7 +348,7 @@ func (lc *L4NetLBController) shouldProcessService(newSvc, oldSvc *v1.Service, sv
 		if annotations.HasLoadBalancerClass(newSvc, annotations.RegionalExternalLoadBalancerClass) {
 			if newSvc.Annotations[annotations.ServiceAnnotationLoadBalancerType] == string(annotations.LBTypeInternal) {
 				lc.ctx.Recorder(newSvc.Namespace).Eventf(newSvc, v1.EventTypeWarning, "ConflictingConfiguration",
-					fmt.Sprintf("loadBalancerClass conflicts with %s: %q annotation. External LoadBalancer Service provisioned.", annotations.ServiceAnnotationLoadBalancerType, string(annotations.LBTypeInternal)))
+					"loadBalancerClass conflicts with %s: %q annotation. External LoadBalancer Service provisioned.", annotations.ServiceAnnotationLoadBalancerType, string(annotations.LBTypeInternal))
 			}
 		} else {
 			svcLogger.Info("Ignoring service managed by another controller", "serviceLoadBalancerClass", *newSvc.Spec.LoadBalancerClass)

--- a/pkg/l4/forwardingrules/netlb_mixed_manager.go
+++ b/pkg/l4/forwardingrules/netlb_mixed_manager.go
@@ -336,5 +336,5 @@ func (m *MixedManagerNetLB) nameLegacy() string {
 }
 
 func (m *MixedManagerNetLB) recordEventf(messageFmt string, args ...any) {
-	m.Recorder.Eventf(m.Service, api_v1.EventTypeNormal, events.SyncIngress, messageFmt, args)
+	m.Recorder.Eventf(m.Service, api_v1.EventTypeNormal, events.SyncIngress, messageFmt, args...)
 }

--- a/pkg/l4/healthchecks/healthchecksl4.go
+++ b/pkg/l4/healthchecks/healthchecksl4.go
@@ -432,7 +432,7 @@ func (l4hc *l4HealthChecks) deleteFirewall(name string, svc *corev1.Service, fwL
 	}
 	// Suppress Firewall XPN error, as this is no retryable and requires action by security admin
 	if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
-		l4hc.recorder.Eventf(svc, corev1.EventTypeNormal, "XPN", fwErr.Message)
+		l4hc.recorder.Event(svc, corev1.EventTypeNormal, "XPN", fwErr.Message)
 		return nil
 	}
 	return err

--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -359,7 +359,7 @@ func (l4 *L4) deleteFirewall(name string, fwLogger klog.Logger) error {
 	err := firewalls.EnsureL4FirewallRuleDeleted(l4.cloud, name, fwLogger)
 	if err != nil {
 		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
-			l4.recorder.Eventf(l4.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
+			l4.recorder.Event(l4.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
 			return nil
 		}
 		return err

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -822,7 +822,7 @@ func (l4netlb *L4NetLB) deleteFirewall(firewallName string, fwLogger klog.Logger
 	err := firewalls.EnsureL4FirewallRuleDeleted(l4netlb.cloud, firewallName, fwLogger)
 	if err != nil {
 		if fwErr, ok := err.(*firewalls.FirewallXPNError); ok {
-			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
+			l4netlb.recorder.Event(l4netlb.Service, corev1.EventTypeNormal, "XPN", fwErr.Message)
 			return nil
 		}
 		return err

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -710,7 +710,7 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 	if needsNEGForILB && !utils.HasL4ILBFinalizerV2(service) {
 		msg := fmt.Sprintf("Ignoring ILB Service %s, namespace %s as it does not have the v2 finalizer", service.Name, service.Namespace)
 		c.logger.Info(msg)
-		c.recorder.Eventf(service, apiv1.EventTypeWarning, "ProcessServiceSkipped", msg)
+		c.recorder.Event(service, apiv1.EventTypeWarning, "ProcessServiceSkipped", msg)
 		return nil
 	}
 
@@ -884,7 +884,7 @@ func (c *Controller) handleErr(err error, key interface{}) {
 		c.logger.Error(err, "Failed to retrieve service from store", "service", key.(string))
 		c.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
 	} else if exists {
-		c.recorder.Eventf(service.(*apiv1.Service), apiv1.EventTypeWarning, "ProcessServiceFailed", msg)
+		c.recorder.Event(service.(*apiv1.Service), apiv1.EventTypeWarning, "ProcessServiceFailed", msg)
 	}
 	c.serviceQueue.AddRateLimited(key)
 }

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -624,7 +624,7 @@ func (manager *syncerManager) processNEGDeletionCandidate(candidate deletionCand
 				// svcneg resource. We do not have a good way of detecting what is wrong and believe user
 				// intervention is safer than accidentally deleting a NEG that is being used.
 				eventMsg := fmt.Sprintf("Detected TO_BE_DELETED NEGs, but unable to parse selflink %s. Please manually delete the NEG and remove the corresponding reference from the svcneg resource", negRef.SelfLink)
-				manager.recorder.Eventf(svcNegCR, v1.EventTypeWarning, negtypes.NegGCError, eventMsg)
+				manager.recorder.Event(svcNegCR, v1.EventTypeWarning, negtypes.NegGCError, eventMsg)
 				continue
 			}
 			deleteByZone = true
@@ -706,7 +706,7 @@ func (manager *syncerManager) deleteNegOrReportErr(name, zone string, svcNegCR *
 	}
 	if err := manager.ensureDeleteNetworkEndpointGroup(name, zone, expectedDesc); err != nil {
 		err = fmt.Errorf("failed to delete NEG %s in %s: %s", name, zone, err)
-		manager.recorder.Eventf(svcNegCR, v1.EventTypeWarning, negtypes.NegGCError, err.Error())
+		manager.recorder.Event(svcNegCR, v1.EventTypeWarning, negtypes.NegGCError, err.Error())
 		*errList = append(*errList, err)
 
 		return false

--- a/pkg/neg/readiness/reflector.go
+++ b/pkg/neg/readiness/reflector.go
@@ -322,7 +322,7 @@ func (r *readinessReflector) ensurePodNegCondition(pod *v1.Pod, expectedConditio
 	if err != nil {
 		return fmt.Errorf("failed to prepare patch bytes for pod %v: %v", pod, err)
 	}
-	r.eventRecorder.Eventf(pod, v1.EventTypeNormal, expectedCondition.Reason, expectedCondition.Message)
+	r.eventRecorder.Event(pod, v1.EventTypeNormal, expectedCondition.Reason, expectedCondition.Message)
 	_, _, err = patchPodStatus(r.client, pod.Namespace, pod.Name, patchBytes, r.negMetrics)
 	return err
 }

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -780,7 +780,7 @@ func checkEndpointBatchErr(err error, operation transactionOp) error {
 
 func (s *transactionSyncer) recordEvent(eventType, reason, eventDesc string) {
 	if svc := getService(s.serviceLister, s.Namespace, s.Name, s.logger, s.negMetrics); svc != nil {
-		s.recorder.Eventf(svc, eventType, reason, eventDesc)
+		s.recorder.Event(svc, eventType, reason, eventDesc)
 	}
 }
 

--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -240,7 +240,7 @@ func (c *Controller) handleErr(err error, key interface{}) {
 		c.logger.Info("failed to retrieve service attachment from the store", "serviceKey", key.(string), "err", err)
 	} else if exists {
 		svcAttachment := obj.(*sav1.ServiceAttachment)
-		c.recorder(svcAttachment.Namespace).Eventf(svcAttachment, v1.EventTypeWarning, "ProcessServiceAttachmentFailed", eventMsg)
+		c.recorder(svcAttachment.Namespace).Event(svcAttachment, v1.EventTypeWarning, "ProcessServiceAttachmentFailed", eventMsg)
 	}
 	c.svcAttachmentQueue.AddRateLimited(key)
 }
@@ -429,7 +429,7 @@ func (c *Controller) processServiceAttachment(key string) error {
 
 	if err == nil {
 		c.recorder(svcAttachment.Namespace).Eventf(svcAttachment, v1.EventTypeNormal, "ServiceAttachmentCreated",
-			fmt.Sprintf("Service Attachment %s was successfully created.", updatedCR.Status.ServiceAttachmentURL))
+			"Service Attachment %s was successfully created.", updatedCR.Status.ServiceAttachmentURL)
 	}
 
 	return err
@@ -491,7 +491,7 @@ func (c *Controller) deleteServiceAttachment(sa *sav1.ServiceAttachment) {
 	if err = c.ensureDeleteGCEServiceAttachment(gceName); err != nil {
 		eventMsg := fmt.Sprintf("Failed to Garbage Collect Service Attachment %s/%s: %q", sa.Namespace, sa.Name, err)
 		c.logger.Error(err, eventMsg)
-		c.recorder(sa.Namespace).Eventf(sa, v1.EventTypeWarning, SvcAttachmentGCError, eventMsg)
+		c.recorder(sa.Namespace).Event(sa, v1.EventTypeWarning, SvcAttachmentGCError, eventMsg)
 		return
 	}
 	c.logger.V(2).Info("Deleted Service Attachment", "attachmentName", gceName)
@@ -500,7 +500,7 @@ func (c *Controller) deleteServiceAttachment(sa *sav1.ServiceAttachment) {
 	if err = c.ensureSAFinalizerRemoved(sa); err != nil {
 		eventMsg := fmt.Sprintf("Failed to remove finalizer on ServiceAttachment %s/%s: %q", sa.Namespace, sa.Name, err)
 		c.logger.Error(err, eventMsg)
-		c.recorder(sa.Namespace).Eventf(sa, v1.EventTypeWarning, SvcAttachmentGCError, eventMsg)
+		c.recorder(sa.Namespace).Event(sa, v1.EventTypeWarning, SvcAttachmentGCError, eventMsg)
 		return
 	}
 	c.logger.V(2).Info("Removed finalizer on Service Attachment", "attachmentName", klog.KRef(sa.Namespace, sa.Name))

--- a/pkg/throttling/strategy.go
+++ b/pkg/throttling/strategy.go
@@ -241,16 +241,16 @@ func NewDynamicStrategy(
 	noRequestsTimeoutBeforeResettingDelay time.Duration,
 	clock clock.Clock) (Strategy, error) {
 	if successesBeforeDecreasingDelay > successesBeforeResettingDelay {
-		return nil, fmt.Errorf("%s: successesBeforeDecreasingDelay=%q should not be greater than successesBeforeResettingDelay=%q", creationErrMsg, successesBeforeDecreasingDelay, successesBeforeResettingDelay)
+		return nil, fmt.Errorf("%s: successesBeforeDecreasingDelay=%d should not be greater than successesBeforeResettingDelay=%d", creationErrMsg, successesBeforeDecreasingDelay, successesBeforeResettingDelay)
 	}
 	if errorsBeforeIncreasingDelay <= 0 {
-		return nil, fmt.Errorf("%s: errorsBeforeIncreasingDelay=%q should be positive", creationErrMsg, errorsBeforeIncreasingDelay)
+		return nil, fmt.Errorf("%s: errorsBeforeIncreasingDelay=%d should be positive", creationErrMsg, errorsBeforeIncreasingDelay)
 	}
 	if successesBeforeDecreasingDelay <= 0 {
-		return nil, fmt.Errorf("%s: successesBeforeDecreasingDelay=%q should be positive", creationErrMsg, successesBeforeDecreasingDelay)
+		return nil, fmt.Errorf("%s: successesBeforeDecreasingDelay=%d should be positive", creationErrMsg, successesBeforeDecreasingDelay)
 	}
 	if successesBeforeResettingDelay <= 0 {
-		return nil, fmt.Errorf("%s: successesBeforeResettingDelay=%q should be positive", creationErrMsg, successesBeforeResettingDelay)
+		return nil, fmt.Errorf("%s: successesBeforeResettingDelay=%d should be positive", creationErrMsg, successesBeforeResettingDelay)
 	}
 	strategy, err := NewTwoWayStrategy(minDelay, maxDelay, noRequestsTimeoutBeforeDecreasingDelay, noRequestsTimeoutBeforeResettingDelay, clock)
 	if err != nil {


### PR DESCRIPTION
…s in go1.26 (code won't build without fixing this on go 1.26)

This is done in preparation for k8s 1.36 that requires go 1.26.