### PR TITLE
Skip empty `networking.gke.io/load-balancer-ip-addresses: ''`

### DIFF
--- a/pkg/l4/annotations/l4_static_address.go
+++ b/pkg/l4/annotations/l4_static_address.go
@@ -51,6 +51,9 @@ func ipAddressFromAnnotation(svc *Service, cloud *gce.Cloud, ipVersion string) (
 
 	for _, addressName := range addressNames {
 		trimmedAddressName := strings.TrimSpace(addressName)
+		if trimmedAddressName == "" {
+			continue
+		}
 		cloudAddress, err := cloud.GetRegionAddress(trimmedAddressName, cloud.Region())
 		if err != nil {
 			if isNotFoundError(err) {

--- a/pkg/l4/annotations/l4_static_address_test.go
+++ b/pkg/l4/annotations/l4_static_address_test.go
@@ -79,6 +79,20 @@ func TestAddressFromAnnotation(t *testing.T) {
 			wantIPv6Address:   "",
 		},
 		{
+			desc:              "Empty annotation",
+			reservedAddresses: []compute.Address{},
+			annotationVal:     "",
+			wantIPv4Address:   "",
+			wantIPv6Address:   "",
+		},
+		{
+			desc:              "Whitespace with comas",
+			reservedAddresses: []compute.Address{},
+			annotationVal:     " , , ,    ,,",
+			wantIPv4Address:   "",
+			wantIPv6Address:   "",
+		},
+		{
 			desc: "Repeated existing IPv4 addresses",
 			reservedAddresses: []compute.Address{
 				ipv4Address,
@@ -102,7 +116,6 @@ func TestAddressFromAnnotation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Current implementation leads to `Error ensuring Resource for L4 External LoadBalancer, err: failed to ensure forwarding rule - json: invalid use of ,string struct tag, trying to unmarshal "projects/xxx/regions/us-central1/addresses/" into uint64`.

I wanted to return an error if it is empty, however based on the already existing implementation we ignore Not Found errors. So it would be fitting if we did the same if no address was specified. So after the change we treat this as if there was no annotation in place and create a new IP address without any failures.

The tests don't capture the error well, the json is burried somewhere deep inside the real implementation which is not present in the fake. I checked it manually.