### PR TITLE
Add a new controller for L4 Standalone NEG

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -662,6 +662,12 @@ func runL4Controllers(ctx *ingctx.ControllerContext, systemHealth *systemhealth.
 		logger.V(0).Info("L4NetLB controller started")
 	}
 
+	if flags.F.RunL4StandaloneNEGLBController {
+		standaloneNEGLBController := controllers.NewStandaloneNEGLBController(ctx, option.stopCh, logger)
+		runWithWg(standaloneNEGLBController.Run, option.wg)
+		logger.V(0).Info("L4 Standalone NEG LB controller started")
+	}
+
 	ctx.Start(option.stopCh)
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -56,44 +56,45 @@ const (
 
 // F are global flags for the controller.
 var F = struct {
-	APIServerHost             string
-	ClusterName               string
-	ConfigFilePath            string
-	DefaultSvc                string
-	DefaultSvcHealthCheckPath string
-	DefaultSvcPortName        string
-	GCEOperationPollInterval  time.Duration
-	GCERateLimit              RateLimitSpecs
-	GCERateLimitScale         float64
-	GKEClusterName            string
-	GKEClusterHash            string
-	GKEClusterType            string
-	HealthCheckPath           string
-	HealthzPort               int
-	THCPort                   int
-	InCluster                 bool
-	IngressClass              string
-	KubeConfigFile            string
-	NegGCPeriod               time.Duration
-	NumNegGCWorkers           int
-	NodePortRanges            PortRanges
-	ResyncPeriod              time.Duration
-	L4NetLBProvisionDeadline  time.Duration
-	NumL4Workers              int
-	NumL4NetLBWorkers         int
-	NumIngressWorkers         int
-	RunIngressController      bool
-	RunL4Controller           bool
-	RunL4NetLBController      bool
-	EnableIGController        bool
-	Version                   bool
-	WatchNamespace            string
-	LeaderElection            LeaderElectionConfiguration
-	MetricsExportInterval     time.Duration
-	NegMetricsExportInterval  time.Duration
-	KubeClientQPS             float32
-	KubeClientBurst           int
-	ReadOnlyMode              bool
+	APIServerHost                  string
+	ClusterName                    string
+	ConfigFilePath                 string
+	DefaultSvc                     string
+	DefaultSvcHealthCheckPath      string
+	DefaultSvcPortName             string
+	GCEOperationPollInterval       time.Duration
+	GCERateLimit                   RateLimitSpecs
+	GCERateLimitScale              float64
+	GKEClusterName                 string
+	GKEClusterHash                 string
+	GKEClusterType                 string
+	HealthCheckPath                string
+	HealthzPort                    int
+	THCPort                        int
+	InCluster                      bool
+	IngressClass                   string
+	KubeConfigFile                 string
+	NegGCPeriod                    time.Duration
+	NumNegGCWorkers                int
+	NodePortRanges                 PortRanges
+	ResyncPeriod                   time.Duration
+	L4NetLBProvisionDeadline       time.Duration
+	NumL4Workers                   int
+	NumL4NetLBWorkers              int
+	NumIngressWorkers              int
+	RunIngressController           bool
+	RunL4Controller                bool
+	RunL4NetLBController           bool
+	RunL4StandaloneNEGLBController bool
+	EnableIGController             bool
+	Version                        bool
+	WatchNamespace                 string
+	LeaderElection                 LeaderElectionConfiguration
+	MetricsExportInterval          time.Duration
+	NegMetricsExportInterval       time.Duration
+	KubeClientQPS                  float32
+	KubeClientBurst                int
+	ReadOnlyMode                   bool
 
 	// Feature flags should be named Enablexxx.
 	EnableNonGCPMode                            bool
@@ -306,6 +307,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, if enabled then the ingress controller will be run.`)
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
+	flag.BoolVar(&F.RunL4StandaloneNEGLBController, "run-l4-standalone-neg-controller", false, `Optional, if enabled then the Standalone NEG L4 LB controller will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
 	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
 	flag.BoolVar(&F.EnableL4NetLBNEG, "enable-l4-netlb-neg", false, `Optional, if enabled then the NetLB controller can create L4 NetLB services with NEG backends.`)

--- a/pkg/l4/annotations/gce_annotations.go
+++ b/pkg/l4/annotations/gce_annotations.go
@@ -56,6 +56,10 @@ const (
 	// LegacyRegionalExternalLoadBalancerClass is the loadBalancerClass name used to select the
 	// GKE CCM NetLB implementation.
 	LegacyRegionalExternalLoadBalancerClass = "networking.gke.io/l4-regional-external-legacy"
+
+	// StandalonePassthroughNegLoadBalancerClass is the loadBalancerClass name used for services that
+	// should use GCE_VM_IP NEGs for L4.
+	StandalonePassthroughNegLoadBalancerClass = "networking.gke.io/standalone-passthrough-lb-neg"
 )
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.

--- a/pkg/l4/annotations/service.go
+++ b/pkg/l4/annotations/service.go
@@ -107,6 +107,9 @@ const (
 
 	// Service annotation key for specifying L4LBConfig
 	L4LBConfigKey = "networking.gke.io/l4lb-config"
+
+	// CustomForwardingRuleKey is the annotation key for custom forwarding rule name.
+	CustomForwardingRuleKey = "networking.gke.io/custom-forwarding-rule"
 )
 
 // Service represents Service annotations.

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/composite"
+	ccontext "k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/l4/annotations"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+type parsedForwardingRule struct {
+	key     *meta.Key
+	rawName string
+}
+
+// StandaloneNEGLBController manages services with CustomNegLoadBalancerClass.
+type StandaloneNEGLBController struct {
+	ctx       *ccontext.ControllerContext
+	svcQueue  utils.TaskQueue
+	logger    klog.Logger
+	stopCh    <-chan struct{}
+	hasSynced func() bool
+}
+
+// NewStandaloneNEGLBController creates a new instance of StandaloneNEGLBController.
+func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan struct{}, logger klog.Logger) *StandaloneNEGLBController {
+	logger = logger.WithName("StandaloneNEGLBController")
+	lc := &StandaloneNEGLBController{
+		ctx:       ctx,
+		stopCh:    stopCh,
+		hasSynced: ctx.HasSynced,
+		logger:    logger,
+	}
+	lc.svcQueue = utils.NewPeriodicTaskQueueWithMultipleWorkers("standalone-l4-neg-lb", "services", 1, lc.sync, logger)
+
+	ctx.ServiceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*v1.Service)
+			if lc.shouldProcess(svc) {
+				lc.enqueue(svc)
+			}
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			curSvc := cur.(*v1.Service)
+			if lc.shouldProcess(curSvc) {
+				lc.enqueue(curSvc)
+			}
+		},
+	})
+
+	return lc
+}
+
+func (lc *StandaloneNEGLBController) shouldProcess(svc *v1.Service) bool {
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return false
+	}
+	return svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass == annotations.StandalonePassthroughNegLoadBalancerClass
+}
+
+func (lc *StandaloneNEGLBController) enqueue(svc *v1.Service) {
+	lc.svcQueue.Enqueue(svc)
+}
+
+func (lc *StandaloneNEGLBController) Run() {
+	lc.logger.Info("Starting StandaloneNEGLBController")
+
+	err := wait.PollUntilContextCancel(wait.ContextForChannel(lc.stopCh), 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		lc.logger.V(2).Info("Waiting for initial cache sync before starting L4 Standalone NEG controller")
+		return lc.hasSynced(), nil
+	})
+	if err != nil {
+		// This will fail if the context is canceled which means the channel was closed. We should return in that case.
+		lc.logger.Error(err, "Failed to wait for initial cache sync")
+		return
+	}
+
+	defer lc.svcQueue.Shutdown()
+	lc.svcQueue.Run()
+	<-lc.stopCh
+}
+
+func (lc *StandaloneNEGLBController) sync(key string) error {
+	obj, exists, err := lc.ctx.ServiceInformer.GetIndexer().GetByKey(key)
+	if err != nil {
+		return fmt.Errorf("failed to lookup service for key %s: %w", key, err)
+	}
+	if !exists || obj == nil {
+		return nil
+	}
+	svc := obj.(*v1.Service)
+	if svc.DeletionTimestamp != nil {
+		return nil
+	}
+	if !lc.shouldProcess(svc) {
+		return nil
+	}
+	svcLogger := lc.logger.WithValues("service", klog.KObj(svc))
+
+	return lc.syncStandaloneNEGLB(svc, svcLogger)
+}
+
+func (lc *StandaloneNEGLBController) parseForwardingRuleKeys(frNamesStr string, svcLogger klog.Logger) ([]parsedForwardingRule, []error) {
+
+	if frNamesStr == "" {
+		return nil, nil
+	}
+	var parsedRules []parsedForwardingRule
+	var errs []error
+	frNames := strings.Split(frNamesStr, ",")
+	for _, frName := range frNames {
+		frName = strings.TrimSpace(frName)
+		if frName == "" {
+			continue
+		}
+		var frKey *meta.Key
+		if strings.Contains(frName, "/") {
+			resourceID, err := cloud.ParseResourceURL(frName)
+			if err != nil {
+				svcLogger.Error(err, "failed to parse forwarding rule reference URL", "frRef", frName)
+				errs = append(errs, fmt.Errorf("failed to parse forwarding rule reference URL %s: %w", frName, err))
+				continue
+			}
+			frKey = resourceID.Key
+		} else {
+			frKey = meta.RegionalKey(frName, lc.ctx.Cloud.Region())
+		}
+		parsedRules = append(parsedRules, parsedForwardingRule{key: frKey, rawName: frName})
+	}
+	return parsedRules, errs
+}
+
+func validateForwardingRule(fr *composite.ForwardingRule, frName string) error {
+	if fr.LoadBalancingScheme != string(cloud.SchemeExternal) {
+		return fmt.Errorf("forwarding rule %s has unsupported load balancing scheme: %s", frName, fr.LoadBalancingScheme)
+	}
+	if fr.IPProtocol != "TCP" && fr.IPProtocol != "UDP" && fr.IPProtocol != "L3_DEFAULT" {
+		return fmt.Errorf("forwarding rule %s has unsupported protocol: %s", frName, fr.IPProtocol)
+	}
+	return nil
+}
+
+func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) error {
+	frNamesStr, ok := svc.Annotations[annotations.CustomForwardingRuleKey]
+	if !ok || frNamesStr == "" {
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
+		svcLogger.V(4).Info("Service has no forwarding rule reference, skipping")
+		err := lc.clearStatusIngressIP(svc, svcLogger)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	parsedRules, parseErrs := lc.parseForwardingRuleKeys(frNamesStr, svcLogger)
+	var errs []error
+	errs = append(errs, parseErrs...)
+
+	if len(parsedRules) == 0 {
+		err := lc.clearStatusIngressIP(svc, svcLogger)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if len(errs) > 0 {
+			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule %s", errors.Join(errs...).Error())
+			return errors.Join(errs...)
+		}
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
+		return nil
+	}
+
+	var lbIngresses []v1.LoadBalancerIngress
+	vipMode := v1.LoadBalancerIPModeVIP
+
+	for _, parsed := range parsedRules {
+		fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsed.key, meta.VersionGA, svcLogger)
+		if err != nil {
+			svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
+			errs = append(errs, err)
+			continue
+		}
+
+		if err := validateForwardingRule(fr, parsed.rawName); err != nil {
+			svcLogger.Error(err, "invalid forwarding rule", "frName", parsed.rawName)
+			errs = append(errs, err)
+			continue
+		}
+
+		lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: fr.IPAddress, IPMode: &vipMode})
+
+	}
+
+	if len(errs) > 0 {
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use all Forwarding Rules %s", errors.Join(errs...).Error())
+	}
+	// if at least one FR was ok then we use it
+	if len(lbIngresses) == 0 {
+		// if none of the FRs is usable remove any that is possibly there
+		err := lc.clearStatusIngressIP(svc, svcLogger)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return errors.Join(errs...)
+	}
+
+	newStatus := &v1.LoadBalancerStatus{
+		Ingress: lbIngresses,
+	}
+
+	if err := updateServiceStatus(lc.ctx, svc, newStatus, nil, svcLogger); err != nil {
+		return err
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {
+	if len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return nil
+	}
+	newStatus := &v1.LoadBalancerStatus{
+		Ingress: nil,
+	}
+
+	if err := updateServiceStatus(lc.ctx, svc, newStatus, nil, svcLogger); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -1,0 +1,666 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/ingress-gce/pkg/composite"
+	ingctx "k8s.io/ingress-gce/pkg/context"
+	"k8s.io/ingress-gce/pkg/l4/annotations"
+	"k8s.io/ingress-gce/pkg/test"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/klog/v2"
+)
+
+func TestStandaloneNEGLBSync(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+	frName := "custom-fr"
+	frIP := "10.0.0.100"
+	project := "test-project"
+	region := "us-central1"
+
+	bsURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs1", project, region)
+
+	testCases := []struct {
+		desc               string
+		svc                *v1.Service
+		frs                map[string]*composite.ForwardingRule
+		expectIPs          []string
+		expectEventReasons []string
+		expectError        bool
+	}{
+		{
+			desc: "Multiple forwarding rules, one missing, success",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc3",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName + ",missing-fr",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:          []string{frIP},
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+		{
+			desc: "Multiple forwarding rules, all missing, error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc4",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "missing-fr1,missing-fr2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs:         map[string]*composite.ForwardingRule{},
+			expectIPs:   nil,
+			expectError: true,
+		},
+		{
+			desc: "Multiple forwarding rules, multiple backend services, success",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc5",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName + ",fr2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+				"fr2": {
+					Name:                "fr2",
+					IPAddress:           "10.0.0.101",
+					BackendService:      bsURL + "-2",
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{frIP, "10.0.0.101"},
+			expectError: false,
+		},
+		{
+			desc: "Multiple forwarding rules, same backend service, success",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc6",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName + ",fr2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+				"fr2": {
+					Name:                "fr2",
+					IPAddress:           "10.0.0.101",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{frIP, "10.0.0.101"},
+			expectError: false,
+		},
+		{
+			desc: "Global forwarding rule sync success",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-global",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/forwardingRules/global-fr", project),
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"global-fr": {
+					Name:                "global-fr",
+					IPAddress:           "10.0.0.200",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Global,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs: []string{"10.0.0.200"},
+		},
+		{
+			desc: "Failure when rule has INTERNAL scheme",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-internal-scheme",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "INTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+		{
+			desc: "Failure when rule protocol is ESP",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-esp-protocol",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "ESP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+		{
+			desc: "Success when rule protocol is L3_DEFAULT",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-l3-default",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "L3_DEFAULT",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs: []string{frIP},
+		},
+		{
+			desc: "Missing forwarding rule annotation entirely",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-missing-annotation",
+					Namespace: "default",
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			expectEventReasons: []string{"NoForwardingRuleRef"},
+		},
+		{
+			desc: "Forwarding rule annotation is empty",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-empty-annotation",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			expectEventReasons: []string{"NoForwardingRuleRef"},
+		},
+		{
+			desc: "Forwarding rule annotation parses to nothing",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-parses-to-nothing",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: ",  , ",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			expectEventReasons: []string{"NoForwardingRuleRef"},
+		},
+		{
+			desc: "Forwarding rule annotation has invalid URL",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-invalid-url",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "invalid/url/format",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+		{
+			desc: "Service with Type != ServiceTypeLoadBalancer is ignored",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-not-lb",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeClusterIP,
+					LoadBalancerClass: &lbClass,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{"1.2.3.4"},
+			expectError: false,
+		},
+		{
+			desc: "Clear status ingress IP when CustomForwardingRuleKey annotation is missing",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-clear-missing-annotation",
+					Namespace: "default",
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectEventReasons: []string{"NoForwardingRuleRef"},
+		},
+		{
+			desc: "Clear status ingress IP when forwarding rule protocol is ESP (unusable)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-clear-esp",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: frName,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				frName: {
+					Name:                frName,
+					IPAddress:           frIP,
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "ESP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+		{
+			desc: "Clear status ingress IP when CustomForwardingRuleKey annotation parses to nothing",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-clear-parses-to-nothing",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: ",  , ",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectEventReasons: []string{"NoForwardingRuleRef"},
+		},
+		{
+			desc: "Clear status ingress IP when CustomForwardingRuleKey annotation has an invalid URL",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-clear-invalid-url",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "invalid/url/format",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{IP: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+			fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
+			namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
+
+			// Populate fakeGCE client with forwarding rules defined in each test case
+			for name, fr := range tc.frs {
+				key, err := composite.CreateKey(fakeGCE, name, fr.Scope)
+				if err != nil {
+					t.Fatalf("Failed to create key for forwarding rule %s: %v", name, err)
+				}
+				err = composite.CreateForwardingRule(fakeGCE, key, fr, klog.TODO())
+				if err != nil {
+					t.Fatalf("Failed to create forwarding rule %s: %v", name, err)
+				}
+			}
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
+			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+			if err != nil {
+				t.Fatalf("Failed to create controller context: %v", err)
+			}
+
+			lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
+
+			// Add service to informer
+			c.ServiceInformer.GetIndexer().Add(tc.svc)
+			// Also add to fake kube client so updateStatus works
+			kubeClient.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{})
+
+			key := tc.svc.Namespace + "/" + tc.svc.Name
+			err = lc.sync(key)
+			if (err != nil) != tc.expectError {
+				t.Errorf("sync() error = %v, expectError %v", err, tc.expectError)
+			}
+
+			updatedSvc, _ := kubeClient.CoreV1().Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
+
+			if len(updatedSvc.Status.LoadBalancer.Ingress) != len(tc.expectIPs) {
+				t.Errorf("Expected %d ingress IPs, got %d", len(tc.expectIPs), len(updatedSvc.Status.LoadBalancer.Ingress))
+			} else {
+				for i, ip := range tc.expectIPs {
+					if updatedSvc.Status.LoadBalancer.Ingress[i].IP != ip {
+						t.Errorf("Expected IP %s, got %v", ip, updatedSvc.Status.LoadBalancer.Ingress[i].IP)
+					}
+				}
+			}
+
+			if len(tc.expectEventReasons) > 0 {
+				for _, expectedReason := range tc.expectEventReasons {
+					expectedReason := expectedReason
+					err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Second, true,
+						func(ctx context.Context) (bool, error) {
+							events, err := kubeClient.CoreV1().Events(tc.svc.Namespace).List(ctx, metav1.ListOptions{})
+							if err != nil {
+								return false, err
+							}
+							for _, e := range events.Items {
+								if e.Reason == expectedReason {
+									return true, nil
+								}
+							}
+							return false, nil
+						})
+					if err != nil {
+						t.Errorf("Expected %s event, but none found within timeout", expectedReason)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateForwardingRule(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		fr             *composite.ForwardingRule
+		frName         string
+		expectError    bool
+		expectErrorMsg string
+	}{
+		{
+			desc: "Valid TCP rule",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "EXTERNAL",
+				IPProtocol:          "TCP",
+			},
+			frName:      "valid-tcp",
+			expectError: false,
+		},
+		{
+			desc: "Valid UDP rule",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "EXTERNAL",
+				IPProtocol:          "UDP",
+			},
+			frName:      "valid-udp",
+			expectError: false,
+		},
+		{
+			desc: "Valid L3_DEFAULT rule",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "EXTERNAL",
+				IPProtocol:          "L3_DEFAULT",
+			},
+			frName:      "valid-l3-default",
+			expectError: false,
+		},
+		{
+			desc: "Internal scheme unsupported",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "INTERNAL",
+				IPProtocol:          "TCP",
+			},
+			frName:         "internal-scheme",
+			expectError:    true,
+			expectErrorMsg: "forwarding rule internal-scheme has unsupported load balancing scheme: INTERNAL",
+		},
+		{
+			desc: "Unsupported scheme",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "INTERNAL_SELF_MANAGED",
+				IPProtocol:          "TCP",
+			},
+			frName:         "invalid-scheme",
+			expectError:    true,
+			expectErrorMsg: "forwarding rule invalid-scheme has unsupported load balancing scheme: INTERNAL_SELF_MANAGED",
+		},
+		{
+			desc: "Unsupported protocol",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "EXTERNAL",
+				IPProtocol:          "ESP",
+			},
+			frName:         "invalid-protocol",
+			expectError:    true,
+			expectErrorMsg: "forwarding rule invalid-protocol has unsupported protocol: ESP",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateForwardingRule(tc.fr, tc.frName)
+			if (err != nil) != tc.expectError {
+				t.Errorf("validateForwardingRule() error = %v, expectError = %v", err, tc.expectError)
+			}
+			if err != nil && tc.expectErrorMsg != "" && err.Error() != tc.expectErrorMsg {
+				t.Errorf("validateForwardingRule() error message = %q, expected = %q", err.Error(), tc.expectErrorMsg)
+			}
+		})
+	}
+}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -701,9 +701,10 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 // mergeVmIpNEGsPortInfo merges the PortInfo for ILB, multinet NetLB and NetLB V3 (variant with NEG default) services using GCE_VM_IP NEGs into portInfoMap
 func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *metricscollector.NegServiceState, networkInfo *network.NetworkInfo) error {
 	wantsILB, _ := l4annotations.WantsL4ILB(service)
+	wantsStandaloneNEGLB := flags.F.RunL4StandaloneNEGLBController && l4annotations.HasLoadBalancerClass(service, l4annotations.StandalonePassthroughNegLoadBalancerClass)
 	needsNEGForILB := c.runL4ForILB && wantsILB
 	needsNEGForNetLB := c.netLBServiceNeedsNEG(service, networkInfo)
-	if !needsNEGForILB && !needsNEGForNetLB {
+	if !needsNEGForILB && !needsNEGForNetLB && !wantsStandaloneNEGLB {
 		return nil
 	}
 	// Only process ILB services after L4 controller has marked it with v2 finalizer.
@@ -714,11 +715,13 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 		return nil
 	}
 
-	// Ignore services with LoadBalancerClass different than "networking.gke.io/l4-regional-external" or
-	// "networking.gke.io/l4-regional-internal" used for L4 controllers that use GCE_VM_IP NEGs.
+	// Ignore services with LoadBalancerClass different than "networking.gke.io/l4-regional-external",
+	// "networking.gke.io/l4-regional-internal" or "networking.gke.io/standalone-passthrough-lb-neg"
+	// used for L4 controllers that use GCE_VM_IP NEGs.
 	if service.Spec.LoadBalancerClass != nil &&
 		!l4annotations.HasLoadBalancerClass(service, l4annotations.RegionalExternalLoadBalancerClass) &&
-		!l4annotations.HasLoadBalancerClass(service, l4annotations.RegionalInternalLoadBalancerClass) {
+		!l4annotations.HasLoadBalancerClass(service, l4annotations.RegionalInternalLoadBalancerClass) &&
+		!l4annotations.HasLoadBalancerClass(service, l4annotations.StandalonePassthroughNegLoadBalancerClass) {
 		msg := fmt.Sprintf("Ignoring Service %s, namespace %s as it uses a LoadBalancerClass %s", service.Name, service.Namespace, *service.Spec.LoadBalancerClass)
 		c.logger.Info(msg)
 		return nil
@@ -728,7 +731,9 @@ func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.Na
 	// Update usage metrics.
 	negUsage.VmIpNeg = metricscollector.NewVmIpNegType(onlyLocal)
 	var l4LBType negtypes.L4LBType
-	if needsNEGForILB {
+	if wantsStandaloneNEGLB {
+		l4LBType = negtypes.L4ExternalLB // for now treat this as external since it has higher limits for backend subset
+	} else if needsNEGForILB {
 		l4LBType = negtypes.L4InternalLB
 	} else {
 		l4LBType = negtypes.L4ExternalLB

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -1293,6 +1293,13 @@ func TestMergeDefaultBackendServicePortInfoMap(t *testing.T) {
 }
 
 func TestMergeVmIpNEGsPortInfo(t *testing.T) {
+	oldRunL4StandaloneNEGLBController := flags.F.RunL4StandaloneNEGLBController
+
+	flags.F.RunL4StandaloneNEGLBController = true
+	defer func() {
+		flags.F.RunL4StandaloneNEGLBController = oldRunL4StandaloneNEGLBController
+	}()
+
 	controller, err := newTestController(fake.NewSimpleClientset())
 	if err != nil {
 		t.Fatalf("failed to create test controller %s", err)
@@ -1314,6 +1321,15 @@ func TestMergeVmIpNEGsPortInfo(t *testing.T) {
 
 	serviceInternalLoadBalancerClass := newL4LBServiceWithLoadBalancerClass(controller, l4annotations.RegionalInternalLoadBalancerClass)
 	serviceInternalLoadBalancerClass.Finalizers = append(serviceInternalLoadBalancerClass.Finalizers, common.ILBFinalizerV2)
+
+	serviceCustomNegLBInternal := newL4LBServiceWithLoadBalancerClass(controller, l4annotations.StandalonePassthroughNegLoadBalancerClass)
+	serviceCustomNegLBInternal.Annotations[l4annotations.ServiceAnnotationLoadBalancerType] = string(l4annotations.LBTypeInternal)
+
+	serviceCustomNegLBExternal := newL4LBServiceWithLoadBalancerClass(controller, l4annotations.StandalonePassthroughNegLoadBalancerClass)
+	serviceCustomNegLBExternal.Annotations[l4annotations.ServiceAnnotationLoadBalancerType] = string(l4annotations.LBTypeExternal)
+
+	serviceCustomNegLBExternalWithoutAnnotation := newL4LBServiceWithLoadBalancerClass(controller, l4annotations.StandalonePassthroughNegLoadBalancerClass)
+	delete(serviceCustomNegLBExternalWithoutAnnotation.Annotations, l4annotations.ServiceAnnotationLoadBalancerType)
 
 	testCases := []struct {
 		desc           string
@@ -1390,6 +1406,24 @@ func TestMergeVmIpNEGsPortInfo(t *testing.T) {
 			networkInfo:    defaultNetwork,
 			runL4ILB:       true,
 			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4InternalLB),
+		},
+		{
+			desc:           "Service with custom-neg-load-balancer loadBalancerClass (internal)",
+			svc:            serviceCustomNegLBInternal,
+			networkInfo:    defaultNetwork,
+			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4ExternalLB),
+		},
+		{
+			desc:           "Service with custom-neg-load-balancer loadBalancerClass (external)",
+			svc:            serviceCustomNegLBExternal,
+			networkInfo:    defaultNetwork,
+			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4ExternalLB),
+		},
+		{
+			desc:           "Service with custom-neg-load-balancer loadBalancerClass (external without annotation)",
+			svc:            serviceCustomNegLBExternalWithoutAnnotation,
+			networkInfo:    defaultNetwork,
+			wantSvcPortMap: negtypes.NewPortInfoMapForVMIPNEG(testServiceNamespace, testServiceName, controller.l4Namer, true, defaultNetwork, negtypes.L4ExternalLB),
 		},
 	}
 


### PR DESCRIPTION
This PR adds the L4 Standalone NEG controller - a controller that allows the user to request a GCE_VM_IP NEG and set up a kubernetes cluster with a custom created external passthrough load balancer.