### PR TITLE
[Cherrypick #3096 #3097 #3105 to release-1.37] Cloud build improvements for tagging images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,7 +39,9 @@ steps:
     # This image is built separately because it has
     # additional dependencies (curl, gcloud-cli), and
     # requires `docker buildx` for multiarch building process
-    gcloud auth configure-docker  \
+    # also install jq for manifest parsing
+    apk add --no-cache jq \
+    && gcloud auth configure-docker  \
     && ./hack/push-multiarch.sh
 substitutions:
   _GIT_TAG: "12345"

--- a/hack/push-multiarch.sh
+++ b/hack/push-multiarch.sh
@@ -45,14 +45,15 @@ docker buildx install
 docker buildx create --use
 
 # Download crane cli
-curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.15.2/go-containerregistry_$(uname -s)_$(uname -m).tar.gz" | tar xvzf - krane
+curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_$(uname -s)_$(uname -m).tar.gz" | tar xvzf - krane
 
 for binary in ${BINARIES}
 do
     # "arm64 amd64" ---> "linux/arm64,linux/amd64"
     PLATFORMS="linux/$(echo ${ALL_ARCH} | sed 's~ ~,linux/~g')"
     echo "docker buildx platform parameters: ${PLATFORMS}"
-    MULTIARCH_IMAGE="${REGISTRY}/ingress-gce-${binary}:${VERSION}"
+    BIN_IMG_REGISTRY=${REGISTRY}/ingress-gce-${binary}
+    MULTIARCH_IMAGE="${BIN_IMG_REGISTRY}:${VERSION}"
     echo "building ${MULTIARCH_IMAGE} image.."
 
     tags="--tag ${MULTIARCH_IMAGE}"
@@ -66,6 +67,58 @@ do
         ${tags} \
         -f Dockerfile.${binary} .
     echo "done, pushed $MULTIARCH_IMAGE image"
+
+    # read the manifest to tag all arch specific images
+    # the manifest is parsed to extract the digests of the per arch images plus
+    # the attestation manifests.
+    # the extracted digests are then used to tag the images so that later
+    # cleanup can work reliably
+    MANIFEST_JSON=$(./krane manifest "$MULTIARCH_IMAGE")
+
+    if [[ $? -ne 0 ]]; then
+      echo "Error: Failed to fetch manifest for $MULTIARCH_IMAGE"
+      exit 1
+    fi
+
+    if [[ -z "$MANIFEST_JSON" ]]; then
+      echo "Error: Manifest for $MULTIARCH_IMAGE is empty"
+      exit 1
+    fi
+
+    # --- Extract digests using jq ---
+    # Process substitution is used to feed the variable content to jq
+    AMD64_DIGEST=$(jq -r '.manifests[] | select(.platform.architecture == "amd64").digest' <<< "$MANIFEST_JSON")
+    ARM64_DIGEST=$(jq -r '.manifests[] | select(.platform.architecture == "arm64").digest' <<< "$MANIFEST_JSON")
+
+    # Extract all attestation digests into a bash array
+    readarray -t ATTESTATION_DIGESTS < <(jq -r '.manifests[] | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest").digest' <<< "$MANIFEST_JSON")
+
+    # Extract attestation digests based on the image they reference
+    ATTESTATION_FOR_AMD64_DIGEST=$(jq -r '.manifests[] | select(.annotations["vnd.docker.reference.digest"] == "'"$AMD64_DIGEST"'").digest' <<< "$MANIFEST_JSON")
+    ATTESTATION_FOR_ARM64_DIGEST=$(jq -r '.manifests[] | select(.annotations["vnd.docker.reference.digest"] == "'"$ARM64_DIGEST"'").digest' <<< "$MANIFEST_JSON")
+
+    # --- Output the variables ---
+    echo "--- Extracted Digests ---"
+    echo "MULTIARCH_IMAGE=$MULTIARCH_IMAGE"
+    echo "AMD64_DIGEST=$AMD64_DIGEST"
+    echo "ARM64_DIGEST=$ARM64_DIGEST"
+
+    echo "ATTESTATION_FOR_AMD64_DIGEST=$ATTESTATION_FOR_AMD64_DIGEST"
+    echo "ATTESTATION_FOR_ARM64_DIGEST=$ATTESTATION_FOR_ARM64_DIGEST"
+
+    if [[ -n "$AMD64_DIGEST" ]]; then
+      ./krane tag "$BIN_IMG_REGISTRY@$AMD64_DIGEST" "${VERSION}-amd64"
+    fi
+    if [[ -n "$ARM64_DIGEST" ]]; then
+      ./krane tag "$BIN_IMG_REGISTRY@$ARM64_DIGEST" "${VERSION}-arm64"
+    fi
+    if [[ -n "$ATTESTATION_FOR_AMD64_DIGEST" ]]; then
+      ./krane tag "$BIN_IMG_REGISTRY@$ATTESTATION_FOR_AMD64_DIGEST" "${VERSION}-amd64-attestation"
+    fi
+    if [[ -n "$ATTESTATION_FOR_ARM64_DIGEST" ]]; then
+      ./krane tag "$BIN_IMG_REGISTRY@$ATTESTATION_FOR_ARM64_DIGEST" "${VERSION}-arm64-attestation"
+    fi
+
 
    # Tag arch specific images for the legacy registries
    for arch in ${ALL_ARCH}

--- a/hack/push-multiarch.sh
+++ b/hack/push-multiarch.sh
@@ -47,6 +47,22 @@ docker buildx create --use
 # Download crane cli
 curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_$(uname -s)_$(uname -m).tar.gz" | tar xvzf - krane
 
+# function that tags the specified digest with ADDITIONAL_TAGS with suffixes
+tag_image_variant() {
+  local digest="$1"
+  local suffix="$2"
+
+  if [[ -z "$digest" ]]; then
+    return
+  fi
+
+  ./krane tag "$BIN_IMG_REGISTRY@$digest" "${VERSION}-${suffix}"
+  for tag in ${ADDITIONAL_TAGS}
+  do
+    ./krane tag "$BIN_IMG_REGISTRY@$digest" "${tag}-${suffix}"
+  done
+}
+
 for binary in ${BINARIES}
 do
     # "arm64 amd64" ---> "linux/arm64,linux/amd64"
@@ -106,18 +122,10 @@ do
     echo "ATTESTATION_FOR_AMD64_DIGEST=$ATTESTATION_FOR_AMD64_DIGEST"
     echo "ATTESTATION_FOR_ARM64_DIGEST=$ATTESTATION_FOR_ARM64_DIGEST"
 
-    if [[ -n "$AMD64_DIGEST" ]]; then
-      ./krane tag "$BIN_IMG_REGISTRY@$AMD64_DIGEST" "${VERSION}-amd64"
-    fi
-    if [[ -n "$ARM64_DIGEST" ]]; then
-      ./krane tag "$BIN_IMG_REGISTRY@$ARM64_DIGEST" "${VERSION}-arm64"
-    fi
-    if [[ -n "$ATTESTATION_FOR_AMD64_DIGEST" ]]; then
-      ./krane tag "$BIN_IMG_REGISTRY@$ATTESTATION_FOR_AMD64_DIGEST" "${VERSION}-amd64-attestation"
-    fi
-    if [[ -n "$ATTESTATION_FOR_ARM64_DIGEST" ]]; then
-      ./krane tag "$BIN_IMG_REGISTRY@$ATTESTATION_FOR_ARM64_DIGEST" "${VERSION}-arm64-attestation"
-    fi
+    tag_image_variant "$AMD64_DIGEST" "amd64"
+    tag_image_variant "$ARM64_DIGEST" "arm64"
+    tag_image_variant "$ATTESTATION_FOR_AMD64_DIGEST" "amd64-attestation"
+    tag_image_variant "$ATTESTATION_FOR_ARM64_DIGEST" "arm64-attestation"
 
 
    # Tag arch specific images for the legacy registries


### PR DESCRIPTION
This change does not affect the binary image, only tagging of test only images so can be safely backported and does not require a release