### PR TITLE
Add mixed protocol NetLB IPv4 support via L3 Forwarding Rule

### DIFF
--- a/pkg/l4/forwardingrules/netlb_mixed_manager.go
+++ b/pkg/l4/forwardingrules/netlb_mixed_manager.go
@@ -46,11 +46,12 @@ type Provider interface {
 // MixedManagerNetLB is responsible for Ensuring and Deleting Forwarding Rules
 // for mixed protocol NetLBs.
 type MixedManagerNetLB struct {
-	Namer    Namer
-	Provider Provider
-	Recorder record.EventRecorder
-	Logger   logr.Logger
-	Cloud    *gce.Cloud
+	Namer            Namer
+	Provider         Provider
+	Recorder         record.EventRecorder
+	Logger           logr.Logger
+	Cloud            *gce.Cloud
+	L3DefaultEnabled bool
 
 	Service *api_v1.Service
 }
@@ -59,6 +60,7 @@ type MixedManagerNetLB struct {
 type EnsureNetLBResult struct {
 	UDPFwdRule *composite.ForwardingRule
 	TCPFwdRule *composite.ForwardingRule
+	L3FwdRule  *composite.ForwardingRule
 	IPManaged  address.IPAddressType
 	SyncStatus utils.ResourceSyncStatus
 }
@@ -85,7 +87,7 @@ func (m *MixedManagerNetLB) EnsureIPv4(backendServiceLink string) (EnsureNetLBRe
 		Recorder:              m.Recorder,
 		Logger:                m.Logger,
 		Service:               m.Service,
-		ExistingRules:         []*composite.ForwardingRule{existing.Legacy, existing.TCP, existing.UDP},
+		ExistingRules:         []*composite.ForwardingRule{existing.Legacy, existing.TCP, existing.UDP, existing.L3},
 		ForwardingRuleDeleter: m.Provider,
 	})
 	if err != nil {
@@ -102,6 +104,32 @@ func (m *MixedManagerNetLB) EnsureIPv4(backendServiceLink string) (EnsureNetLBRe
 	// We need to delete legacy named forwarding rule to avoid port collisions
 	if err := m.deleteLegacy(); err != nil {
 		return res, err
+	}
+
+	if m.L3DefaultEnabled {
+		res.L3FwdRule, res.SyncStatus, err = m.ensure(existing.L3, backendServiceLink, "L3_DEFAULT", addressHandle.IP)
+		if err != nil {
+			return res, err
+		}
+
+		haveToDeleteSplitRules := existing.TCP != nil || existing.UDP != nil
+		if haveToDeleteSplitRules {
+			m.Logger.Info("TCP and UDP forwarding rules are present, deleting them in favor of L3_DEFAULT rule")
+			res.SyncStatus = utils.ResourceUpdate
+			if err := m.deleteExistingSplit(existing); err != nil {
+				return res, err
+			}
+		}
+
+		return res, nil
+	}
+
+	if existing.L3 != nil {
+		m.Logger.Info("L3 forwarding rule is present, deleting it in favor of split TCP and UDP rules")
+		res.SyncStatus = utils.ResourceUpdate
+		if err := m.delete("l3"); err != nil {
+			return res, err
+		}
 	}
 
 	var tcpErr, udpErr error
@@ -210,21 +238,27 @@ func (m *MixedManagerNetLB) buildWanted(backendServiceLink, name, protocol, ip s
 	const version = meta.VersionGA
 	const scheme = string(cloud.SchemeExternal)
 	protocol = strings.ToUpper(protocol)
-	if protocol != "TCP" && protocol != "UDP" {
-		return nil, fmt.Errorf("Unknown protocol %s, expected TCP or UDP", protocol)
+	if protocol != "TCP" && protocol != "UDP" && protocol != "L3_DEFAULT" {
+		return nil, fmt.Errorf("unknown protocol %s, expected TCP, UDP or L3_DEFAULT", protocol)
 	}
 
 	svcKey := utils.ServiceKeyFunc(m.Service.Namespace, m.Service.Name)
 	desc, err := utils.MakeL4LBServiceDescription(svcKey, ip, version, false, utils.XLB)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to compute description for forwarding rule %s, err: %w", name, err)
+		return nil, fmt.Errorf("failed to compute description for forwarding rule %s, err: %w", name, err)
 	}
 
 	ports := GetPorts(m.Service.Spec.Ports, api_v1.Protocol(protocol))
 	var portRange string
+	var allPorts bool
 	if len(ports) > maxForwardedPorts {
 		portRange = utils.MinMaxPortRange(ports)
 		ports = nil
+	}
+	if protocol == "L3_DEFAULT" {
+		allPorts = true
+		ports = nil
+		portRange = ""
 	}
 
 	netTier, _ := annotations.NetworkTier(m.Service)
@@ -236,6 +270,7 @@ func (m *MixedManagerNetLB) buildWanted(backendServiceLink, name, protocol, ip s
 		IPProtocol:          protocol,
 		Ports:               ports,
 		PortRange:           portRange,
+		AllPorts:            allPorts,
 		LoadBalancingScheme: scheme,
 		BackendService:      backendServiceLink,
 		NetworkTier:         netTier.ToGCEValue(),
@@ -264,6 +299,8 @@ type NetLBManagedRules struct {
 	TCP *composite.ForwardingRule
 	// UDP forwarding rule with '-udp-' in a name
 	UDP *composite.ForwardingRule
+	// L3 named forwarding rule with '-l3-' in a name
+	L3 *composite.ForwardingRule
 	// Legacy named forwarding rule (staring with 'a')
 	Legacy *composite.ForwardingRule
 }
@@ -271,10 +308,10 @@ type NetLBManagedRules struct {
 // AllRules returns all forwarding rules for a service specified in the manager
 func (m *MixedManagerNetLB) AllRules() (NetLBManagedRules, error) {
 	var wg sync.WaitGroup
-	var tcp, udp, legacy *composite.ForwardingRule
-	var tcpErr, udpErr, legacyErr error
+	var tcp, udp, l3, legacy *composite.ForwardingRule
+	var tcpErr, udpErr, l3Err, legacyErr error
 
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		tcp, tcpErr = m.Provider.Get(m.name("tcp"))
@@ -285,20 +322,24 @@ func (m *MixedManagerNetLB) AllRules() (NetLBManagedRules, error) {
 	}()
 	go func() {
 		defer wg.Done()
+		l3, l3Err = m.Provider.Get(m.name("l3"))
+	}()
+	go func() {
+		defer wg.Done()
 		legacy, legacyErr = m.Provider.Get(m.nameLegacy())
 	}()
 	wg.Wait()
 
 	return NetLBManagedRules{
-		TCP: tcp, UDP: udp, Legacy: legacy,
-	}, errors.Join(tcpErr, udpErr, legacyErr)
+		TCP: tcp, UDP: udp, L3: l3, Legacy: legacy,
+	}, errors.Join(tcpErr, udpErr, l3Err, legacyErr)
 }
 
 // DeleteIPv4 will try to delete forwarding rules for mixed protocol NetLB service.
 func (m *MixedManagerNetLB) DeleteIPv4() error {
 	var wg sync.WaitGroup
-	var tcpErr, udpErr error
-	wg.Add(2)
+	var tcpErr, udpErr, l3Err error
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -307,6 +348,62 @@ func (m *MixedManagerNetLB) DeleteIPv4() error {
 	go func() {
 		defer wg.Done()
 		udpErr = m.delete("udp")
+	}()
+	go func() {
+		defer wg.Done()
+		l3Err = m.delete("l3")
+	}()
+
+	wg.Wait()
+	return errors.Join(tcpErr, udpErr, l3Err)
+}
+
+// DeleteExistingIPv4 will try to delete forwarding rules for mixed protocol NetLB service
+// only if they have been found. This saves a few GCE calls compared to DeleteIPv4.
+func (m *MixedManagerNetLB) DeleteExistingIPv4(haveRules NetLBManagedRules) error {
+	var wg sync.WaitGroup
+	var tcpErr, udpErr, l3Err error
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		if haveRules.TCP != nil {
+			tcpErr = m.delete("tcp")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if haveRules.UDP != nil {
+			udpErr = m.delete("udp")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if haveRules.L3 != nil {
+			l3Err = m.delete("l3")
+		}
+	}()
+
+	wg.Wait()
+	return errors.Join(tcpErr, udpErr, l3Err)
+}
+
+func (m *MixedManagerNetLB) deleteExistingSplit(haveRules NetLBManagedRules) error {
+	var wg sync.WaitGroup
+	var tcpErr, udpErr error
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		if haveRules.TCP != nil {
+			tcpErr = m.delete("tcp")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if haveRules.UDP != nil {
+			udpErr = m.delete("udp")
+		}
 	}()
 
 	wg.Wait()
@@ -326,6 +423,10 @@ func (m *MixedManagerNetLB) deleteLegacy() error {
 }
 
 func (m *MixedManagerNetLB) name(protocol string) string {
+	if strings.EqualFold(protocol, "L3_DEFAULT") {
+		protocol = "l3"
+	}
+
 	return m.Namer.L4ForwardingRule(
 		m.Service.Namespace, m.Service.Name, strings.ToLower(protocol),
 	)

--- a/pkg/l4/forwardingrules/netlb_mixed_manager_test.go
+++ b/pkg/l4/forwardingrules/netlb_mixed_manager_test.go
@@ -2,6 +2,8 @@ package forwardingrules_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -13,6 +15,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/l4/forwardingrules"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -32,7 +35,7 @@ const (
 	legacyName    = "aksuid123"
 )
 
-func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
+func TestMixedManagerNetLB_EnsureIPv4_SplitRules(t *testing.T) {
 	startingState := []struct {
 		desc   string
 		tcp    *compute.ForwardingRule
@@ -51,6 +54,17 @@ func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
 				NetworkTier:    "PREMIUM",
 				BackendService: bsLink,
 				Ports:          []string{"80"},
+			},
+		},
+		{
+			desc: "l3 default", // When rolling back from L3 to split rules
+			legacy: &compute.ForwardingRule{
+				Name:           legacyName,
+				IPAddress:      ip,
+				IPProtocol:     "L3_DEFAULT",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				AllPorts:       true,
 			},
 		},
 		{
@@ -108,6 +122,33 @@ func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
 				NetworkTier:    "PREMIUM",
 				BackendService: bsLink,
 				Ports:          []string{"53"},
+			},
+		},
+		{
+			desc: "failed_update_with_leftovers",
+			tcp: &compute.ForwardingRule{
+				Name:           tcpName,
+				IPAddress:      ip,
+				IPProtocol:     "TCP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"80"},
+			},
+			udp: &compute.ForwardingRule{
+				Name:           udpName,
+				IPAddress:      ip,
+				IPProtocol:     "UDP",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				Ports:          []string{"53"},
+			},
+			legacy: &compute.ForwardingRule{
+				Name:           legacyName,
+				IPAddress:      ip,
+				IPProtocol:     "L3_DEFAULT",
+				NetworkTier:    "PREMIUM",
+				BackendService: bsLink,
+				AllPorts:       true,
 			},
 		},
 	}
@@ -183,7 +224,7 @@ func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
 				t.Parallel()
 
 				// Arrange
-				fakeGCE, mgr := arrange(end.ports)
+				fakeGCE, mgr := arrange(end.ports, false)
 				region := fakeGCE.Region()
 				for _, rule := range []*compute.ForwardingRule{start.legacy, start.tcp, start.udp} {
 					if rule != nil {
@@ -212,6 +253,261 @@ func TestMixedManagerNetLB_EnsureIPv4(t *testing.T) {
 	}
 }
 
+func TestMixedManagerNetLB_EnsureIPv4_L3Default(t *testing.T) {
+	t.Parallel()
+
+	l3Rule := &composite.ForwardingRule{
+		Name:                "k8s2-l3-axyqjz2d-test-ns-test-svc-pyn67fp6",
+		IPAddress:           ip,
+		AllPorts:            true,
+		IPProtocol:          "L3_DEFAULT",
+		NetworkTier:         "PREMIUM",
+		Version:             "ga",
+		Scope:               "regional",
+		BackendService:      bsLink,
+		LoadBalancingScheme: "EXTERNAL",
+		Region:              "us-central1",
+		Description:         `{"networking.gke.io/service-name":"test-ns/test-svc","networking.gke.io/api-version":"ga","networking.gke.io/service-ip":"1.2.3.4"}`,
+		SelfLink:            "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/forwardingRules/k8s2-l3-axyqjz2d-test-ns-test-svc-pyn67fp6",
+	}
+
+	startingState := []struct {
+		desc            string
+		forwardingRules []*compute.ForwardingRule
+	}{
+		{
+			desc: "nothing",
+		},
+		{
+			desc: "tcp 80",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           legacyName,
+					IPAddress:      ip,
+					IPProtocol:     "TCP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"80"},
+				},
+			},
+		},
+		{
+			desc: "tcp 80, udp 53",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           tcpName,
+					IPAddress:      ip,
+					IPProtocol:     "TCP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"80"},
+				},
+				{
+					Name:           udpName,
+					IPAddress:      ip,
+					IPProtocol:     "UDP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"53"},
+				},
+			},
+		},
+		{
+			desc: "tcp 80, udp 53,60",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           tcpName,
+					IPAddress:      ip,
+					IPProtocol:     "TCP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"80"},
+				},
+				{
+					Name:           udpName,
+					IPAddress:      ip,
+					IPProtocol:     "UDP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"53", "60"},
+				},
+			},
+		},
+		{
+			desc: "tcp 80,81,82,83,84,85,86, udp 53",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           tcpName,
+					IPAddress:      ip,
+					IPProtocol:     "TCP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					PortRange:      "80-86",
+				},
+				{
+					Name:           udpName,
+					IPAddress:      ip,
+					IPProtocol:     "UDP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"53"},
+				},
+			},
+		},
+		{
+			desc: "l3_default",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           legacyName,
+					IPAddress:      ip,
+					IPProtocol:     "L3_DEFAULT",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					AllPorts:       true,
+				},
+			},
+		},
+		{
+			desc: "failed_update_with_leftovers",
+			forwardingRules: []*compute.ForwardingRule{
+				{
+					Name:           tcpName,
+					IPAddress:      ip,
+					IPProtocol:     "TCP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"80"},
+				},
+				{
+					Name:           udpName,
+					IPAddress:      ip,
+					IPProtocol:     "UDP",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					Ports:          []string{"53"},
+				},
+				{
+					Name:           legacyName,
+					IPAddress:      ip,
+					IPProtocol:     "L3_DEFAULT",
+					NetworkTier:    "PREMIUM",
+					BackendService: bsLink,
+					AllPorts:       true,
+				},
+			},
+		},
+	}
+
+	wantResult := forwardingrules.EnsureNetLBResult{
+		TCPFwdRule: nil,
+		UDPFwdRule: nil,
+		L3FwdRule:  l3Rule,
+		SyncStatus: utils.ResourceUpdate,
+		IPManaged:  address.IPAddrManaged,
+	}
+
+	endState := []struct {
+		desc  string
+		ports []api_v1.ServicePort
+		// want is going to be always the same l3 rule
+	}{
+		{
+			desc: "tcp 80, udp 53",
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     53,
+				},
+			},
+		},
+		{
+			desc: "tcp 80, udp 53,60",
+			ports: []api_v1.ServicePort{
+				{
+					Protocol: api_v1.ProtocolTCP,
+					Port:     80,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     53,
+				},
+				{
+					Protocol: api_v1.ProtocolUDP,
+					Port:     60,
+				},
+			},
+		},
+	}
+
+	for _, start := range startingState {
+		for _, end := range endState {
+			desc := start.desc + " -> " + end.desc
+			start, end := start, end
+			t.Run(desc, func(t *testing.T) {
+				t.Parallel()
+
+				// Arrange
+				fakeGCE, mgr := arrange(end.ports, true)
+				region := fakeGCE.Region()
+				for _, rule := range start.forwardingRules {
+					if rule != nil {
+						if err := fakeGCE.CreateRegionForwardingRule(rule, region); err != nil {
+							t.Fatalf("Couldn't set up forwarding rule %v for test", rule)
+						}
+					}
+				}
+
+				// Act
+				result, err := mgr.EnsureIPv4(bsLink)
+				// Assert
+				if err != nil {
+					t.Errorf("EnsureIPv4() error = %v", err)
+				}
+
+				if diff := cmp.Diff(wantResult, result); diff != "" {
+					t.Errorf("EnsureIPv4() mismatch (-want +got):\n%s", diff)
+				}
+
+				for _, unwantedRuleName := range []string{tcpName, udpName} {
+					_, err := fakeGCE.GetRegionForwardingRule(unwantedRuleName, region)
+					if err == nil || !utils.IsNotFoundError(err) {
+						t.Errorf("fakeGCE.GetRegionForwardingRule(%s) got err %v, want not found err", unwantedRuleName, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestMixedManagerNetLB_EnsureIPv4_Resync verifies that in case of
+// no changes, the resync will not update any resources.
+func TestMixedManagerNetLB_EnsureIPv4_Resync(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	ports := []api_v1.ServicePort{{Protocol: api_v1.ProtocolTCP, Port: 80}, {Protocol: api_v1.ProtocolUDP, Port: 53}}
+	_, mgr := arrange(ports, true)
+	// Run first to create resources
+	if _, err := mgr.EnsureIPv4(bsLink); err != nil {
+		t.Fatalf("EnsureIPv4() error = %v", err)
+	}
+
+	// Act
+	result, err := mgr.EnsureIPv4(bsLink)
+	// Assert
+	if err != nil {
+		t.Fatalf("EnsureIPv4() error = %v", err)
+	}
+
+	if result.SyncStatus != utils.ResourceResync {
+		t.Errorf("EnsureIPv4() sync status = %v, want %v", result.SyncStatus, utils.ResourceResync)
+	}
+}
+
 func fwdRule(name, protocol string, ports []string) *composite.ForwardingRule {
 	return &composite.ForwardingRule{
 		Version:             "ga",
@@ -230,20 +526,20 @@ func fwdRule(name, protocol string, ports []string) *composite.ForwardingRule {
 
 func TestMixedManagerNetLB_EnsureIPv4_SingleProtocol(t *testing.T) {
 	t.Parallel()
-	// Arrange
-	_, mgr := arrange([]api_v1.ServicePort{
-		{
-			Protocol: api_v1.ProtocolTCP,
-			Port:     8080,
-		},
-	})
 
-	// Act
-	_, err := mgr.EnsureIPv4(bsLink)
+	for _, enableL3 := range []bool{false, true} {
+		t.Run(fmt.Sprintf("l3DefaultEnabled=%t", enableL3), func(t *testing.T) {
+			// Arrange
+			_, mgr := arrange([]api_v1.ServicePort{{Protocol: api_v1.ProtocolTCP, Port: 8080}}, enableL3)
 
-	// Assert
-	if err == nil {
-		t.Errorf("Expected to receive error for single protocol service")
+			// Act
+			_, err := mgr.EnsureIPv4(bsLink)
+
+			// Assert
+			if err == nil {
+				t.Errorf("Expected to receive error for single protocol service")
+			}
+		})
 	}
 }
 
@@ -258,7 +554,7 @@ func TestMixedManagerNetLB_AllRules(t *testing.T) {
 			desc: "no rules",
 		},
 		{
-			desc:   "single protocol exists",
+			desc:   "legacy named exists",
 			legacy: &compute.ForwardingRule{Name: legacyName},
 		},
 		{
@@ -266,15 +562,20 @@ func TestMixedManagerNetLB_AllRules(t *testing.T) {
 			tcp:  &compute.ForwardingRule{Name: tcpName},
 			udp:  &compute.ForwardingRule{Name: udpName},
 		},
+		{
+			desc:   "mixed protocol after failed cleanup",
+			tcp:    &compute.ForwardingRule{Name: tcpName},
+			udp:    &compute.ForwardingRule{Name: udpName},
+			legacy: &compute.ForwardingRule{Name: legacyName},
+		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			fakeGCE, mgr := arrange(nil)
+			fakeGCE, mgr := arrange(nil, true)
 			region := fakeGCE.Region()
 			for _, rule := range []*compute.ForwardingRule{tc.tcp, tc.udp, tc.legacy} {
 				if rule != nil {
@@ -301,6 +602,94 @@ func TestMixedManagerNetLB_AllRules(t *testing.T) {
 	}
 }
 
+// TestMixedManagerNetLB_EnsureIPv4_L3ExistsDuringMigration verifies that
+// when there is a mixed protocol service that has been created using split rules
+// (has both TCP and UDP rule) it can be migrated to L3 rule without traffic interruption
+// by creating the L3 rule before TCP and UPD rules are deleted.
+//
+// This can be done thanks to:
+// https://docs.cloud.google.com/load-balancing/docs/network/networklb-backend-service#forwarding-rule-selection
+func TestMixedManagerNetLB_EnsureIPv4_L3ExistsDuringMigration(t *testing.T) {
+	// Arrange
+	fakeGCE, m := arrange([]api_v1.ServicePort{{Protocol: api_v1.ProtocolTCP, Port: 8080}, {Protocol: api_v1.ProtocolUDP, Port: 8080}}, false)
+
+	rt := resourceTracker{}
+
+	mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+	mockGCE.MockForwardingRules.PatchHook = func(ctx context.Context, k *meta.Key, fr *compute.ForwardingRule, mfr *cloud.MockForwardingRules, o ...cloud.Option) error {
+		// For our use case here we should never attempt to modify Forwarding Rules
+		return fmt.Errorf("forwarding rules are immutable")
+	}
+
+	backendServiceLink := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-ai-ml-enabler"
+	res, err := m.EnsureIPv4(backendServiceLink)
+	if err != nil {
+		t.Errorf("EnsureIPv4() error = %v", err)
+	}
+
+	// Check that split rules are present
+	if res.TCPFwdRule == nil || res.UDPFwdRule == nil {
+		t.Errorf("EnsureIPv4() didn't create TCP and UDP forwarding rules, got %v", res)
+	}
+
+	// Check that L3 rule is not present
+	if res.L3FwdRule != nil {
+		t.Errorf("EnsureIPv4() created L3 forwarding rule without the flag enabled, got %v", res)
+	}
+
+	// For the second call with the flag enabled let's monitor order of calls made
+	mockGCE.MockForwardingRules.InsertHook = func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules, options ...cloud.Option) (bool, error) {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		rt.ops = append(rt.ops, operation{name: obj.Name, opType: create})
+		return false, nil
+	}
+	mockGCE.MockForwardingRules.DeleteHook = func(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules, options ...cloud.Option) (bool, error) {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		rt.ops = append(rt.ops, operation{name: key.Name, opType: delete})
+		return false, nil
+	}
+
+	// Act
+	m.L3DefaultEnabled = true
+	res, err = m.EnsureIPv4(backendServiceLink)
+	if err != nil {
+		t.Errorf("EnsureIPv4() error = %v", err)
+	}
+
+	if res.TCPFwdRule != nil || res.UDPFwdRule != nil {
+		t.Errorf("EnsureIPv4() didn't delete TCP and UDP forwarding rules, got %v", res)
+	}
+	if res.L3FwdRule == nil {
+		t.Errorf("EnsureIPv4() didn't create L3 forwarding rule, got %v", res)
+	}
+
+	t.Logf("Ops performed during migration: %v", rt.ops)
+
+	// Check that the L3 rule was created before the TCP and UDP rules were deleted
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	l3CreateIdx := len(rt.ops)
+	for i, op := range rt.ops {
+		if op.name == res.L3FwdRule.Name && op.opType == create {
+			l3CreateIdx = i
+			break
+		}
+	}
+
+	for i, op := range rt.ops {
+		if (op.name == tcpName || op.name == udpName) && op.opType == delete {
+			if i < l3CreateIdx {
+				t.Errorf("TCP or UDP forwarding rule was deleted before creation of L3 forwarding rule, i=%d, ops: %v", i, rt.ops)
+			} else {
+				t.Logf("Found delete op at idx=%d for name=%s, which is after L3 create op at idx=%d", i, op.name, l3CreateIdx)
+			}
+		}
+	}
+}
+
 func TestMixedManagerNetLB_DeleteIPv4(t *testing.T) {
 	testCases := []struct {
 		desc   string
@@ -323,12 +712,11 @@ func TestMixedManagerNetLB_DeleteIPv4(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
 			// Arrange
-			fakeGCE, mgr := arrange(nil)
+			fakeGCE, mgr := arrange(nil, false)
 			region := fakeGCE.Region()
 			for _, rule := range []*compute.ForwardingRule{tc.tcp, tc.udp, tc.legacy} {
 				if rule != nil {
@@ -363,7 +751,7 @@ func TestMixedManagerNetLB_DeleteIPv4(t *testing.T) {
 	}
 }
 
-func arrange(ports []api_v1.ServicePort) (*gce.Cloud, *forwardingrules.MixedManagerNetLB) {
+func arrange(ports []api_v1.ServicePort, l3DefaultEnabled bool) (*gce.Cloud, *forwardingrules.MixedManagerNetLB) {
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
 	mockGCE.MockAddresses.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockAddresses, options ...cloud.Option) (bool, *compute.Address, error) {
@@ -382,11 +770,12 @@ func arrange(ports []api_v1.ServicePort) (*gce.Cloud, *forwardingrules.MixedMana
 	}
 
 	m := &forwardingrules.MixedManagerNetLB{
-		Namer:    namer.NewL4Namer(kubeSystemUID, nil),
-		Provider: forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
-		Recorder: &record.FakeRecorder{},
-		Logger:   klog.TODO(),
-		Cloud:    fakeGCE,
+		Namer:            namer.NewL4Namer(kubeSystemUID, nil),
+		Provider:         forwardingrules.New(fakeGCE, meta.VersionGA, meta.Regional, klog.TODO()),
+		Recorder:         &record.FakeRecorder{},
+		Logger:           klog.TODO(),
+		Cloud:            fakeGCE,
+		L3DefaultEnabled: l3DefaultEnabled,
 		Service: &api_v1.Service{
 			ObjectMeta: meta_v1.ObjectMeta{
 				UID:       kubeSystemUID,
@@ -400,3 +789,22 @@ func arrange(ports []api_v1.ServicePort) (*gce.Cloud, *forwardingrules.MixedMana
 	}
 	return fakeGCE, m
 }
+
+type resourceTracker struct {
+	mu  sync.Mutex
+	ops []operation
+}
+
+type operation struct {
+	name   string
+	opType operationType
+}
+
+// enum for operation type
+type operationType string
+
+const (
+	create operationType = "create"
+	update operationType = "update"
+	delete operationType = "delete"
+)

--- a/pkg/l4/resources/forwarding_rules.go
+++ b/pkg/l4/resources/forwarding_rules.go
@@ -201,7 +201,7 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 		Recorder:              l4netlb.recorder,
 		Logger:                l4netlb.svcLogger,
 		Service:               l4netlb.Service,
-		ExistingRules:         []*composite.ForwardingRule{rules.Legacy, rules.TCP, rules.UDP},
+		ExistingRules:         []*composite.ForwardingRule{rules.Legacy, rules.TCP, rules.UDP, rules.L3},
 		ForwardingRuleDeleter: l4netlb.forwardingRules,
 	})
 	if err != nil {
@@ -217,12 +217,9 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 
 	// Leaving this without feature flag, so after rollback
 	// forwarding rules will be cleaned up
-	mixedRulesExist := rules.TCP != nil || rules.UDP != nil
-	if mixedRulesExist {
-		if err := l4netlb.mixedManager.DeleteIPv4(); err != nil {
-			frLogger.Error(err, "l4netlb.mixedManager.DeleteIPv4 returned an error")
-			return nil, address.IPAddrUndefined, utils.ResourceResync, err
-		}
+	if err := l4netlb.mixedManager.DeleteExistingIPv4(rules); err != nil {
+		frLogger.Error(err, "l4netlb.mixedManager.DeleteExistingIPv4 returned an error")
+		return nil, address.IPAddrUndefined, utils.ResourceResync, err
 	}
 
 	existingFwdRule := rules.Legacy

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -157,12 +157,13 @@ func NewL4NetLB(params *L4NetLBParams, logger klog.Logger) *L4NetLB {
 	logger = logger.WithName("L4NetLBHandler")
 	forwardingRulesProvider := forwardingrules.New(params.Cloud, meta.VersionGA, meta.Regional, logger)
 	mixedManager := &forwardingrules.MixedManagerNetLB{
-		Namer:    params.Namer,
-		Provider: forwardingRulesProvider,
-		Recorder: params.Recorder,
-		Logger:   logger,
-		Cloud:    params.Cloud,
-		Service:  params.Service,
+		Namer:            params.Namer,
+		Provider:         forwardingRulesProvider,
+		Recorder:         params.Recorder,
+		Logger:           logger,
+		Cloud:            params.Cloud,
+		Service:          params.Service,
+		L3DefaultEnabled: params.UseL3DefaultForMixedProtocol,
 	}
 	l4netlb := &L4NetLB{
 		cloud:                              params.Cloud,
@@ -539,6 +540,13 @@ func (l4netlb *L4NetLB) ensureIPv4MixedResources(result *L4NetLBSyncResult, node
 		}
 		ipAddr = res.TCPFwdRule.IPAddress
 	}
+	if res.L3FwdRule != nil {
+		result.Annotations[annotations.L3ForwardingRuleKey] = res.L3FwdRule.Name
+		if res.L3FwdRule.NetworkTier == cloud.NetworkTierPremium.ToGCEValue() {
+			result.MetricsLegacyState.IsPremiumTier = true
+		}
+		ipAddr = res.L3FwdRule.IPAddress
+	}
 
 	l4netlb.ensureIPv4NodesFirewall(nodeNames, ipAddr, result)
 	if result.Error != nil {
@@ -739,7 +747,7 @@ func (l4netlb *L4NetLB) deleteIPv4ResourcesOnDelete(result *L4NetLBSyncResult) {
 // This function does not delete Backend Service and Health Check, because they are shared between IPv4 and IPv6.
 // IPv4 Firewall Rule for Health Check also will not be deleted here, and will be left till the Service Deletion.
 func (l4netlb *L4NetLB) deleteIPv4ResourcesAnnotationBased(result *L4NetLBSyncResult, shouldIgnoreAnnotations bool) {
-	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.TCPForwardingRuleKey) || l4netlb.hasAnnotation(annotations.UDPForwardingRuleKey) {
+	if shouldIgnoreAnnotations || l4netlb.hasAnnotation(annotations.TCPForwardingRuleKey) || l4netlb.hasAnnotation(annotations.UDPForwardingRuleKey) || l4netlb.hasAnnotation(annotations.L3ForwardingRuleKey) {
 		err := l4netlb.deleteIPv4ForwardingRule()
 		if err != nil {
 			l4netlb.svcLogger.Error(err, "Failed to delete forwarding rule for NetLB RBS service")

--- a/pkg/l4/resources/l4netlb_mixed_test.go
+++ b/pkg/l4/resources/l4netlb_mixed_test.go
@@ -65,6 +65,12 @@ func TestEnsureMixedNetLB(t *testing.T) {
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 		},
 		{
+			desc:        "ipv4 mixed l3",
+			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
+			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
+		},
+		{
 			desc:        "ipv6 tcp",
 			resources:   mixedprotocolnetlbtest.IPv6TCPResources(),
 			annotations: mixedprotocolnetlbtest.AnnotationsTCPIPv6(),
@@ -87,7 +93,8 @@ func TestEnsureMixedNetLB(t *testing.T) {
 	endState := []struct {
 		desc string
 		// have
-		spec api_v1.ServiceSpec
+		spec  api_v1.ServiceSpec
+		useL3 bool
 		// want
 		resources   mixedprotocoltest.GCEResources
 		annotations map[string]string
@@ -110,23 +117,48 @@ func TestEnsureMixedNetLB(t *testing.T) {
 			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
 			resources:   mixedprotocolnetlbtest.MixedResources(),
 		},
+		// Test cases below have L3 flag enabled
+		{
+			desc:        "ipv4 tcp l3",
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, nil),
+			annotations: mixedprotocolnetlbtest.AnnotationsTCP(),
+			resources:   mixedprotocolnetlbtest.TCPResources(),
+			useL3:       true,
+		},
+		{
+			desc:        "ipv4 udp l3",
+			spec:        mixedprotocoltest.SpecIPv4(nil, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsUDP(),
+			resources:   mixedprotocolnetlbtest.UDPResources(),
+			useL3:       true,
+		},
+		{
+			desc:        "ipv4 mixed l3",
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedL3(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
+			useL3:       true,
+		},
 		{
 			desc:        "ipv6 tcp",
 			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
 			annotations: mixedprotocolnetlbtest.AnnotationsTCPIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6TCPResources(),
+			useL3:       true,
 		},
 		{
 			desc:        "ipv6 udp",
 			spec:        mixedprotocoltest.SpecIPv6(nil, []int32{53}),
 			resources:   mixedprotocolnetlbtest.IPv6UDPResources(),
 			annotations: mixedprotocolnetlbtest.AnnotationsUDPIPv6(),
+			useL3:       true,
 		},
 		{
 			desc:        "ipv6 mixed",
 			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
 			annotations: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6MixedResources(),
+			useL3:       true,
 		},
 	}
 
@@ -152,7 +184,7 @@ func TestEnsureMixedNetLB(t *testing.T) {
 						},
 					},
 				}
-				l4netlb, fakeGCE := arrangeNetLB(t, s.resources, svc)
+				l4netlb, fakeGCE := arrangeNetLB(t, s.resources, svc, e.useL3)
 
 				result := l4netlb.EnsureFrontend([]string{mixedprotocoltest.TestNode}, svc, time.Now())
 
@@ -186,7 +218,7 @@ func assertNetLBResult(t *testing.T, got, want *L4NetLBSyncResult) {
 	}
 }
 
-func arrangeNetLB(t *testing.T, existing mixedprotocoltest.GCEResources, svc *api_v1.Service) (*L4NetLB, *gce.Cloud) {
+func arrangeNetLB(t *testing.T, existing mixedprotocoltest.GCEResources, svc *api_v1.Service, useL3 bool) (*L4NetLB, *gce.Cloud) {
 	t.Helper()
 	vals := gce.DefaultTestClusterValues()
 	fakeGCE := gce.NewFakeGCECloud(vals)
@@ -206,7 +238,7 @@ func arrangeNetLB(t *testing.T, existing mixedprotocoltest.GCEResources, svc *ap
 		Recorder:                     &record.FakeRecorder{},
 		NetworkResolver:              network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
 		EnableMixedProtocol:          true,
-		UseL3DefaultForMixedProtocol: true,
+		UseL3DefaultForMixedProtocol: useL3,
 		DualStackEnabled:             true,
 	}
 	l4NetLB := NewL4NetLB(params, klog.TODO())
@@ -239,6 +271,7 @@ func TestDeleteMixedNetLB(t *testing.T) {
 		desc        string
 		resources   mixedprotocoltest.GCEResources
 		spec        api_v1.ServiceSpec
+		useL3       bool
 		annotations map[string]string
 		ingress     []api_v1.LoadBalancerIngress
 	}{
@@ -264,20 +297,47 @@ func TestDeleteMixedNetLB(t *testing.T) {
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 		},
 		{
+			desc:        "ipv4 tcp l3 enabled",
+			resources:   mixedprotocolnetlbtest.TCPResources(),
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, nil),
+			annotations: mixedprotocolnetlbtest.AnnotationsTCP(),
+			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
+			useL3:       true,
+		},
+		{
+			desc:        "ipv4 udp l3 enabled",
+			resources:   mixedprotocolnetlbtest.UDPResources(),
+			spec:        mixedprotocoltest.SpecIPv4(nil, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsTCP(),
+			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
+			useL3:       true,
+		},
+		{
+			desc:        "ipv4 mixed l3 enabled",
+			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
+			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedL3(),
+			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
+			useL3:       true,
+		},
+		{
 			desc:        "ipv6 tcp",
 			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
+			useL3:       true,
 			annotations: mixedprotocolnetlbtest.AnnotationsTCPIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6TCPResources(),
 		},
 		{
 			desc:        "ipv6 udp",
 			spec:        mixedprotocoltest.SpecIPv6(nil, []int32{53}),
+			useL3:       true,
 			resources:   mixedprotocolnetlbtest.IPv6UDPResources(),
 			annotations: mixedprotocolnetlbtest.AnnotationsUDPIPv6(),
 		},
 		{
 			desc:        "ipv6 mixed",
 			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
+			useL3:       true,
 			annotations: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6MixedResources(),
 		},
@@ -301,7 +361,7 @@ func TestDeleteMixedNetLB(t *testing.T) {
 					},
 				},
 			}
-			l4NetLB, fakeGCE := arrangeNetLB(t, tc.resources, svc)
+			l4NetLB, fakeGCE := arrangeNetLB(t, tc.resources, svc, tc.useL3)
 
 			result := l4NetLB.EnsureLoadBalancerDeleted(svc)
 
@@ -372,18 +432,17 @@ func TestMixedFlagsTriggerCorrectCodePaths(t *testing.T) {
 			mixedProtocolFlag:                true,
 			wantForwardingRuleAnnotationKeys: []string{annotations.TCPForwardingRuleIPv6Key},
 		},
-		// TODO(TortillaZHawaii): implement this to use L3 forwarding rule
-		// {
-		// 	// With both flags enabled we should have single L3 forwarding rules
-		// 	desc: "on_ipv4_l3",
-		// 	svc: api_v1.Service{
-		// 		ObjectMeta: commonMeta,
-		// 		Spec:       mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
-		// 	},
-		// 	mixedProtocolFlag:                true,
-		// 	useL3Flag:                        true,
-		// 	wantForwardingRuleAnnotationKeys: []string{annotations.L3ForwardingRuleKey},
-		// },
+		{
+			// With both flags enabled we should have single L3 forwarding rules
+			desc: "on_ipv4_l3",
+			svc: api_v1.Service{
+				ObjectMeta: commonMeta,
+				Spec:       mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
+			},
+			mixedProtocolFlag:                true,
+			useL3Flag:                        true,
+			wantForwardingRuleAnnotationKeys: []string{annotations.L3ForwardingRuleKey},
+		},
 		{
 			// With both flags enabled we should have single L3 forwarding rules
 			desc: "on_ipv6_l3",

--- a/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/annotations.go
+++ b/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/annotations.go
@@ -84,6 +84,17 @@ func AnnotationsMixed() map[string]string {
 	}
 }
 
+// AnnotationsMixed returns annotations for mixed protocol NetLB
+func AnnotationsMixedL3() map[string]string {
+	return map[string]string{
+		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
+		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
+		"service.kubernetes.io/backend-service":      "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/l3-forwarding-rule":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/firewall-rule":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+	}
+}
+
 // AnnotationsMixedIPv6 returns annotations for mixed protocol NetLB
 func AnnotationsMixedIPv6() map[string]string {
 	return map[string]string{

--- a/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/resources.go
+++ b/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/resources.go
@@ -106,6 +106,26 @@ func MixedResources() mixedprotocoltest.GCEResources {
 	}
 }
 
+// MixedResourcesL3 returns GCE resources for a mixed protocol IPv4 NetLB, that listens on tcp:80, tcp:443 and udp:53
+func MixedResourcesL3() mixedprotocoltest.GCEResources {
+	return mixedprotocoltest.GCEResources{
+		ForwardingRules: map[string]*compute.ForwardingRule{
+			mixedprotocoltest.ForwardingRuleL3IPv4Name: ForwardingRuleL3(
+				mixedprotocoltest.ForwardingRuleL3IPv4Name,
+			),
+		},
+		Firewalls: map[string]*compute.Firewall{
+			mixedprotocoltest.FirewallIPv4Name: mixedprotocoltest.Firewall([]*compute.FirewallAllowed{
+				{IPProtocol: "udp", Ports: []string{"53"}},
+				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			}),
+			mixedprotocoltest.HealthCheckFirewallIPv4Name: mixedprotocoltest.HealthCheckFirewall(),
+		},
+		HealthCheck:    HealthCheck(),
+		BackendService: BackendService("UNSPECIFIED"),
+	}
+}
+
 // IPv6MixedResources returns GCE resources for a mixed protocol IPv6 NetLB, that listens on tcp:80, tcp:443 and udp:53
 func IPv6MixedResources() mixedprotocoltest.GCEResources {
 	return mixedprotocoltest.GCEResources{
@@ -181,6 +201,20 @@ func ForwardingRuleTCPIPv6(name string, ports []string) *compute.ForwardingRule 
 		LoadBalancingScheme: "EXTERNAL",
 		NetworkTier:         "PREMIUM",
 		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name"}`,
+	}
+}
+
+// ForwardingRuleL3 returns an IPv4 L3 Forwarding Rule
+func ForwardingRuleL3(name string) *compute.ForwardingRule {
+	return &compute.ForwardingRule{
+		Name:                name,
+		Region:              "us-central1",
+		IPProtocol:          "L3_DEFAULT",
+		AllPorts:            true,
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/backendServices/k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		LoadBalancingScheme: "EXTERNAL",
+		NetworkTier:         "PREMIUM",
+		Description:         `{"networking.gke.io/service-name":"test-namespace/test-name","networking.gke.io/api-version":"ga"}`,
 	}
 }
 

--- a/pkg/l4/resources/mixedprotocoltest/resources.go
+++ b/pkg/l4/resources/mixedprotocoltest/resources.go
@@ -85,6 +85,12 @@ func VerifyResourcesExist(t *testing.T, cloud *gce.Cloud, want GCEResources) {
 		ignoreFields := cmpopts.IgnoreFields(compute.ForwardingRule{}, "SelfLink")
 		if diff := cmp.Diff(wantFr, fr, ignoreFields); diff != "" {
 			t.Errorf("Forwarding rule mismatch (-want +got):\n%s", diff)
+			if fr == nil {
+				allFrs, err := cloud.ListRegionForwardingRules(cloud.Region())
+				if err == nil {
+					t.Errorf("Have not found forwarding rule %s. Existing forwarding rules: %+v", frName, allFrs)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds code paths to replace already existing split rules with a single L3 Forwarding Rule which should be hitless (based on observations and https://docs.cloud.google.com/load-balancing/docs/network/networklb-backend-service#forwarding-rule-selection). Change is flag gated, allowing rollbacks from single L3 to split rules as well.

The L3 forwarding rule is using `k8s2-l3-...` naming scheme instead of `auid`. This is done so that it could be potentially used alongside targetpool LB, which uses `auid` naming.

All transitions from {mixed,tcp,udp} x {dualstack, ipv4, ipv6} x {split mixed rules, l3 rule} are supported. Split rules and L3 rule are only relevant to mixed.