### PR TITLE
Sync endpoints of the ensured NEGs before resync if error caused by fail while ensuring only part of the NEGs

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -38,6 +38,7 @@ import (
 
 	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -288,12 +289,31 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	// Only matters for L4 Local mode.
 	needInitDrainStatus := s.needInit && s.enableL4NEGDetachCancel && s.endpointsCalculator.Mode() == negtypes.L4LocalMode
 
+	var ensureErr error
+	var ensuredSubnetZones map[string]sets.Set[string]
 	if s.needInit || topologyChange {
 		s.logger.Info("Need to ensure network endpoint groups", "needInit", s.needInit, "topologyChange", topologyChange)
-		if err := s.ensureNetworkEndpointGroups(); err != nil {
-			return fmt.Errorf("%w: %v", negtypes.ErrNegNotFound, err)
+
+		// Passing ensured NEGs forward from ensureNetworkEndpointGroups() if called during this sync as reading from statusHandler in the same sync might result in reading stale data.
+		ensuredSubnetZones, ensureErr = s.ensureNetworkEndpointGroups()
+		if ensureErr == nil {
+			s.needInit = false
+		} else {
+			// Resync will be triggered only after this iteration will complete syncing ensured NEGs.
+			ensureErr = fmt.Errorf("%w: %v", negtypes.ErrNegNotFound, ensureErr)
+			s.needInit = true
+
+			// if not a single NEG ensured - no need to continue resync
+			if len(ensuredSubnetZones) == 0 {
+				return ensureErr
+			}
 		}
-		s.needInit = false
+	} else {
+		var err error
+		ensuredSubnetZones, err = s.statusHandler.SubnetToZonesMap()
+		if err != nil {
+			return fmt.Errorf("failed to get subnet to zones map from status handler: %w", err)
+		}
 	}
 	s.logger.V(2).Info("Sync NEG", "negSyncerKey", s.NegSyncerKey.String(), "endpointsCalculatorMode", s.endpointsCalculator.Mode())
 
@@ -304,7 +324,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		return err
 	}
 
-	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.networkInfo, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
+	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, ensuredSubnetZones, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.enableDualStackNEG, s.networkInfo, s.logger, s.negMetrics, needInitDrainStatus)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -366,6 +386,10 @@ func (s *transactionSyncer) syncInternalImpl() error {
 			s.logger.Info("Using normal mode endpoint calculation")
 		}
 	}
+
+	// Filter out locations without NEGs to prevent attaching endpoints in locations where is no NEG
+	targetMap = s.dropLocationsWithoutNEGs(targetMap, currentMap)
+
 	// When the flags are not enabled, error state should be reset when no
 	// error occurs in the sync.
 	// notInDegraded and onlyInDegraded are not populated when the flags are
@@ -419,13 +443,16 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	}
 
 	if len(addEndpoints) == 0 && len(removeEndpoints) == 0 {
-		s.logger.V(3).Info("No endpoint change. Skip syncing NEG. ", s.Namespace, s.Name)
-		return nil
+		s.logger.V(3).Info("No endpoint change. Skip syncing NEG.", s.Namespace, s.Name)
+		return ensureErr
 	}
+
 	s.logEndpoints(addEndpoints, "adding endpoint")
 	s.logEndpoints(removeEndpoints, "removing endpoint")
-
-	return s.syncNetworkEndpoints(addEndpoints, removeEndpoints, endpointPodLabelMap, migrationZone)
+	if syncErr := s.syncNetworkEndpoints(addEndpoints, removeEndpoints, endpointPodLabelMap, migrationZone); syncErr != nil {
+		return utilerrors.NewAggregate([]error{ensureErr, syncErr})
+	}
+	return ensureErr
 }
 
 // reAddDrainingEndpointsThatAreInTargetMap will make sure that endpoints that are draining
@@ -556,23 +583,24 @@ func (s *transactionSyncer) listTargetZonesPerSubnet() (shared.ZonesPerSubnetMap
 }
 
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
-func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
+func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnetMap, error) {
 
 	zonesPerSubnet, err := s.listTargetZonesPerSubnet()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var errList []error
 	var negObjs []*composite.NetworkEndpointGroup
 	updateNEGStatus := true
 	negsByLocation := make(map[string]int)
+	ensuredSubnetZones := make(shared.ZonesPerSubnetMap)
 
 	// Get default subnet from syncer's networkInfo.
 	defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
 	if err != nil {
 		s.logger.Error(err, "Errored getting default subnet from NetworkInfo when ensuring NEGs")
-		return err
+		return nil, err
 	}
 
 	var subnetConfigs []nodetopologyv1.SubnetConfig
@@ -591,7 +619,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 
 		subnetConfig, err := nodetopology.SubnetConfigFromSubnetURL(s.networkInfo.SubnetworkURL)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		subnetConfigs = []nodetopologyv1.SubnetConfig{subnetConfig}
 	}
@@ -599,7 +627,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	for _, subnetConfig := range subnetConfigs {
 		zones, ok := zonesPerSubnet[subnetConfig.Name]
 		if !ok {
-			// s.topologyProvider.ListSubnetsInDefaultNetwork and s.topologyProvider.ListZonesPerSubnet should return same set of subnets.
+			// s.topologyProvider.ListSubnetsInDefaultNetwork and s.topologyProvider.ListZonesPerSubnet should return same set of subnets for Multi-Subnet.
 			// Therefore this condition should be true only for multi-networking where we don't want NEGs in default subnet
 			continue
 		}
@@ -659,6 +687,10 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 			if err == nil {
 				negObjs = append(negObjs, negObj)
 				negsByLocation[zone]++
+				if _, ok := ensuredSubnetZones[subnetConfig.Name]; !ok {
+					ensuredSubnetZones[subnetConfig.Name] = sets.New[string]()
+				}
+				ensuredSubnetZones[subnetConfig.Name].Insert(zone)
 			}
 		}
 	}
@@ -670,7 +702,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	}
 
 	s.syncMetricsCollector.UpdateSyncerNegCount(s.NegSyncerKey, negsByLocation)
-	return utilerrors.NewAggregate(errList)
+	return ensuredSubnetZones, utilerrors.NewAggregate(errList)
 }
 
 // syncNetworkEndpoints spins off go routines to execute NEG operations
@@ -952,6 +984,19 @@ func (s *transactionSyncer) isTopologyChange() bool {
 	}
 
 	return !wantSubnetZones.Equal(existingSubnetZones)
+}
+
+// dropLocationsWithoutNEGs excludes locations from targetMap that do not exist in currentMap.
+func (s *transactionSyncer) dropLocationsWithoutNEGs(targetMap, currentMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet) map[negtypes.NEGLocation]negtypes.NetworkEndpointSet {
+	filteredMap := make(map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, len(targetMap))
+	for loc, endpoints := range targetMap {
+		if _, ok := currentMap[loc]; ok {
+			filteredMap[loc] = endpoints
+		} else {
+			s.logger.Info("Excluding target endpoints for location as there is no NEG", "location", loc)
+		}
+	}
+	return filteredMap
 }
 
 // filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -37,6 +37,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -98,7 +99,10 @@ func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to initialize transaction syncer: %v", err)
 		}
-		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
+
+		createAndAddMockSvcNEG(t, transactionSyncer)
+
+		if _, err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
 		var targetPort string
@@ -304,6 +308,8 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to initialize transaction syncer: %v", err)
 		}
+		createAndAddMockSvcNEG(t, transactionSyncer)
+
 		if err := zonegetter.AddNodeTopologyCR(transactionSyncer.topologyProvider.(*zonegetter.ZoneGetter), &nodeTopologyCrWithAdditionalSubnets); err != nil {
 			t.Fatalf("Failed to add node topology CR: %v", err)
 		}
@@ -329,7 +335,7 @@ func TestTransactionSyncNetworkEndpointsMSC(t *testing.T) {
 			t.Fatalf("Failed to get non-default subnet NEG name: %v", err)
 		}
 
-		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
+		if _, err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
 		var targetPort string
@@ -571,9 +577,11 @@ func TestNegNameMultiNetworking(t *testing.T) {
 		}
 	}
 
+	createAndAddMockSvcNEG(t, transactionSyncer)
+
 	// Start syncer without starting syncer goroutine
 	(transactionSyncer.syncer.(*syncer)).stopped = false
-	if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
+	if _, err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 		t.Errorf("Expect error == nil, but got %v", err)
 	}
 
@@ -778,7 +786,10 @@ func TestSyncNetworkEndpointLabel(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to initialize transaction syncer: %v", err)
 		}
-		if err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
+
+		createAndAddMockSvcNEG(t, transactionSyncer)
+
+		if _, err := transactionSyncer.ensureNetworkEndpointGroups(); err != nil {
 			t.Errorf("Expect error == nil, but got %v", err)
 		}
 		err = transactionSyncer.syncNetworkEndpoints(tc.addEndpoints, map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}, tc.endpointPodLabelMap, negtypes.NEGLocation{})
@@ -1898,7 +1909,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			}
 			syncer.statusHandler.(*negstatushandler.TestSvcNegStatusHandler).SvcNEGLister().Add(neg)
 
-			err = syncer.ensureNetworkEndpointGroups()
+			_, err = syncer.ensureNetworkEndpointGroups()
 			if !tc.expectErr && err != nil {
 				t.Errorf("Expected no error, but got: %v", err)
 			}
@@ -2150,7 +2161,7 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 				}
 			}
 
-			err = syncer.ensureNetworkEndpointGroups()
+			_, err = syncer.ensureNetworkEndpointGroups()
 
 			if tc.expectError && err == nil {
 				t.Errorf("Got no errors after ensureNetworkEndpointGroupsFromNodeTopology(), expected errors")
@@ -3178,7 +3189,11 @@ func TestUnknownNodes(t *testing.T) {
 	}
 
 	// Check that unknown zone did not cause endpoints to be removed
-	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
+	ensuredZones, err := s.statusHandler.SubnetToZonesMap()
+	if err != nil {
+		t.Fatalf("failed to get subnet to zones map: %v", err)
+	}
+	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 	if err != nil {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
@@ -3442,11 +3457,10 @@ func TestEnableDegradedMode(t *testing.T) {
 					NetworkEndpointGroups: objRefs,
 				},
 			}
-			_, s, err := newTestTransactionSyncer(fakeCloud, negtypes.VmIpPortEndpointType, "")
+			_, s, err := newTestTransactionSyncer(fakeCloud, negtypes.VmIpPortEndpointType, tc.negName)
 			if err != nil {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
 			}
-			s.NegSyncerKey.NegName = tc.negName
 			s.needInit = false
 			addPodsToLister(s.podLister, getDefaultEndpointSlices())
 			for i := 1; i <= 4; i++ {
@@ -3481,7 +3495,11 @@ func TestEnableDegradedMode(t *testing.T) {
 			tc.modify(s)
 
 			subnetToNegMapping := map[string]string{defaultTestSubnet: tc.negName}
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
+			ensuredZones, err := s.statusHandler.SubnetToZonesMap()
+			if err != nil {
+				t.Fatalf("failed to get subnet to zones map: %v", err)
+			}
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints")
 			}
@@ -3494,7 +3512,11 @@ func TestEnableDegradedMode(t *testing.T) {
 				t.Errorf("syncInternal returned %v, expected %v", err, tc.expectErr)
 			}
 			err = wait.PollImmediate(time.Second, 3*time.Second, func() (bool, error) {
-				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
+				ensuredZones, statusErr := s.statusHandler.SubnetToZonesMap()
+				if statusErr != nil {
+					return false, nil
+				}
+				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 				if err != nil {
 					return false, nil
 				}
@@ -4173,7 +4195,7 @@ func TestSyncL4NEGs(t *testing.T) {
 			}
 			neg := &negv1beta1.ServiceNetworkEndpointGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      testNegName,
+					Name:      testL4NegName,
 					Namespace: testServiceNamespace,
 				},
 				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
@@ -4193,7 +4215,15 @@ func TestSyncL4NEGs(t *testing.T) {
 			for _, eps := range tc.endpointSlices {
 				s.endpointSliceLister.Add(eps)
 			}
-			s.statusHandler.(*negstatushandler.TestSvcNegStatusHandler).SvcNEGLister().Add(neg)
+			testStatusHandler := s.statusHandler.(*negstatushandler.TestSvcNegStatusHandler)
+			_, err = testStatusHandler.SvcNEGClient().NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), neg, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create SvcCRD: %v", err)
+			}
+			err = testStatusHandler.SvcNEGLister().Add(neg)
+			if err != nil {
+				t.Fatalf("Failed to add SvcCRD to lister: %v", err)
+			}
 			// mark syncer as started without starting the syncer routine
 			(s.syncer.(*syncer)).stopped = false
 			// add transactions to the syncer if any were defined in the test case
@@ -4210,7 +4240,11 @@ func TestSyncL4NEGs(t *testing.T) {
 			// give a little time for the syncer attach/detach goroutines to finish
 			time.Sleep(50 * time.Millisecond)
 
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, s.NegSyncerKey.IncludeDrainNodesL4Local)
+			ensuredZones, err := s.statusHandler.SubnetToZonesMap()
+			if err != nil {
+				t.Fatalf("failed to get subnet to zones map: %v", err)
+			}
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints: %v", err)
 			}
@@ -4346,6 +4380,42 @@ func TestReAddDrainingEndpointsThatAreInTargetMap(t *testing.T) {
 		if !reflect.DeepEqual(tc.addEndpoints, tc.expectEndpoints) {
 			t.Errorf("For case %q, expect addEndpoints to be %+v, but got %+v", tc.desc, tc.expectEndpoints, tc.addEndpoints)
 		}
+	}
+}
+
+func TestDropLocationsWithoutNEGs(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
+	negtypes.MockNetworkEndpointAPIs(fakeGCE)
+	fakeCloud := negtypes.NewAdapter(fakeGCE, negtypes.NewTestContext().NegMetrics)
+
+	_, ts, err := newTestTransactionSyncer(fakeCloud, negtypes.VmIpPortEndpointType, "")
+	if err != nil {
+		t.Fatalf("failed to initialize transaction syncer: %v", err)
+	}
+
+	targetMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+			negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: negtypes.TestInstance1},
+		),
+		{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+			negtypes.NetworkEndpoint{IP: "1.2.3.5", Node: negtypes.TestInstance2},
+		),
+	}
+
+	currentMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+	}
+
+	filteredMap := ts.dropLocationsWithoutNEGs(targetMap, currentMap)
+
+	expectedMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+		{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+			negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: negtypes.TestInstance1},
+		),
+	}
+
+	if !reflect.DeepEqual(filteredMap, expectedMap) {
+		t.Errorf("dropLocationsWithoutNEGs failed: got %+v, expected %+v", filteredMap, expectedMap)
 	}
 }
 
@@ -4900,6 +4970,25 @@ func addFakeNodeWithSubnet(zg *zonegetter.ZoneGetter, nodeIndexer cache.Indexer,
 	return zonegetter.AddFakeNode(zg, node)
 }
 
+func createAndAddMockSvcNEG(t *testing.T, s *transactionSyncer) {
+	t.Helper()
+	neg := &negv1beta1.ServiceNetworkEndpointGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.NegName,
+			Namespace: testServiceNamespace,
+		},
+	}
+	testStatusHandler := s.statusHandler.(*negstatushandler.TestSvcNegStatusHandler)
+	_, err := testStatusHandler.SvcNEGClient().NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), neg, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create SvcCRD: %v", err)
+	}
+	err = testStatusHandler.SvcNEGLister().Add(neg)
+	if err != nil {
+		t.Fatalf("Failed to add SvcCRD to lister: %v", err)
+	}
+}
+
 // TestNEGPreprovisioningTransition tests the complete lifecycle transition of NEG pre-provisioning:
 //  1. Starts with a "usual" annotation (workload-only zones). Verifies that NEGs are only created in zones
 //     with workload nodes (zone1) and marked as ActiveState in the NEG CR.
@@ -4965,7 +5054,7 @@ func TestNEGPreprovisioningTransition(t *testing.T) {
 	svcNegLister.Add(svcNeg)
 
 	// Step 1: Sync Usual Annotation (should only create NEG in zone1)
-	err = ts.ensureNetworkEndpointGroups()
+	_, err = ts.ensureNetworkEndpointGroups()
 	if err != nil {
 		t.Fatalf("ensureNetworkEndpointGroups (usual) failed: %v", err)
 	}
@@ -4999,7 +5088,7 @@ func TestNEGPreprovisioningTransition(t *testing.T) {
 	svc.Annotations[negannotation.NEGAnnotationKey] = `{"exposed_ports":{"80":{}},"zones":["zone2"]}`
 	ts.serviceLister.Update(svc)
 
-	err = ts.ensureNetworkEndpointGroups()
+	_, err = ts.ensureNetworkEndpointGroups()
 	if err != nil {
 		t.Fatalf("ensureNetworkEndpointGroups (pre-provisioning) failed: %v", err)
 	}
@@ -5035,7 +5124,7 @@ func TestNEGPreprovisioningTransition(t *testing.T) {
 	svc.Annotations[negannotation.NEGAnnotationKey] = `{"exposed_ports":{"80":{}}}`
 	ts.serviceLister.Update(svc)
 
-	err = ts.ensureNetworkEndpointGroups()
+	_, err = ts.ensureNetworkEndpointGroups()
 	if err != nil {
 		t.Fatalf("ensureNetworkEndpointGroups (transition back) failed: %v", err)
 	}
@@ -5065,5 +5154,168 @@ func TestNEGPreprovisioningTransition(t *testing.T) {
 	}
 	if !foundInactiveZone2 {
 		t.Errorf("Step 3: expected NEG in zone2 to be InactiveState, got status: %+v", negCR.Status)
+	}
+}
+
+func TestSyncNEGsPartialFailure(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		negType           negtypes.NetworkEndpointType
+		negName           string
+		gceEpType         string
+		expectedEndpoints negtypes.NetworkEndpointSet
+	}{
+		{
+			desc:      "L4 VM_IP NEG",
+			negType:   negtypes.VmIpEndpointType,
+			negName:   testL4NegName,
+			gceEpType: "GCE_VM_IP",
+			expectedEndpoints: negtypes.NewNetworkEndpointSet(
+				negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: negtypes.TestInstance1},
+				negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: negtypes.TestInstance2},
+			),
+		},
+		{
+			desc:      "L7 VM_IP_PORT NEG",
+			negType:   negtypes.VmIpPortEndpointType,
+			negName:   testNegName,
+			gceEpType: "GCE_VM_IP_PORT",
+			expectedEndpoints: negtypes.NewNetworkEndpointSet(
+				negtypes.NetworkEndpoint{IP: "10.100.1.1", Node: negtypes.TestInstance1, Port: "80"},
+				negtypes.NetworkEndpoint{IP: "10.100.1.2", Node: negtypes.TestInstance1, Port: "80"},
+				negtypes.NetworkEndpoint{IP: "10.100.1.3", Node: negtypes.TestInstance1, Port: "80"},
+				negtypes.NetworkEndpoint{IP: "10.100.1.4", Node: negtypes.TestInstance1, Port: "80"},
+				negtypes.NetworkEndpoint{IP: "10.100.2.1", Node: negtypes.TestInstance2, Port: "80"},
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nodeInformer := zonegetter.FakeNodeInformer()
+			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+			fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
+			negtypes.MockNetworkEndpointAPIs(fakeGCE)
+			fakeCloud := negtypes.NewAdapter(fakeGCE, negtypes.NewTestContext().NegMetrics)
+
+			// Create initial NEGs in GCE (both Zone1 and Zone2)
+			fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: tc.negName, Version: meta.VersionGA, NetworkEndpointType: tc.gceEpType}, negtypes.TestZone1, klog.TODO())
+			fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: tc.negName, Version: meta.VersionGA, NetworkEndpointType: tc.gceEpType}, negtypes.TestZone2, klog.TODO())
+
+			// Build SvcNEG CR
+			crEpType := negv1beta1.VmIpPortEndpointType
+			if tc.negType == negtypes.VmIpEndpointType {
+				crEpType = negv1beta1.VmIpEndpointType
+			}
+			neg1, _ := fakeCloud.GetNetworkEndpointGroup(tc.negName, negtypes.TestZone1, meta.VersionGA, klog.TODO())
+			neg2, _ := fakeCloud.GetNetworkEndpointGroup(tc.negName, negtypes.TestZone2, meta.VersionGA, klog.TODO())
+			objRefs := []negv1beta1.NegObjectReference{
+				{SelfLink: neg1.SelfLink, SubnetURL: defaultTestSubnetURL, NetworkEndpointType: crEpType},
+				{SelfLink: neg2.SelfLink, SubnetURL: defaultTestSubnetURL, NetworkEndpointType: crEpType},
+			}
+
+			svcNegCR := &negv1beta1.ServiceNetworkEndpointGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.negName,
+					Namespace: testServiceNamespace,
+				},
+				Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+					NetworkEndpointGroups: objRefs,
+				},
+			}
+
+			testContext := negtypes.NewTestContext()
+			testContext.NodeInformer = nodeInformer
+
+			// Add Service to lister. Important for L7 endpoints calculator.
+			testContext.ServiceInformer.GetIndexer().Add(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testServiceName,
+					Namespace: testServiceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"run": "foo",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "",
+							Port:       80,
+							TargetPort: intstr.FromInt(80), // match port in getDefaultEndpointSlices
+						},
+					},
+				},
+			})
+
+			_, s, err := newTestTransactionSyncerWithCustomContext(fakeCloud, tc.negType, "", testContext)
+			if err != nil {
+				t.Fatalf("failed to initialize transaction syncer: %v", err)
+			}
+			s.needInit = false
+
+			for _, eps := range getDefaultEndpointSlices() {
+				s.endpointSliceLister.Add(eps)
+			}
+			addPodsToLister(s.podLister, getDefaultEndpointSlices())
+
+			testStatusHandler := s.statusHandler.(*negstatushandler.TestSvcNegStatusHandler)
+			_, err = testStatusHandler.SvcNEGClient().NetworkingV1beta1().ServiceNetworkEndpointGroups(testServiceNamespace).Create(context.Background(), svcNegCR, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create SvcCRD: %v", err)
+			}
+			err = testStatusHandler.SvcNEGLister().Add(svcNegCR)
+			if err != nil {
+				t.Fatalf("Failed to add SvcCRD to lister: %v", err)
+			}
+
+			(s.syncer.(*syncer)).stopped = false
+
+			// Mock GCE to fail for Zone2 Get
+			(fakeGCE.Compute().(*cloud.MockGCE)).MockNetworkEndpointGroups.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockNetworkEndpointGroups, options ...cloud.Option) (bool, *compute.NetworkEndpointGroup, error) {
+				if key.Zone == negtypes.TestZone2 {
+					return true, nil, fmt.Errorf("mock error for zone %s", key.Zone)
+				}
+				return false, nil, nil
+			}
+
+			// syncInternal should return error
+			err = s.syncInternal()
+			if err == nil {
+				t.Errorf("syncInternal returned nil, expected error")
+			}
+
+			// Wait for the syncer attach/detach goroutines to finish
+			if err := waitForTransactions(s); err != nil {
+				t.Errorf("waitForTransactions() got %v, want nil", err)
+			}
+
+			// Verify that endpoints were attached in Zone1.
+			endpoints, err := s.cloud.ListNetworkEndpoints(tc.negName, negtypes.TestZone1, false, meta.VersionGA, klog.TODO())
+			if err != nil {
+				t.Fatalf("failed to list endpoints in zone1: %v", err)
+			}
+			got := negtypes.NewNetworkEndpointSet()
+			for _, ep := range endpoints {
+				portStr := ""
+				if ep.NetworkEndpoint.Port != 0 {
+					portStr = strconv.Itoa(int(ep.NetworkEndpoint.Port))
+				}
+				got.Insert(negtypes.NetworkEndpoint{IP: ep.NetworkEndpoint.IpAddress, Node: ep.NetworkEndpoint.Instance, Port: portStr})
+			}
+			if !reflect.DeepEqual(tc.expectedEndpoints, got) {
+				t.Errorf("endpoints in zone1 were not synced: got %+v,\n expected %+v", got, tc.expectedEndpoints)
+			}
+
+			// Verify that endpoints in Zone2 remain empty.
+			// Disable hook to allow ListNetworkEndpoints to succeed (it calls Get internally in mock)
+			(fakeGCE.Compute().(*cloud.MockGCE)).MockNetworkEndpointGroups.GetHook = nil
+			endpointsZone2, err := s.cloud.ListNetworkEndpoints(tc.negName, negtypes.TestZone2, false, meta.VersionGA, klog.TODO())
+			if err != nil {
+				t.Fatalf("failed to list endpoints in zone2: %v", err)
+			}
+			if len(endpointsZone2) != 0 {
+				t.Errorf("endpoints in zone2 were synced, expected empty: %+v", endpointsZone2)
+			}
+		})
 	}
 }

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -687,39 +687,37 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter negtypes.TopologyProvider, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, topologyProvider negtypes.TopologyProvider, ensuredZonesPerSubnet map[string]sets.Set[string], cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, enableDualStackNEG bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
 	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	drainingEndpoints := make(map[negtypes.NetworkEndpoint]string)
 
 	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
 	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
-	allZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(zonegetter.AllNodesFilter, networkInfo, logger)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	candidateZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), networkInfo, logger)
+	allZonesPerSubnet, err := topologyProvider.ListZonesPerSubnet(zonegetter.AllNodesFilter, networkInfo, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	for subnet, negName := range subnetToNegMapping {
-		zones := allZonesPerSubnet[subnet]
-		candidateZonesMap := candidateZonesPerSubnet[subnet]
+		allZones := allZonesPerSubnet[subnet]
+		ensuredZones := ensuredZonesPerSubnet[subnet]
 
-		for zone := range zones {
+		for zone := range allZones {
+			loc := negtypes.NEGLocation{Subnet: subnet, Zone: zone}
 			networkEndpointsWithHealthStatus, err := cloud.ListNetworkEndpoints(negName, zone, retrieveDrainStatus, version, logger)
 			if err != nil {
 				// It is possible for a NEG to be missing in a zone without candidate nodes. Log and ignore this error.
-				// NEG not found in a candidate zone is an error.
-				if utils.IsNotFoundError(err) && !candidateZonesMap.Has(zone) {
+				// NEG not found in a candidate zone is an error. ensuredZones in fact contains only candidate zones,
+				// but only successfully ensured ones.
+				if utils.IsNotFoundError(err) && !ensuredZones.Has(zone) {
 					logger.Info("Ignoring NotFound error for NEG", "negName", negName, "zone", zone, "subnet", subnet)
 					negMetrics.PublishNegControllerErrorCountMetrics(err, true)
 					continue
 				}
-				return nil, nil, nil, fmt.Errorf("failed to lookup NEG in zone %q, candidate zones %v, err - %w", zone, candidateZonesMap, err)
+				return nil, nil, nil, fmt.Errorf("failed to lookup NEG in zone %q, ensured zones %v, err - %w", zone, ensuredZones.UnsortedList(), err)
 			}
-			zoneNetworkEndpointMap[negtypes.NEGLocation{Zone: zone, Subnet: subnet}] = negtypes.NewNetworkEndpointSet()
+			zoneNetworkEndpointMap[loc] = negtypes.NewNetworkEndpointSet()
 			for _, ne := range networkEndpointsWithHealthStatus {
 
 				newNE := negtypes.NetworkEndpoint{IP: ne.NetworkEndpoint.IpAddress, Node: ne.NetworkEndpoint.Instance}
@@ -729,7 +727,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 				if enableDualStackNEG {
 					newNE.IPv6 = parseIPAddress(ne.NetworkEndpoint.Ipv6Address)
 				}
-				zoneNetworkEndpointMap[negtypes.NEGLocation{Zone: zone, Subnet: subnet}].Insert(newNE)
+				zoneNetworkEndpointMap[loc].Insert(newNE)
 				endpointPodLabelMap[newNE] = ne.NetworkEndpoint.Annotations
 				if retrieveDrainStatus && healthStatusIndicatesDraining(ne) {
 					drainingEndpoints[newNE] = ne.Healths[0].HealthState

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -861,6 +861,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 		expect              map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 		expectAnnotationMap labels.EndpointPodLabelMap
 		expectErr           bool
+		ensuredSubnetZones  map[string]sets.Set[string]
 	}{
 		{
 			desc:               "neg does not exist",
@@ -1391,15 +1392,65 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone2, meta.VersionGA, klog.TODO())
 			},
 			subnetToNegMapping: mappingWithDefaultSubnetOnly,
-			expectErr:          true,
+			ensuredSubnetZones: map[string]sets.Set[string]{
+				defaultTestSubnet: sets.New(negtypes.TestZone1, negtypes.TestZone2, negtypes.TestZone3, negtypes.TestZone4),
+			},
+			expectErr: true,
+		},
+		{
+			desc: "limit locations to zone1 only, ignore missing NEG in zone2",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone3, meta.VersionGA, klog.TODO())
+				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone4, meta.VersionGA, klog.TODO())
+			},
+			subnetToNegMapping: mappingWithDefaultSubnetOnly,
+			ensuredSubnetZones: map[string]sets.Set[string]{
+				defaultTestSubnet: sets.New(negtypes.TestZone1),
+			},
+			expect: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+					endpoint1,
+					endpoint2,
+				),
+			},
+			expectAnnotationMap: labels.EndpointPodLabelMap{
+				endpoint1: labels.PodLabelMap{
+					"foo": "bar",
+				},
+				endpoint2: labels.PodLabelMap{
+					"foo": "bar",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			desc: "empty non-nil locations returns empty map",
+			mutate: func(cloud negtypes.NetworkEndpointGroupCloud) {
+				cloud.DeleteNetworkEndpointGroup(testNegName, negtypes.TestZone1, meta.VersionGA, klog.TODO())
+			},
+			subnetToNegMapping:  mappingWithDefaultSubnetOnly,
+			ensuredSubnetZones:  map[string]sets.Set[string]{},
+			expect:              map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{},
+			expectAnnotationMap: labels.EndpointPodLabelMap{},
+			expectErr:           false,
 		},
 	}
 
 	for _, tc := range testCases {
 		tc.mutate(negCloud)
+
 		// tc.mode of "" will result in the default node predicate being selected, which is ok for this test.
 		defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
-		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, negCloud, meta.VersionGA, tc.mode, tc.enableDualStackNEG, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, false)
+
+		ensuredSubnetZones := tc.ensuredSubnetZones
+		if ensuredSubnetZones == nil {
+			var err error
+			ensuredSubnetZones, err = zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(tc.mode, false), defaultNetInfo, klog.TODO())
+			if err != nil {
+				t.Fatalf("failed to list zones for test case %q: %v", tc.desc, err)
+			}
+		}
+		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, ensuredSubnetZones, negCloud, meta.VersionGA, tc.enableDualStackNEG, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 
 		if tc.expectErr {
 			if err == nil {
@@ -1573,7 +1624,11 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 			subnetToNegMapping := map[string]string{defaultTestSubnet: negName}
 			defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
 
-			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus, false)
+			ensuredZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, false), defaultNetInfo, klog.TODO())
+			if err != nil {
+				t.Fatalf("failed to list zones: %v", err)
+			}
+			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesPerSubnet, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus)
 			if err != nil {
 				t.Fatalf("retrieveExistingZoneNetworkEndpointMap: %v", err)
 			}
@@ -1649,10 +1704,14 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: zone, Version: meta.VersionGA}, zone, klog.TODO())
 	}
 
+	defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
 	// With includeDrainNodesL4Local=false: zone4 has no NEG but is not a
 	// candidate zone, so the NotFound is suppressed and no error is returned.
-	defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, false)
+	ensuredZonesNoDrain, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, false), defaultNetInfo, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to list zones: %v", err)
+	}
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesNoDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err != nil {
 		t.Errorf("expected no error with includeDrainNodesL4Local=false and missing zone4 NEG, got: %v", err)
 	}
@@ -1661,7 +1720,11 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	// NEG yet. The NotFound is not suppressed, so an error is returned.
 	// This is the plausible race documented in the review: if ensureNetworkEndpointGroups
 	// silently failed for zone4, the subsequent retrieve would fail here.
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	ensuredZonesWithDrain, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, true), defaultNetInfo, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to list zones: %v", err)
+	}
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err == nil {
 		t.Errorf("expected error with includeDrainNodesL4Local=true and missing zone4 NEG, got nil")
 	}
@@ -1671,7 +1734,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	drainEndpoint := &composite.NetworkEndpoint{IpAddress: "10.0.4.1", Instance: "upgrade-instance1"}
 	fakeCloud.AttachNetworkEndpoints(negName, negtypes.TestZone4, []*composite.NetworkEndpoint{drainEndpoint}, meta.VersionGA, klog.TODO())
 
-	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err != nil {
 		t.Fatalf("retrieveExistingZoneNetworkEndpointMap(drain=true, NEG exists): %v", err)
 	}


### PR DESCRIPTION
If during the ensuring of NetworkEndpointGroups one (or more) NEGs failed to be ensured first endpoints of the correctly ensured will be synced and only then resync will start. Before changes - such failure will result in immediate resync, which potentially can lead to endpoints never attached/detached in case one (or more) NEGs can't be ensured.