### PR TITLE
Remove direct dependency on deprecated github.com/golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/GoogleCloudPlatform/gke-networking-api v0.2.1-0.20250318085121-e88f4ed9f50a
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.34.0
 	github.com/go-logr/logr v1.4.3
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/kr/pretty v0.3.1
 	github.com/prometheus/client_golang v1.23.2
@@ -100,6 +99,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/compute/v1"
 	ga "google.golang.org/api/compute/v1"
@@ -1291,7 +1290,7 @@ func TestCheckStrongSessionAffinityRequirements(t *testing.T) {
 				annotations.StrongSessionAffinityAnnotationKey: annotations.StrongSessionAffinityEnabled,
 			},
 			sessionAffinityType:   v1.ServiceAffinityNone,
-			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: proto.Int32(minStrongSessionAffinityIdleTimeout)}},
+			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: ptr.To[int32](minStrongSessionAffinityIdleTimeout)}},
 			expectError:           true,
 		},
 		{
@@ -1301,7 +1300,7 @@ func TestCheckStrongSessionAffinityRequirements(t *testing.T) {
 				annotations.StrongSessionAffinityAnnotationKey: annotations.StrongSessionAffinityEnabled,
 			},
 			sessionAffinityType:   v1.ServiceAffinityClientIP,
-			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: proto.Int32(maxSessionAffinityIdleTimeout + 1)}},
+			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: ptr.To[int32](maxSessionAffinityIdleTimeout + 1)}},
 			expectError:           true,
 		},
 		{
@@ -1321,7 +1320,7 @@ func TestCheckStrongSessionAffinityRequirements(t *testing.T) {
 				annotations.StrongSessionAffinityAnnotationKey: annotations.StrongSessionAffinityEnabled,
 			},
 			sessionAffinityType:   v1.ServiceAffinityClientIP,
-			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: proto.Int32(minStrongSessionAffinityIdleTimeout)}},
+			sessionAffinityConfig: &v1.SessionAffinityConfig{ClientIP: &v1.ClientIPConfig{TimeoutSeconds: ptr.To[int32](minStrongSessionAffinityIdleTimeout)}},
 			expectError:           false,
 		},
 	}


### PR DESCRIPTION
The only direct import of github.com/golang/protobuf/proto in the module was three proto.Int32() calls in pkg/l4/resources/l4netlb_test.go. Replace them with ptr.To[int32]() from k8s.io/utils/ptr, which is already vendored and used elsewhere in the repo.

Running go mod tidy + go mod vendor demotes golang/protobuf from a direct require to an indirect one (it is still transitively required by istio.io/api).