### PR TITLE
Update cloudbuild.yaml to use a newer builder image.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_8
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2
   id: push-images
   entrypoint: bash
   env:
@@ -19,8 +19,8 @@ steps:
   - |
     # Build and push every image except the e2e-test ones 
     make all-push ALL_ARCH="amd64 arm64" \
-      CONTAINER_BINARIES="glbc 404-server 404-server-with-metrics echo fuzzer"
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+      CONTAINER_BINARIES="glbc 404-server-with-metrics echo"
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2
   id: push-e2e-test-image
   entrypoint: bash
   env:


### PR DESCRIPTION
The old image is no longer present in the repository. Also it seems that there are no tags in that repository anymore.