### PR TITLE
Replace deprecated wait.PollUntil with wait.PollUntilContextCancel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,6 @@ linters-settings:
   errcheck:
     exclude-functions:
       - (*flag.FlagSet).Parse
-      - k8s.io/apimachinery/pkg/util/wait.PollUntil
   forbidigo:
     analyze-types: true
     forbid:

--- a/pkg/experimental/workload/controller.go
+++ b/pkg/experimental/workload/controller.go
@@ -135,10 +135,14 @@ func NewController(ctx *ControllerContext, logger klog.Logger) *Controller {
 }
 
 func (c *Controller) Run(stopCh <-chan struct{}) {
-	wait.PollUntil(5*time.Second, func() (bool, error) {
+	// An error means stopCh was closed while waiting; proceed anyway since the
+	// workers below exit immediately and the deferred cleanup still runs.
+	if err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), 5*time.Second, false, func(context.Context) (bool, error) {
 		c.logger.V(2).Info("Waiting for initial sync")
 		return c.hasSynced(), nil
-	}, stopCh)
+	}); err != nil {
+		c.logger.Error(err, "Stopped waiting for initial sync")
+	}
 
 	c.logger.V(2).Info("Starting workload controller")
 	defer func() {

--- a/pkg/l4/controllers/l4controller.go
+++ b/pkg/l4/controllers/l4controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	context2 "context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -260,10 +261,14 @@ func (l4c *L4Controller) SystemHealth() error {
 func (l4c *L4Controller) Run() {
 	defer l4c.shutdown()
 
-	wait.PollUntil(5*time.Second, func() (bool, error) {
+	// An error means stopCh was closed while waiting; proceed anyway since the
+	// queue below exits immediately and the deferred cleanup still runs.
+	if err := wait.PollUntilContextCancel(wait.ContextForChannel(l4c.stopCh), 5*time.Second, false, func(context2.Context) (bool, error) {
 		l4c.logger.V(2).Info("Waiting for initial cache sync before starting L4 Controller")
 		return l4c.hasSynced(), nil
-	}, l4c.stopCh)
+	}); err != nil {
+		l4c.logger.Error(err, "Stopped waiting for initial cache sync")
+	}
 
 	l4c.logger.Info("Running L4 Controller", "numWorkers", l4c.numWorkers)
 	activecontrollermetrics.RecordRunningController(activecontrollermetrics.L4ILBControllerLabel)

--- a/pkg/l4/controllers/l4netlbcontroller.go
+++ b/pkg/l4/controllers/l4netlbcontroller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	context2 "context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -508,10 +509,14 @@ func (lc *L4NetLBController) SystemHealth() error {
 func (lc *L4NetLBController) Run() {
 	defer lc.shutdown()
 
-	wait.PollUntil(5*time.Second, func() (bool, error) {
+	// An error means stopCh was closed while waiting; proceed anyway since the
+	// queue below exits immediately and the deferred cleanup still runs.
+	if err := wait.PollUntilContextCancel(wait.ContextForChannel(lc.stopCh), 5*time.Second, false, func(context2.Context) (bool, error) {
 		lc.logger.V(2).Info("Waiting for initial cache sync before starting L4 Net LB Controller")
 		return lc.hasSynced(), nil
-	}, lc.stopCh)
+	}); err != nil {
+		lc.logger.Error(err, "Stopped waiting for initial cache sync")
+	}
 
 	lc.logger.Info("Running L4 Net Controller", "numWorkers", lc.ctx.NumL4NetLBWorkers)
 	activecontrollermetrics.RecordRunningController(activecontrollermetrics.L4NetLBControllerLabel)

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package neg
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -386,10 +387,14 @@ func NewController(
 }
 
 func (c *Controller) Run() {
-	wait.PollUntil(5*time.Second, func() (bool, error) {
+	// An error means stopCh was closed while waiting; proceed anyway since the
+	// workers below exit immediately and the deferred cleanup still runs.
+	if err := wait.PollUntilContextCancel(wait.ContextForChannel(c.stopCh), 5*time.Second, false, func(context.Context) (bool, error) {
 		c.logger.V(2).Info("Waiting for initial sync")
 		return c.hasSynced(), nil
-	}, c.stopCh)
+	}); err != nil {
+		c.logger.V(2).Info("Stopped waiting for initial sync", "err", err)
+	}
 
 	c.logger.V(2).Info("Starting network endpoint group controller")
 	activecontrollermetrics.RecordRunningController(activecontrollermetrics.NEGControllerLabel)

--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -179,10 +179,14 @@ func NewController(ctx *context.ControllerContext, stopCh <-chan struct{}, logge
 // Run waits for the initial sync and will process keys in the queue and run GC
 // until signaled
 func (c *Controller) Run() {
-	wait.PollUntil(5*time.Second, func() (bool, error) {
+	// An error means stopCh was closed while waiting; proceed anyway since the
+	// workers below exit immediately and the deferred cleanup still runs.
+	if err := wait.PollUntilContextCancel(wait.ContextForChannel(c.stopCh), 5*time.Second, false, func(context2.Context) (bool, error) {
 		c.logger.V(2).Info("Waiting for initial sync")
 		return c.hasSynced(), nil
-	}, c.stopCh)
+	}); err != nil {
+		c.logger.Error(err, "Stopped waiting for initial sync")
+	}
 
 	c.logger.V(2).Info("Starting private service connect controller")
 	activecontrollermetrics.RecordRunningController(activecontrollermetrics.PSCControllerLabel)


### PR DESCRIPTION
wait.PollUntil has been deprecated in apimachinery in favor of the context-aware wait.PollUntilContextCancel. Migrate the five initial-sync wait loops, preserving the previous behavior: the interval elapses before the first condition check (immediate=false), and a poll interrupted by stopCh closing logs and proceeds so the existing shutdown paths still run.

Also drop the errcheck exclusion for wait.PollUntil from .golangci.yaml since the return value is now checked at every call site.