### PR TITLE
Bump go to 1.26.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ OS ?= linux
 ALL_ARCH := amd64
 
 # Image to use for building.
-BUILD_IMAGE ?= golang:1.26.3
+BUILD_IMAGE ?= golang:1.26.4
 # Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION).
 CONTAINER_PREFIX ?= ingress-gce
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/ingress-gce
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/GoogleCloudPlatform/gke-networking-api v0.2.1-0.20250318085121-e88f4ed9f50a

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/ingress-gce/hack/tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ashanbrown/forbidigo v1.6.0


### PR DESCRIPTION
To include security fixes to the crypto/x509, mime, and net/textproto packages.