### PR TITLE
fix(check-gke-ingress): dedupe repeated service and BackendConfig checks

### DIFF
--- a/cmd/check-gke-ingress/app/ingress/ingress.go
+++ b/cmd/check-gke-ingress/app/ingress/ingress.go
@@ -107,15 +107,16 @@ func RunChecks(ingresses []networkingv1.Ingress, client kubernetes.Interface, be
 
 		// Get the names of the services referenced by the ingress.
 		svcNames := []string{}
+		seenServices := make(map[string]struct{})
 		if ingress.Spec.DefaultBackend != nil {
-			svcNames = append(svcNames, ingress.Spec.DefaultBackend.Service.Name)
+			svcNames = appendUnique(svcNames, seenServices, ingress.Spec.DefaultBackend.Service.Name)
 		}
 		if ingress.Spec.Rules != nil {
 			for _, rule := range ingress.Spec.Rules {
 				if rule.HTTP != nil {
 					for _, path := range rule.HTTP.Paths {
 						if path.Backend.Service != nil {
-							svcNames = append(svcNames, path.Backend.Service.Name)
+							svcNames = appendUnique(svcNames, seenServices, path.Backend.Service.Name)
 						}
 					}
 				}
@@ -138,12 +139,13 @@ func RunChecks(ingresses []networkingv1.Ingress, client kubernetes.Interface, be
 
 			// Get all the BackendConfigs referenced by the service.
 			beconfigNames := []string{}
+			seenBackendConfigs := make(map[string]struct{})
 			if serviceChecker.beConfigs != nil {
 				if serviceChecker.beConfigs.Default != "" {
-					beconfigNames = append(beconfigNames, serviceChecker.beConfigs.Default)
+					beconfigNames = appendUnique(beconfigNames, seenBackendConfigs, serviceChecker.beConfigs.Default)
 				}
 				for _, beconfig := range serviceChecker.beConfigs.Ports {
-					beconfigNames = append(beconfigNames, beconfig)
+					beconfigNames = appendUnique(beconfigNames, seenBackendConfigs, beconfig)
 				}
 			}
 			// BackendConfig related rules
@@ -173,4 +175,12 @@ func addCheckResult(ingressRes *report.Resource, checkName, msg, res string) {
 		Message: msg,
 		Result:  res,
 	})
+}
+
+func appendUnique(names []string, seen map[string]struct{}, name string) []string {
+	if _, ok := seen[name]; ok {
+		return names
+	}
+	seen[name] = struct{}{}
+	return append(names, name)
 }

--- a/cmd/check-gke-ingress/app/ingress/rule_test.go
+++ b/cmd/check-gke-ingress/app/ingress/rule_test.go
@@ -870,3 +870,88 @@ func TestCheckFunctions(t *testing.T) {
 		}
 	}
 }
+
+func TestRunChecksDeduplicatesRepeatedServiceReferences(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	beClient := fakebeconfig.NewSimpleClientset()
+	feClient := fakefeconfig.NewSimpleClientset()
+
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-1",
+			Namespace: "test",
+		},
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: "svc-1",
+				},
+			},
+			Rules: []networkingv1.IngressRule{
+				{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "svc-1",
+										},
+									},
+								},
+								{
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "svc-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	client.NetworkingV1().Ingresses("test").Create(context.TODO(), &ingress, metav1.CreateOptions{})
+
+	client.CoreV1().Services("test").Create(context.TODO(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "test",
+			Annotations: map[string]string{
+				annotations.BackendConfigKey: `{"default":"beconfig-1","ports":{"80":"beconfig-1"}}`,
+			},
+		},
+	}, metav1.CreateOptions{})
+
+	beClient.CloudV1().BackendConfigs("test").Create(context.TODO(), &beconfigv1.BackendConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "beconfig-1",
+			Namespace: "test",
+		},
+	}, metav1.CreateOptions{})
+
+	result := CheckAllIngresses("test", client, beClient, feClient)
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	checkCounts := map[string]int{}
+	for _, check := range result.Resources[0].Checks {
+		checkCounts[check.Name]++
+	}
+
+	for _, checkName := range []string{
+		ServiceExistenceCheck,
+		BackendConfigAnnotationCheck,
+		AppProtocolAnnotationCheck,
+		L7ILBNegAnnotationCheck,
+		BackendConfigExistenceCheck,
+		HealthCheckTimeoutCheck,
+	} {
+		if diff := cmp.Diff(1, checkCounts[checkName]); diff != "" {
+			t.Errorf("expected check %s to appear once (-want +got):\n%s", checkName, diff)
+		}
+	}
+}


### PR DESCRIPTION
this fixes duplicate results in `check-gke-ingress` when one Ingress points to the same Service more than once.

what changed
- dedupe referenced Service names before service checks run
- dedupe referenced BackendConfig names before backendconfig checks run

repro
1. create an Ingress that uses `svc-1` in `defaultBackend` and again in one or more `rules[].http.paths[]`
2. add `cloud.google.com/backend-config: {"default":"beconfig-1","ports":{"80":"beconfig-1"}}` to that Service
3. run `check-gke-ingress -n test`
4. before this patch it spits duplicate `ServiceExistenceCheck`, `BackendConfigAnnotationCheck`, `BackendConfigExistenceCheck`, and `HealthCheckTimeoutCheck`
5. after this patch each of those shows once per ingress

why this is real
GKE docs support one Ingress reusing the same Service across multiple host or path rules, so this isnt a lab-only edge case.

tests
`go test ./cmd/check-gke-ingress/...`
