### PR TITLE
fix: classify GCE 403 Forbidden firewall errors as user errors

### DIFF
--- a/pkg/l4/resources/user_error.go
+++ b/pkg/l4/resources/user_error.go
@@ -21,6 +21,7 @@ func IsUserError(err error) bool {
 		utils.IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
 		utils.IsUnsupportedNetworkTierError(err) ||
 		utils.IsConstraintViolationError(err) ||
+		utils.IsFirewallForbiddenError(err) ||
 		errors.As(err, &firewallErr) ||
 		errors.As(err, &userErr)
 }

--- a/pkg/l4/resources/user_error_test.go
+++ b/pkg/l4/resources/user_error_test.go
@@ -68,6 +68,10 @@ func TestIsUserError(t *testing.T) {
 			err:  &googleapi.Error{Code: 400, Message: "Requested internal IP address is outside the network/subnetwork range"},
 			want: true,
 		},
+		{
+			err:  &googleapi.Error{Code: 403, Message: "Required 'compute.firewalls.get' permission for 'projects/.../global/firewalls/...', forbidden"},
+			want: true,
+		},
 	}
 	for _, tC := range testCases {
 		tC := tC

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -273,6 +273,11 @@ func IsConstraintViolationError(err error) bool {
 	return IsHTTPErrorCode(err, http.StatusPreconditionFailed) && strings.Contains(err.Error(), "Constraint") && strings.Contains(err.Error(), "violated")
 }
 
+// IsFirewallForbiddenError checks if error is a GCE firewall forbidden error (e.g. missing IAM permission).
+func IsFirewallForbiddenError(err error) bool {
+	return IsHTTPErrorCode(err, http.StatusForbidden) && strings.Contains(strings.ToLower(err.Error()), "compute.firewalls")
+}
+
 // IsIPConfigurationError checks if wrapped error is an IP configuration error.
 func IsIPConfigurationError(err error) bool {
 	var ipConfigError *IPConfigurationError

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1954,3 +1954,55 @@ func TestIsIPOutOfRangeError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFirewallForbiddenError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			desc: "other error",
+			err:  fmt.Errorf("some error"),
+			want: false,
+		},
+		{
+			desc: "forbidden error but not firewall related",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Message: "Access denied to resources"},
+			want: false,
+		},
+		{
+			desc: "firewall error but not forbidden",
+			err:  &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for 'compute.firewalls' resource"},
+			want: false,
+		},
+		{
+			desc: "generic firewall forbidden without compute.firewalls prefix",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Message: "Forbidden access to firewall rules"},
+			want: false,
+		},
+		{
+			desc: "forbidden and compute.firewalls.get permission related",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Message: "Required 'compute.firewalls.get' permission for 'projects/.../global/firewalls/...', forbidden"},
+			want: true,
+		},
+		{
+			desc: "forbidden and compute.firewalls.create permission related",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Message: "Required 'compute.firewalls.create' permission for 'projects/.../global/firewalls/...', forbidden"},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := utils.IsFirewallForbiddenError(tc.err); got != tc.want {
+				t.Errorf("IsFirewallForbiddenError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Classifies raw GCE `403 Forbidden` errors on firewall resources (e.g., missing `compute.firewalls.get` IAM permissions or Shared VPC setup issues) as User Errors instead of system errors.

This stops active requeuing loops and loud error-level logs on permission-related sync failures, preventing false-positive SLO burns for L4 ILB availability.

What was changed:
- pkg/utils: Added IsFirewallForbiddenError utility and corresponding unit tests.
- pkg/l4/resources: Integrated IsFirewallForbiddenError into IsUserError and added unit tests.