### PR TITLE
Fix concurrent map writes panic in GCEFake by using a mutex in GCEForProviderConfig

### DIFF
--- a/pkg/multiproject/common/gce/fake.go
+++ b/pkg/multiproject/common/gce/fake.go
@@ -2,6 +2,7 @@ package gce
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -13,6 +14,7 @@ import (
 )
 
 type GCEFake struct {
+	mu                        sync.Mutex
 	defaultTestClusterValues  cloudgce.TestClusterValues
 	clientsForProviderConfigs map[string]*cloudgce.Cloud
 }
@@ -31,6 +33,8 @@ func providerConfigKey(providerConfig *v1.ProviderConfig) string {
 // GCEForProviderConfig returns a new Fake GCE client for the given provider config.
 // It stores the client in the GCEFake and returns it if the same provider config is requested again.
 func (g *GCEFake) GCEForProviderConfig(providerConfig *v1.ProviderConfig, logger klog.Logger) (*cloudgce.Cloud, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	pcKey := providerConfigKey(providerConfig)
 	if g.clientsForProviderConfigs[pcKey] != nil {
 		return g.clientsForProviderConfigs[pcKey], nil


### PR DESCRIPTION
# Root Cause Analysis: Concurrent Map Writes Panic in `GCEFake`

This document provides a detailed root cause analysis (RCA) for the `concurrent map writes` panic observed in the multi-project test package, the fix applied, and the validation results.

---

## Problem Statement

In the multi-project test package, tests such as `TestStartProviderConfigIntegration` would intermittently fail or panic with a fatal Go runtime error under parallel/sequential execution load:

```
fatal error: concurrent map writes

goroutine 267 [running]:
internal/runtime/maps.fatal({0x44a88ef?, 0x3c12420?})
k8s.io/ingress-gce/pkg/multiproject/common/gce.(*GCEFake).GCEForProviderConfig()
    /go/src/k8s.io/ingress-gce/pkg/multiproject/common/gce/fake.go:58 +0x52a
```

---

## Root Cause Analysis

### 1. Concurrent Map Access without Synchronization
* **Symptom**: The test panics with `fatal error: concurrent map writes`.
* **Root Cause**: The `GCEFake` struct maintains a `clientsForProviderConfigs` map (`map[string]*cloudgce.Cloud`) to cache mock GCE clients for each `ProviderConfig`. Go maps are not safe for concurrent read and write operations.
* **Execution Flow triggering the Data Race**:
  1. The `TestStartProviderConfigIntegration` test creates multiple `ProviderConfig` resources.
  2. The background ProviderConfig controller processes these events concurrently using its worker pool (`numWorkers=5`).
  3. Multiple workers execute `StartControllersForProviderConfig` at the exact same time.
  4. These workers concurrently call `GCEForProviderConfig` to instantiate and store the mock GCE client for each ProviderConfig:
     ```go
     g.clientsForProviderConfigs[pcKey] = fakeCloud
     ```
  5. This concurrent write to the `clientsForProviderConfigs` map causes a fatal panic.
* **Impact**: Intermittent test execution panic causing tests to fail.

---

## Resolution Applied

We added a `sync.Mutex` to the `GCEFake` struct and synchronized all accesses to the `clientsForProviderConfigs` map in `GCEForProviderConfig`:

```go
type GCEFake struct {
	mu                        sync.Mutex
	defaultTestClusterValues  cloudgce.TestClusterValues
	clientsForProviderConfigs map[string]*cloudgce.Cloud
}

func (g *GCEFake) GCEForProviderConfig(providerConfig *v1.ProviderConfig, logger klog.Logger) (*cloudgce.Cloud, error) {
	g.mu.Lock()
	defer g.mu.Unlock()
	pcKey := providerConfigKey(providerConfig)
	if g.clientsForProviderConfigs[pcKey] != nil {
		return g.clientsForProviderConfigs[pcKey], nil
	}
    ...
	g.clientsForProviderConfigs[pcKey] = fakeCloud
	return fakeCloud, nil
}
```
This ensures that map reads and writes are strictly synchronized across all worker goroutines.

---

## Validation Results

### 1. Baseline (Original Code)
We ran **5 iterations** of the test with the Go race detector (`-race`) enabled. The race detector immediately flagged multiple data race warnings on `clientsForProviderConfigs` map write operations:

```
WARNING: DATA RACE
Write at 0x00c000a14060 by goroutine 308:
  k8s.io/ingress-gce/pkg/multiproject/common/gce.(*GCEFake).GCEForProviderConfig()
      /usr/local/google/home/zxinyi/Workspace/ingress-gce/pkg/multiproject/common/gce/fake.go:58 +0x824
```

### 2. After Applying Fix (Mutex Synchronization)
We ran **5 iterations** of the test with the Go race detector (`-race`) enabled with our mutex fix applied:
* **Data Races on GCEFake map**: **0 data races** (100% resolved).
* **Data Races on clientsForProviderConfigs**: **0 data races** (100% resolved).
* **Test Execution Outcome**: **All tests passed reliably**.
