### PR TITLE
Add support for blocking svc deletion until svcnegs are fully cleaned up

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -18,6 +18,7 @@ package neg
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
@@ -51,6 +52,7 @@ import (
 	"k8s.io/ingress-gce/pkg/network"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/common"
 	"k8s.io/ingress-gce/pkg/utils/endpointslices"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/patch"
@@ -72,6 +74,7 @@ type Controller struct {
 	hasSynced             func() bool
 	ingressLister         cache.Indexer
 	serviceLister         cache.Indexer
+	svcNegLister          cache.Indexer
 	client                kubernetes.Interface
 	defaultBackendService utils.ServicePort
 
@@ -249,6 +252,7 @@ func NewController(
 		hasSynced:                      hasSynced,
 		ingressLister:                  ingressInformer.GetIndexer(),
 		serviceLister:                  serviceInformer.GetIndexer(),
+		svcNegLister:                   svcNegInformer.GetIndexer(),
 		networkResolver:                network.NewNetworksResolver(networkIndexer, gkeNetworkParamSetIndexer, cloud, enableMultiNetworking, logger),
 		serviceQueue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_service_queue"),
 		endpointQueue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_endpoint_queue"),
@@ -321,6 +325,9 @@ func NewController(
 		UpdateFunc: func(old, cur interface{}) {
 			negController.enqueueService(cur)
 		},
+	})
+	svcNegInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: negController.handleSvcNegDelete,
 	})
 	endpointSliceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    negController.enqueueEndpointSlice,
@@ -552,6 +559,47 @@ func (c *Controller) processService(key string) error {
 	if service == nil {
 		return fmt.Errorf("cannot convert to Service (%T)", obj)
 	}
+
+	// Add an additional finalizer if WaitForNegCleanupKey is set. This will not be removed from the
+	// service until associated SvcNeg objects are fully deleted
+	if service.DeletionTimestamp == nil && service.Annotations != nil {
+		if val, ok := service.Annotations[negannotation.WaitForNegCleanupKey]; ok && strings.ToLower(val) == "enabled" {
+			if err := common.EnsureServiceFinalizer(service, common.SvcNegCleanupFinalizer, c.client, c.logger); err != nil {
+				return fmt.Errorf("failed to ensure service finalizer: %w", err)
+			}
+		}
+	}
+
+	if service.DeletionTimestamp != nil && common.HasGivenFinalizer(service.ObjectMeta, common.SvcNegCleanupFinalizer) {
+		// Wait for L4 controller to clean up before deleting NEGs
+		if common.HasGivenFinalizer(service.ObjectMeta, common.NetLBFinalizerV3) {
+			c.logger.Info("Waiting for L4 controller to remove finalizer before cleaning up NEGs", "service", key)
+			return nil
+		}
+
+		c.manager.StopSyncer(namespace, name)
+
+		negCRs := c.svcNegLister.List()
+		found := false
+		for _, obj := range negCRs {
+			neg := obj.(*svcnegv1beta1.ServiceNetworkEndpointGroup)
+			if neg.Namespace == service.Namespace && neg.Labels[negtypes.NegCRServiceNameKey] == service.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			c.logger.Info("All SvcNegs are gone, removing finalizer from service", "service", key)
+			err := common.EnsureDeleteServiceFinalizer(service, common.SvcNegCleanupFinalizer, c.client, c.logger)
+			if err != nil {
+				return fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+			return nil
+		}
+		c.logger.Info("Waiting for SvcNegs to be deleted before removing finalizer", "service", key)
+		return nil // Wait for next sync
+	}
+
 	negUsage := metricscollector.NegServiceState{}
 	svcPortInfoMap := make(negtypes.PortInfoMap)
 	networkInfo, err := c.networkResolver.ServiceNetwork(service)
@@ -887,6 +935,28 @@ func (c *Controller) handleErr(err error, key interface{}) {
 		c.recorder.Event(service.(*apiv1.Service), apiv1.EventTypeWarning, "ProcessServiceFailed", msg)
 	}
 	c.serviceQueue.AddRateLimited(key)
+}
+
+func (c *Controller) handleSvcNegDelete(obj interface{}) {
+	negCR, ok := obj.(*svcnegv1beta1.ServiceNetworkEndpointGroup)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			c.logger.Error(nil, "Unexpected object type", "type", fmt.Sprintf("%T", obj))
+			return
+		}
+		negCR, ok = tombstone.Obj.(*svcnegv1beta1.ServiceNetworkEndpointGroup)
+		if !ok {
+			c.logger.Error(nil, "Unexpected tombstone object", "type", fmt.Sprintf("%T", obj))
+			return
+		}
+	}
+	if negCR != nil {
+		svcName := negCR.Labels[negtypes.NegCRServiceNameKey]
+		if svcName != "" {
+			c.enqueueService(cache.ExplicitKey(fmt.Sprintf("%s/%s", negCR.Namespace, svcName)))
+		}
+	}
 }
 
 func (c *Controller) enqueueEndpointSlice(obj interface{}) {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
+	svcnegv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/flags"
 	l4annotations "k8s.io/ingress-gce/pkg/l4/annotations"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
@@ -675,6 +676,210 @@ func TestDisableNEGServiceWithIngress(t *testing.T) {
 		t.Fatalf("Failed to process service: %v", err)
 	}
 	validateSyncers(t, controller, 3, true)
+}
+
+func TestBlockDeletionUntilSvcNegCleanup(t *testing.T) {
+	t.Parallel()
+
+	controller, err := newTestController(fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("failed to create test controller %s", err)
+	}
+	defer controller.stop()
+
+	svc := newTestService(controller, true, []int32{80})
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[negannotation.WaitForNegCleanupKey] = "enabled"
+
+	controller.serviceLister.Add(svc)
+	controller.ingressLister.Add(newTestIngress(testServiceName))
+
+	_, err = controller.client.CoreV1().Services(testServiceNamespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		existingSvc, err := controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get service: %v", err)
+		}
+		if existingSvc.Annotations == nil {
+			existingSvc.Annotations = make(map[string]string)
+		}
+		existingSvc.Annotations[negannotation.WaitForNegCleanupKey] = "enabled"
+		_, err = controller.client.CoreV1().Services(testServiceNamespace).Update(context.TODO(), existingSvc, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update service in fake client: %v", err)
+		}
+	}
+
+	svcKey := utils.ServiceKeyFunc(testServiceNamespace, testServiceName)
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+
+	updatedSvc, err := controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get service: %v", err)
+	}
+	if !common.HasGivenFinalizer(updatedSvc.ObjectMeta, common.SvcNegCleanupFinalizer) {
+		t.Fatalf("Expected service to have finalizer %s", common.SvcNegCleanupFinalizer)
+	}
+
+	negName := controller.namer.NEG(testServiceNamespace, testServiceName, 80)
+	negCR := &svcnegv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      negName,
+			Namespace: testServiceNamespace,
+			Labels: map[string]string{
+				negtypes.NegCRServiceNameKey: testServiceName,
+			},
+		},
+	}
+	controller.svcNegLister.Add(negCR)
+
+	now := metav1.Now()
+	updatedSvc.DeletionTimestamp = &now
+	controller.serviceLister.Update(updatedSvc)
+
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+
+	validateSyncers(t, controller, 3, true)
+
+	updatedSvc, err = controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get service: %v", err)
+	}
+	if !common.HasGivenFinalizer(updatedSvc.ObjectMeta, common.SvcNegCleanupFinalizer) {
+		t.Fatalf("Expected service to still have finalizer %s", common.SvcNegCleanupFinalizer)
+	}
+
+	controller.svcNegLister.Delete(negCR)
+
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+
+	updatedSvc, err = controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get service: %v", err)
+	}
+	if common.HasGivenFinalizer(updatedSvc.ObjectMeta, common.SvcNegCleanupFinalizer) {
+		t.Fatalf("Expected service to NOT have finalizer %s", common.SvcNegCleanupFinalizer)
+	}
+}
+
+func TestBlockDeletionUntilL4Cleanup(t *testing.T) {
+	t.Parallel()
+
+	controller, err := newTestController(fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("failed to create test controller %s", err)
+	}
+	defer controller.stop()
+
+	svc := newTestService(controller, true, []int32{80})
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[negannotation.WaitForNegCleanupKey] = "enabled"
+
+	controller.serviceLister.Add(svc)
+	controller.ingressLister.Add(newTestIngress(testServiceName))
+
+	existingSvc, err := controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err == nil {
+		if existingSvc.Annotations == nil {
+			existingSvc.Annotations = make(map[string]string)
+		}
+		existingSvc.Annotations[negannotation.WaitForNegCleanupKey] = "enabled"
+		_, err = controller.client.CoreV1().Services(testServiceNamespace).Update(context.TODO(), existingSvc, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to update service in fake client: %v", err)
+		}
+	} else {
+		if svc.Annotations == nil {
+			svc.Annotations = make(map[string]string)
+		}
+		svc.Annotations[negannotation.WaitForNegCleanupKey] = "enabled"
+		_, err = controller.client.CoreV1().Services(testServiceNamespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create service in fake client: %v", err)
+		}
+	}
+
+	svcKey := utils.ServiceKeyFunc(testServiceNamespace, testServiceName)
+
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+	validateSyncers(t, controller, 3, false)
+
+	now := metav1.Now()
+	updatedSvc, err := controller.client.CoreV1().Services(testServiceNamespace).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get service: %v", err)
+	}
+	updatedSvc.DeletionTimestamp = &now
+	updatedSvc.Finalizers = []string{common.SvcNegCleanupFinalizer, common.NetLBFinalizerV3}
+	controller.serviceLister.Update(updatedSvc)
+	_, err = controller.client.CoreV1().Services(testServiceNamespace).Update(context.TODO(), updatedSvc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update service in fake client: %v", err)
+	}
+
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+
+	validateSyncers(t, controller, 3, false)
+
+	updatedSvc.Finalizers = []string{common.SvcNegCleanupFinalizer}
+	controller.serviceLister.Update(updatedSvc)
+	_, err = controller.client.CoreV1().Services(testServiceNamespace).Update(context.TODO(), updatedSvc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update service in fake client: %v", err)
+	}
+
+	err = controller.processService(svcKey)
+	if err != nil {
+		t.Fatalf("Failed to process service: %v", err)
+	}
+
+	validateSyncers(t, controller, 3, true)
+}
+
+func TestSvcNegDeleteEnqueuesService(t *testing.T) {
+	t.Parallel()
+
+	controller, err := newTestController(fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("failed to create test controller %s", err)
+	}
+	defer controller.stop()
+
+	negCR := &svcnegv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-neg",
+			Namespace: testServiceNamespace,
+			Labels: map[string]string{
+				negtypes.NegCRServiceNameKey: testServiceName,
+			},
+		},
+	}
+
+	// Call the handler directly
+	controller.handleSvcNegDelete(negCR)
+
+	// Verify enqueue
+	svcKey := utils.ServiceKeyFunc(testServiceNamespace, testServiceName)
+	ensureEnqueue(t, svcKey, &controller.serviceQueue)
 }
 
 func TestGatherPortMappingUsedByIngress(t *testing.T) {

--- a/pkg/negannotation/negannotation.go
+++ b/pkg/negannotation/negannotation.go
@@ -38,6 +38,9 @@ const NEGAnnotationKey = "cloud.google.com/neg"
 // on the Service, and is applied by the NEG Controller.
 const NEGStatusKey = "cloud.google.com/neg-status"
 
+// WaitForNegCleanupKey is the annotation key to block service deletion until SvcNeg cleanup is complete.
+const WaitForNegCleanupKey = "cloud.google.com/wait-for-neg-cleanup"
+
 var (
 	ErrNEGAnnotationInvalid = errors.New("NEG annotation is invalid.")
 )

--- a/pkg/utils/common/finalizer.go
+++ b/pkg/utils/common/finalizer.go
@@ -40,6 +40,8 @@ const (
 	ILBFinalizerV2 = "gke.networking.io/l4-ilb-v2"
 	// NegFinalizerKey is the finalizer used by neg controller to ensure NEG CRs are deleted after corresponding negs are deleted
 	NegFinalizerKey = "networking.gke.io/neg-finalizer"
+	// SvcNegCleanupFinalizer is the finalizer used by neg controller to ensure SvcNeg CRs are deleted before the parent service is deleted
+	SvcNegCleanupFinalizer = "networking.gke.io/svcneg-cleanup"
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
 	// NetLBFinalizerV3 is the finalizer used by the NEG backed variant of the L4 External LoadBalancer services.


### PR DESCRIPTION
This PR introduces a new annotation (`cloud.google.com/wait-for-neg-cleanup`) that can be set on Service objects.

When set on NEG backed services, the NEG controller will add an additional finalizer to the service object (`networking.gke.io/svcneg-cleanup`). This finalizer is only removed once the NEGs associated with a service have been fully deleted.

Googlers - see b/514228484 for internal context.