### PR TITLE
Fix swallowed error in L4Controller.linkNEG

### DIFF
--- a/pkg/l4/controllers/l4controller.go
+++ b/pkg/l4/controllers/l4controller.go
@@ -500,7 +500,7 @@ func (l4c *L4Controller) linkNEG(l4 *resources.L4, svcLogger klog.Logger) error 
 	// link neg to backend service
 	zones, err := l4c.zoneGetter.ListZones(zonegetter.CandidateAndUnreadyNodesFilter, svcLogger)
 	if err != nil {
-		return nil
+		return err
 	}
 	var groupKeys []backends.GroupKey
 	for _, zone := range zones {


### PR DESCRIPTION
linkNEG returned nil instead of the error when listing zones failed, reporting the NEG-to-backend-service link as successful without ever performing it. The equivalent NetLB code path in l4netlbcontroller.go correctly propagates the error.

The bug dates back to the original L4 ILB controller (eb6e2291b, 2019).