### PR TITLE
Implement NEGBinding-based NEG namer

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -1131,7 +1131,7 @@ func (s *transactionSyncer) getNonDefaultSubnetNEGName(subnet string) (string, e
 		return negName, nil
 	}
 
-	return s.namer.NonDefaultSubnetNEG(s.NegSyncerKey.Namespace, s.NegSyncerKey.Name, subnet, s.NegSyncerKey.PortTuple.Port), nil
+	return s.namer.NonDefaultSubnetNEG(s.NegSyncerKey.Namespace, s.NegSyncerKey.Name, subnet, s.NegSyncerKey.PortTuple.Port)
 }
 
 // computeDegradedModeCorrectness computes degraded mode correctness metrics based on the difference between degraded mode and normal calculation

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1501,7 +1501,10 @@ func TestCommitPodsMSC(t *testing.T) {
 	defaultSubnetNegName := transactionSyncer.NegName
 	defaultSubnetSyncerKey := transactionSyncer.NegSyncerKey
 
-	nonDefaultSubnetNegName := transactionSyncer.namer.NonDefaultSubnetNEG(transactionSyncer.NegSyncerKey.Namespace, transactionSyncer.NegSyncerKey.Name, additionalTestSubnet, transactionSyncer.NegSyncerKey.PortTuple.Port)
+	nonDefaultSubnetNegName, err := transactionSyncer.namer.NonDefaultSubnetNEG(transactionSyncer.NegSyncerKey.Namespace, transactionSyncer.NegSyncerKey.Name, additionalTestSubnet, transactionSyncer.NegSyncerKey.PortTuple.Port)
+	if err != nil {
+		t.Fatalf("Failed to get non-default subnet NEG name: %v", err)
+	}
 	nonDefaultSubnetSyncerKey := transactionSyncer.NegSyncerKey
 	nonDefaultSubnetSyncerKey.NegName = nonDefaultSubnetNegName
 

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -43,8 +43,8 @@ func (*negNamer) IsNEG(name string) bool {
 	return false
 }
 
-func (*negNamer) NonDefaultSubnetNEG(namespace, name, subnetName string, svcPort int32) string {
-	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, svcPort, subnetName)
+func (*negNamer) NonDefaultSubnetNEG(namespace, name, subnetName string, svcPort int32) (string, error) {
+	return fmt.Sprintf("%v-%v-%v-%v", namespace, name, svcPort, subnetName), nil
 }
 
 func (*negNamer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {

--- a/pkg/utils/namer/interfaces.go
+++ b/pkg/utils/namer/interfaces.go
@@ -78,7 +78,7 @@ type BackendNamer interface {
 type NonDefaultSubnetNEGNamer interface {
 	// NonDefaultSubnetNEG returns the gce neg name for NEGs created in non-default
 	// subnet.
-	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string
+	NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) (string, error)
 	// NonDefaultSubnetCustomNEG returns the gce neg name for custom NEGs created
 	// in non-default subnets.
 	NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error)

--- a/pkg/utils/namer/l4_namer.go
+++ b/pkg/utils/namer/l4_namer.go
@@ -76,14 +76,14 @@ func (namer *L4Namer) L4Backend(namespace, name string) string {
 //
 // subnetHash length = 6, nsNameHash length = 8, and the remainings are trimmed evenly.
 // Output name is at most 63 characters.
-func (namer *L4Namer) NonDefaultSubnetNEG(namespace, name, subnetName string, _ int32) string {
+func (namer *L4Namer) NonDefaultSubnetNEG(namespace, name, subnetName string, _ int32) (string, error) {
 	return strings.Join([]string{
 		namer.v2Prefix,
 		namer.v2ClusterUID,
 		getTrimmedNamespacedName(namespace, name, maximumL4CombinedLength-subnetHashLength-1),
 		subnetHash(subnetName),
 		namer.getServiceHash(namespace, name),
-	}, "-")
+	}, "-"), nil
 }
 
 // NonDefaultSubnetCustomNEG returns the gce neg name in the non-default subnet

--- a/pkg/utils/namer/l4_namer_test.go
+++ b/pkg/utils/namer/l4_namer_test.go
@@ -208,6 +208,10 @@ func TestL4Namer(t *testing.T) {
 			t.Parallel()
 			const frNumber = uint(10)
 
+			nonDefaultNEGName, err := namer.NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName, 0)
+			if err != nil {
+				t.Fatalf("NonDefaultSubnetNEG: unexpected error: %v", err)
+			}
 			// Act
 			got := names{
 				FRName:            namer.L4ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto)),
@@ -215,7 +219,7 @@ func TestL4Namer(t *testing.T) {
 				IPv6FRName:        namer.L4IPv6ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto)),
 				NetLbIPv6FRName:   namer.L4NetLBIPv6ForwardingRule(tc.namespace, tc.name, strings.ToLower(tc.proto), frNumber),
 				NEGName:           namer.L4Backend(tc.namespace, tc.name),
-				NonDefaultNEGName: namer.NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName, 0), // Port is not used for L4 NEG
+				NonDefaultNEGName: nonDefaultNEGName,
 				FWName:            namer.L4Firewall(tc.namespace, tc.name),
 				FWDenyName:        namer.L4FirewallDeny(tc.namespace, tc.name),
 				IPv6FWName:        namer.L4IPv6Firewall(tc.namespace, tc.name),

--- a/pkg/utils/namer/namer.go
+++ b/pkg/utils/namer/namer.go
@@ -484,14 +484,14 @@ func (n *Namer) NEG(namespace, name string, port int32) string {
 // information as possible, while avoiding potential conflicts with the NEGs in
 // the default subnet, or conflicts due to the naming pattern for non default
 // subnets(e.g.: us-central1-subnet, us-central2-subnet).
-func (n *Namer) NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) string {
+func (n *Namer) NonDefaultSubnetNEG(namespace, name, subnetName string, port int32) (string, error) {
 	portStr := fmt.Sprintf("%v", port)
 	hashedSubnet := subnetHash(subnetName)
 	truncFields := TrimFieldsEvenly(n.maxNEGLabelLength-subnetHashLength-1, namespace, name, portStr)
 	truncNamespace := truncFields[0]
 	truncName := truncFields[1]
 	truncPort := truncFields[2]
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, hashedSubnet, negSuffix(n.shortUID(), namespace, name, portStr, ""))
+	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", n.negPrefix(), truncNamespace, truncName, truncPort, hashedSubnet, negSuffix(n.shortUID(), namespace, name, portStr, "")), nil
 }
 
 // RXLBBackendName returns the gce Backend name based on the service namespace, name

--- a/pkg/utils/namer/namer_test.go
+++ b/pkg/utils/namer/namer_test.go
@@ -538,7 +538,10 @@ func TestNamerNonDefaultSubnetNEG(t *testing.T) {
 
 	newNamer := NewNamer(clusterId, "", klog.TODO())
 	for _, tc := range testCases {
-		res := newNamer.NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName, tc.port)
+		res, err := newNamer.NonDefaultSubnetNEG(tc.namespace, tc.name, tc.subnetName, tc.port)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.desc, err)
+		}
 		if len(res) > 63 {
 			t.Errorf("%s: got len(res) == %v, want <= 63", tc.desc, len(res))
 		}

--- a/pkg/utils/namer/negbinding_namer.go
+++ b/pkg/utils/namer/negbinding_namer.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namer
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/client-go/tools/cache"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+)
+
+var (
+	ErrNegBindingNotFound       = errors.New("negbinding is not in store")
+	ErrNegNameNotFound          = errors.New("NEG name for subnet not found in NegBinding Spec")
+	ErrNBNamerNotImplemented    = errors.New("not implemented for NegBindingNamer")
+	ErrNBNamerInvalidBackendRef = errors.New("NEGBinding's backendRef doesn't match")
+)
+
+// NegBindingNamer resolves NEG names based on NetworkEndpointGroupBinding CR.
+// It implements NonDefaultSubnetNEGNamer.
+type NegBindingNamer struct {
+	namespace        string
+	name             string
+	negBindingLister cache.Indexer
+}
+
+// NewNegBindingNamer constructs a new NegBindingNamer
+func NewNegBindingNamer(namespace, name string, negBindingLister cache.Indexer) *NegBindingNamer {
+	return &NegBindingNamer{
+		namespace:        namespace,
+		name:             name,
+		negBindingLister: negBindingLister,
+	}
+}
+
+func (n *NegBindingNamer) getBinding() (*negbindingv1beta1.NetworkEndpointGroupBinding, error) {
+	key := fmt.Sprintf("%s/%s", n.namespace, n.name)
+	obj, exists, err := n.negBindingLister.GetByKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("error getting negbinding from cache: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("%w: key %s", ErrNegBindingNotFound, key)
+	}
+
+	binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type %T in negbinding cache for key %s", obj, key)
+	}
+	return binding, nil
+}
+
+// negNameForSubnet returns the NEG name defined in the NegBinding CR Spec for the given subnet.
+func (n *NegBindingNamer) negNameForSubnet(subnet, namespace, svcName string, port int32) (string, error) {
+	binding, err := n.getBinding()
+	if err != nil {
+		return "", err
+	}
+
+	if binding.Namespace != namespace ||
+		binding.Spec.BackendRef.Name != svcName ||
+		binding.Spec.BackendRef.Port != port {
+		gotRef := fmt.Sprintf("%s/%s:%v", namespace, svcName, port)
+		expectedRef := fmt.Sprintf("%s/%s:%v", binding.Namespace, binding.Spec.BackendRef.Name, port)
+		return "", fmt.Errorf("%w: backendRef %s, negBinding.Spec.BackendRef %s", ErrNBNamerInvalidBackendRef, gotRef, expectedRef)
+	}
+
+	for _, ref := range binding.Spec.NetworkEndpointGroups {
+		if ref.Subnet == subnet {
+			return ref.Name, nil
+		}
+	}
+	return "", fmt.Errorf("%w: subnet %s, negBinding %s/%s", ErrNegNameNotFound, subnet, n.namespace, n.name)
+}
+
+// NonDefaultSubnetNEG returns the NEG name for the given subnet based on NegBinding's Spec.
+func (n *NegBindingNamer) NonDefaultSubnetNEG(namespace, svcName, subnetName string, port int32) (string, error) {
+	return n.negNameForSubnet(subnetName, namespace, svcName, port)
+}
+
+// NonDefaultSubnetCustomNEG implements NonDefaultSubnetNEGNamer.NonDefaultSubnetCustomNEG.
+// Returns a not implemented error as custom names should not be set for NegBinding-based syncers.
+func (n *NegBindingNamer) NonDefaultSubnetCustomNEG(customNEGName, subnetName string) (string, error) {
+	return "", ErrNBNamerNotImplemented
+}

--- a/pkg/utils/namer/negbinding_namer_test.go
+++ b/pkg/utils/namer/negbinding_namer_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namer
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+)
+
+func TestNegBindingNamer(t *testing.T) {
+	namespace := "test-ns"
+	name := "test-name"
+	svcName := "svc-name"
+	svcPort := int32(80)
+
+	subnetName := "subnet-name"
+	negName := "neg-name"
+	subnetName2 := "subnet-name-2"
+	negName2 := "neg-name-2"
+
+	negBindingLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	namer := NewNegBindingNamer(namespace, name, negBindingLister)
+
+	// NEGBinding not in store
+	_, err := namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
+	if err == nil {
+		t.Errorf("Expected error when NEGBinding is not in store, got nil")
+	} else if !errors.Is(err, ErrNegBindingNotFound) {
+		t.Errorf("Expected error to be ErrNegBindingNotFound, got %v", err)
+	}
+
+	// Add NEGBinding to store
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Name: svcName,
+				Port: svcPort,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Subnet: subnetName,
+					Name:   negName,
+				},
+				{
+					Subnet: subnetName2,
+					Name:   negName2,
+				},
+			},
+		},
+	}
+	err = negBindingLister.Add(binding)
+	if err != nil {
+		t.Fatalf("Failed to add NEGBinding to store: %v", err)
+	}
+
+	// Subnet in the NEGBinding's spec
+	gotNegName, err := namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
+	if err != nil {
+		t.Errorf("NonDefaultSubnetNEG: Unexpected error: %v", err)
+	}
+	if gotNegName != negName {
+		t.Errorf("NonDefaultSubnetNEG: Expected %s, got %s", negName, gotNegName)
+	}
+
+	gotNegName, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName2, svcPort)
+	if err != nil {
+		t.Errorf("NonDefaultSubnetNEG: Unexpected error: %v", err)
+	}
+	if gotNegName != negName2 {
+		t.Errorf("NonDefaultSubnetNEG: Expected %s, got %s", negName2, gotNegName)
+	}
+
+	_, err = namer.NonDefaultSubnetCustomNEG("custom-neg", subnetName)
+	if err == nil {
+		t.Errorf("NonDefaultSubnetCustomNEG: Expected error, got nil")
+	} else if !errors.Is(err, ErrNBNamerNotImplemented) {
+		t.Errorf("Expected error to be ErrNBNamerNotImplemented, got %v", err)
+	}
+
+	// Subnet not on in the NEGBinding's spec
+	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, "unset-subnet", svcPort)
+	if err == nil {
+		t.Errorf("NonDefaultSubnetNEG: Expected error for subnet which not set in NEGBinding spec, got nil")
+	} else if !errors.Is(err, ErrNegNameNotFound) {
+		t.Errorf("Expected error to be ErrNegNameNotFound, got %v", err)
+	}
+
+	_, err = namer.NonDefaultSubnetCustomNEG("custom-neg", "unset-subnet")
+	if err == nil {
+		t.Errorf("NonDefaultSubnetCustomNEG: Expected error for subnet which not set in NEGBinding spec, got nil")
+	} else if !errors.Is(err, ErrNBNamerNotImplemented) {
+		t.Errorf("Expected error to be ErrNBNamerNotImplemented, got %v", err)
+	}
+
+	// BackendRef validation
+	_, err = namer.NonDefaultSubnetNEG("wrong-ns", svcName, subnetName, svcPort)
+	if err == nil {
+		t.Errorf("Expected error for wrong namespace, got nil")
+	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
+		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
+	}
+
+	_, err = namer.NonDefaultSubnetNEG(namespace, "wrong-svc", subnetName, svcPort)
+	if err == nil {
+		t.Errorf("Expected error for wrong service name, got nil")
+	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
+		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
+	}
+
+	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, 999)
+	if err == nil {
+		t.Errorf("Expected error for wrong port, got nil")
+	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
+		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
+	}
+
+	// Unexpected object type in cache
+	invalidObj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	err = negBindingLister.Update(invalidObj)
+	if err != nil {
+		t.Fatalf("Failed to update NEGBinding store with invalid object: %v", err)
+	}
+
+	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
+	if err == nil {
+		t.Errorf("Expected error for unexpected object type in cache, got nil")
+	}
+}


### PR DESCRIPTION
Implements NEG namer which will return NEG name for subnet based solely on the Spec of the NetworkEndpointGroupBinding CR ([CRD](https://github.com/kubernetes/ingress-gce/pull/3103)).

`NonDefaultSubnetNEGNamer`'s `NonDefaultSubnetNEG` was updated to be able to return error. In practice it will allow to return not found error if trying to receive NEG name from NEGBinding-based namer for subnet which is not specified in the Spec. Also becomes more consistent with `NonDefaultSubnetCustomNEG` receiver.