### PR TITLE
Use the 'k8s-l3-...-ipv6' names for NetLB Mixed Protocol IPv6

### DIFF
--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -148,7 +148,19 @@ func (l4 *L4) deleteChangedIPv6ForwardingRule(existingFwdRule *composite.Forward
 
 func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.ForwardingRule, utils.ResourceSyncStatus, error) {
 	start := time.Now()
+
+	// Single and mixed protocol use different names for ipv6 forwarding rules. We need to handle the transition between the two.
+	// The expected name is the one that should be used for the current state of the service, and the toDelete name is the one that should be deleted if it exists.
 	expectedIPv6FrName := l4netlb.ipv6FRName()
+	toDeleteIPv6FrName := l4netlb.l3FRName()
+
+	if l4netlb.mixedProtocolUsingL3() {
+		protocol := forwardingrules.GetProtocol(l4netlb.Service.Spec.Ports)
+		if protocol == forwardingrules.ProtocolL3 {
+			expectedIPv6FrName = l4netlb.l3FRName()
+			toDeleteIPv6FrName = l4netlb.ipv6FRName()
+		}
+	}
 
 	frLogger := l4netlb.svcLogger.WithValues("forwardingRuleName", expectedIPv6FrName)
 	frLogger.V(2).Info("Ensuring external ipv6 forwarding rule for L4 NetLB Service", "backendServiceLink", bsLink)
@@ -162,6 +174,17 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 		return nil, utils.ResourceResync, err
 	}
 
+	toDeleteIPv6FwdRule, err := l4netlb.forwardingRules.Get(toDeleteIPv6FrName)
+	if err != nil {
+		frLogger.Error(err, "l4netlb.forwardingRules.Get returned error for alt FR")
+		return nil, utils.ResourceResync, err
+	}
+
+	fwdRuleToDetermineIP := existingIPv6FwdRule
+	if fwdRuleToDetermineIP == nil {
+		fwdRuleToDetermineIP = toDeleteIPv6FwdRule
+	}
+
 	subnetworkURL, err := l4netlb.ipv6SubnetURL()
 	if err != nil {
 		return nil, utils.ResourceResync, fmt.Errorf("error getting ipv6 forwarding rule subnet: %w", err)
@@ -170,7 +193,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
 	// or specified in the Service spec, then requestedIP = "".
-	ipv6AddrToUse, ipv6AddressName, err := address.IPv6ToUse(l4netlb.cloud, l4netlb.Service, existingIPv6FwdRule, subnetworkURL, frLogger)
+	ipv6AddrToUse, ipv6AddressName, err := address.IPv6ToUse(l4netlb.cloud, l4netlb.Service, fwdRuleToDetermineIP, subnetworkURL, frLogger)
 	if err != nil {
 		frLogger.Error(err, "address.IPv6ToUse for service returned error")
 		return nil, utils.ResourceResync, err
@@ -195,7 +218,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 		// check if it matches network tiers from forwarding rule and external ip Address.
 		// If they do not match, tear down the existing resources with the wrong tier.
 		if isFromAnnotation {
-			if err := l4netlb.tearDownResourcesWithWrongNetworkTier(existingIPv6FwdRule, netTier, addrMgr, frLogger); err != nil {
+			if err := l4netlb.tearDownResourcesWithWrongNetworkTier(fwdRuleToDetermineIP, netTier, addrMgr, frLogger); err != nil {
 				return nil, utils.ResourceResync, err
 			}
 		}
@@ -205,6 +228,16 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 			return nil, utils.ResourceResync, err
 		}
 		frLogger.V(2).Info("ensureIPv6ForwardingRule: reserved IP for the forwarding rule", "ip", ipv6AddrToUse)
+		// We delete the alt Forwarding Rule as it is not needed when switching from single to mixed and vice versa
+		if toDeleteIPv6FwdRule != nil {
+			err = l4netlb.forwardingRules.Delete(toDeleteIPv6FwdRule.Name)
+			if err != nil {
+				frLogger.Error(err, "l4netlb.forwardingRules.Delete returned error for alt FR")
+				return nil, utils.ResourceUpdate, err
+			}
+			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, events.SyncIngress, "External ForwardingRule %q deleted", toDeleteIPv6FwdRule.Name)
+			toDeleteIPv6FwdRule = nil
+		}
 		defer func() {
 			// Release the address that was reserved, in all cases. If the forwarding rule was successfully created,
 			// the ephemeral IP is not needed anymore. If it was not created, the address should be released to prevent leaks.
@@ -258,6 +291,13 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 
 func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse, subnetworkURL string, netTier cloud.NetworkTier) (*composite.ForwardingRule, error) {
 	frName := l4netlb.ipv6FRName()
+
+	if l4netlb.mixedProtocolUsingL3() {
+		protocol := forwardingrules.GetProtocol(l4netlb.Service.Spec.Ports)
+		if protocol == forwardingrules.ProtocolL3 {
+			frName = l4netlb.l3FRName()
+		}
+	}
 
 	frDesc, err := utils.MakeL4IPv6ForwardingRuleDescription(l4netlb.Service)
 	if err != nil {

--- a/pkg/l4/resources/l4netlb_mixed_test.go
+++ b/pkg/l4/resources/l4netlb_mixed_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -60,14 +61,14 @@ func TestEnsureMixedNetLB(t *testing.T) {
 		},
 		{
 			desc:        "ipv4 mixed",
-			resources:   mixedprotocolnetlbtest.MixedResources(),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesSplit(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedSplit(),
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 		},
 		{
 			desc:        "ipv4 mixed l3",
-			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
+			resources:   mixedprotocolnetlbtest.MixedResources(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedSplit(),
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 		},
 		{
@@ -87,6 +88,24 @@ func TestEnsureMixedNetLB(t *testing.T) {
 			resources:   mixedprotocolnetlbtest.IPv6MixedResources(),
 			annotations: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
 			ingress:     mixedprotocolnetlbtest.IPv6Ingress(),
+		},
+		{
+			desc:        "dual stack tcp",
+			resources:   mixedprotocolnetlbtest.TCPResourcesDualStack(),
+			annotations: mixedprotocolnetlbtest.AnnotationsTCPDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack udp",
+			resources:   mixedprotocolnetlbtest.UDPResourcesDualStack(),
+			annotations: mixedprotocolnetlbtest.AnnotationsUDPDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack mixed",
+			resources:   mixedprotocolnetlbtest.MixedResourcesDualStack(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
 		},
 	}
 
@@ -114,8 +133,8 @@ func TestEnsureMixedNetLB(t *testing.T) {
 		{
 			desc:        "ipv4 mixed",
 			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
-			resources:   mixedprotocolnetlbtest.MixedResources(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedSplit(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesSplit(),
 		},
 		// Test cases below have L3 flag enabled
 		{
@@ -135,8 +154,8 @@ func TestEnsureMixedNetLB(t *testing.T) {
 		{
 			desc:        "ipv4 mixed l3",
 			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixedL3(),
-			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
+			resources:   mixedprotocolnetlbtest.MixedResources(),
 			useL3:       true,
 		},
 		{
@@ -158,6 +177,27 @@ func TestEnsureMixedNetLB(t *testing.T) {
 			spec:        mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
 			annotations: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6MixedResources(),
+			useL3:       true,
+		},
+		{
+			desc:        "dual stack tcp",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, nil),
+			annotations: mixedprotocolnetlbtest.AnnotationsTCPDualStack(),
+			resources:   mixedprotocolnetlbtest.TCPResourcesDualStack(),
+			useL3:       true,
+		},
+		{
+			desc:        "dual stack udp",
+			spec:        mixedprotocoltest.SpecDualStack(nil, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsUDPDualStack(),
+			resources:   mixedprotocolnetlbtest.UDPResourcesDualStack(),
+			useL3:       true,
+		},
+		{
+			desc:        "dual stack mixed",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, []int32{53}),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedDualStack(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesDualStack(),
 			useL3:       true,
 		},
 	}
@@ -291,9 +331,9 @@ func TestDeleteMixedNetLB(t *testing.T) {
 		},
 		{
 			desc:        "ipv4 mixed",
-			resources:   mixedprotocolnetlbtest.MixedResources(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesSplit(),
 			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedSplit(),
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 		},
 		{
@@ -314,9 +354,9 @@ func TestDeleteMixedNetLB(t *testing.T) {
 		},
 		{
 			desc:        "ipv4 mixed l3 enabled",
-			resources:   mixedprotocolnetlbtest.MixedResourcesL3(),
+			resources:   mixedprotocolnetlbtest.MixedResources(),
 			spec:        mixedprotocoltest.SpecIPv4([]int32{80, 443}, []int32{53}),
-			annotations: mixedprotocolnetlbtest.AnnotationsMixedL3(),
+			annotations: mixedprotocolnetlbtest.AnnotationsMixed(),
 			ingress:     mixedprotocolnetlbtest.IPv4Ingress(),
 			useL3:       true,
 		},
@@ -340,6 +380,30 @@ func TestDeleteMixedNetLB(t *testing.T) {
 			useL3:       true,
 			annotations: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
 			resources:   mixedprotocolnetlbtest.IPv6MixedResources(),
+		},
+		{
+			desc:        "dual stack tcp",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, nil),
+			useL3:       true,
+			annotations: mixedprotocolnetlbtest.AnnotationsTCPDualStack(),
+			resources:   mixedprotocolnetlbtest.TCPResourcesDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack udp",
+			spec:        mixedprotocoltest.SpecDualStack(nil, []int32{53}),
+			useL3:       true,
+			annotations: mixedprotocolnetlbtest.AnnotationsUDPDualStack(),
+			resources:   mixedprotocolnetlbtest.UDPResourcesDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
+		},
+		{
+			desc:        "dual stack mixed",
+			spec:        mixedprotocoltest.SpecDualStack([]int32{80, 443}, []int32{53}),
+			useL3:       true,
+			annotations: mixedprotocolnetlbtest.AnnotationsMixedDualStack(),
+			resources:   mixedprotocolnetlbtest.MixedResourcesDualStack(),
+			ingress:     mixedprotocolnetlbtest.DualStackIngress(),
 		},
 	}
 
@@ -454,6 +518,17 @@ func TestMixedFlagsTriggerCorrectCodePaths(t *testing.T) {
 			useL3Flag:                        true,
 			wantForwardingRuleAnnotationKeys: []string{annotations.L3ForwardingRuleIPv6Key},
 		},
+		{
+			// With both flags enabled we should have single L3 forwarding rules on both stacks
+			desc: "on_dualstack_l3",
+			svc: api_v1.Service{
+				ObjectMeta: commonMeta,
+				Spec:       mixedprotocoltest.SpecDualStack([]int32{80, 443}, []int32{53}),
+			},
+			mixedProtocolFlag:                true,
+			useL3Flag:                        true,
+			wantForwardingRuleAnnotationKeys: []string{annotations.L3ForwardingRuleKey, annotations.L3ForwardingRuleIPv6Key},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -516,6 +591,69 @@ func TestMixedFlagsTriggerCorrectCodePaths(t *testing.T) {
 				if got != want {
 					t.Errorf("For key %s: got %v, want %v", k, got, want)
 				}
+			}
+		})
+	}
+}
+
+// TestIPv6MixedAndSingleMigrationNoCoexistence verifies that when updating
+// IPv6 only LB from mixed to single and vice versa, there is no point in time
+// where both forwarding rules coexist at the same time.
+func TestIPv6MixedAndSingleMigrationNoCoexistence(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc     string
+		startRes mixedprotocoltest.GCEResources
+		startAnn map[string]string
+		startIng []api_v1.LoadBalancerIngress
+
+		spec api_v1.ServiceSpec
+	}{
+		{
+			desc:     "single to mixed",
+			startRes: mixedprotocolnetlbtest.IPv6TCPResources(),
+			startAnn: mixedprotocolnetlbtest.AnnotationsTCPIPv6(),
+			startIng: mixedprotocolnetlbtest.IPv6Ingress(),
+			spec:     mixedprotocoltest.SpecIPv6([]int32{80, 443}, []int32{53}),
+		},
+		{
+			desc:     "mixed to single",
+			startRes: mixedprotocolnetlbtest.IPv6MixedResources(),
+			startAnn: mixedprotocolnetlbtest.AnnotationsMixedIPv6(),
+			startIng: mixedprotocolnetlbtest.IPv6Ingress(),
+			spec:     mixedprotocoltest.SpecIPv6([]int32{80, 443}, nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &api_v1.Service{
+				ObjectMeta: meta_v1.ObjectMeta{
+					UID:         mixedprotocoltest.TestUID,
+					Name:        mixedprotocoltest.TestName,
+					Namespace:   mixedprotocoltest.TestNamespace,
+					Annotations: tc.startAnn,
+				},
+				Spec:   tc.spec,
+				Status: api_v1.ServiceStatus{LoadBalancer: api_v1.LoadBalancerStatus{Ingress: tc.startIng}},
+			}
+
+			l4netlb, fakeGCE := arrangeNetLB(t, tc.startRes, svc, true)
+
+			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+			mockGCE.MockForwardingRules.InsertHook = func(ctx context.Context, key *meta.Key, obj *compute.ForwardingRule, m *cloud.MockForwardingRules, options ...cloud.Option) (bool, error) {
+				if len(m.Objects) > 0 {
+					return true, fmt.Errorf("when adding %s forwarding rule found more than one rule %v", key.Name, m.Objects)
+				}
+				return false, nil
+			}
+
+			result := l4netlb.EnsureFrontend([]string{mixedprotocoltest.TestNode}, svc, time.Now())
+			if result.Error != nil {
+				t.Fatalf("EnsureFrontend() returned error %v", result.Error)
 			}
 		})
 	}

--- a/pkg/l4/resources/l4netlbipv6.go
+++ b/pkg/l4/resources/l4netlbipv6.go
@@ -17,8 +17,10 @@ limitations under the License.
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -112,6 +114,10 @@ func (l4netlb *L4NetLB) ipv6FRName() string {
 	return namer.GetSuffixedName(l4netlb.frName(), ipv6Suffix)
 }
 
+func (l4netlb *L4NetLB) l3FRName() string {
+	return l4netlb.namer.L4IPv6ForwardingRule(l4netlb.Service.Namespace, l4netlb.Service.Name, "l3")
+}
+
 func (l4netlb *L4NetLB) ensureIPv6NodesFirewall(ipRange string, nodeNames []string, syncResult *L4NetLBSyncResult) {
 	// DisableL4LBFirewall flag disables L4 FW enforcment to remove conflicts with firewall policies
 	if l4netlb.disableNodesFirewallProvisioning {
@@ -191,17 +197,31 @@ func (l4netlb *L4NetLB) ensureDenyIPv6(syncResult *L4NetLBSyncResult, nodeNames 
 }
 
 func (l4netlb *L4NetLB) deleteIPv6ForwardingRule(syncResult *L4NetLBSyncResult) {
-	ipv6FrName := l4netlb.ipv6FRName()
-
+	names := []string{l4netlb.ipv6FRName(), l4netlb.l3FRName()}
 	start := time.Now()
-	l4netlb.svcLogger.V(2).Info("Deleting IPv6 forwarding rule for L4 NetLB Service", "forwardingRuleName", ipv6FrName)
+	l4netlb.svcLogger.V(2).Info("Deleting IPv6 forwarding rule for L4 NetLB Service", "forwardingRuleNames", names)
 	defer func() {
-		l4netlb.svcLogger.V(2).Info("Finished deleting IPv6 forwarding rule for L4 NetLB Service", "forwardingRuleName", ipv6FrName, "timeTaken", time.Since(start))
+		l4netlb.svcLogger.V(2).Info("Finished deleting IPv6 forwarding rule for L4 NetLB Service", "forwardingRuleNames", names, "timeTaken", time.Since(start))
 	}()
 
-	err := l4netlb.forwardingRules.Delete(ipv6FrName)
-	if err != nil {
-		l4netlb.svcLogger.Error(err, "Failed to delete ipv6 forwarding rule for external loadbalancer service")
+	var wg sync.WaitGroup
+	var errs []error
+	var mu sync.Mutex
+
+	for _, frName := range names {
+		wg.Go(func() {
+			err := l4netlb.forwardingRules.Delete(frName)
+			if err != nil {
+				l4netlb.svcLogger.Error(err, "Failed to delete ipv6 forwarding rule for external loadbalancer service", "frName", frName)
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	if err := errors.Join(errs...); err != nil {
 		syncResult.Error = err
 		syncResult.GCEResourceInError = annotations.ForwardingRuleIPv6Resource
 	}

--- a/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/annotations.go
+++ b/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/annotations.go
@@ -72,8 +72,8 @@ func AnnotationsUDPDualStack() map[string]string {
 	}
 }
 
-// AnnotationsMixed returns annotations for mixed protocol NetLB
-func AnnotationsMixed() map[string]string {
+// AnnotationsMixedSplit returns annotations for mixed protocol NetLB
+func AnnotationsMixedSplit() map[string]string {
 	return map[string]string{
 		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
 		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
@@ -85,7 +85,7 @@ func AnnotationsMixed() map[string]string {
 }
 
 // AnnotationsMixed returns annotations for mixed protocol NetLB
-func AnnotationsMixedL3() map[string]string {
+func AnnotationsMixed() map[string]string {
 	return map[string]string{
 		"service.kubernetes.io/healthcheck":          "k8s2-axyqjz2d-l4-shared-hc",
 		"service.kubernetes.io/firewall-rule-for-hc": "k8s2-axyqjz2d-l4-shared-hc-fw",
@@ -101,7 +101,7 @@ func AnnotationsMixedIPv6() map[string]string {
 		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
 		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
 		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
-		"service.kubernetes.io/l3-forwarding-rule-ipv6":   "a1234567890-ipv6",
+		"service.kubernetes.io/l3-forwarding-rule-ipv6":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
 		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
 	}
 }
@@ -112,12 +112,10 @@ func AnnotationsMixedDualStack() map[string]string {
 		"service.kubernetes.io/healthcheck":               "k8s2-axyqjz2d-l4-shared-hc",
 		"service.kubernetes.io/firewall-rule-for-hc":      "k8s2-axyqjz2d-l4-shared-hc-fw",
 		"service.kubernetes.io/backend-service":           "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
-		"service.kubernetes.io/udp-forwarding-rule":       "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
-		"service.kubernetes.io/tcp-forwarding-rule":       "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i",
+		"service.kubernetes.io/l3-forwarding-rule":        "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i",
 		"service.kubernetes.io/firewall-rule":             "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i",
 		"service.kubernetes.io/firewall-rule-for-hc-ipv6": "k8s2-axyqjz2d-l4-shared-hc-fw-ipv6",
-		"service.kubernetes.io/udp-forwarding-rule-ipv6":  "k8s2-udp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
-		"service.kubernetes.io/tcp-forwarding-rule-ipv6":  "k8s2-tcp-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
+		"service.kubernetes.io/l3-forwarding-rule-ipv6":   "k8s2-l3-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
 		"service.kubernetes.io/firewall-rule-ipv6":        "k8s2-axyqjz2d-test-namespace-test-name-yuvhdy7i-ipv6",
 	}
 }

--- a/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/resources.go
+++ b/pkg/l4/resources/mixedprotocoltest/mixedprotocolnetlbtest/resources.go
@@ -83,8 +83,8 @@ func IPv6UDPResources() mixedprotocoltest.GCEResources {
 	}
 }
 
-// MixedResources returns GCE resources for a mixed protocol IPv4 NetLB, that listens on tcp:80, tcp:443 and udp:53
-func MixedResources() mixedprotocoltest.GCEResources {
+// MixedResourcesSplit returns GCE resources for a mixed protocol IPv4 NetLB, that listens on tcp:80, tcp:443 and udp:53
+func MixedResourcesSplit() mixedprotocoltest.GCEResources {
 	return mixedprotocoltest.GCEResources{
 		ForwardingRules: map[string]*compute.ForwardingRule{
 			mixedprotocoltest.ForwardingRuleTCPIPv4Name: ForwardingRuleTCP(
@@ -106,8 +106,8 @@ func MixedResources() mixedprotocoltest.GCEResources {
 	}
 }
 
-// MixedResourcesL3 returns GCE resources for a mixed protocol IPv4 NetLB, that listens on tcp:80, tcp:443 and udp:53
-func MixedResourcesL3() mixedprotocoltest.GCEResources {
+// MixedResources returns GCE resources for a mixed protocol IPv4 NetLB, that listens on tcp:80, tcp:443 and udp:53
+func MixedResources() mixedprotocoltest.GCEResources {
 	return mixedprotocoltest.GCEResources{
 		ForwardingRules: map[string]*compute.ForwardingRule{
 			mixedprotocoltest.ForwardingRuleL3IPv4Name: ForwardingRuleL3(
@@ -130,8 +130,8 @@ func MixedResourcesL3() mixedprotocoltest.GCEResources {
 func IPv6MixedResources() mixedprotocoltest.GCEResources {
 	return mixedprotocoltest.GCEResources{
 		ForwardingRules: map[string]*compute.ForwardingRule{
-			mixedprotocoltest.ForwardingRuleLegacyIPv6Name: ForwardingRuleL3IPv6(
-				mixedprotocoltest.ForwardingRuleLegacyIPv6Name,
+			mixedprotocoltest.ForwardingRuleL3IPv6Name: ForwardingRuleL3IPv6(
+				mixedprotocoltest.ForwardingRuleL3IPv6Name,
 			),
 		},
 		Firewalls: map[string]*compute.Firewall{
@@ -139,6 +139,86 @@ func IPv6MixedResources() mixedprotocoltest.GCEResources {
 				{IPProtocol: "udp", Ports: []string{"53"}},
 				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
 			}),
+			mixedprotocoltest.HealthCheckFirewallIPv6Name: HealthCheckFirewallIPv6(),
+		},
+		HealthCheck:    HealthCheck(),
+		BackendService: BackendService("UNSPECIFIED"),
+	}
+}
+
+// TCPResourcesDualStack returns GCE resources for a TCP dual stack NetLB that listens on ports 80 and 443
+func TCPResourcesDualStack() mixedprotocoltest.GCEResources {
+	return mixedprotocoltest.GCEResources{
+		ForwardingRules: map[string]*compute.ForwardingRule{
+			mixedprotocoltest.ForwardingRuleLegacyName: ForwardingRuleTCP(
+				mixedprotocoltest.ForwardingRuleLegacyName, []string{"80", "443"},
+			),
+			mixedprotocoltest.ForwardingRuleLegacyIPv6Name: ForwardingRuleTCPIPv6(
+				mixedprotocoltest.ForwardingRuleLegacyIPv6Name, []string{"80", "443"},
+			),
+		},
+		Firewalls: map[string]*compute.Firewall{
+			mixedprotocoltest.FirewallIPv4Name: mixedprotocoltest.Firewall([]*compute.FirewallAllowed{
+				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			}),
+			mixedprotocoltest.FirewallIPv6Name: mixedprotocoltest.FirewallIPv6([]*compute.FirewallAllowed{
+				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			}),
+			mixedprotocoltest.HealthCheckFirewallIPv4Name: mixedprotocoltest.HealthCheckFirewall(),
+			mixedprotocoltest.HealthCheckFirewallIPv6Name: HealthCheckFirewallIPv6(),
+		},
+		HealthCheck:    HealthCheck(),
+		BackendService: BackendService("TCP"),
+	}
+}
+
+// UDPResourcesDualStack returns GCE resources for a UDP dual stack NetLB that listens on port 53
+func UDPResourcesDualStack() mixedprotocoltest.GCEResources {
+	return mixedprotocoltest.GCEResources{
+		ForwardingRules: map[string]*compute.ForwardingRule{
+			mixedprotocoltest.ForwardingRuleLegacyName: ForwardingRuleUDP(
+				mixedprotocoltest.ForwardingRuleLegacyName, []string{"53"},
+			),
+			mixedprotocoltest.ForwardingRuleLegacyIPv6Name: ForwardingRuleUDPIPv6(
+				mixedprotocoltest.ForwardingRuleLegacyIPv6Name, []string{"53"},
+			),
+		},
+		Firewalls: map[string]*compute.Firewall{
+			mixedprotocoltest.FirewallIPv4Name: mixedprotocoltest.Firewall([]*compute.FirewallAllowed{
+				{IPProtocol: "udp", Ports: []string{"53"}},
+			}),
+			mixedprotocoltest.FirewallIPv6Name: mixedprotocoltest.FirewallIPv6([]*compute.FirewallAllowed{
+				{IPProtocol: "udp", Ports: []string{"53"}},
+			}),
+			mixedprotocoltest.HealthCheckFirewallIPv4Name: mixedprotocoltest.HealthCheckFirewall(),
+			mixedprotocoltest.HealthCheckFirewallIPv6Name: HealthCheckFirewallIPv6(),
+		},
+		HealthCheck:    HealthCheck(),
+		BackendService: BackendService("UDP"),
+	}
+}
+
+// MixedResourcesDualStack returns GCE resources for a mixed protocol dual stack NetLB, that listens on tcp:80, tcp:443 and udp:53
+func MixedResourcesDualStack() mixedprotocoltest.GCEResources {
+	return mixedprotocoltest.GCEResources{
+		ForwardingRules: map[string]*compute.ForwardingRule{
+			mixedprotocoltest.ForwardingRuleL3IPv4Name: ForwardingRuleL3(
+				mixedprotocoltest.ForwardingRuleL3IPv4Name,
+			),
+			mixedprotocoltest.ForwardingRuleL3IPv6Name: ForwardingRuleL3IPv6(
+				mixedprotocoltest.ForwardingRuleL3IPv6Name,
+			),
+		},
+		Firewalls: map[string]*compute.Firewall{
+			mixedprotocoltest.FirewallIPv4Name: mixedprotocoltest.Firewall([]*compute.FirewallAllowed{
+				{IPProtocol: "udp", Ports: []string{"53"}},
+				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			}),
+			mixedprotocoltest.FirewallIPv6Name: mixedprotocoltest.FirewallIPv6([]*compute.FirewallAllowed{
+				{IPProtocol: "udp", Ports: []string{"53"}},
+				{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			}),
+			mixedprotocoltest.HealthCheckFirewallIPv4Name: mixedprotocoltest.HealthCheckFirewall(),
 			mixedprotocoltest.HealthCheckFirewallIPv6Name: HealthCheckFirewallIPv6(),
 		},
 		HealthCheck:    HealthCheck(),


### PR DESCRIPTION
We want to use a new naming schema instead of the legacy one. The feature is not released yet in any release branch so those rules haven't been created yet.

I also add missing dualstack tests for NetLB Mixed Protocol as those were missing.