### PR TITLE
Create TopologyProvider for NEG controller's syncers

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -86,7 +86,7 @@ type transactionSyncer struct {
 	svcNegLister        cache.Indexer
 	recorder            record.EventRecorder
 	cloud               negtypes.NetworkEndpointGroupCloud
-	zoneGetter          *zonegetter.ZoneGetter
+	topologyProvider    negtypes.TopologyProvider
 	endpointsCalculator negtypes.NetworkEndpointsCalculator
 
 	// retry handles back off retry for NEG API operations
@@ -148,7 +148,7 @@ func NewTransactionSyncer(
 	negSyncerKey negtypes.NegSyncerKey,
 	recorder record.EventRecorder,
 	cloud negtypes.NetworkEndpointGroupCloud,
-	zoneGetter *zonegetter.ZoneGetter,
+	topologyProvider negtypes.TopologyProvider,
 	podLister cache.Indexer,
 	serviceLister cache.Indexer,
 	endpointSliceLister cache.Indexer,
@@ -182,7 +182,7 @@ func NewTransactionSyncer(
 		svcNegLister:              svcNegLister,
 		recorder:                  recorder,
 		cloud:                     cloud,
-		zoneGetter:                zoneGetter,
+		topologyProvider:          topologyProvider,
 		endpointsCalculator:       epc,
 		reflector:                 reflector,
 		kubeSystemUID:             kubeSystemUID,
@@ -300,14 +300,14 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	}
 	s.logger.V(2).Info("Sync NEG", "negSyncerKey", s.NegSyncerKey.String(), "endpointsCalculatorMode", s.endpointsCalculator.Mode())
 
-	subnetConfigs := s.zoneGetter.ListSubnets(s.logger)
+	subnetConfigs := s.topologyProvider.ListSubnets(s.logger)
 	subnetToNegMapping, err := s.generateSubnetToNegNameMap(subnetConfigs)
 	if err != nil {
 		s.logger.Error(err, "failed to generate subnet to neg name mapping")
 		return err
 	}
 
-	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
+	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -532,7 +532,7 @@ func (s *transactionSyncer) candidateNodeFilter() zonegetter.Filter {
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	// NEGs should be created in zones with candidate nodes only.
-	zonesPerSubnet, err := s.zoneGetter.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
+	zonesPerSubnet, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 		// zoneGetter.
 
 		// List all existing subnets from the cluster.
-		subnetConfigs = s.zoneGetter.ListSubnets(s.logger)
+		subnetConfigs = s.topologyProvider.ListSubnets(s.logger)
 	} else {
 		// This is the multi-networking case where the VPC under consideration
 		// is not the default. Use the pre configured subnet from the
@@ -573,7 +573,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	for _, subnetConfig := range subnetConfigs {
 		zones, ok := zonesPerSubnet[subnetConfig.Name]
 		if !ok {
-			// s.zoneGetter.ListSubnets and s.zoneGetter.ListZonesPerSubnet should return same set of subnets.
+			// s.topologyProvider.ListSubnets and s.topologyProvider.ListZonesPerSubnet should return same set of subnets.
 			// Therefore this condition should be true only for multi-networking where we don't want NEGs in default subnet
 			continue
 		}
@@ -940,7 +940,7 @@ func (s *transactionSyncer) isTopologyChange() bool {
 		existingSubnetZones[subnetName].Insert(id.Key.Zone)
 	}
 
-	wantSubnetZones, err := s.zoneGetter.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
+	wantSubnetZones, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		s.logger.Error(err, "unable to list zones")
 		s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
@@ -1045,7 +1045,7 @@ func (s *transactionSyncer) updateInitStatus(negObjRefs []negv1beta1.NegObjectRe
 
 	neg := origNeg.DeepCopy()
 	if flags.F.EnableMultiSubnetClusterPhase1 {
-		nonActiveNegRefs := getNonActiveNegRefs(origNeg.Status.NetworkEndpointGroups, negObjRefs, s.zoneGetter.ListSubnets(s.logger), s.networkInfo.SubnetworkURL, s.logger)
+		nonActiveNegRefs := getNonActiveNegRefs(origNeg.Status.NetworkEndpointGroups, negObjRefs, s.topologyProvider.ListSubnets(s.logger), s.networkInfo.SubnetworkURL, s.logger)
 		negObjRefs = append(negObjRefs, nonActiveNegRefs...)
 	}
 	neg.Status.NetworkEndpointGroups = negObjRefs

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -532,7 +532,7 @@ func (s *transactionSyncer) candidateNodeFilter() zonegetter.Filter {
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	// NEGs should be created in zones with candidate nodes only.
-	zones, err := s.zoneGetter.ListZones(s.candidateNodeFilter(), s.logger)
+	zonesPerSubnet, err := s.zoneGetter.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		return err
 	}
@@ -571,6 +571,12 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	}
 
 	for _, subnetConfig := range subnetConfigs {
+		zones, ok := zonesPerSubnet[subnetConfig.Name]
+		if !ok {
+			// s.zoneGetter.ListSubnets and s.zoneGetter.ListZonesPerSubnet should return same set of subnets.
+			// Therefore this condition should be true only for multi-networking where we don't want NEGs in default subnet
+			continue
+		}
 		negName := s.NegSyncerKey.NegName
 		networkInfo := s.networkInfo
 
@@ -594,7 +600,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 			networkInfo.SubnetworkURL = cloud.SelfLink(meta.VersionGA, resourceID.ProjectID, resourceID.Resource, resourceID.Key)
 		}
 
-		for _, zone := range zones {
+		for zone := range zones {
 			var negObj negv1beta1.NegObjectReference
 			negObj, err = ensureNetworkEndpointGroup(
 				s.Namespace,

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/syncers/dualstack"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils/patch"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
@@ -285,14 +286,13 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		s.logger.Info("Skip syncing NEG", "negSyncerKey", s.NegSyncerKey.String(), "syncerStopped", isStopped, "syncerShuttingDown", isShuttingDown)
 		return nil
 	}
-	zoneChange := s.isZoneChange()
-	subnetChange := s.isSubnetChange()
+	topologyChange := s.isTopologyChange()
 	// Decide if endpoint health should be retrieved when listing endpoints.
 	// Only matters for L4 Local mode.
 	needInitDrainStatus := s.needInit && s.enableL4NEGDetachCancel && s.endpointsCalculator.Mode() == negtypes.L4LocalMode
 
-	if s.needInit || zoneChange || subnetChange {
-		s.logger.Info("Need to ensure network endpoint groups", "needInit", s.needInit, "zoneChange", zoneChange, "subnetChange", subnetChange)
+	if s.needInit || topologyChange {
+		s.logger.Info("Need to ensure network endpoint groups", "needInit", s.needInit, "topologyChange", topologyChange)
 		if err := s.ensureNetworkEndpointGroups(); err != nil {
 			return fmt.Errorf("%w: %v", negtypes.ErrNegNotFound, err)
 		}
@@ -900,9 +900,9 @@ func (s *transactionSyncer) commitPods(endpointMap map[negtypes.NEGLocation]negt
 	}
 }
 
-// isZoneChange returns true if a zone change has occurred by comparing which zones the nodes are in
-// with the zones that NEGs are initialized in
-func (s *transactionSyncer) isZoneChange() bool {
+// isTopologyChange returns true if a topology (zones/subnets) change has occurred by comparing which zones/subnets have NEGs are initialized in
+// to zones/subnets NEGs are expected to be in
+func (s *transactionSyncer) isTopologyChange() bool {
 	negCR, err := getNegFromStore(s.svcNegLister, s.Namespace, s.NegSyncerKey.NegName)
 	if err != nil {
 		s.logger.Error(err, "unable to retrieve neg from the store", "neg", klog.KRef(s.Namespace, s.NegName))
@@ -910,63 +910,38 @@ func (s *transactionSyncer) isZoneChange() bool {
 		return false
 	}
 
-	existingZones := sets.NewString()
+	existingSubnetZones := make(shared.ZonesPerSubnetMap)
 	for _, ref := range negCR.Status.NetworkEndpointGroups {
+		subnetURL := ref.SubnetURL
+		if ref.SubnetURL == "" {
+			subnetURL = s.networkInfo.SubnetworkURL
+		}
+		subnetName, err := utils.KeyName(subnetURL)
+		if err != nil {
+			s.logger.Error(err, "unable to parse subnet url", "url", subnetURL)
+			s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
+			continue
+		}
 		id, err := cloud.ParseResourceURL(ref.SelfLink)
 		if err != nil {
 			s.logger.Error(err, "unable to parse selflink", "selfLink", ref.SelfLink)
 			s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
 			continue
 		}
-		existingZones.Insert(id.Key.Zone)
+		if _, ok := existingSubnetZones[subnetName]; !ok {
+			existingSubnetZones[subnetName] = sets.New[string]()
+		}
+		existingSubnetZones[subnetName].Insert(id.Key.Zone)
 	}
 
-	zones, err := s.zoneGetter.ListZones(s.candidateNodeFilter(), s.logger)
+	wantSubnetZones, err := s.zoneGetter.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		s.logger.Error(err, "unable to list zones")
 		s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
 		return false
 	}
-	currZones := sets.NewString(zones...)
 
-	return !currZones.Equal(existingZones)
-}
-
-func (s *transactionSyncer) isSubnetChange() bool {
-	negCR, err := getNegFromStore(s.svcNegLister, s.Namespace, s.NegSyncerKey.NegName)
-	if err != nil {
-		s.logger.Error(err, "unable to retrieve neg from the store", "neg", klog.KRef(s.Namespace, s.NegName))
-		s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
-		return false
-	}
-
-	existingSubnets := sets.New[string]()
-	for _, ref := range negCR.Status.NetworkEndpointGroups {
-		// If the subnet url is empty it means that the reference was created before
-		// Subnets were populated by the controller. This is only possible with the subnetwork
-		// that is specificed in networkInfo, and therefore we can assume which subnetwork was
-		// used for this NEG
-		subnetURL := s.networkInfo.SubnetworkURL
-		if ref.SubnetURL != "" {
-			subnetURL = ref.SubnetURL
-		}
-		id, err := cloud.ParseResourceURL(subnetURL)
-		if err != nil {
-			s.logger.Error(err, "unable to parse subnet url", "url", ref.SubnetURL)
-			s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
-			continue
-		}
-
-		existingSubnets.Insert(id.Key.Name)
-	}
-
-	currSubnets := sets.New[string]()
-	subnets := s.zoneGetter.ListSubnets(s.logger)
-	for _, subnet := range subnets {
-		currSubnets.Insert(subnet.Name)
-	}
-
-	return !currSubnets.Equal(existingSubnets)
+	return !wantSubnetZones.Equal(existingSubnetZones)
 }
 
 // filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -302,10 +302,26 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to initialize transaction syncer: %v", err)
 		}
-		if err := zonegetter.AddNodeTopologyCR(transactionSyncer.zoneGetter, &nodeTopologyCrWithAdditionalSubnets); err != nil {
+		if err := zonegetter.AddNodeTopologyCR(transactionSyncer.topologyProvider.(*zonegetter.ZoneGetter), &nodeTopologyCrWithAdditionalSubnets); err != nil {
 			t.Fatalf("Failed to add node topology CR: %v", err)
 		}
-		zonegetter.SetNodeTopologyHasSynced(transactionSyncer.zoneGetter, func() bool { return true })
+		zonegetter.SetNodeTopologyHasSynced(transactionSyncer.topologyProvider.(*zonegetter.ZoneGetter), func() bool { return true })
+
+		// Though the test cases below only add instances in zone1 and zone2, NEGs will be created in zone3 or zone4 as well since fakeZoneGetter includes those zones.
+		expectZones := []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone4}
+		if testNegType == negtypes.VmIpEndpointType {
+			expectZones = []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3}
+		}
+
+		zg := transactionSyncer.topologyProvider.(*zonegetter.ZoneGetter)
+		// Add nodes for additionalTestSubnet in expectZones so ListZonesForSubnet finds them
+		for _, zone := range expectZones {
+			nodeName := fmt.Sprintf("additional-node-%s-%s", zone, additionalTestSubnet)
+			if err := addFakeNodeWithSubnet(zg, transactionSyncer.nodeLister, nodeName, zone, additionalTestSubnet); err != nil {
+				t.Fatalf("Failed to add fake node for additional subnet: %v", err)
+			}
+		}
+
 		nonDefaultNegName, err := transactionSyncer.getNonDefaultSubnetNEGName(additionalTestSubnet)
 		if err != nil {
 			t.Fatalf("Failed to get non-default subnet NEG name: %v", err)
@@ -321,13 +337,7 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 
 		// Verify the NEGs are created as expected
 		ret, _ := transactionSyncer.cloud.AggregatedListNetworkEndpointGroup(transactionSyncer.NegSyncerKey.GetAPIVersion(), klog.TODO())
-		// Though the test cases below only add instances in zone1 and zone2, NEGs will be created in zone3 or zone4 as well since fakeZoneGetter includes those zones.
-		var expectZones []string
-		if testNegType == negtypes.VmIpEndpointType {
-			expectZones = []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3}
-		} else {
-			expectZones = []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone4}
-		}
+
 		retZones := sets.NewString()
 
 		for key := range ret {
@@ -524,15 +534,26 @@ func TestNegNameMultiNetworking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize transaction syncer: %v", err)
 	}
-	zg := transactionSyncer.zoneGetter
-	zonegetter.SetNodeTopologyHasSynced(zg, func() bool { return true })
+
+	subnetName, err := utils.KeyName(subnetInSecondaryNetwork)
+	if err != nil {
+		t.Fatalf("Failed to parse subnet name: %v", err)
+	}
+
+	defaultSubnet, err := utils.KeyName(subnetInDefaultNetwork)
+	if err != nil {
+		t.Fatalf("Failed to parse default subnet name: %v", err)
+	}
+
+	zg := transactionSyncer.topologyProvider.(*zonegetter.ZoneGetter)
 	nodeTopologyCR := &nodetopologyv1.NodeTopology{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: flags.F.NodeTopologyCRName,
 		},
 		Status: nodetopologyv1.NodeTopologyStatus{
 			Subnets: []nodetopologyv1.SubnetConfig{
-				{Name: "multi-net-secondary-subnet", SubnetPath: subnetInSecondaryNetwork},
+				{Name: defaultSubnet, SubnetPath: subnetInDefaultNetwork},
+				{Name: subnetName, SubnetPath: subnetInSecondaryNetwork},
 			},
 		},
 	}
@@ -540,10 +561,11 @@ func TestNegNameMultiNetworking(t *testing.T) {
 		t.Fatalf("failed to add node topology CR: %v", err)
 	}
 
+	zonegetter.SetNodeTopologyHasSynced(zg, func() bool { return true })
 	for _, zone := range []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3} {
-		nodeName := fmt.Sprintf("node-%s-secondary", zone)
-		if err := addFakeNodeWithSubnet(zg, transactionSyncer.nodeLister, nodeName, zone, "multi-net-secondary-subnet"); err != nil {
-			t.Fatalf("Failed to add fake node: %v", err)
+		nodeName := fmt.Sprintf("additional-node-%s-%s", zone, subnetName)
+		if err := addFakeNodeWithSubnet(zg, transactionSyncer.nodeLister, nodeName, zone, subnetName); err != nil {
+			t.Fatalf("Failed to add fake node for secondary subnet: %v", err)
 		}
 	}
 
@@ -2074,7 +2096,7 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 			if tc.customNEGName != "" {
 				syncer.NegSyncerKey.NegName = tc.customNEGName
 			}
-			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+			zonegetter.SetNodeTopologyHasSynced(syncer.topologyProvider.(*zonegetter.ZoneGetter), func() bool { return true })
 
 			negName := syncer.NegSyncerKey.NegName
 
@@ -2109,10 +2131,10 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 			syncer.svcNegLister.Add(initialNegCr)
 
 			if tc.nodeTopologyCr != nil {
-				if err := zonegetter.AddNodeTopologyCR(syncer.zoneGetter, tc.nodeTopologyCr); err != nil {
+				if err := zonegetter.AddNodeTopologyCR(syncer.topologyProvider.(*zonegetter.ZoneGetter), tc.nodeTopologyCr); err != nil {
 					t.Fatalf("Failed to create Node Topology CR: %v", err)
 				}
-				zg := syncer.zoneGetter
+				zg := syncer.topologyProvider.(*zonegetter.ZoneGetter)
 				for _, subnetConfig := range tc.nodeTopologyCr.Status.Subnets {
 					if subnetConfig.Name != defaultTestSubnet {
 						for _, zone := range zones {
@@ -2229,7 +2251,7 @@ func TestUpdateInitStatusWithMultiSubnetCluster(t *testing.T) {
 			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(defaultTestSubnetURL, testNetwork)
 			nodeTopologyInformer := zonegetter.FakeNodeTopologyInformer()
 			_, syncer, err := newTestTransactionSyncerWithTopologyInformer(fakeCloud, testNegType, false, nodeTopologyInformer)
-			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+			zonegetter.SetNodeTopologyHasSynced(syncer.topologyProvider.(*zonegetter.ZoneGetter), func() bool { return true })
 			if err != nil {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
 			}
@@ -2352,7 +2374,7 @@ func TestUpdateInitStatusTransitions(t *testing.T) {
 	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(defaultTestSubnetURL, testNetwork)
 	nodeTopologyInformer := zonegetter.FakeNodeTopologyInformer()
 	_, syncer, err := newTestTransactionSyncerWithTopologyInformer(fakeCloud, testNegType, false, nodeTopologyInformer)
-	zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+	zonegetter.SetNodeTopologyHasSynced(syncer.topologyProvider.(*zonegetter.ZoneGetter), func() bool { return true })
 	if err != nil {
 		t.Fatalf("failed to initialize transaction syncer: %v", err)
 	}
@@ -2456,7 +2478,7 @@ func TestSubnetChanges(t *testing.T) {
 	// mark syncer as started without starting the syncer routine
 	(ts.syncer.(*syncer)).stopped = false
 	ts.needInit = false
-	zonegetter.SetNodeTopologyHasSynced(ts.zoneGetter, func() bool { return true })
+	zonegetter.SetNodeTopologyHasSynced(ts.topologyProvider.(*zonegetter.ZoneGetter), func() bool { return true })
 
 	svcNegClient := ts.svcNegClient
 	currentSubnets := []nodetopologyv1.SubnetConfig{defaultSubnetConfig}
@@ -2878,8 +2900,8 @@ func TestIsTopologyChange(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
 			}
-			syncer.zoneGetter = initialZg
-			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+			syncer.topologyProvider = initialZg
+			zonegetter.SetNodeTopologyHasSynced(initialZg, func() bool { return true })
 
 			var allRefs []negv1beta1.NegObjectReference
 			for subnet, zones := range tc.initialTopology {
@@ -2905,8 +2927,8 @@ func TestIsTopologyChange(t *testing.T) {
 			}
 
 			finalZg, _ := createZoneGetterFromTopology(t, tc.finalTopology, nodeTopologyInformer, !tc.enableMSC)
-			syncer.zoneGetter = finalZg
-			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+			syncer.topologyProvider = finalZg
+			zonegetter.SetNodeTopologyHasSynced(finalZg, func() bool { return true })
 
 			if tc.addNodeWithInvalidProviderID {
 				if err := zonegetter.AddFakeNode(finalZg, &corev1.Node{
@@ -3036,7 +3058,8 @@ func TestIsTopologyChangeZeroCandidateNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize transaction syncer: %v", err)
 	}
-	zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+	zg := syncer.topologyProvider.(*zonegetter.ZoneGetter)
+	zonegetter.SetNodeTopologyHasSynced(zg, func() bool { return true })
 
 	// Define subnets: default and secondary
 	defaultSubnetName := defaultTestSubnet
@@ -3054,13 +3077,13 @@ func TestIsTopologyChangeZeroCandidateNodes(t *testing.T) {
 			},
 		},
 	}
-	if err := zonegetter.AddNodeTopologyCR(syncer.zoneGetter, nodeTopologyCR); err != nil {
+	if err := zonegetter.AddNodeTopologyCR(zg, nodeTopologyCR); err != nil {
 		t.Fatalf("failed to add node topology CR: %v", err)
 	}
 
 	// Delete all default nodes to ensure 0 candidate nodes.
 	for _, zone := range []string{"zone1", "zone2", "zone3", "zone4"} {
-		zonegetter.DeleteFakeNodesInZone(t, zone, syncer.zoneGetter)
+		zonegetter.DeleteFakeNodesInZone(t, zone, zg)
 	}
 
 	// isTopologyChange should return false because expectedSubnetZones is empty and no NEGs exist.

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -524,6 +524,28 @@ func TestNegNameMultiNetworking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize transaction syncer: %v", err)
 	}
+	zg := transactionSyncer.zoneGetter
+	zonegetter.SetNodeTopologyHasSynced(zg, func() bool { return true })
+	nodeTopologyCR := &nodetopologyv1.NodeTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flags.F.NodeTopologyCRName,
+		},
+		Status: nodetopologyv1.NodeTopologyStatus{
+			Subnets: []nodetopologyv1.SubnetConfig{
+				{Name: "multi-net-secondary-subnet", SubnetPath: subnetInSecondaryNetwork},
+			},
+		},
+	}
+	if err := zonegetter.AddNodeTopologyCR(zg, nodeTopologyCR); err != nil {
+		t.Fatalf("failed to add node topology CR: %v", err)
+	}
+
+	for _, zone := range []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3} {
+		nodeName := fmt.Sprintf("node-%s-secondary", zone)
+		if err := addFakeNodeWithSubnet(zg, transactionSyncer.nodeLister, nodeName, zone, "multi-net-secondary-subnet"); err != nil {
+			t.Fatalf("Failed to add fake node: %v", err)
+		}
+	}
 
 	// Start syncer without starting syncer goroutine
 	(transactionSyncer.syncer.(*syncer)).stopped = false
@@ -2089,6 +2111,17 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 			if tc.nodeTopologyCr != nil {
 				if err := zonegetter.AddNodeTopologyCR(syncer.zoneGetter, tc.nodeTopologyCr); err != nil {
 					t.Fatalf("Failed to create Node Topology CR: %v", err)
+				}
+				zg := syncer.zoneGetter
+				for _, subnetConfig := range tc.nodeTopologyCr.Status.Subnets {
+					if subnetConfig.Name != defaultTestSubnet {
+						for _, zone := range zones {
+							nodeName := fmt.Sprintf("node-%s-%s", zone, subnetConfig.Name)
+							if err := addFakeNodeWithSubnet(zg, syncer.nodeLister, nodeName, zone, subnetConfig.Name); err != nil {
+								t.Fatalf("Failed to add fake node for subnet %s: %v", subnetConfig.Name, err)
+							}
+						}
+					}
 				}
 			}
 
@@ -4785,4 +4818,31 @@ func generateExpectedNegObjReferences(t *testing.T, cloud negtypes.NetworkEndpoi
 	}
 
 	return expectedNegRefs
+}
+
+func addFakeNodeWithSubnet(zg *zonegetter.ZoneGetter, nodeIndexer cache.Indexer, name, zone, subnet string) error {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				utils.LabelNodeSubnet: subnet,
+			},
+		},
+		Spec: corev1.NodeSpec{
+			ProviderID: fmt.Sprintf("gce://foo-project/%s/%s", zone, name),
+			PodCIDR:    "10.100.99.0/24",
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	if err := nodeIndexer.Add(node); err != nil {
+		return err
+	}
+	return zonegetter.AddFakeNode(zg, node)
 }

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/readiness"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/test"
@@ -2482,147 +2483,6 @@ func TestSubnetChanges(t *testing.T) {
 	checkNegCRWithParams(t, fakeCloud, params)
 }
 
-func TestIsSubnetChange(t *testing.T) {
-	//Create all VPC and Subnets needed
-	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
-	testSubnetwork := defaultTestSubnetURL
-	defaultSubnetConfig := nodetopologyv1.SubnetConfig{Name: defaultTestSubnet, SubnetPath: fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", defaultTestSubnet)}
-	secondarySubnetConfig1 := nodetopologyv1.SubnetConfig{Name: secondaryTestSubnet1, SubnetPath: fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", secondaryTestSubnet1)}
-
-	// Save old flags to reset at end of test
-	prevNodeTopologyCRName := flags.F.NodeTopologyCRName
-	defer func() {
-		flags.F.NodeTopologyCRName = prevNodeTopologyCRName
-	}()
-	flags.F.NodeTopologyCRName = "default"
-
-	testCases := []struct {
-		desc            string
-		originalSubnets []nodetopologyv1.SubnetConfig
-		currentSubnets  []nodetopologyv1.SubnetConfig
-		enableMSCPhase1 bool
-		// emptySubnetURL refers to whether the origRefs have subnetURL populated. If this is true,
-		// originalSubnets can only include the defaultSubnetConfig
-		emptySubnetURL bool
-		expectedResult bool
-	}{
-		{
-			desc:            "subnet was added",
-			originalSubnets: []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig, secondarySubnetConfig1},
-			enableMSCPhase1: true,
-			expectedResult:  true,
-		},
-		{
-			desc:            "subnet was deleted",
-			originalSubnets: []nodetopologyv1.SubnetConfig{secondarySubnetConfig1, defaultSubnetConfig},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			enableMSCPhase1: true,
-			expectedResult:  true,
-		},
-		{
-			desc:            "no subnet change occurred",
-			originalSubnets: []nodetopologyv1.SubnetConfig{defaultSubnetConfig, secondarySubnetConfig1},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig, secondarySubnetConfig1},
-			enableMSCPhase1: true,
-			expectedResult:  false,
-		},
-		{
-			desc:            "no subnet change occurred, origRefs have empty URLs",
-			originalSubnets: []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			enableMSCPhase1: true,
-			emptySubnetURL:  true,
-			expectedResult:  false,
-		},
-		{
-			desc:            "subnet was added and MSC is disabled",
-			originalSubnets: []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig, secondarySubnetConfig1},
-			enableMSCPhase1: false,
-			expectedResult:  false,
-		},
-
-		// In this case NEGs allready exist in secondary subnet previously. We assume that MSC was
-		// disabled after a controller update, so the controller should recognize it as a subnet change.
-		{
-			desc:            "subnet was deleted and MSC is disabled",
-			originalSubnets: []nodetopologyv1.SubnetConfig{defaultSubnetConfig, secondarySubnetConfig1},
-			currentSubnets:  []nodetopologyv1.SubnetConfig{defaultSubnetConfig},
-			enableMSCPhase1: false,
-			expectedResult:  true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			// Initialize syncer
-			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
-			nodeTopologyInformer := zonegetter.FakeNodeTopologyInformer()
-			testNegType := negtypes.VmIpPortEndpointType
-			_, ts, err := newTestTransactionSyncerWithTopologyInformer(fakeCloud, testNegType, false, nodeTopologyInformer)
-			if err != nil {
-				t.Fatalf("failed to initialize transaction syncer: %v", err)
-			}
-
-			// overwrite the ZoneGetter to pipe in flag gate value
-			nodeInformer := zonegetter.FakeNodeInformer()
-			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
-			fakeZoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, nodeTopologyInformer, defaultTestSubnetURL, !tc.enableMSCPhase1)
-			if err != nil {
-				t.Errorf("failed to initialize zone getter: %v", err)
-			}
-
-			ts.zoneGetter = fakeZoneGetter
-			//Make sure NodeTopologyInformer is considered as synced, otherwise only defaultSubnet is returned
-			zonegetter.SetNodeTopologyHasSynced(ts.zoneGetter, func() bool { return true })
-			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(ts.EpCalculatorMode, ts.IncludeDrainNodesL4Local), klog.TODO())
-			if err != nil {
-				t.Errorf("errored when retrieving zones: %s", err)
-			}
-
-			var allRefs []negv1beta1.NegObjectReference
-			for _, subnet := range tc.originalSubnets {
-				negName := fmt.Sprintf("testNegName-%s", subnet.Name)
-				refs := createNEGs(t, ts, fakeCloud, negName, subnet.SubnetPath, sets.NewString(origZones...), negv1beta1.ActiveState)
-
-				if !tc.emptySubnetURL {
-					allRefs = append(allRefs, refs...)
-					continue
-				}
-				for _, ref := range refs {
-					ref.SubnetURL = ""
-					allRefs = append(allRefs, ref)
-				}
-			}
-
-			negCR := createNegCR(ts.NegName, metav1.Now(), true, true, allRefs)
-			if err = ts.svcNegLister.Add(negCR); err != nil {
-				t.Errorf("failed to add neg to store:%s", err)
-			}
-			// Add topology to relect new state
-			nodeTopologyInformer.GetIndexer().Add(&nodetopologyv1.NodeTopology{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "NodeTopology",
-					APIVersion: "networking.gke.io/v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: flags.F.NodeTopologyCRName,
-				},
-
-				Status: nodetopologyv1.NodeTopologyStatus{
-					Subnets: tc.currentSubnets,
-				},
-			})
-
-			isSubnetChange := ts.isSubnetChange()
-			if isSubnetChange != tc.expectedResult {
-				t.Errorf("isSubnetChange() returned %t, wanted %t", isSubnetChange, tc.expectedResult)
-			}
-		})
-	}
-}
-
 func generateNonDefaultSubnetNegNameMap(t *testing.T, ts *transactionSyncer, subnetConfigs []nodetopologyv1.SubnetConfig) map[nodetopologyv1.SubnetConfig]string {
 	t.Helper()
 	negNameSubnetMap := make(map[nodetopologyv1.SubnetConfig]string)
@@ -2806,100 +2666,217 @@ func TestUpdateStatus(t *testing.T) {
 	}
 }
 
-func TestIsZoneChange(t *testing.T) {
+func TestIsTopologyChange(t *testing.T) {
 	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
 	testSubnetwork := defaultTestSubnetURL
-	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
 	testNegType := negtypes.VmIpPortEndpointType
 
 	testCases := []struct {
-		desc                           string
-		zoneDeleted                    bool
-		zoneAdded                      bool
-		nodeWithNoProviderIDAdded      bool
-		nodeWithInvalidProviderIDAdded bool
-		expectedResult                 bool
+		desc                         string
+		initialTopology              shared.ZonesPerSubnetMap
+		finalTopology                shared.ZonesPerSubnetMap
+		enableMSC                    bool
+		emptySubnetURL               bool
+		addNodeWithInvalidProviderID bool
+		addNodeWithNoProviderID      bool
+		expectedResult               bool
 	}{
 		{
-			desc:           "zone was added",
-			zoneAdded:      true,
+			desc: "zone was added",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2", "zone3"),
+			},
+			enableMSC:      true,
 			expectedResult: true,
 		},
 		{
-			desc:           "zone was deleted",
-			zoneDeleted:    true,
+			desc: "zone was deleted",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone2"),
+			},
+			enableMSC:      true,
 			expectedResult: true,
 		},
 		{
-			desc:                           "node with invalid providerID was added",
-			nodeWithInvalidProviderIDAdded: true,
-			expectedResult:                 false,
+			desc: "node with invalid providerID was added",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			enableMSC:                    true,
+			addNodeWithInvalidProviderID: true,
+			expectedResult:               false,
 		},
 		{
-			desc:                      "node with no providerID was added",
-			nodeWithNoProviderIDAdded: true,
-			expectedResult:            false,
+			desc: "node with no providerID was added",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			enableMSC:               true,
+			addNodeWithNoProviderID: true,
+			expectedResult:          false,
 		},
 		{
-			desc:                      "node with no providerID was added and normal nodes added",
-			zoneAdded:                 true,
-			nodeWithNoProviderIDAdded: true,
-			expectedResult:            true,
+			desc: "node with no providerID was added and normal nodes added",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2", "zone3"),
+			},
+			enableMSC:               true,
+			addNodeWithNoProviderID: true,
+			expectedResult:          true,
 		},
 		{
-			desc:           "no zone change occurred",
+			desc: "no zone change occurred",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1", "zone2"),
+			},
+			enableMSC:      true,
 			expectedResult: false,
+		},
+		{
+			desc: "subnet was added",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			enableMSC:      true,
+			expectedResult: true,
+		},
+		{
+			desc: "subnet was deleted",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			enableMSC:      true,
+			expectedResult: true,
+		},
+		{
+			desc: "no subnet change occurred",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			enableMSC:      true,
+			expectedResult: false,
+		},
+		{
+			desc: "no subnet change occurred, origRefs have empty URLs",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			enableMSC:      true,
+			emptySubnetURL: true,
+			expectedResult: false,
+		},
+		{
+			desc: "subnet was added and MSC is disabled",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			enableMSC:      false,
+			expectedResult: false,
+		},
+		{
+			desc: "subnet was deleted and MSC is disabled",
+			initialTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet:    sets.New("zone1"),
+				secondaryTestSubnet1: sets.New("zone1"),
+			},
+			finalTopology: shared.ZonesPerSubnetMap{
+				defaultTestSubnet: sets.New("zone1"),
+			},
+			enableMSC:      false,
+			expectedResult: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, syncer, err := newTestTransactionSyncer(fakeCloud, testNegType, false)
+			// Save old flags to reset at end of test
+			prevNodeTopologyCRName := flags.F.NodeTopologyCRName
+			prevEnableMultiSubnetClusterPhase1 := flags.F.EnableMultiSubnetClusterPhase1
+			defer func() {
+				flags.F.NodeTopologyCRName = prevNodeTopologyCRName
+				flags.F.EnableMultiSubnetClusterPhase1 = prevEnableMultiSubnetClusterPhase1
+			}()
+			flags.F.NodeTopologyCRName = "default"
+			flags.F.EnableMultiSubnetClusterPhase1 = tc.enableMSC
+
+			nodeTopologyInformer := zonegetter.FakeNodeTopologyInformer()
+			initialZg, _ := createZoneGetterFromTopology(t, tc.initialTopology, nodeTopologyInformer, !tc.enableMSC)
+
+			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+			_, syncer, err := newTestTransactionSyncerWithTopologyInformer(fakeCloud, testNegType, false, nodeTopologyInformer)
 			if err != nil {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
 			}
-			fakeZoneGetter := syncer.zoneGetter
-			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(syncer.EpCalculatorMode, syncer.IncludeDrainNodesL4Local), klog.TODO())
-			if err != nil {
-				t.Errorf("errored when retrieving zones: %s", err)
+			syncer.zoneGetter = initialZg
+			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+
+			var allRefs []negv1beta1.NegObjectReference
+			for subnet, zones := range tc.initialTopology {
+				negName := testNegName
+				if subnet != defaultTestSubnet {
+					negName, err = syncer.getNonDefaultSubnetNEGName(subnet)
+					if err != nil {
+						t.Fatalf("failed to get non-default subnet NEG name: %v", err)
+					}
+				}
+				refs := createNEGs(t, syncer, fakeCloud, negName, fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", subnet), sets.String(zones), negv1beta1.ActiveState)
+				if tc.emptySubnetURL {
+					for i := range refs {
+						refs[i].SubnetURL = ""
+					}
+				}
+				allRefs = append(allRefs, refs...)
 			}
 
-			for _, zone := range origZones {
-				fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
-					Version:             syncer.NegSyncerKey.GetAPIVersion(),
-					Name:                testNegName,
-					NetworkEndpointType: string(syncer.NegSyncerKey.NegType),
-					Network:             fakeCloud.NetworkURL(),
-					Subnetwork:          fakeCloud.SubnetworkURL(),
-				}, zone, klog.TODO())
-			}
-			negRefMap, err := negObjectReferences(fakeCloud, negv1beta1.ActiveState, sets.NewString(origZones...), syncer.NegSyncerKey.NegName)
-			if err != nil {
-				t.Errorf("Failed to get negObjRef from NEG CR: %v", err)
-			}
-
-			var refs []negv1beta1.NegObjectReference
-			for _, neg := range negRefMap {
-				refs = append(refs, neg)
-			}
-			negCR := createNegCR(syncer.NegName, metav1.Now(), true, true, refs)
+			negCR := createNegCR(syncer.NegName, metav1.Now(), true, true, allRefs)
 			if err = syncer.svcNegLister.Add(negCR); err != nil {
 				t.Errorf("failed to add neg to store:%s", err)
 			}
 
-			if tc.zoneDeleted {
-				zonegetter.DeleteFakeNodesInZone(t, "zone1", fakeZoneGetter)
-			}
+			finalZg, _ := createZoneGetterFromTopology(t, tc.finalTopology, nodeTopologyInformer, !tc.enableMSC)
+			syncer.zoneGetter = finalZg
+			zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
 
-			if tc.zoneAdded {
-				// Add a node in the zone to add a new zone to the ZoneGetter.
-				if err := zonegetter.AddFakeNodes(fakeZoneGetter, "zoneA", "instance-1"); err != nil {
-					t.Errorf("failed to add zone:%s", err)
-				}
-			}
-
-			if tc.nodeWithInvalidProviderIDAdded {
-				if err := zonegetter.AddFakeNode(fakeZoneGetter, &corev1.Node{
+			if tc.addNodeWithInvalidProviderID {
+				if err := zonegetter.AddFakeNode(finalZg, &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-with-invalid-providerID",
 					},
@@ -2918,9 +2895,8 @@ func TestIsZoneChange(t *testing.T) {
 					t.Errorf("failed to add node with invalid providerID:%s", err)
 				}
 			}
-
-			if tc.nodeWithNoProviderIDAdded {
-				if err := zonegetter.AddFakeNode(fakeZoneGetter, &corev1.Node{
+			if tc.addNodeWithNoProviderID {
+				if err := zonegetter.AddFakeNode(finalZg, &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node-without-providerID",
 					},
@@ -2937,12 +2913,127 @@ func TestIsZoneChange(t *testing.T) {
 				}
 			}
 
-			isZoneChange := syncer.isZoneChange()
-			if isZoneChange != tc.expectedResult {
-				t.Errorf("isZoneChange() returned %t, wanted %t", isZoneChange, tc.expectedResult)
+			var finalSubnets []nodetopologyv1.SubnetConfig
+			for subnet := range tc.finalTopology {
+				finalSubnets = append(finalSubnets, nodetopologyv1.SubnetConfig{
+					Name:       subnet,
+					SubnetPath: fmt.Sprintf("projects/mock-project/regions/test-region/subnetworks/%s", subnet),
+				})
+			}
+			nodeTopologyInformer.GetIndexer().Add(&nodetopologyv1.NodeTopology{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "NodeTopology",
+					APIVersion: "networking.gke.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: flags.F.NodeTopologyCRName,
+				},
+				Status: nodetopologyv1.NodeTopologyStatus{
+					Subnets: finalSubnets,
+				},
+			})
+
+			isTopologyChange := syncer.isTopologyChange()
+			if isTopologyChange != tc.expectedResult {
+				t.Errorf("isTopologyChange() returned %t, wanted %t", isTopologyChange, tc.expectedResult)
 			}
 		})
+	}
+}
 
+func createZoneGetterFromTopology(t *testing.T, topology shared.ZonesPerSubnetMap, nodeTopologyInformer cache.SharedIndexInformer, onlyIncludeDefaultSubnetNodes bool) (*zonegetter.ZoneGetter, cache.Indexer) {
+	t.Helper()
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zg, err := zonegetter.NewFakeZoneGetter(nodeInformer, nodeTopologyInformer, defaultTestSubnetURL, onlyIncludeDefaultSubnetNodes)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
+	nodeIndexer := nodeInformer.GetIndexer()
+	populateNodesFromTopology(t, nodeIndexer, zg, topology)
+	return zg, nodeIndexer
+}
+
+func populateNodesFromTopology(t *testing.T, nodeIndexer cache.Indexer, zg *zonegetter.ZoneGetter, topology shared.ZonesPerSubnetMap) {
+	t.Helper()
+	for subnet, zones := range topology {
+		for zone := range zones {
+			nodeName := fmt.Sprintf("node-%s-%s", zone, subnet)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						utils.LabelNodeSubnet: subnet,
+					},
+				},
+				Spec: corev1.NodeSpec{
+					ProviderID: fmt.Sprintf("gce://foo-project/%s/%s", zone, nodeName),
+					PodCIDR:    "10.100.99.0/24",
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			}
+			if err := nodeIndexer.Add(node); err != nil {
+				t.Fatalf("Failed to add node to indexer: %v", err)
+			}
+			if err := zonegetter.AddFakeNode(zg, node); err != nil {
+				t.Fatalf("Failed to add node to zone getter: %v", err)
+			}
+		}
+	}
+}
+
+func TestIsTopologyChangeZeroCandidateNodes(t *testing.T) {
+	prevFlag := flags.F.EnableMultiSubnetClusterPhase1
+	defer func() { flags.F.EnableMultiSubnetClusterPhase1 = prevFlag }()
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+
+	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
+	testSubnetwork := defaultTestSubnetURL
+	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+	testNegType := negtypes.VmIpPortEndpointType
+
+	nodeTopologyInformer := zonegetter.FakeNodeTopologyInformer()
+	_, syncer, err := newTestTransactionSyncerWithTopologyInformer(fakeCloud, testNegType, false, nodeTopologyInformer)
+	if err != nil {
+		t.Fatalf("failed to initialize transaction syncer: %v", err)
+	}
+	zonegetter.SetNodeTopologyHasSynced(syncer.zoneGetter, func() bool { return true })
+
+	// Define subnets: default and secondary
+	defaultSubnetName := defaultTestSubnet
+	secondarySubnetName := "secondary-subnet"
+	secondarySubnetURL := "projects/mock-project/regions/test-region/subnetworks/secondary-subnet"
+
+	nodeTopologyCR := &nodetopologyv1.NodeTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flags.F.NodeTopologyCRName,
+		},
+		Status: nodetopologyv1.NodeTopologyStatus{
+			Subnets: []nodetopologyv1.SubnetConfig{
+				{Name: defaultSubnetName, SubnetPath: defaultTestSubnetURL},
+				{Name: secondarySubnetName, SubnetPath: secondarySubnetURL},
+			},
+		},
+	}
+	if err := zonegetter.AddNodeTopologyCR(syncer.zoneGetter, nodeTopologyCR); err != nil {
+		t.Fatalf("failed to add node topology CR: %v", err)
+	}
+
+	// Delete all default nodes to ensure 0 candidate nodes.
+	for _, zone := range []string{"zone1", "zone2", "zone3", "zone4"} {
+		zonegetter.DeleteFakeNodesInZone(t, zone, syncer.zoneGetter)
+	}
+
+	// isTopologyChange should return false because expectedSubnetZones is empty and no NEGs exist.
+	isTopologyChange := syncer.isTopologyChange()
+	if isTopologyChange {
+		t.Errorf("isTopologyChange() returned %t, wanted false (zero candidate nodes should not trigger change if no NEGs exist)", isTopologyChange)
 	}
 }
 

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -698,25 +698,27 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter *zonegetter.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
-	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
-	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
-	zones, err := zoneGetter.ListZones(zonegetter.AllNodesFilter, logger)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), logger)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	candidateZonesMap := sets.NewString(candidateNodeZones...)
-
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter negtypes.TopologyProvider, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
 	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	drainingEndpoints := make(map[negtypes.NetworkEndpoint]string)
+
+	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
+	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
+	allZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(zonegetter.AllNodesFilter, logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	candidateZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	for subnet, negName := range subnetToNegMapping {
-		for _, zone := range zones {
+		zones := allZonesPerSubnet[subnet]
+		candidateZonesMap := candidateZonesPerSubnet[subnet]
+
+		for zone := range zones {
 			networkEndpointsWithHealthStatus, err := cloud.ListNetworkEndpoints(negName, zone, retrieveDrainStatus, version, logger)
 			if err != nil {
 				// It is possible for a NEG to be missing in a zone without candidate nodes. Log and ignore this error.

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
@@ -775,9 +776,52 @@ func TestIpsForPod(t *testing.T) {
 func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	nodeInformer := zonegetter.FakeNodeInformer()
 	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+
+	for _, zone := range []string{negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone4} {
+		nodeName := fmt.Sprintf("additional-node-%s-%s", zone, additionalTestSubnet)
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+				Labels: map[string]string{
+					utils.LabelNodeSubnet: additionalTestSubnet,
+				},
+			},
+			Spec: v1.NodeSpec{
+				ProviderID: fmt.Sprintf("gce://foo-project/%s/%s", zone, nodeName),
+				PodCIDR:    "10.100.99.0/24",
+			},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		}
+		if err := nodeInformer.GetIndexer().Add(node); err != nil {
+			t.Fatalf("Failed to add fake node: %v", err)
+		}
+	}
+
 	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
 	if err != nil {
 		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
+	zonegetter.SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
+	nodeTopologyCR := &nodetopologyv1.NodeTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flags.F.NodeTopologyCRName,
+		},
+		Status: nodetopologyv1.NodeTopologyStatus{
+			Subnets: []nodetopologyv1.SubnetConfig{
+				{Name: defaultTestSubnet, SubnetPath: defaultTestSubnetURL},
+				{Name: additionalTestSubnet, SubnetPath: "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/additional-subnet"},
+			},
+		},
+	}
+	if err := zonegetter.AddNodeTopologyCR(zoneGetter, nodeTopologyCR); err != nil {
+		t.Fatalf("failed to add node topology CR: %v", err)
 	}
 	negCloud := negtypes.NewFakeNetworkEndpointGroupCloud("test-subnetwork", "test-network")
 	defaultSubnetNegName := "test-neg-name"

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -17,10 +17,14 @@ limitations under the License.
 package types
 
 import (
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	compute "google.golang.org/api/compute/v1"
+
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 )
 
@@ -93,4 +97,11 @@ type NetworkEndpointsCalculator interface {
 	Mode() EndpointsCalculatorMode
 	// ValidateEndpoints validates the NEG endpoint information is correct
 	ValidateEndpoints(endpointData []EndpointsData, endpointPodMap EndpointPodMap, endpointsExcludedInCalculation int) error
+}
+
+// TopologyProvider is an interface for looking up zone and subnet information for NEG syncer.
+// It helps to determine GCE locations (subnets and zones) where NEGs should be created and/or synced.
+type TopologyProvider interface {
+	ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConfig
+	ListZonesPerSubnet(filter zonegetter.Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error)
 }

--- a/pkg/neg/types/shared/types.go
+++ b/pkg/neg/types/shared/types.go
@@ -16,6 +16,24 @@ limitations under the License.
 
 package shared
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 const (
 	NegReadinessGate = "cloud.google.com/load-balancer-neg-ready"
 )
+
+type ZonesPerSubnetMap map[string]sets.Set[string]
+
+func (m ZonesPerSubnetMap) Equal(other ZonesPerSubnetMap) bool {
+	if len(m) != len(other) {
+		return false
+	}
+
+	for subnet, zones := range m {
+		zones_other, ok := other[subnet]
+		if !ok || !zones.Equal(zones_other) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/neg/types/shared/types_test.go
+++ b/pkg/neg/types/shared/types_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestZonesPerSubnetMapEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		desc           string
+		a              ZonesPerSubnetMap
+		b              ZonesPerSubnetMap
+		expectedResult bool
+	}{
+		{
+			desc:           "both nil",
+			a:              nil,
+			b:              nil,
+			expectedResult: true,
+		},
+		{
+			desc:           "both empty",
+			a:              ZonesPerSubnetMap{},
+			b:              ZonesPerSubnetMap{},
+			expectedResult: true,
+		},
+		{
+			desc:           "one nil, one empty",
+			a:              nil,
+			b:              ZonesPerSubnetMap{},
+			expectedResult: true,
+		},
+		{
+			desc: "equal maps, single subnet",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone2"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone2"),
+			},
+			expectedResult: true,
+		},
+		{
+			desc: "equal maps, multiple subnets",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone2"),
+				"subnet2": sets.New("zone3"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone2", "zone1"),
+				"subnet2": sets.New("zone3"),
+			},
+			expectedResult: true,
+		},
+		{
+			desc: "different lengths",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1"),
+				"subnet2": sets.New("zone2"),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "same subnets, different zones",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone2"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone3"),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "different subnets, same zones",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet2": sets.New("zone1"),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "one set is subset of another",
+			a: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1", "zone2"),
+			},
+			b: ZonesPerSubnetMap{
+				"subnet1": sets.New("zone1"),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := tc.a.Equal(tc.b)
+			if result != tc.expectedResult {
+				t.Errorf("ZonesPerSubnetMap.Equal() = %t, want %t", result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -29,6 +29,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -236,6 +237,30 @@ func (z *ZoneGetter) ListZones(filter Filter, logger klog.Logger) ([]string, err
 // node filtering mode.
 func (z *ZoneGetter) ListZonesInDefaultSubnet(filter Filter, logger klog.Logger) ([]string, error) {
 	return z.listZones(filter, true, logger)
+}
+
+// ListZonesPerSubnet returns a list of zones containing nodes that satisfy the given node filtering mode per subnet.
+func (z *ZoneGetter) ListZonesPerSubnet(filter Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
+	subnetConfigs := z.ListSubnets(logger)
+	if subnetConfigs == nil {
+		return shared.ZonesPerSubnetMap{}, nil
+	}
+
+	zones, err := z.ListZones(filter, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't return subnets with empty zones set. As ZoneGetter returns all zones per all subnets - don't return any.
+	if len(zones) == 0 {
+		return shared.ZonesPerSubnetMap{}, nil
+	}
+
+	zonesPerSubnet := make(shared.ZonesPerSubnetMap)
+	for _, subnetConfig := range subnetConfigs {
+		zonesPerSubnet[subnetConfig.Name] = sets.New(zones...)
+	}
+	return zonesPerSubnet, nil
 }
 
 func (z *ZoneGetter) listZones(filter Filter, defaultSubnetOnly bool, logger klog.Logger) ([]string, error) {

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -28,7 +28,9 @@ import (
 	api_v1 "k8s.io/api/core/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -724,13 +726,35 @@ func TestNonGCPZoneGetter(t *testing.T) {
 	zone := "foo"
 	subnet := ""
 	zoneGetter := NewNonGCPZoneGetter(zone)
+	SetNodeTopologyHasSynced(zoneGetter, func() bool { return false })
+	expectZones := []string{zone}
+
+	// ListZones
 	ret, err := zoneGetter.ListZones(AllNodesFilter, klog.TODO())
 	if err != nil {
-		t.Errorf("expect err = nil, but got %v", err)
+		t.Errorf("expect err = nil for ListZones, but got %v", err)
 	}
-	expectZones := []string{zone}
 	if !reflect.DeepEqual(expectZones, ret) {
-		t.Errorf("expect list zones = %v, but got %v", expectZones, ret)
+		t.Errorf("expect ListZones = %v, but got %v", expectZones, ret)
+	}
+
+	// ListZonesInDefaultSubnet
+	retInDefault, err := zoneGetter.ListZonesInDefaultSubnet(AllNodesFilter, klog.TODO())
+	if err != nil {
+		t.Errorf("expect err = nil for ListZonesInDefaultSubnet, but got %v", err)
+	}
+	if !reflect.DeepEqual(expectZones, retInDefault) {
+		t.Errorf("expect ListZonesInDefaultSubnet = %v, but got %v", expectZones, retInDefault)
+	}
+
+	// ListZonesPerSubnet
+	retPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, klog.TODO())
+	if err != nil {
+		t.Errorf("expect err = nil for ListZonesPerSubnet, but got %v", err)
+	}
+	expectZonesPerSubnet := shared.ZonesPerSubnetMap{"": sets.New(expectZones...)}
+	if !reflect.DeepEqual(expectZonesPerSubnet, retPerSubnet) {
+		t.Errorf("expect ListZonesPerSubnet = %v, but got %v", expectZonesPerSubnet, retPerSubnet)
 	}
 
 	validateGetZoneForNode := func(node string) {
@@ -1610,7 +1634,7 @@ func TestListSubnets(t *testing.T) {
 			fakeTopologyInformer := FakeNodeTopologyInformer()
 			zoneGetter, err := NewFakeZoneGetter(FakeNodeInformer(), fakeTopologyInformer, defaultTestSubnetURL, !tc.enableMSC)
 			if err != nil {
-				t.Fatalf("failed to initialize zone getter")
+				t.Fatalf("failed to initialize zone getter: %v", err)
 			}
 
 			zoneGetter.nodeTopologyHasSynced = func() bool { return tc.nodeTopologySynced }
@@ -1637,5 +1661,117 @@ func TestLegacyListSubnets(t *testing.T) {
 	subnets := zoneGetter.ListSubnets(klog.TODO())
 	if len(subnets) != 0 {
 		t.Errorf("In legacy mode, ListSubnets() returned %d, expected 0 subnets", len(subnets))
+	}
+}
+
+func TestLegacyListZonesPerSubnet(t *testing.T) {
+	t.Parallel()
+
+	nodeInformer := FakeNodeInformer()
+	PopulateFakeNodeInformer(nodeInformer, true)
+	zoneGetter := NewLegacyZoneGetter(nodeInformer, FakeNodeTopologyInformer())
+
+	zonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, klog.TODO())
+	if err != nil {
+		t.Errorf("expect err = nil for ListZonesPerSubnet, but got %v", err)
+	}
+
+	expectZonesPerSubnet := shared.ZonesPerSubnetMap{}
+	if !reflect.DeepEqual(expectZonesPerSubnet, zonesPerSubnet) {
+		t.Errorf("expect ListZonesPerSubnet = %v, but got %v", expectZonesPerSubnet, zonesPerSubnet)
+	}
+}
+
+func TestListZonesPerSubnet(t *testing.T) {
+	t.Parallel()
+
+	nodeInformer := FakeNodeInformer()
+	PopulateFakeNodeInformer(nodeInformer, true)
+	zoneGetter, err := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter")
+	}
+	nodeTopologyCR := &nodetopologyv1.NodeTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: flags.F.NodeTopologyCRName,
+		},
+		Status: nodetopologyv1.NodeTopologyStatus{
+			Subnets: []nodetopologyv1.SubnetConfig{
+				{Name: defaultTestSubnet, SubnetPath: defaultTestSubnetURL},
+				{Name: nonDefaultTestSubnet, SubnetPath: "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/non-default"},
+			},
+		},
+	}
+	if err := AddNodeTopologyCR(zoneGetter, nodeTopologyCR); err != nil {
+		t.Fatalf("failed to add node topology CR: %v", err)
+	}
+	SetNodeTopologyHasSynced(zoneGetter, func() bool { return true })
+
+	testCases := []struct {
+		desc                          string
+		filter                        Filter
+		wantZonesPerSubnetOnlyDefault shared.ZonesPerSubnetMap
+		wantZonesPerSubnetAllSubnets  shared.ZonesPerSubnetMap
+	}{
+		{
+			desc:   "List with AllNodesFilter",
+			filter: AllNodesFilter,
+			wantZonesPerSubnetOnlyDefault: shared.ZonesPerSubnetMap{
+				"default": sets.New("zone1", "zone2", "zone3", "zone4", "zone5", "zone6"),
+			},
+			wantZonesPerSubnetAllSubnets: shared.ZonesPerSubnetMap{
+				"default":     sets.New("zone1", "zone2", "zone3", "zone4", "zone5", "zone6", "zone7", "zone8"),
+				"non-default": sets.New("zone1", "zone2", "zone3", "zone4", "zone5", "zone6", "zone7", "zone8"),
+			},
+		},
+		{
+			desc:   "List with CandidateNodesFilter",
+			filter: CandidateNodesFilter,
+			wantZonesPerSubnetOnlyDefault: shared.ZonesPerSubnetMap{
+				"default": sets.New("zone1", "zone2", "zone4", "zone5", "zone6"),
+			},
+			wantZonesPerSubnetAllSubnets: shared.ZonesPerSubnetMap{
+				"default":     sets.New("zone1", "zone2", "zone4", "zone5", "zone6", "zone7", "zone8"),
+				"non-default": sets.New("zone1", "zone2", "zone4", "zone5", "zone6", "zone7", "zone8"),
+			},
+		},
+		{
+			desc:   "List with CandidateAndUnreadyNodesFilter",
+			filter: CandidateAndUnreadyNodesFilter,
+			wantZonesPerSubnetOnlyDefault: shared.ZonesPerSubnetMap{
+				"default": sets.New("zone1", "zone2", "zone3", "zone5", "zone6"),
+			},
+			wantZonesPerSubnetAllSubnets: shared.ZonesPerSubnetMap{
+				"default":     sets.New("zone1", "zone2", "zone3", "zone5", "zone6", "zone7", "zone8"),
+				"non-default": sets.New("zone1", "zone2", "zone3", "zone5", "zone6", "zone7", "zone8"),
+			},
+		},
+		{
+			desc:                          "List with filter matching no nodes",
+			filter:                        Filter("non-existent-filter"),
+			wantZonesPerSubnetOnlyDefault: shared.ZonesPerSubnetMap{},
+			wantZonesPerSubnetAllSubnets:  shared.ZonesPerSubnetMap{},
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, onlyIncludeDefaultSubnetNodes := range []bool{true, false} {
+			t.Run(tc.desc, func(t *testing.T) {
+				zoneGetter.onlyIncludeDefaultSubnetNodes = onlyIncludeDefaultSubnetNodes
+				gotZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(tc.filter, klog.TODO())
+				if err != nil {
+					t.Errorf("expect err = nil, but got %v", err)
+				}
+
+				wantZonesPerSubnet := tc.wantZonesPerSubnetAllSubnets
+				if onlyIncludeDefaultSubnetNodes {
+					wantZonesPerSubnet = tc.wantZonesPerSubnetOnlyDefault
+				}
+
+				if diff := cmp.Diff(wantZonesPerSubnet, gotZonesPerSubnet); diff != "" {
+					t.Errorf("ListZonesPerSubnet() mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Create interface for providing target subnets/zones where NEGs should be created/managed by NEG controller, so it will be possible to provide these in future APIs instead of solely rely on the NodeTopology CR.

Also makes zones list subnet-aware for syncer - for different subnets different subsets of zones can be provided.

EDIT:
Overview:
* `ZoneGetter` accessed through `TopologyProvider` by the `transactionSyncer`
* Zones list provided by `TopologyProvider` is subnet-dependent (possible to have different zones for different subnets)
* `transactionSyncer.IsZoneChange` checks zones per subnet, which leads to verifying subnets' change as well - `transactionSyncer.IsSubnetChange` removed, `transactionSyncer.IsZoneChange` updated and renamed into `transactionSyncer.IsLocationChange`