### PR TITLE
Reduce very noisy logs that bring very little benefit for debugging.

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -788,7 +788,7 @@ func collectLockAvailabilityMetrics(lockName, clusterType string, stopCh <-chan 
 			return
 		case <-ticker.C:
 			app.PublishLockAvailabilityMetrics(lockName, clusterType)
-			lockLogger.Info("Exported resource lock availability metrics")
+			lockLogger.V(6).Info("Exported resource lock availability metrics")
 		}
 	}
 }

--- a/pkg/systemhealth/systemhealth.go
+++ b/pkg/systemhealth/systemhealth.go
@@ -40,11 +40,17 @@ func (sh *SystemHealth) HealthCheck() HealthCheckResults {
 	defer sh.hcLock.Unlock()
 
 	healthChecks := make(map[string]error)
+	anyFailed := false
 	for component, f := range sh.healthChecks {
-		sh.logger.Info("Running health check", "component", component)
-		healthChecks[component] = f()
+		sh.logger.V(5).Info("Running health check", "component", component)
+		result := f()
+		healthChecks[component] = result
+		if result != nil {
+			anyFailed = true
+		}
 	}
-
-	sh.logger.Info("Health check results", "results", healthChecks)
+	if anyFailed {
+		sh.logger.Info("Health check results", "results", healthChecks)
+	}
 	return healthChecks
 }


### PR DESCRIPTION
The resource lock export log was emitted every second and doesnt bring any signal. The Health messages were emitted very often - changed that one to log only if there is a failed check.