### PR TITLE
[Cherrypick #3128 to release-1.40] keep draining nodes in L4 ETP Local NEGs while pods remain

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -753,6 +753,7 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
 		flags.F.EnableNEGsForIngress,
+		flags.F.EnableL4NEGLocalIncludeDrainNodes,
 		stopCh,
 		logger,
 		negMetrics,

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -153,6 +153,7 @@ var F = struct {
 	EnableIPv6NodeNEGEndpoints                  bool
 	EnableL4NEGDetachCancel                     bool
 	EnablePSCReconcileConnections               bool
+	EnableL4NEGLocalIncludeDrainNodes           bool
 	// EnableL4DenyFirewallExplicitlySet will be set to true if the argument was explicitly set by the user.
 	EnableL4DenyFirewallExplicitlySet bool
 	// ===============================
@@ -371,6 +372,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableIPv6NodeNEGEndpoints, "enable-ipv6-node-neg-endpoints", false, "Enable populating IPv6 addresses for Node IPs in GCE_VM_IP NEGs.")
 	flag.BoolVar(&F.EnableL4NEGDetachCancel, "enable-l4-neg-detach-cancel", false, "Enable cancelling NEG detach when endpoints need to be re-attached.")
 	flag.BoolVar(&F.EnablePSCReconcileConnections, "enable-psc-reconcile-connections", false, "Enable support for PSC ServiceAttachment reconcile connections field")
+	flag.BoolVar(&F.EnableL4NEGLocalIncludeDrainNodes, "enable-l4-neg-local-include-drain-nodes", false, "For L4 LB NEGs with externalTrafficPolicy=Local, keep nodes carrying the GKE drain label in the NEG as long as they still host a backing pod. Unready-node behavior is unchanged.")
 }
 
 func Validate() {

--- a/pkg/multiproject/neg/neg.go
+++ b/pkg/multiproject/neg/neg.go
@@ -193,6 +193,7 @@ func createNEGController(
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
 		flags.F.EnableNEGsForIngress,
+		flags.F.EnableL4NEGLocalIncludeDrainNodes,
 		stopCh,
 		logger,
 		negMetrics,

--- a/pkg/multiproject/neg/neg_test.go
+++ b/pkg/multiproject/neg/neg_test.go
@@ -89,11 +89,11 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 		es cache.SharedIndexInformer, sn cache.SharedIndexInformer, netInf cache.SharedIndexInformer, gke cache.SharedIndexInformer, nt cache.SharedIndexInformer,
 		synced func() bool, l4 namer.L4ResourcesNamer, defSP utils.ServicePort, cloud negtypes.NetworkEndpointGroupCloud, zg *zonegetter.ZoneGetter, nm negtypes.NetworkEndpointGroupNamer,
 		resync time.Duration, gc time.Duration, workers int, enableRR bool, runL4 bool, nonGCP bool, dualStack bool, lp labels.PodLabelPropagationConfig,
-		multiNetworking bool, ingressRegional bool, runNetLB bool, readOnly bool, enableNEGsForIngress bool,
+		multiNetworking bool, ingressRegional bool, runNetLB bool, readOnly bool, enableNEGsForIngress bool, includeDrainNodesL4Local bool,
 		stopCh <-chan struct{}, l klog.Logger, negMetrics *metrics.NegMetrics, syncerMetrics *syncMetrics.SyncerMetrics) (*neg.Controller, error) {
 		capturedStopCh = stopCh
 		return neg.NewController(kc, sc, ec, uid, ing, svc, pod, node, es, sn, netInf, gke, nt, synced, l4, defSP, cloud, zg, nm,
-			resync, gc, workers, enableRR, runL4, nonGCP, dualStack, lp, multiNetworking, ingressRegional, runNetLB, readOnly, enableNEGsForIngress, stopCh, l, negMetrics, syncerMetrics)
+			resync, gc, workers, enableRR, runL4, nonGCP, dualStack, lp, multiNetworking, ingressRegional, runNetLB, readOnly, enableNEGsForIngress, includeDrainNodesL4Local, stopCh, l, negMetrics, syncerMetrics)
 	}
 	t.Cleanup(func() { newNEGController = orig })
 

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -116,11 +116,54 @@ type Controller struct {
 	// enableNEGsForIngress indicates whether the NEG controller will create NEGs for Ingress services
 	enableNEGsForIngress bool
 
+	// includeDrainNodesL4Local indicates whether to include draining nodes for NEGs with L4Local mode
+	includeDrainNodesL4Local bool
+
+	// nodeMembershipFilters is the deduplicated set of zone filters that decide
+	// whether a node belongs in a NEG. The node update handler treats a node
+	// change as relevant when the node's inclusion under any of these filters
+	// flips. Precomputed at controller initialization so the handler has a single
+	// source of truth and does not rebuild the set on every event.
+	nodeMembershipFilters []zonegetter.Filter
+
 	stopCh <-chan struct{}
 	logger klog.Logger
 
 	// negMetrics is used to collect metrics for NEG
 	negMetrics *metrics.NegMetrics
+}
+
+// buildNodeMembershipFilters returns the deduplicated set of node filters that
+// the NEG syncers use to decide whether a node belongs in a NEG. A node update
+// is only worth a resync if it changes the node's inclusion under one of these.
+// Dedup matters because several modes resolve to the same filter (L4 Cluster
+// and VM_IP_PORT both use CandidateNodesFilter; with includeDrainNodesL4Local
+// the L4 Local filter may coincide too), so we never evaluate a filter twice.
+func buildNodeMembershipFilters(includeDrainNodesL4Local bool) []zonegetter.Filter {
+	set := map[zonegetter.Filter]struct{}{
+		negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, includeDrainNodesL4Local): {},
+		negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4ClusterMode, false):                  {},
+		zonegetter.CandidateNodesFilter: {},
+	}
+	filters := make([]zonegetter.Filter, 0, len(set))
+	for f := range set {
+		filters = append(filters, f)
+	}
+	return filters
+}
+
+// nodeUpdateRequiresResync reports whether the change from oldNode to
+// currentNode could alter NEG membership and therefore needs a resync. The
+// change is relevant when the node's inclusion under any membership filter
+// flips.
+func (c *Controller) nodeUpdateRequiresResync(oldNode, currentNode *apiv1.Node) bool {
+	for _, filter := range c.nodeMembershipFilters {
+		if c.zoneGetter.IsNodeSelectedByFilter(oldNode, filter, c.logger) !=
+			c.zoneGetter.IsNodeSelectedByFilter(currentNode, filter, c.logger) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewController returns a network endpoint group controller.
@@ -157,6 +200,7 @@ func NewController(
 	runL4ForNetLB bool,
 	readOnlyMode bool,
 	enableNEGsForIngress bool,
+	includeDrainNodesL4Local bool,
 	stopCh <-chan struct{},
 	logger klog.Logger,
 	negMetrics *metrics.NegMetrics,
@@ -206,6 +250,7 @@ func NewController(
 		lpConfig,
 		logger,
 		negMetrics,
+		includeDrainNodesL4Local,
 	)
 
 	var reflector readiness.Reflector
@@ -262,6 +307,8 @@ func NewController(
 		runL4ForNetLB:                  runL4ForNetLB,
 		readOnlyMode:                   readOnlyMode,
 		enableNEGsForIngress:           enableNEGsForIngress,
+		includeDrainNodesL4Local:       includeDrainNodesL4Local,
+		nodeMembershipFilters:          buildNodeMembershipFilters(includeDrainNodesL4Local),
 		stopCh:                         stopCh,
 		logger:                         logger,
 		negMetrics:                     negMetrics,
@@ -342,12 +389,8 @@ func NewController(
 			oldNode := old.(*apiv1.Node)
 			currentNode := cur.(*apiv1.Node)
 
-			vmIpCandidateNodeCheck := zonegetter.CandidateAndUnreadyNodesFilter
-			vmIpPortCandidateNodeCheck := zonegetter.CandidateNodesFilter
-
-			if zoneGetter.IsNodeSelectedByFilter(oldNode, vmIpCandidateNodeCheck, logger) != zoneGetter.IsNodeSelectedByFilter(currentNode, vmIpCandidateNodeCheck, logger) ||
-				zoneGetter.IsNodeSelectedByFilter(oldNode, vmIpPortCandidateNodeCheck, logger) != zoneGetter.IsNodeSelectedByFilter(currentNode, vmIpPortCandidateNodeCheck, logger) {
-				logger.Info("Node has changed, enqueueing", "node", currentNode.Name)
+			if negController.nodeUpdateRequiresResync(oldNode, currentNode) {
+				logger.Info("Node membership-relevant change, enqueueing", "node", currentNode.Name)
 				negController.enqueueNode(currentNode)
 			}
 			// Trigger a sync when node provider ID changed.
@@ -824,7 +867,7 @@ func (c *Controller) mergeDefaultBackendServicePortInfoMap(key string, service *
 // syncNegStatusAnnotation syncs the neg status annotation
 // it takes service namespace, name and the expected service ports for NEGs.
 func (c *Controller) syncNegStatusAnnotation(namespace, name string, portMap negtypes.PortInfoMap) error {
-	zones, err := c.zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portMap.EndpointsCalculatorMode()), c.logger)
+	zones, err := c.zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portMap.EndpointsCalculatorMode(), c.includeDrainNodesL4Local), c.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -163,7 +163,8 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		false,
 		false,
 		readOnlyMode,
-		true, // enableNEGsForIngress
+		true,  // enableNEGsForIngress
+		false, // includeDrainNodesL4Local
 		make(<-chan struct{}),
 		klog.TODO(),
 		testContext.NegMetrics,
@@ -1870,7 +1871,7 @@ func validateServiceAnnotationWithPortInfoMap(t *testing.T, svc *apiv1.Service, 
 	if err != nil {
 		t.Fatalf("Failed to initialize zone getter: %s", err)
 	}
-	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode()), klog.TODO())
+	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(portInfoMap.EndpointsCalculatorMode(), false), klog.TODO())
 	if !sets.NewString(expectZones...).Equal(sets.NewString(zones...)) {
 		t.Errorf("Unexpected zones listed by the predicate function, got %v, want %v", zones, expectZones)
 	}
@@ -1955,7 +1956,7 @@ func validateServiceStateAnnotationExceptNames(t *testing.T, svc *apiv1.Service,
 		t.Fatalf("Failed to initialize zone getter: %v", err)
 	}
 	// This routine is called from tests verifying L7 NEGs.
-	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L7Mode), klog.TODO())
+	zones, _ := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L7Mode, false), klog.TODO())
 
 	// negStatus validation
 	negStatus, err := negannotation.ParseNegStatus(v)
@@ -2480,4 +2481,167 @@ func TestMergeDefaultBackendServiceWithNEGsForIngressDisabled(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
+	t.Parallel()
+	kubeClient := fake.NewSimpleClientset()
+	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
+
+	// Populate initially with some nodes, but we will add the test node manually.
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to create fake zone getter: %v", err)
+	}
+
+	// Create controller with includeDrainNodesL4Local = true
+	controller, err := NewController(
+		kubeClient,
+		testContext.SvcNegClient,
+		kubeClient,
+		testContext.KubeSystemUID,
+		testContext.IngressInformer,
+		testContext.ServiceInformer,
+		testContext.PodInformer,
+		testContext.NodeInformer, // use the testContext node informer
+		testContext.EndpointSliceInformer,
+		testContext.SvcNegInformer,
+		testContext.NetworkInformer,
+		testContext.GKENetworkParamSetInformer,
+		testContext.NodeTopologyInformer,
+		func() bool { return true },
+		testContext.L4Namer,
+		defaultBackend,
+		negtypes.NewAdapter(testContext.Cloud, testContext.NegMetrics),
+		zoneGetter,
+		testContext.NegNamer,
+		testContext.ResyncPeriod,
+		testContext.ResyncPeriod,
+		testContext.NumGCWorkers,
+		false, // enableReadinessReflector
+		true,  // runL4Controller
+		false, // enableNonGcpMode
+		testContext.EnableDualStackNEG,
+		labels.PodLabelPropagationConfig{},
+		true,
+		false,
+		false,
+		false, // readOnlyMode
+		true,  // enableNEGsForIngress
+		true,  // includeDrainNodesL4Local = true
+		make(<-chan struct{}),
+		klog.TODO(),
+		testContext.NegMetrics,
+		metricscollector.FakeSyncerMetrics(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create test controller: %v", err)
+	}
+	defer controller.stop()
+
+	stopChan := make(chan struct{}, 1)
+	go testContext.NodeInformer.Run(stopChan)
+	defer func() {
+		stopChan <- struct{}{}
+	}()
+	if !cache.WaitForCacheSync(stopChan, testContext.NodeInformer.HasSynced) {
+		t.Fatal("timed out waiting for node informer to sync")
+	}
+
+	// We will create a node that is initially upgrading
+	upgradingNode := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "upgrading-node",
+			Labels: map[string]string{
+				utils.GKECurrentOperationLabel: utils.NodeDrain,
+				utils.LabelNodeSubnet:          "default",
+			},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "gce://foo-project/zone1/upgrading-node",
+			PodCIDR:    "10.100.1.0/24",
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{
+				{
+					Type:   apiv1.NodeReady,
+					Status: apiv1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	// Create the node in fake client / informer
+	_, err = kubeClient.CoreV1().Nodes().Create(ctx, upgradingNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	// Wait for the add event to propagate and clear it from the queue
+	ensureNodeEnqueue(t, "upgrading-node", controller)
+
+	// Now update the node to remove the drain label (so it becomes ready)
+	readyNode := upgradingNode.DeepCopy()
+	delete(readyNode.Labels, utils.GKECurrentOperationLabel)
+
+	_, err = kubeClient.CoreV1().Nodes().Update(ctx, readyNode, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update node: %v", err)
+	}
+
+	// This update transitions the node from:
+	// - CandidateAndUnreadyNodesFilter: Selected=False -> Selected=True (Change!)
+	// - CandidateNodesFilter: Selected=True -> Selected=True (No Change)
+	// Since includeDrainNodesL4Local is true, if we only check CandidateNodesFilter,
+	// we will not enqueue this node update.
+	// We want to verify that the node IS enqueued (because we also check CandidateAndUnreadyNodesFilter).
+	ensureNodeEnqueue(t, "upgrading-node", controller)
+
+	// Second scenario: verify CandidateAndDrainingNodesFilter detects a change
+	// that CandidateAndUnreadyNodesFilter misses.
+	//
+	// A node carrying both the drain label and the exclude-from-external-load-balancers
+	// label is rejected by every filter (drain exclusion and balancer exclusion both
+	// apply). When the exclude-balancer label is removed while the drain label is kept:
+	//   - CandidateAndUnreadyNodesFilter: false → false (drain label still blocks it)
+	//   - CandidateAndDrainingNodesFilter: false → true  (exclude-balancer gone; drain tolerated)
+	// Only CandidateAndDrainingNodesFilter detects the change, so removing it from
+	// the filter set would cause this enqueue to be missed.
+	drainExcludedNode := &apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "drain-excluded-node",
+			Labels: map[string]string{
+				utils.GKECurrentOperationLabel:     utils.NodeDrain,
+				utils.LabelNodeRoleExcludeBalancer: "true",
+				utils.LabelNodeSubnet:              "default",
+			},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "gce://foo-project/zone1/drain-excluded-node",
+			PodCIDR:    "10.100.2.0/24",
+		},
+		Status: apiv1.NodeStatus{
+			Conditions: []apiv1.NodeCondition{
+				{Type: apiv1.NodeReady, Status: apiv1.ConditionTrue},
+			},
+		},
+	}
+	_, err = kubeClient.CoreV1().Nodes().Create(ctx, drainExcludedNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create drain-excluded-node: %v", err)
+	}
+	ensureNodeEnqueue(t, "drain-excluded-node", controller)
+
+	// Remove only the exclude-balancer label; keep the drain label.
+	drainOnlyNode := drainExcludedNode.DeepCopy()
+	delete(drainOnlyNode.Labels, utils.LabelNodeRoleExcludeBalancer)
+	_, err = kubeClient.CoreV1().Nodes().Update(ctx, drainOnlyNode, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update drain-excluded-node: %v", err)
+	}
+	// CandidateAndDrainingNodesFilter sees false→true; CandidateAndUnreadyNodesFilter
+	// stays false→false (drain label still present). The enqueue must happen via the
+	// drain filter — if that filter were missing from the set the queue would stay empty.
+	ensureNodeEnqueue(t, "drain-excluded-node", controller)
 }

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -117,6 +117,9 @@ type syncerManager struct {
 	// lpConfig configures the pod label to be propagated to NEG endpoints.
 	lpConfig podlabels.PodLabelPropagationConfig
 
+	// includeDrainNodesL4Local indicates whether to include draining nodes for L4 local mode NEGs
+	includeDrainNodesL4Local bool
+
 	negMetrics *metrics.NegMetrics
 }
 
@@ -138,34 +141,36 @@ func newSyncerManager(namer negtypes.NetworkEndpointGroupNamer,
 	numGCWorkers int,
 	lpConfig podlabels.PodLabelPropagationConfig,
 	logger klog.Logger,
-	negMetrics *metrics.NegMetrics) *syncerManager {
+	negMetrics *metrics.NegMetrics,
+	includeDrainNodesL4Local bool) *syncerManager {
 
 	var vmIpPortZoneMap map[string]struct{}
 	updateZoneMap(&vmIpPortZoneMap, negtypes.NodeFilterForNetworkEndpointType(negtypes.VmIpPortEndpointType), zoneGetter, logger, negMetrics)
 
 	return &syncerManager{
-		namer:               namer,
-		l4Namer:             l4Namer,
-		recorder:            recorder,
-		cloud:               cloud,
-		zoneGetter:          zoneGetter,
-		nodeLister:          nodeLister,
-		podLister:           podLister,
-		serviceLister:       serviceLister,
-		endpointSliceLister: endpointSliceLister,
-		svcNegLister:        svcNegLister,
-		svcPortMap:          make(map[serviceKey]negtypes.PortInfoMap),
-		syncerMap:           make(map[negtypes.NegSyncerKey]negtypes.NegSyncer),
-		syncerMetrics:       syncerMetrics,
-		svcNegClient:        svcNegClient,
-		kubeSystemUID:       kubeSystemUID,
-		enableNonGcpMode:    enableNonGcpMode,
-		enableDualStackNEG:  enableDualStackNEG,
-		numGCWorkers:        numGCWorkers,
-		logger:              logger,
-		vmIpPortZoneMap:     vmIpPortZoneMap,
-		lpConfig:            lpConfig,
-		negMetrics:          negMetrics,
+		namer:                    namer,
+		l4Namer:                  l4Namer,
+		recorder:                 recorder,
+		cloud:                    cloud,
+		zoneGetter:               zoneGetter,
+		nodeLister:               nodeLister,
+		podLister:                podLister,
+		serviceLister:            serviceLister,
+		endpointSliceLister:      endpointSliceLister,
+		svcNegLister:             svcNegLister,
+		svcPortMap:               make(map[serviceKey]negtypes.PortInfoMap),
+		syncerMap:                make(map[negtypes.NegSyncerKey]negtypes.NegSyncer),
+		syncerMetrics:            syncerMetrics,
+		svcNegClient:             svcNegClient,
+		kubeSystemUID:            kubeSystemUID,
+		enableNonGcpMode:         enableNonGcpMode,
+		enableDualStackNEG:       enableDualStackNEG,
+		numGCWorkers:             numGCWorkers,
+		logger:                   logger,
+		vmIpPortZoneMap:          vmIpPortZoneMap,
+		lpConfig:                 lpConfig,
+		includeDrainNodesL4Local: includeDrainNodesL4Local,
+		negMetrics:               negMetrics,
 	}
 }
 
@@ -907,13 +912,14 @@ func (manager *syncerManager) getSyncerKey(namespace, name string, servicePortKe
 	}
 
 	return negtypes.NegSyncerKey{
-		Namespace:        namespace,
-		Name:             name,
-		NegName:          portInfo.NegName,
-		PortTuple:        portInfo.PortTuple,
-		NegType:          networkEndpointType,
-		EpCalculatorMode: calculatorMode,
-		L4LBType:         portInfo.L4LBType,
+		Namespace:                namespace,
+		Name:                     name,
+		NegName:                  portInfo.NegName,
+		PortTuple:                portInfo.PortTuple,
+		NegType:                  networkEndpointType,
+		EpCalculatorMode:         calculatorMode,
+		L4LBType:                 portInfo.L4LBType,
+		IncludeDrainNodesL4Local: manager.includeDrainNodesL4Local,
 	}
 }
 

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -115,6 +115,7 @@ func NewTestSyncerManager(kubeClient kubernetes.Interface) (*syncerManager, *gce
 		labels.PodLabelPropagationConfig{},
 		klog.TODO(),
 		metrics.NewNegMetrics(),
+		false,
 	)
 	return manager, testContext.Cloud, testContext, nil
 }
@@ -2285,4 +2286,56 @@ func populateSvcNegCache(t *testing.T, manager *syncerManager, svcNegClient svcn
 func rebuildSvcNegCache(t *testing.T, manager *syncerManager, svcNegClient svcnegclient.Interface, namespace string) {
 	manager.svcNegLister.Replace([]any{}, "")
 	populateSvcNegCache(t, manager, svcNegClient, namespace)
+}
+
+// TestGetSyncerKeyIncludeDrainNodesL4Local verifies that getSyncerKey correctly
+// stamps the manager-level includeDrainNodesL4Local flag into NegSyncerKey so
+// that syncer-map lookups are always consistent with the key used at creation.
+func TestGetSyncerKeyIncludeDrainNodesL4Local(t *testing.T) {
+	t.Parallel()
+	kubeClient := fake.NewSimpleClientset()
+	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("NewFakeZoneGetter: %v", err)
+	}
+
+	portInfo := negtypes.PortInfo{
+		PortTuple: negtypes.SvcPortTuple{},
+		NegName:   "test-neg",
+	}
+	portKey := negtypes.PortInfoMapKey{ServicePort: 80}
+
+	for _, wantDrain := range []bool{false, true} {
+		manager := newSyncerManager(
+			testContext.NegNamer,
+			testContext.L4Namer,
+			record.NewFakeRecorder(100),
+			negtypes.NewAdapter(testContext.Cloud, testContext.NegMetrics),
+			zoneGetter,
+			testContext.SvcNegClient,
+			testContext.KubeSystemUID,
+			testContext.PodInformer.GetIndexer(),
+			testContext.ServiceInformer.GetIndexer(),
+			testContext.EndpointSliceInformer.GetIndexer(),
+			testContext.NodeInformer.GetIndexer(),
+			testContext.SvcNegInformer.GetIndexer(),
+			metricscollector.FakeSyncerMetrics(),
+			false,
+			testContext.EnableDualStackNEG,
+			testContext.NumGCWorkers,
+			labels.PodLabelPropagationConfig{},
+			klog.TODO(),
+			metrics.NewNegMetrics(),
+			wantDrain,
+		)
+
+		key := manager.getSyncerKey("ns", "svc", portKey, portInfo)
+		if key.IncludeDrainNodesL4Local != wantDrain {
+			t.Errorf("getSyncerKey with includeDrainNodesL4Local=%v: got key.IncludeDrainNodesL4Local=%v",
+				wantDrain, key.IncludeDrainNodesL4Local)
+		}
+	}
 }

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -42,23 +42,25 @@ import (
 // In a cluster with nodes node1... node 50. If nodes node10 to node 45 run the pods for a given ILB service, all these
 // nodes - node10, node 11 ... node45 will be part of the subset.
 type LocalL4EndpointsCalculator struct {
-	nodeLister      listers.NodeLister
-	zoneGetter      *zonegetter.ZoneGetter
-	subsetSizeLimit int
-	svcId           string
-	logger          klog.Logger
-	networkInfo     *network.NetworkInfo
-	negMetrics      *metrics.NegMetrics
+	nodeLister               listers.NodeLister
+	zoneGetter               *zonegetter.ZoneGetter
+	subsetSizeLimit          int
+	svcId                    string
+	includeDrainNodesL4Local bool
+	logger                   klog.Logger
+	networkInfo              *network.NetworkInfo
+	negMetrics               *metrics.NegMetrics
 }
 
 // LocalL4EndpointsCalculatorParams contains the parameters for the LocalL4EndpointsCalculator
 type LocalL4EndpointsCalculatorParams struct {
-	NodeLister  listers.NodeLister
-	ZoneGetter  *zonegetter.ZoneGetter
-	SvcId       string
-	NetworkInfo *network.NetworkInfo
-	LbType      types.L4LBType
-	NegMetrics  *metrics.NegMetrics
+	NodeLister               listers.NodeLister
+	ZoneGetter               *zonegetter.ZoneGetter
+	SvcId                    string
+	NetworkInfo              *network.NetworkInfo
+	LbType                   types.L4LBType
+	NegMetrics               *metrics.NegMetrics
+	IncludeDrainNodesL4Local bool
 }
 
 func NewLocalL4EndpointsCalculator(params LocalL4EndpointsCalculatorParams, logger klog.Logger) *LocalL4EndpointsCalculator {
@@ -68,13 +70,14 @@ func NewLocalL4EndpointsCalculator(params LocalL4EndpointsCalculatorParams, logg
 	}
 
 	return &LocalL4EndpointsCalculator{
-		nodeLister:      params.NodeLister,
-		zoneGetter:      params.ZoneGetter,
-		subsetSizeLimit: subsetSize,
-		svcId:           params.SvcId,
-		logger:          logger.WithName("LocalL4EndpointsCalculator"),
-		networkInfo:     params.NetworkInfo,
-		negMetrics:      params.NegMetrics,
+		nodeLister:               params.NodeLister,
+		zoneGetter:               params.ZoneGetter,
+		subsetSizeLimit:          subsetSize,
+		svcId:                    params.SvcId,
+		includeDrainNodesL4Local: params.IncludeDrainNodesL4Local,
+		logger:                   logger.WithName("LocalL4EndpointsCalculator"),
+		networkInfo:              params.NetworkInfo,
+		negMetrics:               params.NegMetrics,
 	}
 }
 
@@ -93,6 +96,7 @@ func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsDat
 	if err != nil {
 		return nil, nil, 0, err
 	}
+	nodeFilter := types.NodeFilterForEndpointCalculatorMode(types.L4LocalMode, l.includeDrainNodesL4Local)
 	for _, ed := range eds {
 		for _, addr := range ed.Addresses {
 			if addr.NodeName == nil {
@@ -114,7 +118,8 @@ func (l *LocalL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsDat
 				l.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
 				continue
 			}
-			if ok := l.zoneGetter.IsNodeSelectedByFilter(node, zonegetter.CandidateAndUnreadyNodesFilter, l.logger); !ok {
+
+			if ok := l.zoneGetter.IsNodeSelectedByFilter(node, nodeFilter, l.logger); !ok {
 				l.logger.Info("Dropping Node from subset since it is not a valid LB candidate", "nodeName", node.Name)
 				continue
 			}
@@ -212,7 +217,7 @@ func (l *ClusterL4EndpointsCalculator) Mode() types.EndpointsCalculatorMode {
 // CalculateEndpoints determines the endpoints in the NEGs based on the current service endpoints and the current NEGs.
 func (l *ClusterL4EndpointsCalculator) CalculateEndpoints(eds []types.EndpointsData, currentMap map[types.NEGLocation]types.NetworkEndpointSet) (map[types.NEGLocation]types.NetworkEndpointSet, types.EndpointPodMap, int, error) {
 	// In this mode, any of the cluster nodes can be part of the subset, whether or not a matching pod runs on it.
-	nodes, _ := l.zoneGetter.ListNodes(zonegetter.CandidateAndUnreadyNodesFilter, l.logger)
+	nodes, _ := l.zoneGetter.ListNodes(types.NodeFilterForEndpointCalculatorMode(types.L4ClusterMode, false), l.logger)
 	zoneNodeMap := make(map[string][]*nodeWithSubnet)
 	zoneSubnetPairs := make(map[string]any)
 	networkInfoSubnetName, err := utils.KeyName(l.networkInfo.SubnetworkURL)

--- a/pkg/neg/syncers/endpoints_calculator.go
+++ b/pkg/neg/syncers/endpoints_calculator.go
@@ -51,20 +51,30 @@ type LocalL4EndpointsCalculator struct {
 	negMetrics      *metrics.NegMetrics
 }
 
-func NewLocalL4EndpointsCalculator(nodeLister listers.NodeLister, zoneGetter *zonegetter.ZoneGetter, svcId string, logger klog.Logger, networkInfo *network.NetworkInfo, lbType types.L4LBType, negMetrics *metrics.NegMetrics) *LocalL4EndpointsCalculator {
+// LocalL4EndpointsCalculatorParams contains the parameters for the LocalL4EndpointsCalculator
+type LocalL4EndpointsCalculatorParams struct {
+	NodeLister  listers.NodeLister
+	ZoneGetter  *zonegetter.ZoneGetter
+	SvcId       string
+	NetworkInfo *network.NetworkInfo
+	LbType      types.L4LBType
+	NegMetrics  *metrics.NegMetrics
+}
+
+func NewLocalL4EndpointsCalculator(params LocalL4EndpointsCalculatorParams, logger klog.Logger) *LocalL4EndpointsCalculator {
 	subsetSize := maxSubsetSizeLocal
-	if lbType == types.L4ExternalLB {
+	if params.LbType == types.L4ExternalLB {
 		subsetSize = maxSubsetSizeNetLBLocal
 	}
 
 	return &LocalL4EndpointsCalculator{
-		nodeLister:      nodeLister,
-		zoneGetter:      zoneGetter,
+		nodeLister:      params.NodeLister,
+		zoneGetter:      params.ZoneGetter,
 		subsetSizeLimit: subsetSize,
-		svcId:           svcId,
+		svcId:           params.SvcId,
 		logger:          logger.WithName("LocalL4EndpointsCalculator"),
-		networkInfo:     networkInfo,
-		negMetrics:      negMetrics,
+		networkInfo:     params.NetworkInfo,
+		negMetrics:      params.NegMetrics,
 	}
 }
 
@@ -168,19 +178,29 @@ type ClusterL4EndpointsCalculator struct {
 	negMetrics *metrics.NegMetrics
 }
 
-func NewClusterL4EndpointsCalculator(nodeLister listers.NodeLister, zoneGetter *zonegetter.ZoneGetter, svcId string, logger klog.Logger, networkInfo *network.NetworkInfo, l4LBtype types.L4LBType, negMetrics *metrics.NegMetrics) *ClusterL4EndpointsCalculator {
+// ClusterL4EndpointsCalculatorParams contains the parameters for the ClusterL4EndpointsCalculator.
+type ClusterL4EndpointsCalculatorParams struct {
+	NodeLister  listers.NodeLister
+	ZoneGetter  *zonegetter.ZoneGetter
+	SvcId       string
+	NetworkInfo *network.NetworkInfo
+	LbType      types.L4LBType
+	NegMetrics  *metrics.NegMetrics
+}
+
+func NewClusterL4EndpointsCalculator(params ClusterL4EndpointsCalculatorParams, logger klog.Logger) *ClusterL4EndpointsCalculator {
 	subsetSize := maxSubsetSizeDefault
-	if l4LBtype == types.L4ExternalLB {
+	if params.LbType == types.L4ExternalLB {
 		subsetSize = maxSubsetSizeNetLBCluster
 	}
 	return &ClusterL4EndpointsCalculator{
-		zoneGetter:      zoneGetter,
+		zoneGetter:      params.ZoneGetter,
 		subsetSizeLimit: subsetSize,
-		svcId:           svcId,
-		lbType:          l4LBtype,
+		svcId:           params.SvcId,
+		lbType:          params.LbType,
 		logger:          logger.WithName("ClusterL4EndpointsCalculator"),
-		networkInfo:     networkInfo,
-		negMetrics:      negMetrics,
+		networkInfo:     params.NetworkInfo,
+		negMetrics:      params.NegMetrics,
 	}
 }
 

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -163,7 +163,14 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ec := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network, negtypes.L4InternalLB, metrics.NewNegMetrics())
+			ec := NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
+				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:  zoneGetter,
+				SvcId:       svcKey,
+				NetworkInfo: &tc.network,
+				LbType:      negtypes.L4InternalLB,
+				NegMetrics:  metrics.NewNegMetrics(),
+			}, klog.TODO())
 			updateNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, tc.nodeReadyStatusMap, nodeInformer.GetIndexer())
 			retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 			if err != nil {
@@ -324,7 +331,14 @@ func TestClusterGetEndpointSet(t *testing.T) {
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ec := NewClusterL4EndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &tc.network, negtypes.L4InternalLB, metrics.NewNegMetrics())
+			ec := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:  zoneGetter,
+				SvcId:       svcKey,
+				NetworkInfo: &tc.network,
+				LbType:      negtypes.L4InternalLB,
+				NegMetrics:  metrics.NewNegMetrics(),
+			}, klog.TODO())
 			updateNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, tc.nodeReadyStatusMap, nodeInformer.GetIndexer())
 			retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
 			if err != nil {
@@ -595,7 +609,14 @@ func TestClusterWantedNEGsCount(t *testing.T) {
 				}
 			}
 
-			ec := NewClusterL4EndpointsCalculator(listers.NewNodeLister(nodeInformer.GetIndexer()), zoneGetter, svcKey, klog.TODO(), &defaultNetwork, lbType, metrics.NewNegMetrics())
+			ec := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:  zoneGetter,
+				SvcId:       svcKey,
+				NetworkInfo: &defaultNetwork,
+				LbType:      lbType,
+				NegMetrics:  metrics.NewNegMetrics(),
+			}, klog.TODO())
 
 			// Act
 			res, _, _, err := ec.CalculateEndpoints(eds, currentMap)
@@ -941,11 +962,14 @@ func TestEndpointsSplitAcrossZonesILB(t *testing.T) {
 
 			// We use ILB so that it doesn't trigger code that linearly calculates number of NEGs needed
 			// based on actual number of Pods.
-			c := NewClusterL4EndpointsCalculator(
-				listers.NewNodeLister(nodeInformer.GetIndexer()),
-				zoneGetter, "svc", klog.TODO(), &defaultNetwork, negtypes.L4InternalLB,
-				metrics.NewNegMetrics(),
-			)
+			c := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:  zoneGetter,
+				SvcId:       "svc",
+				NetworkInfo: &defaultNetwork,
+				LbType:      negtypes.L4InternalLB,
+				NegMetrics:  metrics.NewNegMetrics(),
+			}, klog.TODO())
 
 			var endpointsMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
 			for _, stage := range tc.stages {
@@ -1103,11 +1127,14 @@ func TestEndpointsMigrationFrom25To24ForILBEtpCluster(t *testing.T) {
 			defaultNetwork := network.NetworkInfo{IsDefault: true, K8sNetwork: "default", SubnetworkURL: defaultTestSubnetURL}
 			// We use ILB so that it doesn't trigger code that linearly calculates number of NEGs needed
 			// based on actual number of Pods.
-			c := NewClusterL4EndpointsCalculator(
-				listers.NewNodeLister(nodeInformer.GetIndexer()),
-				zoneGetter, "svc", klog.TODO(), &defaultNetwork, negtypes.L4InternalLB,
-				metrics.NewNegMetrics(),
-			)
+			c := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:  zoneGetter,
+				SvcId:       "svc",
+				NetworkInfo: &defaultNetwork,
+				LbType:      negtypes.L4InternalLB,
+				NegMetrics:  metrics.NewNegMetrics(),
+			}, klog.TODO())
 
 			// Set up nodes
 			for zone, nodes := range tc.nodes {
@@ -1223,8 +1250,22 @@ func TestValidateEndpoints(t *testing.T) {
 	}
 	L7EndpointsCalculatorMSC := NewL7EndpointsCalculator(zoneGetterMSC, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics(), testContext.NegMetrics)
 	L7EndpointsCalculatorMSC.enableMultiSubnetCluster = true
-	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL}, negtypes.L4InternalLB, testContext.NegMetrics)
-	L4ClusterEndpointCalculator := NewClusterL4EndpointsCalculator(listers.NewNodeLister(nodeLister), zoneGetter, fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace), klog.TODO(), &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL}, negtypes.L4InternalLB, testContext.NegMetrics)
+	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
+		NodeLister:  listers.NewNodeLister(nodeLister),
+		ZoneGetter:  zoneGetter,
+		SvcId:       fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace),
+		NetworkInfo: &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL},
+		LbType:      negtypes.L4InternalLB,
+		NegMetrics:  testContext.NegMetrics,
+	}, klog.TODO())
+	L4ClusterEndpointCalculator := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+		NodeLister:  listers.NewNodeLister(nodeLister),
+		ZoneGetter:  zoneGetter,
+		SvcId:       fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace),
+		NetworkInfo: &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL},
+		LbType:      negtypes.L4InternalLB,
+		NegMetrics:  testContext.NegMetrics,
+	}, klog.TODO())
 
 	l7TestEPS := []*discovery.EndpointSlice{
 		{

--- a/pkg/neg/syncers/endpoints_calculator_test.go
+++ b/pkg/neg/syncers/endpoints_calculator_test.go
@@ -55,15 +55,16 @@ func TestLocalGetEndpointSet(t *testing.T) {
 	defer func() { flags.F.EnableMultiSubnetCluster = prevFlag }()
 	flags.F.EnableMultiSubnetCluster = false
 	testCases := []struct {
-		desc                string
-		endpointsData       []negtypes.EndpointsData
-		wantEndpointSets    map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
-		networkEndpointType negtypes.NetworkEndpointType
-		nodeLabelsMap       map[string]map[string]string
-		nodeAnnotationsMap  map[string]map[string]string
-		nodeReadyStatusMap  map[string]v1.ConditionStatus
-		nodeNames           []string
-		network             network.NetworkInfo
+		desc                     string
+		endpointsData            []negtypes.EndpointsData
+		wantEndpointSets         map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+		networkEndpointType      negtypes.NetworkEndpointType
+		nodeLabelsMap            map[string]map[string]string
+		nodeAnnotationsMap       map[string]map[string]string
+		nodeReadyStatusMap       map[string]v1.ConditionStatus
+		nodeNames                []string
+		network                  network.NetworkInfo
+		includeDrainNodesL4Local bool
 	}{
 		{
 			desc:          "default endpoints",
@@ -159,17 +160,89 @@ func TestLocalGetEndpointSet(t *testing.T) {
 			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
 			network:             defaultNetwork,
 		},
+		{
+			desc:          "all nodes unready with IncludeDrainNodesL4Local: unready still tolerated",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			// The flag is additive: it stops dropping drain-labeled nodes but leaves
+			// the existing unready tolerance untouched, so the picked set matches the
+			// flag-off "all nodes unready" case.
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			nodeReadyStatusMap: map[string]v1.ConditionStatus{
+				testInstance1: v1.ConditionFalse, testInstance2: v1.ConditionFalse, testInstance3: v1.ConditionFalse, testInstance4: v1.ConditionFalse, testInstance5: v1.ConditionFalse, testInstance6: v1.ConditionFalse,
+			},
+			network:                  defaultNetwork,
+			includeDrainNodesL4Local: true,
+		},
+		{
+			desc:          "some nodes unready with IncludeDrainNodesL4Local: unready still tolerated",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			// Same expectation as the flag-off "default endpoints" case — the flag
+			// has no effect when no node is drain-labeled.
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType: negtypes.VmIpEndpointType,
+			nodeNames:           []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			nodeReadyStatusMap: map[string]v1.ConditionStatus{
+				testInstance1: v1.ConditionTrue, testInstance2: v1.ConditionFalse, testInstance3: v1.ConditionTrue, testInstance4: v1.ConditionFalse, testInstance5: v1.ConditionTrue, testInstance6: v1.ConditionTrue,
+			},
+			network:                  defaultNetwork,
+			includeDrainNodesL4Local: true,
+		},
+		{
+			desc:          "draining node kept with IncludeDrainNodesL4Local, exclude-balancer still dropped",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			nodeLabelsMap: map[string]map[string]string{
+				testInstance1: {utils.LabelNodeRoleExcludeBalancer: "true"},
+				testInstance3: {utils.GKECurrentOperationLabel: utils.NodeDrain},
+			},
+			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			// testInstance3 (draining) is kept because it still has pods; testInstance1
+			// (exclude-from-external-load-balancers) is still excluded — that exclusion
+			// is unconditional and not affected by the flag.
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType:      negtypes.VmIpEndpointType,
+			network:                  defaultNetwork,
+			includeDrainNodesL4Local: true,
+		},
+		{
+			desc:          "draining node without pods dropped naturally with IncludeDrainNodesL4Local",
+			endpointsData: negtypes.EndpointsDataFromEndpointSlices(getDefaultEndpointSlices()),
+			nodeLabelsMap: map[string]map[string]string{
+				// testInstance5 has the drain label but no endpoints reference it,
+				// so it is never iterated by the per-pod loop and never enters the subset.
+				testInstance5: {utils.GKECurrentOperationLabel: utils.NodeDrain},
+			},
+			nodeNames: []string{testInstance1, testInstance2, testInstance3, testInstance4, testInstance5, testInstance6},
+			wantEndpointSets: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.1", Node: testInstance1}, negtypes.NetworkEndpoint{IP: "1.2.3.2", Node: testInstance2}),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.2.3.3", Node: testInstance3}, negtypes.NetworkEndpoint{IP: "1.2.3.4", Node: testInstance4}),
+			},
+			networkEndpointType:      negtypes.VmIpEndpointType,
+			network:                  defaultNetwork,
+			includeDrainNodesL4Local: true,
+		},
 	}
 	svcKey := fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace)
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ec := NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
-				NodeLister:  listers.NewNodeLister(nodeInformer.GetIndexer()),
-				ZoneGetter:  zoneGetter,
-				SvcId:       svcKey,
-				NetworkInfo: &tc.network,
-				LbType:      negtypes.L4InternalLB,
-				NegMetrics:  metrics.NewNegMetrics(),
+				NodeLister:               listers.NewNodeLister(nodeInformer.GetIndexer()),
+				ZoneGetter:               zoneGetter,
+				SvcId:                    svcKey,
+				NetworkInfo:              &tc.network,
+				LbType:                   negtypes.L4InternalLB,
+				NegMetrics:               metrics.NewNegMetrics(),
+				IncludeDrainNodesL4Local: tc.includeDrainNodesL4Local,
 			}, klog.TODO())
 			updateNodes(t, tc.nodeNames, tc.nodeLabelsMap, tc.nodeAnnotationsMap, tc.nodeReadyStatusMap, nodeInformer.GetIndexer())
 			retSet, _, _, err := ec.CalculateEndpoints(tc.endpointsData, nil)
@@ -1251,12 +1324,13 @@ func TestValidateEndpoints(t *testing.T) {
 	L7EndpointsCalculatorMSC := NewL7EndpointsCalculator(zoneGetterMSC, podLister, nodeLister, serviceLister, svcPort, klog.TODO(), testContext.EnableDualStackNEG, metricscollector.FakeSyncerMetrics(), testContext.NegMetrics)
 	L7EndpointsCalculatorMSC.enableMultiSubnetCluster = true
 	L4LocalEndpointCalculator := NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
-		NodeLister:  listers.NewNodeLister(nodeLister),
-		ZoneGetter:  zoneGetter,
-		SvcId:       fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace),
-		NetworkInfo: &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL},
-		LbType:      negtypes.L4InternalLB,
-		NegMetrics:  testContext.NegMetrics,
+		NodeLister:               listers.NewNodeLister(nodeLister),
+		ZoneGetter:               zoneGetter,
+		SvcId:                    fmt.Sprintf("%s/%s", testServiceName, testServiceNamespace),
+		NetworkInfo:              &network.NetworkInfo{SubnetworkURL: defaultTestSubnetURL},
+		LbType:                   negtypes.L4InternalLB,
+		NegMetrics:               testContext.NegMetrics,
+		IncludeDrainNodesL4Local: false,
 	}, klog.TODO())
 	L4ClusterEndpointCalculator := NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
 		NodeLister:  listers.NewNodeLister(nodeLister),

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -215,12 +215,13 @@ func GetEndpointsCalculator(podLister, nodeLister, serviceLister cache.Indexer, 
 		switch mode {
 		case negtypes.L4LocalMode:
 			return NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
-				NodeLister:  nodeLister,
-				ZoneGetter:  zoneGetter,
-				SvcId:       serviceKey,
-				NetworkInfo: networkInfo,
-				LbType:      l4LBType,
-				NegMetrics:  negMetrics,
+				NodeLister:               nodeLister,
+				ZoneGetter:               zoneGetter,
+				SvcId:                    serviceKey,
+				NetworkInfo:              networkInfo,
+				LbType:                   l4LBType,
+				NegMetrics:               negMetrics,
+				IncludeDrainNodesL4Local: syncerKey.IncludeDrainNodesL4Local,
 			}, logger)
 		default:
 			return NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
@@ -306,7 +307,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		return err
 	}
 
-	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger, s.negMetrics, needInitDrainStatus)
+	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.zoneGetter, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -521,10 +522,17 @@ func (s *transactionSyncer) resetErrorState() {
 	s.errorState = false
 }
 
+// candidateNodeFilter returns the zone filter appropriate for this syncer's
+// endpoint calculator mode. Centralises the derivation used by both
+// ensureNetworkEndpointGroups and isZoneChange so they always agree.
+func (s *transactionSyncer) candidateNodeFilter() zonegetter.Filter {
+	return negtypes.NodeFilterForEndpointCalculatorMode(s.EpCalculatorMode, s.NegSyncerKey.IncludeDrainNodesL4Local)
+}
+
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	// NEGs should be created in zones with candidate nodes only.
-	zones, err := s.zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(s.EpCalculatorMode), s.logger)
+	zones, err := s.zoneGetter.ListZones(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		return err
 	}
@@ -913,7 +921,7 @@ func (s *transactionSyncer) isZoneChange() bool {
 		existingZones.Insert(id.Key.Zone)
 	}
 
-	zones, err := s.zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(s.EpCalculatorMode), s.logger)
+	zones, err := s.zoneGetter.ListZones(s.candidateNodeFilter(), s.logger)
 	if err != nil {
 		s.logger.Error(err, "unable to list zones")
 		s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -214,9 +214,23 @@ func GetEndpointsCalculator(podLister, nodeLister, serviceLister cache.Indexer, 
 		nodeLister := listers.NewNodeLister(nodeLister)
 		switch mode {
 		case negtypes.L4LocalMode:
-			return NewLocalL4EndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo, l4LBType, negMetrics)
+			return NewLocalL4EndpointsCalculator(LocalL4EndpointsCalculatorParams{
+				NodeLister:  nodeLister,
+				ZoneGetter:  zoneGetter,
+				SvcId:       serviceKey,
+				NetworkInfo: networkInfo,
+				LbType:      l4LBType,
+				NegMetrics:  negMetrics,
+			}, logger)
 		default:
-			return NewClusterL4EndpointsCalculator(nodeLister, zoneGetter, serviceKey, logger, networkInfo, l4LBType, negMetrics)
+			return NewClusterL4EndpointsCalculator(ClusterL4EndpointsCalculatorParams{
+				NodeLister:  nodeLister,
+				ZoneGetter:  zoneGetter,
+				SvcId:       serviceKey,
+				NetworkInfo: networkInfo,
+				LbType:      l4LBType,
+				NegMetrics:  negMetrics,
+			}, logger)
 		}
 	}
 	return NewL7EndpointsCalculator(

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -2573,7 +2573,7 @@ func TestIsSubnetChange(t *testing.T) {
 			ts.zoneGetter = fakeZoneGetter
 			//Make sure NodeTopologyInformer is considered as synced, otherwise only defaultSubnet is returned
 			zonegetter.SetNodeTopologyHasSynced(ts.zoneGetter, func() bool { return true })
-			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(ts.EpCalculatorMode), klog.TODO())
+			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(ts.EpCalculatorMode, ts.IncludeDrainNodesL4Local), klog.TODO())
 			if err != nil {
 				t.Errorf("errored when retrieving zones: %s", err)
 			}
@@ -2856,7 +2856,7 @@ func TestIsZoneChange(t *testing.T) {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
 			}
 			fakeZoneGetter := syncer.zoneGetter
-			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(syncer.EpCalculatorMode), klog.TODO())
+			origZones, err := fakeZoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(syncer.EpCalculatorMode, syncer.IncludeDrainNodesL4Local), klog.TODO())
 			if err != nil {
 				t.Errorf("errored when retrieving zones: %s", err)
 			}
@@ -3022,7 +3022,7 @@ func TestUnknownNodes(t *testing.T) {
 	}
 
 	// Check that unknown zone did not cause endpoints to be removed
-	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false)
+	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
 	if err != nil {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
@@ -3325,7 +3325,7 @@ func TestEnableDegradedMode(t *testing.T) {
 			tc.modify(s)
 
 			subnetToNegMapping := map[string]string{defaultTestSubnet: tc.negName}
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints")
 			}
@@ -3338,7 +3338,7 @@ func TestEnableDegradedMode(t *testing.T) {
 				t.Errorf("syncInternal returned %v, expected %v", err, tc.expectErr)
 			}
 			err = wait.PollImmediate(time.Second, 3*time.Second, func() (bool, error) {
-				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false)
+				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
 				if err != nil {
 					return false, nil
 				}
@@ -3748,12 +3748,13 @@ func TestSyncL4NEGs(t *testing.T) {
 	testNodeIP5 := "1.2.3.5"
 
 	testCases := []struct {
-		desc                   string
-		existingGCEEndpoints   map[negtypes.NEGLocation][]*composite.NetworkEndpoint
-		endpointSlices         []*discovery.EndpointSlice
-		inProgressTransactions map[negtypes.NetworkEndpoint]transactionEntry
-		expectedEndpoints      map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
-		enableL4DetachCancel   bool
+		desc                     string
+		existingGCEEndpoints     map[negtypes.NEGLocation][]*composite.NetworkEndpoint
+		endpointSlices           []*discovery.EndpointSlice
+		inProgressTransactions   map[negtypes.NetworkEndpoint]transactionEntry
+		expectedEndpoints        map[negtypes.NEGLocation]negtypes.NetworkEndpointSet
+		enableL4DetachCancel     bool
+		includeDrainNodesL4Local bool
 	}{
 		{
 			// test if the syncer can attach endpoints to L4 NEG.
@@ -3946,6 +3947,44 @@ func TestSyncL4NEGs(t *testing.T) {
 				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
 			},
 		},
+		{
+			// test if the syncer excludes upgrading nodes when includeDrainNodesL4Local is false.
+			desc: "add endpoints on upgrading node with includeDrainNodesL4Local disabled",
+			existingGCEEndpoints: map[negtypes.NEGLocation][]*composite.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: {},
+			},
+			endpointSlices:           getUpgradingEndpointSlices(testServiceName, testServiceNamespace),
+			includeDrainNodesL4Local: false,
+			expectedEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+			},
+		},
+		{
+			// test if the syncer includes upgrading nodes when includeDrainNodesL4Local is true.
+			desc: "add endpoints on upgrading node with includeDrainNodesL4Local enabled",
+			existingGCEEndpoints: map[negtypes.NEGLocation][]*composite.NetworkEndpoint{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: {},
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: {},
+			},
+			endpointSlices:           getUpgradingEndpointSlices(testServiceName, testServiceNamespace),
+			includeDrainNodesL4Local: true,
+			expectedEndpoints: map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+				{Zone: negtypes.TestZone1, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone2, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone3, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(),
+				{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}: negtypes.NewNetworkEndpointSet(
+					negtypes.NetworkEndpoint{IP: "1.2.3.9", Node: "upgrade-instance1"},
+				),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -3990,6 +4029,7 @@ func TestSyncL4NEGs(t *testing.T) {
 			}
 			testContext := negtypes.NewTestContext()
 			testContext.NodeInformer = nodeInformer
+			testContext.IncludeDrainNodesL4Local = tc.includeDrainNodesL4Local
 			_, s, err := newTestTransactionSyncerWithCustomContext(fakeCloud, negtypes.VmIpEndpointType, false, testContext)
 			if err != nil {
 				t.Fatalf("failed to initialize transaction syncer: %v", err)
@@ -4017,7 +4057,7 @@ func TestSyncL4NEGs(t *testing.T) {
 			// give a little time for the syncer attach/detach goroutines to finish
 			time.Sleep(50 * time.Millisecond)
 
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), s.negMetrics, false)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), s.negMetrics, false, s.NegSyncerKey.IncludeDrainNodesL4Local)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints: %v", err)
 			}
@@ -4028,6 +4068,43 @@ func TestSyncL4NEGs(t *testing.T) {
 		})
 	}
 
+}
+
+func getUpgradingEndpointSlices(name, namespace string) []*discovery.EndpointSlice {
+	upgradeInstance1 := "upgrade-instance1"
+	port80 := int32(80)
+	emptyNamedPort := ""
+	protocolTCP := corev1.ProtocolTCP
+	return []*discovery.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "-upgrade",
+				Namespace: namespace,
+				Labels: map[string]string{
+					discovery.LabelServiceName: name,
+					discovery.LabelManagedBy:   managedByEPSControllerValue,
+				},
+			},
+			AddressType: "IPv4",
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"10.100.9.1"},
+					NodeName:  &upgradeInstance1,
+					TargetRef: &corev1.ObjectReference{
+						Namespace: namespace,
+						Name:      "pod-upgrade-1",
+					},
+				},
+			},
+			Ports: []discovery.EndpointPort{
+				{
+					Name:     &emptyNamedPort,
+					Port:     &port80,
+					Protocol: &protocolTCP,
+				},
+			},
+		},
+	}
 }
 
 func TestReAddDrainingEndpointsThatAreInTargetMap(t *testing.T) {
@@ -4165,6 +4242,7 @@ func newCustomTestTransactionSyncer(fakeGCE negtypes.NetworkEndpointGroupCloud, 
 		svcPort.PortTuple.Name = string(negtypes.VmIpEndpointType)
 		mode = negtypes.L4LocalMode
 		svcPort.EpCalculatorMode = mode
+		svcPort.IncludeDrainNodesL4Local = testContext.IncludeDrainNodesL4Local
 	}
 
 	// TODO(freehan): use real readiness reflector

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -698,7 +698,7 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter *zonegetter.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter *zonegetter.ZoneGetter, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
 	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
 	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
 	zones, err := zoneGetter.ListZones(zonegetter.AllNodesFilter, logger)
@@ -706,7 +706,7 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 		return nil, nil, nil, err
 	}
 
-	candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(mode), logger)
+	candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1355,7 +1355,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc.mutate(negCloud)
 		// tc.mode of "" will result in the default node predicate being selected, which is ok for this test.
-		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, negCloud, meta.VersionGA, tc.mode, tc.enableDualStackNEG, klog.TODO(), metrics.NewNegMetrics(), false)
+		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, negCloud, meta.VersionGA, tc.mode, tc.enableDualStackNEG, klog.TODO(), metrics.NewNegMetrics(), false, false)
 
 		if tc.expectErr {
 			if err == nil {
@@ -1497,7 +1497,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 			negName := "testNEG"
 
 			// ensure a NEG exists in each zone with relevant nodes
-			candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode), klog.TODO())
+			candidateNodeZones, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, false), klog.TODO())
 			if err != nil {
 				t.Fatalf("zoneGetter.ListZones() %v", err)
 			}
@@ -1528,7 +1528,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 
 			subnetToNegMapping := map[string]string{defaultTestSubnet: negName}
 
-			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus)
+			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus, false)
 			if err != nil {
 				t.Fatalf("retrieveExistingZoneNetworkEndpointMap: %v", err)
 			}
@@ -1541,6 +1541,97 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 				t.Errorf("Unexpected drainingEndpoints(-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes verifies that when
+// includeDrainNodesL4Local=true, zone4 (drain-only nodes) is promoted to a
+// candidateNodeZone, which means:
+//   - A NotFound error for a missing zone4 NEG is NOT suppressed (the zone is
+//     now expected to have a NEG, so absence is an error rather than cleanup
+//     of a stale zone).
+//   - When a zone4 NEG does exist, its endpoints are included just like any
+//     other candidate zone.
+//
+// With includeDrainNodesL4Local=false, zone4 is absent from candidateNodeZones
+// so a missing NEG there is silently skipped (cleanup semantics).
+func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
+	t.Parallel()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	negtypes.MockNetworkEndpointAPIs(fakeGCE)
+	fakeCloud := negtypes.NewAdapter(fakeGCE, negtypes.NewTestContext().NegMetrics)
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
+
+	negName := "testNEGDrain"
+	subnetToNegMapping := map[string]string{defaultTestSubnet: negName}
+
+	// Verify the zone4 membership assertion: with drain=true, zone4 must be in
+	// candidateNodeZones; with drain=false, it must not be.
+	zonesWithDrain, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, true), klog.TODO())
+	if err != nil {
+		t.Fatalf("ListZones(drain=true): %v", err)
+	}
+	zonesNoDrain, err := zoneGetter.ListZones(negtypes.NodeFilterForEndpointCalculatorMode(negtypes.L4LocalMode, false), klog.TODO())
+	if err != nil {
+		t.Fatalf("ListZones(drain=false): %v", err)
+	}
+	hasZone4WithDrain := false
+	for _, z := range zonesWithDrain {
+		if z == negtypes.TestZone4 {
+			hasZone4WithDrain = true
+		}
+	}
+	hasZone4NoDrain := false
+	for _, z := range zonesNoDrain {
+		if z == negtypes.TestZone4 {
+			hasZone4NoDrain = true
+		}
+	}
+	if !hasZone4WithDrain {
+		t.Fatalf("expected zone4 in candidate zones with includeDrainNodesL4Local=true, got %v", zonesWithDrain)
+	}
+	if hasZone4NoDrain {
+		t.Fatalf("expected zone4 absent from candidate zones with includeDrainNodesL4Local=false, got %v", zonesNoDrain)
+	}
+
+	// Create NEGs only in zones 1-3 (NOT zone4) to test NotFound suppression.
+	for _, zone := range zonesNoDrain {
+		fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: zone, Version: meta.VersionGA}, zone, klog.TODO())
+	}
+
+	// With includeDrainNodesL4Local=false: zone4 has no NEG but is not a
+	// candidate zone, so the NotFound is suppressed and no error is returned.
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, false)
+	if err != nil {
+		t.Errorf("expected no error with includeDrainNodesL4Local=false and missing zone4 NEG, got: %v", err)
+	}
+
+	// With includeDrainNodesL4Local=true: zone4 IS a candidate zone but has no
+	// NEG yet. The NotFound is not suppressed, so an error is returned.
+	// This is the plausible race documented in the review: if ensureNetworkEndpointGroups
+	// silently failed for zone4, the subsequent retrieve would fail here.
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	if err == nil {
+		t.Errorf("expected error with includeDrainNodesL4Local=true and missing zone4 NEG, got nil")
+	}
+
+	// Now create the zone4 NEG and attach an endpoint — the call must succeed.
+	fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{Name: negName, Zone: negtypes.TestZone4, Version: meta.VersionGA}, negtypes.TestZone4, klog.TODO())
+	drainEndpoint := &composite.NetworkEndpoint{IpAddress: "10.0.4.1", Instance: "upgrade-instance1"}
+	fakeCloud.AttachNetworkEndpoints(negName, negtypes.TestZone4, []*composite.NetworkEndpoint{drainEndpoint}, meta.VersionGA, klog.TODO())
+
+	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	if err != nil {
+		t.Fatalf("retrieveExistingZoneNetworkEndpointMap(drain=true, NEG exists): %v", err)
+	}
+	zone4Key := negtypes.NEGLocation{Zone: negtypes.TestZone4, Subnet: defaultTestSubnet}
+	if _, ok := endpointSets[zone4Key]; !ok {
+		t.Errorf("expected zone4 in endpointSets after NEG creation, got keys: %v", endpointSets)
 	}
 }
 

--- a/pkg/neg/types/testing.go
+++ b/pkg/neg/types/testing.go
@@ -71,10 +71,11 @@ type TestContext struct {
 	GKENetworkParamSetInformer cache.SharedIndexInformer
 	NodeTopologyInformer       cache.SharedIndexInformer
 
-	KubeSystemUID      types.UID
-	ResyncPeriod       time.Duration
-	NumGCWorkers       int
-	EnableDualStackNEG bool
+	KubeSystemUID            types.UID
+	ResyncPeriod             time.Duration
+	NumGCWorkers             int
+	EnableDualStackNEG       bool
+	IncludeDrainNodesL4Local bool
 
 	NegMetrics *metrics.NegMetrics
 }

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -296,10 +296,24 @@ type NegSyncerKey struct {
 
 	// L4LBType indicates which L4 LB this syncer is running for. For non L4 GCE_GM_IP NEGs this should be empty.
 	L4LBType L4LBType
+
+	// IncludeDrainNodesL4Local mirrors the controller-level flag of the same
+	// name. It is placed on the key (rather than read from flags.F at the call
+	// site) so syncer identity, equality, and the syncerManager.syncerMap keying
+	// reflect the configuration the syncer was created under. In practice the
+	// value is identical for every syncer because it is a controller-wide flag,
+	// but keeping it here keeps the controller and syncer code free of direct
+	// flag access — see the GetAPIVersion comment below for the trade-off we
+	// chose not to take.
+	IncludeDrainNodesL4Local bool
 }
 
 func (key NegSyncerKey) String() string {
-	return fmt.Sprintf("%s/%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	s := fmt.Sprintf("%s/%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	if key.IncludeDrainNodesL4Local {
+		s += "-includeDrainNodesL4Local=true"
+	}
+	return s
 }
 
 // GetAPIVersion returns the compute API version to be used in order
@@ -384,15 +398,24 @@ func EndpointsDataFromEndpointSlices(slices []*discovery.EndpointSlice) []Endpoi
 }
 
 // NodeFilterForEndpointCalculatorMode returns the filter type to select candidate nodes, given the endpoints calculator mode.
-func NodeFilterForEndpointCalculatorMode(mode EndpointsCalculatorMode) zonegetter.Filter {
-	// VM_IP NEGs can include unready and upgrading nodes.
-	if mode == L4ClusterMode || mode == L4LocalMode {
-		return NodeFilterForNetworkEndpointType(VmIpEndpointType)
+//
+// For L4 ETP=Local with includeDrainNodesL4Local enabled, returns a filter
+// that also tolerates GKE drain nodes. Because LocalL4EndpointsCalculator
+// iterates per pod, the resulting subset still drops the node once its pods
+// are gone, only the node's "drain" label no longer evicts it preemptively.
+// Unready-node behavior is unchanged.
+func NodeFilterForEndpointCalculatorMode(mode EndpointsCalculatorMode, includeDrainNodesL4Local bool) zonegetter.Filter {
+	if mode == L4LocalMode && includeDrainNodesL4Local {
+		return zonegetter.CandidateAndDrainingNodesFilter
 	}
-	return NodeFilterForNetworkEndpointType(VmIpPortEndpointType)
+	if mode == L4ClusterMode || mode == L4LocalMode {
+		return zonegetter.CandidateAndUnreadyNodesFilter
+	}
+	return zonegetter.CandidateNodesFilter
 }
 
-// NodeFilterForNetworkEndpointType returns the filter type to select candidate nodes, given the NEG type.
+// NodeFilterForNetworkEndpointType returns the filter type to select candidate
+// nodes, given the NEG endpoint type.
 func NodeFilterForNetworkEndpointType(negType NetworkEndpointType) zonegetter.Filter {
 	if negType == VmIpEndpointType {
 		return zonegetter.CandidateAndUnreadyNodesFilter

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -752,16 +752,24 @@ func TestEndpointsCalculatorMode(t *testing.T) {
 func TestNodePredicateForEndpointCalculatorMode(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		desc             string
-		epCalculatorMode EndpointsCalculatorMode
-		expectZones      []string
+		desc                     string
+		epCalculatorMode         EndpointsCalculatorMode
+		includeDrainNodesL4Local bool
+		expectZones              []string
 	}{
-		{"L4 Local mode, includes unready, excludes upgrading", L4LocalMode, []string{TestZone1, TestZone2, TestZone3}},
-		{"L4 Cluster mode, includes unready, excludes upgrading", L4ClusterMode, []string{TestZone1, TestZone2, TestZone3}},
-		{"L7 mode, includes upgrading, excludes unready", L7Mode, []string{TestZone1, TestZone2, TestZone4}},
+		{"L4 Local mode, includes unready, excludes upgrading", L4LocalMode, false, []string{TestZone1, TestZone2, TestZone3}},
+		{"L4 Cluster mode, includes unready, excludes upgrading", L4ClusterMode, false, []string{TestZone1, TestZone2, TestZone3}},
+		{"L7 mode, includes upgrading, excludes unready", L7Mode, false, []string{TestZone1, TestZone2, TestZone4}},
+		// IncludeDrainNodesL4Local is additive: L4 Local now includes both unready
+		// AND upgrading nodes, so every populated zone is selected.
+		{"L4 Local mode with includeDrainNodesL4Local=true, includes unready and upgrading", L4LocalMode, true, []string{TestZone1, TestZone2, TestZone3, TestZone4}},
+		// L4 Cluster mode is unaffected by the flag.
+		{"L4 Cluster mode with includeDrainNodesL4Local=true, includes unready, excludes upgrading", L4ClusterMode, true, []string{TestZone1, TestZone2, TestZone3}},
+		// L7 mode is unaffected by the flag.
+		{"L7 mode with includeDrainNodesL4Local=true, includes upgrading, excludes unready", L7Mode, true, []string{TestZone1, TestZone2, TestZone4}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			predicate := NodeFilterForEndpointCalculatorMode(tc.epCalculatorMode)
+			predicate := NodeFilterForEndpointCalculatorMode(tc.epCalculatorMode, tc.includeDrainNodesL4Local)
 			nodeInformer := zonegetter.FakeNodeInformer()
 			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
 			zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -55,8 +55,17 @@ const (
 	AllNodesFilter                 = Filter("AllNodesFilter")
 	CandidateNodesFilter           = Filter("CandidateNodesFilter")
 	CandidateAndUnreadyNodesFilter = Filter("CandidateAndUnreadyNodesFilter")
-	EmptyZone                      = ""
-	EmptySubnet                    = ""
+	// CandidateAndDrainingNodesFilter is a strict superset of
+	// CandidateAndUnreadyNodesFilter: it includes unready nodes AND nodes
+	// carrying the GKE drain label (operation.gke.io/type=drain). Intended for
+	// L4 ETP=Local NEGs: the per-pod iteration in LocalL4EndpointsCalculator
+	// already removes a node from the subset once its pods are gone, so we
+	// want the filter to keep draining nodes that still host backing pods.
+	// All other exclusions (ToBeDeletedTaint, exclude-balancer label, subnet
+	// membership) still apply unconditionally.
+	CandidateAndDrainingNodesFilter = Filter("CandidateAndDrainingNodesFilter")
+	EmptyZone                       = ""
+	EmptySubnet                     = ""
 )
 
 var ErrProviderIDNotFound = errors.New("providerID not found")
@@ -318,6 +327,8 @@ func (z *ZoneGetter) IsNodeSelectedByFilter(node *api_v1.Node, filter Filter, fi
 		return z.candidateNodesPredicate(node, nodeAndFilterLogger)
 	case CandidateAndUnreadyNodesFilter:
 		return z.candidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes(node, nodeAndFilterLogger)
+	case CandidateAndDrainingNodesFilter:
+		return z.candidateNodesPredicateIncludeUnreadyAndDrainingNodes(node, nodeAndFilterLogger)
 	default:
 		return false
 	}
@@ -359,6 +370,15 @@ func (z *ZoneGetter) candidateNodesPredicate(node *api_v1.Node, nodeAndFilterLog
 // TODO(prameshj) - Once the kubernetes/kubernetes Predicate function includes Unready nodes and the GKE nodepool code sets exclude labels on upgrade, this can be replaced with CandidateNodesPredicate.
 func (z *ZoneGetter) candidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes(node *api_v1.Node, nodeAndFilterLogger klog.Logger) bool {
 	return z.nodePredicateInternal(node, true, true, nodeAndFilterLogger)
+}
+
+// candidateNodesPredicateIncludeUnreadyAndDrainingNodes is like
+// candidateNodesPredicateIncludeUnreadyExcludeUpgradingNodes but does not
+// exclude nodes carrying the GKE drain label. All other exclusions
+// (ToBeDeleted taint, master/exclude-balancer labels, default-subnet check,
+// missing status conditions) still apply.
+func (z *ZoneGetter) candidateNodesPredicateIncludeUnreadyAndDrainingNodes(node *api_v1.Node, nodeAndFilterLogger klog.Logger) bool {
+	return z.nodePredicateInternal(node, true, false, nodeAndFilterLogger)
 }
 
 func (z *ZoneGetter) nodePredicateInternal(node *api_v1.Node, includeUnreadyNodes, excludeUpgradingNodes bool, nodeAndFilterLogger klog.Logger) bool {

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -63,6 +63,13 @@ func TestListZones(t *testing.T) {
 			filter:    CandidateAndUnreadyNodesFilter,
 			expectLen: 3,
 		},
+		{
+			// CandidateAndDrainingNodesFilter includes unready AND draining nodes,
+			// so zone4 (which has only draining/upgrading nodes) is also included.
+			desc:      "List with CandidateAndDrainingNodesFilter",
+			filter:    CandidateAndDrainingNodesFilter,
+			expectLen: 4,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -756,6 +763,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 		expectAcceptByAll       bool
 		expectAcceptByCandidate bool
 		expectAcceptByUnready   bool
+		expectAcceptByDraining  bool
 		name                    string
 	}{
 		{
@@ -763,6 +771,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       false,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 			name:                    "empty",
 		},
 		{
@@ -785,6 +794,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "ready node",
 		},
 		{
@@ -807,6 +817,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "unready node",
 		},
 		{
@@ -829,6 +840,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "ready status unknown",
 		},
 		{
@@ -853,7 +865,9 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
-			name:                    "ready node, excluded from loadbalancers",
+			// exclude-from-external-load-balancers is unconditional; drain flag does not override it.
+			expectAcceptByDraining: false,
+			name:                   "ready node, excluded from loadbalancers",
 		},
 		{
 			node: apiv1.Node{
@@ -877,7 +891,36 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   false,
-			name:                    "ready node, upgrade/drain in progress",
+			// CandidateAndDrainingNodesFilter does not exclude drain-labeled nodes.
+			expectAcceptByDraining: true,
+			name:                   "ready node, upgrade/drain in progress",
+		},
+		{
+			node: apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Labels: map[string]string{
+						utils.GKECurrentOperationLabel: utils.NodeDrain,
+						utils.LabelNodeSubnet:          defaultTestSubnet,
+					},
+				},
+				Spec: apiv1.NodeSpec{
+					PodCIDR:  "10.100.1.0/24",
+					PodCIDRs: []string{"10.100.1.0/24"},
+				},
+				Status: apiv1.NodeStatus{
+					Conditions: []apiv1.NodeCondition{
+						{Type: apiv1.NodeReady, Status: apiv1.ConditionFalse},
+					},
+				},
+			},
+			expectAcceptByAll:       true,
+			expectAcceptByCandidate: false,
+			// CandidateAndUnreadyNodesFilter includes unready but still excludes drain nodes.
+			expectAcceptByUnready: false,
+			// CandidateAndDrainingNodesFilter includes both unready and drain nodes.
+			expectAcceptByDraining: true,
+			name:                   "unready node, upgrade/drain in progress",
 		},
 		{
 			node: apiv1.Node{
@@ -901,6 +944,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "ready node, non-drain operation",
 		},
 		{
@@ -924,6 +968,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "unschedulable",
 		},
 		{
@@ -953,7 +998,9 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
-			name:                    "ToBeDeletedByClusterAutoscaler-taint",
+			// ToBeDeletedTaint exclusion is unconditional; drain flag does not override it.
+			expectAcceptByDraining: false,
+			name:                   "ToBeDeletedByClusterAutoscaler-taint",
 		},
 		{
 			node: apiv1.Node{
@@ -975,6 +1022,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       false,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 			name:                    "node in non-default subnet",
 		},
 		{
@@ -992,6 +1040,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 			name:                    "node without subnet label",
 		},
 		{
@@ -1011,6 +1060,7 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       false,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 			name:                    "node without PodCIDR",
 		},
 	}
@@ -1028,6 +1078,10 @@ func TestIsNodeSelectedByFilter(t *testing.T) {
 		if acceptByUnready != tc.expectAcceptByUnready {
 			t.Errorf("Test failed for %s & unreadyNodesPredicate, got %v, want %v", tc.name, acceptByUnready, tc.expectAcceptByUnready)
 		}
+		acceptByDraining := zoneGetter.IsNodeSelectedByFilter(&tc.node, CandidateAndDrainingNodesFilter, klog.TODO())
+		if acceptByDraining != tc.expectAcceptByDraining {
+			t.Errorf("Test failed for %s & drainingNodesPredicate, got %v, want %v", tc.name, acceptByDraining, tc.expectAcceptByDraining)
+		}
 	}
 }
 
@@ -1041,6 +1095,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 		expectAcceptByAll       bool
 		expectAcceptByCandidate bool
 		expectAcceptByUnready   bool
+		expectAcceptByDraining  bool
 	}{
 		{
 			name:                    "empty",
@@ -1048,6 +1103,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 		},
 		{
 			name: "ready node",
@@ -1070,6 +1126,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "unready node",
@@ -1092,6 +1149,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "ready status unknown",
@@ -1114,6 +1172,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "ready node, excluded from loadbalancers",
@@ -1138,6 +1197,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 		},
 		{
 			name: "ready node, upgrade/drain in progress",
@@ -1162,6 +1222,8 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   false,
+			// CandidateAndDrainingNodesFilter does not exclude drain-labeled nodes.
+			expectAcceptByDraining: true,
 		},
 		{
 			name: "ready node, non-drain operation",
@@ -1186,6 +1248,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "unschedulable",
@@ -1209,6 +1272,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "ToBeDeletedByClusterAutoscaler-taint",
@@ -1238,6 +1302,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: false,
 			expectAcceptByUnready:   false,
+			expectAcceptByDraining:  false,
 		},
 		// This case is not possible for legacy networks, but for comprehensive
 		// testing and understanding of the legacy network zone getter this test
@@ -1263,6 +1328,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		{
 			name: "node without subnet label",
@@ -1280,6 +1346,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 		// Pod CIDR is only checked when checking the subnet. For legacy networks no subnet exists, so nodes without PodCIDR are still included.
 		{
@@ -1300,6 +1367,7 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 			expectAcceptByAll:       true,
 			expectAcceptByCandidate: true,
 			expectAcceptByUnready:   true,
+			expectAcceptByDraining:  true,
 		},
 	}
 	for _, tc := range testCases {
@@ -1315,6 +1383,10 @@ func TestLegacyIsNodeSelectedByFilter(t *testing.T) {
 		acceptByUnready := zoneGetter.IsNodeSelectedByFilter(&tc.node, CandidateAndUnreadyNodesFilter, klog.TODO())
 		if acceptByUnready != tc.expectAcceptByUnready {
 			t.Errorf("Test failed for %s & unreadyNodesPredicate, got %v, want %v", tc.name, acceptByUnready, tc.expectAcceptByUnready)
+		}
+		acceptByDraining := zoneGetter.IsNodeSelectedByFilter(&tc.node, CandidateAndDrainingNodesFilter, klog.TODO())
+		if acceptByDraining != tc.expectAcceptByDraining {
+			t.Errorf("Test failed for %s & drainingNodesPredicate, got %v, want %v", tc.name, acceptByDraining, tc.expectAcceptByDraining)
 		}
 	}
 }


### PR DESCRIPTION
When enabled, nodes carrying the GKE drain label (operation.gke.io/type=drain) are kept in L4 External Traffic Policy (ETP=Local) Network Endpoint Groups (NEGs) as long as they still host at least one backing pod. Without this flag, the drain label causes a node to be evicted from the NEG immediately, which drops in-flight connections before the pods have finished draining.