### PR TITLE
Move L4-specific error types and helpers to pkg/l4/utils

### DIFF
--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -23,9 +23,10 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
-	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -240,7 +241,7 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 
 	m.frLogger.V(2).Info("Unable to reserve address (could be expected). Checking for conflict", "err", reserveErr)
 
-	if utils.IsNetworkTierMismatchGCEError(reserveErr) {
+	if l4utils.IsNetworkTierMismatchGCEError(reserveErr) {
 		receivedNetworkTier := cloud.NetworkTierPremium
 		if receivedNetworkTier == m.networkTier {
 			// We don't have information of current ephemeral IP address Network Tier since
@@ -249,7 +250,7 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 			receivedNetworkTier = cloud.NetworkTierStandard
 		}
 		resource := fmt.Sprintf("Reserved static IP (%v)", m.name)
-		networkTierError := utils.NewNetworkTierErr(resource, string(m.networkTier), string(receivedNetworkTier))
+		networkTierError := l4utils.NewNetworkTierErr(resource, string(m.networkTier), string(receivedNetworkTier))
 		return "", IPAddrUndefined, networkTierError
 	}
 
@@ -274,7 +275,7 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	addr, err := m.svc.GetRegionAddressByIP(m.region, m.targetIP)
 	if err != nil {
 		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
-			return "", IPAddrUndefined, utils.NewIPConfigurationError(m.targetIP, "address not found. Check if the IP is valid and is reserved in your VPC.")
+			return "", IPAddrUndefined, l4utils.NewIPConfigurationError(m.targetIP, "address not found. Check if the IP is valid and is reserved in your VPC.")
 		}
 		return "", IPAddrUndefined, fmt.Errorf("failed to get address by IP %q after reservation attempt, err: %q, reservation err: %q", m.targetIP, err, reserveErr)
 	}
@@ -302,10 +303,10 @@ func (m *Manager) validateAddress(addr *compute.Address) error {
 		return fmt.Errorf("IP mismatch, expected %q, actual: %q", m.targetIP, addr.Address)
 	}
 	if addr.AddressType != string(m.addressType) {
-		return utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("address type mismatch, expected %q, actual: %q", m.addressType, addr.AddressType))
+		return l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("address type mismatch, expected %q, actual: %q", m.addressType, addr.AddressType))
 	}
 	if addr.NetworkTier != m.networkTier.ToGCEValue() {
-		return utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
+		return l4utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
 	}
 	return nil
 }
@@ -342,7 +343,7 @@ func (m *Manager) TearDownAddressIPIfNetworkTierMismatch() error {
 	}
 	if addr != nil && addr.NetworkTier != m.networkTier.ToGCEValue() {
 		if !m.isManagedAddress(addr) {
-			return utils.NewNetworkTierErr(fmt.Sprintf("User specific address IP (%v)", m.name), string(m.networkTier), addr.NetworkTier)
+			return l4utils.NewNetworkTierErr(fmt.Sprintf("User specific address IP (%v)", m.name), string(m.networkTier), addr.NetworkTier)
 		}
 		m.frLogger.V(3).Info("Deleting IP address because it has a wrong network tier", "ip", m.targetIP)
 		if err := m.svc.DeleteRegionAddress(addr.Name, m.targetIP); err != nil {

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -33,6 +33,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 )
 
 const (
@@ -195,7 +196,7 @@ func TestAddressManagerNonExisting(t *testing.T) {
 	svc.Compute().(*cloud.MockGCE).MockAddresses.InsertHook = test.InsertAddressNotAllocatedToProjectErrorHook
 	_, _, err = mgr.HoldAddress()
 	require.Error(t, err)
-	assert.True(t, utils.IsIPConfigurationError(err))
+	assert.True(t, l4utils.IsIPConfigurationError(err))
 }
 
 // TestAddressManagerWrongTypeReserved tests the case where the address was reserved by the user but it is of the wrong type.
@@ -214,7 +215,7 @@ func TestAddressManagerWrongTypeReserved(t *testing.T) {
 
 	_, _, err = mgr.HoldAddress()
 	require.Error(t, err)
-	assert.True(t, utils.IsIPConfigurationError(err))
+	assert.True(t, l4utils.IsIPConfigurationError(err))
 }
 
 // TestAddressManagerExternallyOwnedWrongNetworkTier tests the case where the address exists but isn't
@@ -230,8 +231,8 @@ func TestAddressManagerExternallyOwnedWrongNetworkTier(t *testing.T) {
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierPremium, address.IPv4Version, klog.TODO())
 	svc.Compute().(*cloud.MockGCE).MockAddresses.InsertHook = test.InsertAddressNetworkErrorHook
 	_, _, err = mgr.HoldAddress()
-	if err == nil || !utils.IsNetworkTierError(err) {
-		t.Fatalf("mgr.HoldAddress() = %v, utils.IsNetworkTierError(err) = %t, want %t", err, utils.IsNetworkTierError(err), true)
+	if err == nil || !l4utils.IsNetworkTierError(err) {
+		t.Fatalf("mgr.HoldAddress() = %v, l4utils.IsNetworkTierError(err) = %t, want %t", err, l4utils.IsNetworkTierError(err), true)
 	}
 }
 

--- a/pkg/l4/controllers/l4controller.go
+++ b/pkg/l4/controllers/l4controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/ingress-gce/pkg/l4/backends"
 	"k8s.io/ingress-gce/pkg/l4/forwardingrules"
 	"k8s.io/ingress-gce/pkg/l4/metrics"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
@@ -707,7 +708,7 @@ func (l4c *L4Controller) publishMetrics(result *resources.L4ILBSyncResult, names
 		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
 		isZonalAffinityLB := result.MetricsState.ZonalAffinity
 		isLoggingControlEnabled := result.MetricsState.LoggingControlEnabled
-		metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB, result.MetricsState.Protocol, isZonalAffinityLB, isLoggingControlEnabled)
+		metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, l4utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB, result.MetricsState.Protocol, isZonalAffinityLB, isLoggingControlEnabled)
 		if l4c.enableDualStack {
 			svcLogger.V(2).Info("Internal L4 DualStack Loadbalancer for Service ensured, updating its state in metrics cache", "serviceState", result.MetricsState)
 			metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, isResync)
@@ -727,7 +728,7 @@ func (l4c *L4Controller) publishMetrics(result *resources.L4ILBSyncResult, names
 		isWeightedLB := result.MetricsState.WeightedLBPodsPerNode
 		isZonalAffinityLB := result.MetricsState.ZonalAffinity
 		isLoggingControlEnabled := result.MetricsState.LoggingControlEnabled
-		metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, false, isWeightedLB, result.MetricsState.Protocol, isZonalAffinityLB, isLoggingControlEnabled)
+		metrics.PublishILBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, l4utils.GetErrorType(result.Error), result.StartTime, false, isWeightedLB, result.MetricsState.Protocol, isZonalAffinityLB, isLoggingControlEnabled)
 		if l4c.enableDualStack {
 			metrics.PublishL4ILBDualStackSyncLatency(result.Error == nil, result.SyncType, result.MetricsState.IPFamilies, result.StartTime, false)
 		}

--- a/pkg/l4/controllers/l4netlbcontroller.go
+++ b/pkg/l4/controllers/l4netlbcontroller.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/ingress-gce/pkg/l4/backends"
 	"k8s.io/ingress-gce/pkg/l4/forwardingrules"
 	"k8s.io/ingress-gce/pkg/l4/metrics"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	activecontrollermetrics "k8s.io/ingress-gce/pkg/metrics/activecontroller"
 	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
@@ -988,5 +989,5 @@ func (lc *L4NetLBController) publishSyncMetrics(result *resources.L4NetLBSyncRes
 	backendType := result.MetricsState.BackendType
 	isLoggingControlEnabled := result.MetricsState.LoggingControlEnabled
 
-	metrics.PublishNetLBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB, result.MetricsState.Protocol, backendType, isLoggingControlEnabled)
+	metrics.PublishNetLBSyncMetrics(result.Error == nil, result.SyncType, result.GCEResourceInError, l4utils.GetErrorType(result.Error), result.StartTime, isResync, isWeightedLB, result.MetricsState.Protocol, backendType, isLoggingControlEnabled)
 }

--- a/pkg/l4/controllers/l4netlbcontroller_test.go
+++ b/pkg/l4/controllers/l4netlbcontroller_test.go
@@ -1651,7 +1651,7 @@ func TestControllerUserIPWithStandardNetworkTier(t *testing.T) {
 	key, _ := common.KeyFunc(svc)
 	addUsersStaticAddress(lc, cloud.NetworkTierStandard)
 	// Sync should return error that Network Tier mismatch because we cannot tear User Managed Address.
-	if err := lc.sync(key, klog.TODO()); !utils.IsNetworkTierError(err) {
+	if err := lc.sync(key, klog.TODO()); !l4utils.IsNetworkTierError(err) {
 		t.Errorf("Expected error when trying to ensure service with wrong Network Tier, err: %v", err)
 	}
 	svc.Annotations[annotations.NetworkTierAnnotationKey] = string(cloud.NetworkTierStandard)

--- a/pkg/l4/forwardingrules/netlb_mixed_manager.go
+++ b/pkg/l4/forwardingrules/netlb_mixed_manager.go
@@ -193,7 +193,7 @@ func (m *MixedManagerNetLB) ensure(existing *composite.ForwardingRule, backendSe
 	// Can't update
 	if networkMismatch := existing.NetworkTier != wanted.NetworkTier; networkMismatch {
 		resource := fmt.Sprintf("Forwarding rule (%v)", name)
-		networkTierMismatchErr := utils.NewNetworkTierErr(resource, wanted.NetworkTier, wanted.NetworkTier)
+		networkTierMismatchErr := l4utils.NewNetworkTierErr(resource, wanted.NetworkTier, wanted.NetworkTier)
 		return nil, l4utils.ResourceUpdate, networkTierMismatchErr
 	}
 

--- a/pkg/l4/resources/forwarding_rules.go
+++ b/pkg/l4/resources/forwarding_rules.go
@@ -166,10 +166,10 @@ func (l4 *L4) createFwdRule(newFr *composite.ForwardingRule, frLogger klog.Logge
 	frLogger.V(2).Info("ensureIPv4ForwardingRule: Creating/Recreating forwarding rule")
 	if err := l4.forwardingRules.Create(newFr); err != nil {
 		if isAddressAlreadyInUseError(err) {
-			return utils.NewIPConfigurationError(newFr.IPAddress, err.Error())
+			return l4utils.NewIPConfigurationError(newFr.IPAddress, err.Error())
 		}
 		if isConflictingPortsError(err) {
-			return utils.NewConflictingPortsConfigurationError(newFr.PortRange, err.Error())
+			return l4utils.NewConflictingPortsConfigurationError(newFr.PortRange, err.Error())
 		}
 		return err
 	}
@@ -255,7 +255,7 @@ func (l4netlb *L4NetLB) ensureIPv4ForwardingRule(bsLink string) (*composite.Forw
 	if existingFwdRule != nil {
 		if existingFwdRule.NetworkTier != newFwdRule.NetworkTier {
 			resource := fmt.Sprintf("Forwarding rule (%v)", frName)
-			networkTierMismatchError := utils.NewNetworkTierErr(resource, existingFwdRule.NetworkTier, newFwdRule.NetworkTier)
+			networkTierMismatchError := l4utils.NewNetworkTierErr(resource, existingFwdRule.NetworkTier, newFwdRule.NetworkTier)
 			return nil, address.IPAddrUndefined, l4utils.ResourceUpdate, networkTierMismatchError
 		}
 		equal, err := forwardingrules.EqualIPv4(existingFwdRule, newFwdRule)
@@ -316,10 +316,10 @@ func (l4netlb *L4NetLB) createFwdRule(newFr *composite.ForwardingRule, frLogger 
 	frLogger.V(2).Info("ensureIPv4ForwardingRule: Creating/Recreating forwarding rule")
 	if err := l4netlb.forwardingRules.Create(newFr); err != nil {
 		if isAddressAlreadyInUseError(err) {
-			return utils.NewIPConfigurationError(newFr.IPAddress, addressAlreadyInUseMessageExternal)
+			return l4utils.NewIPConfigurationError(newFr.IPAddress, addressAlreadyInUseMessageExternal)
 		}
 		if isConflictingPortsError(err) {
-			return utils.NewConflictingPortsConfigurationError(newFr.PortRange, err.Error())
+			return l4utils.NewConflictingPortsConfigurationError(newFr.PortRange, err.Error())
 		}
 		return err
 	}

--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -207,7 +207,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	// IPv6 address is not supported for External Regional Network Load Balancing with Standard network tier.
 	if netTier == cloud.NetworkTierStandard {
 		resourceErr := "IPv6 External Load Balancer"
-		return nil, l4utils.ResourceResync, utils.NewUnsupportedNetworkTierErr(resourceErr, string(cloud.NetworkTierStandard))
+		return nil, l4utils.ResourceResync, l4utils.NewUnsupportedNetworkTierErr(resourceErr, string(cloud.NetworkTierStandard))
 	}
 
 	// Only for IPv6, address reservation is not supported on Standard Tier
@@ -263,7 +263,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	if existingIPv6FwdRule != nil {
 		if existingIPv6FwdRule.NetworkTier != expectedIPv6FwdRule.NetworkTier {
 			resource := fmt.Sprintf("Forwarding rule (%v)", existingIPv6FwdRule.Name)
-			networkTierMismatchError := utils.NewNetworkTierErr(resource, existingIPv6FwdRule.NetworkTier, expectedIPv6FwdRule.NetworkTier)
+			networkTierMismatchError := l4utils.NewNetworkTierErr(resource, existingIPv6FwdRule.NetworkTier, expectedIPv6FwdRule.NetworkTier)
 			return nil, l4utils.ResourceResync, networkTierMismatchError
 		}
 

--- a/pkg/l4/resources/forwarding_rules_test.go
+++ b/pkg/l4/resources/forwarding_rules_test.go
@@ -39,12 +39,12 @@ func TestL4CreateExternalForwardingRuleUserErrors(t *testing.T) {
 		{
 			desc:                  "Address already in-use",
 			insertError:           &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.IPAddress': '1.1.1.1'. Specified IP address is in-use and would result in a conflict., invalid"},
-			expectedUserErrorFunc: utils.IsIPConfigurationError,
+			expectedUserErrorFunc: l4utils.IsIPConfigurationError,
 		},
 		{
 			desc:                  "Conflicting port range",
 			insertError:           &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid resource usage: 'Forwarding rule's port range is conflicting with forwarding rule: abcd'."},
-			expectedUserErrorFunc: utils.IsConflictingPortsConfigurationError,
+			expectedUserErrorFunc: l4utils.IsConflictingPortsConfigurationError,
 		},
 	}
 	for _, tc := range testCases {
@@ -365,12 +365,12 @@ func TestL4EnsureIPv4ForwardingRuleAddressAlreadyInUse(t *testing.T) {
 		{
 			desc:                  "Address already in-use",
 			insertError:           &googleapi.Error{Code: http.StatusConflict, Message: "IP_IN_USE_BY_ANOTHER_RESOURCE - IP '10.107.116.14' is already being used by another resource."},
-			expectedUserErrorFunc: utils.IsIPConfigurationError,
+			expectedUserErrorFunc: l4utils.IsIPConfigurationError,
 		},
 		{
 			desc:                  "Conflicting port range",
 			insertError:           &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid resource usage: 'Forwarding rule's port range is conflicting with forwarding rule: abcd'."},
-			expectedUserErrorFunc: utils.IsConflictingPortsConfigurationError,
+			expectedUserErrorFunc: l4utils.IsConflictingPortsConfigurationError,
 		},
 	}
 

--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -585,10 +585,10 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 			result.Conditions = append(result.Conditions, l4lbconfig.NewConditionLoggingError(err))
 		}
 
-		if utils.IsUnsupportedFeatureError(err, string(backends.LocalityLbPolicyRendezvous)) {
+		if l4utils.IsUnsupportedFeatureError(err, string(backends.LocalityLbPolicyRendezvous)) {
 			result.GCEResourceInError = annotations.BackendServiceResource
 			l4.recorder.Eventf(l4.Service, corev1.EventTypeWarning, "AllowlistingRequired", WeightedLBPodsPerNodeAllowlistMessage)
-			result.Error = utils.NewUserError(err)
+			result.Error = l4utils.NewUserError(err)
 		} else {
 			result.GCEResourceInError = annotations.BackendServiceResource
 			result.Error = err
@@ -799,7 +799,7 @@ func (l4 *L4) getSubnetworkURLByName(subnetName string) (string, error) {
 	subnetwork, err := l4.cloud.GetSubnetwork(l4.cloud.Region(), subnetName)
 	if err != nil {
 		if utils.IsNotFoundError(err) {
-			return "", utils.NewInvalidSubnetConfigurationError(l4.cloud.ProjectID(), subnetName)
+			return "", l4utils.NewInvalidSubnetConfigurationError(l4.cloud.ProjectID(), subnetName)
 		}
 		return "", err
 	}

--- a/pkg/l4/resources/l4ipv6.go
+++ b/pkg/l4/resources/l4ipv6.go
@@ -277,7 +277,7 @@ func (l4 *L4) serviceSubnetHasInternalIPv6Range() error {
 	if !hasIPv6SubnetRange {
 		// We don't need to emit custom event, because errors are already emitted to the user as events.
 		l4.svcLogger.Info("Subnet for IPv6 Service does not have internal IPv6 ranges", "subnetName", subnetName)
-		return utils.NewUserError(
+		return l4utils.NewUserError(
 			fmt.Errorf(
 				"subnet %s does not have internal IPv6 ranges, required for an internal IPv6 Service. You can specify an internal IPv6 subnet using the \"%s\" annotation on the Service", subnetName, annotations.CustomSubnetAnnotationKey))
 	}

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -211,29 +211,29 @@ func isSessionAffinityConfigEmpty(sessionAffinityConfig *corev1.SessionAffinityC
 //   - with anything else than ExternalTrafficPolicy=Local
 //   - with anything else than v1.ServiceAffinityClientIP
 //     passes silently if the SSA annotation wasn't enabled
-func (l4netlb *L4NetLB) checkStrongSessionAffinityRequirements() *utils.UserError {
+func (l4netlb *L4NetLB) checkStrongSessionAffinityRequirements() *l4utils.UserError {
 	if !annotations.HasStrongSessionAffinityAnnotation(l4netlb.Service) {
 		return nil
 	}
 	// there is no strong session affinity flag but annotation was added
 	if !l4netlb.enableStrongSessionAffinity {
 		err := fmt.Errorf("strong session affinity set on service but not yet enabled on the cluster")
-		return utils.NewUserError(err)
+		return l4utils.NewUserError(err)
 	}
 	if l4netlb.Service.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
 		err := fmt.Errorf("strong session affinity is supported only with ServiceType=%s for Service %s", corev1.ServiceAffinityClientIP, l4netlb.Service.Name)
-		return utils.NewUserError(err)
+		return l4utils.NewUserError(err)
 	}
 	// Don't use the config if it's empty
 	if isSessionAffinityConfigEmpty(l4netlb.Service.Spec.SessionAffinityConfig) {
 		err := fmt.Errorf("session affinity config was not set as required for strong session affinity")
-		return utils.NewUserError(err)
+		return l4utils.NewUserError(err)
 	}
 	idleTimeout := *l4netlb.Service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds
 	// idle idleTimeout is not supported
 	if idleTimeout < minStrongSessionAffinityIdleTimeout || idleTimeout > maxSessionAffinityIdleTimeout {
 		err := fmt.Errorf("session affinity config has an unsupported idleTimeout (%d). It should be in [%d, %d]", idleTimeout, minStrongSessionAffinityIdleTimeout, maxSessionAffinityIdleTimeout)
-		return utils.NewUserError(err)
+		return l4utils.NewUserError(err)
 	}
 	return nil
 }
@@ -442,10 +442,10 @@ func (l4netlb *L4NetLB) provideBackendService(syncResult *L4NetLBSyncResult, hcL
 			// Set condition if there is an error and logging control is enabled
 			syncResult.Conditions = append(syncResult.Conditions, l4lbconfig.NewConditionLoggingError(err))
 		}
-		if utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
+		if l4utils.IsUnsupportedFeatureError(err, strongSessionAffinityFeatureName) {
 			syncResult.GCEResourceInError = annotations.BackendServiceResource
 			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeWarning, strongSessionAffinityFeatureName, strongSessionAffinityConditionedSupportMsg)
-			syncResult.Error = utils.NewUserError(err)
+			syncResult.Error = l4utils.NewUserError(err)
 			syncResult.MetricsLegacyState.IsUserError = true
 		} else { // not UserError but something else
 			syncResult.GCEResourceInError = annotations.BackendServiceResource

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -296,7 +296,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	// Check that service sync will return error if User Address IP Network Tier mismatch with service Network Tier.
 	svc.ObjectMeta.Annotations[annotations.NetworkTierAnnotationKey] = string(cloud.NetworkTierPremium)
 	result = l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
-	if result.Error == nil || !utils.IsNetworkTierError(result.Error) {
+	if result.Error == nil || !l4utils.IsNetworkTierError(result.Error) {
 		t.Errorf("LoadBalancer sync should return Network Tier error, err %v", result.Error)
 	}
 	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
@@ -312,7 +312,7 @@ func TestMetricsForStandardNetworkTier(t *testing.T) {
 	delete(svc.ObjectMeta.Annotations, annotations.NetworkTierAnnotationKey)
 
 	result = l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
-	if result.Error == nil || !utils.IsNetworkTierError(result.Error) {
+	if result.Error == nil || !l4utils.IsNetworkTierError(result.Error) {
 		t.Errorf("LoadBalancer sync should return Network Tier error, err %v", result.Error)
 	}
 	if err := checkMetrics(result.MetricsLegacyState /*isManaged = */, false /*isPremium = */, false /*isUserError =*/, true); err != nil {
@@ -455,8 +455,8 @@ func TestEnsureDualStackNetLBNetworkTierChange(t *testing.T) {
 
 	// Ensure dualstack load balancer with Standard Network Tier and verify it did not synced successfully.
 	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
-	if _, ok := result.Error.(*utils.UnsupportedNetworkTierError); !ok {
-		t.Errorf("Expected error to be of type *utils.UnsupportedNetworkTierError, got %T", result.Error)
+	if _, ok := result.Error.(*l4utils.UnsupportedNetworkTierError); !ok {
+		t.Errorf("Expected error to be of type *l4utils.UnsupportedNetworkTierError, got %T", result.Error)
 	}
 
 	// Change network Tier to Premium, and trigger sync.
@@ -971,8 +971,8 @@ func TestEnsureIPv6OnlyNetLBNetworkTierChange(t *testing.T) {
 
 	// Initial Sync with Standard Tier: Expect an error - external IPv6 LoadBalancers require Premium Tier.
 	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
-	if _, ok := result.Error.(*utils.UnsupportedNetworkTierError); !ok {
-		t.Errorf("Expected error to be of type *utils.UnsupportedNetworkTierError for Stanard Tier, got %T", result.Error)
+	if _, ok := result.Error.(*l4utils.UnsupportedNetworkTierError); !ok {
+		t.Errorf("Expected error to be of type *l4utils.UnsupportedNetworkTierError for Stanard Tier, got %T", result.Error)
 	}
 
 	// Change network Tier to Premium, and trigger sync.

--- a/pkg/l4/resources/l4netlbipv6.go
+++ b/pkg/l4/resources/l4netlbipv6.go
@@ -287,7 +287,7 @@ func (l4netlb *L4NetLB) serviceSubnetHasExternalIPv6Range() error {
 	if !hasIPv6SubnetRange {
 		// We don't need to emit custom event, because errors are already emitted to the user as events.
 		l4netlb.svcLogger.Info("Subnet for IPv6 Service does not have external IPv6 ranges", "subnetName", subnetName)
-		return utils.NewUserError(
+		return l4utils.NewUserError(
 			fmt.Errorf(
 				"subnet %s does not have external IPv6 ranges, required for an external IPv6 Service. You can specify an external IPv6 subnet using the \"%s\" annotation on the Service", subnetName, annotations.CustomSubnetAnnotationKey))
 	}

--- a/pkg/l4/resources/user_error.go
+++ b/pkg/l4/resources/user_error.go
@@ -5,23 +5,22 @@ import (
 
 	"k8s.io/ingress-gce/pkg/firewalls"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
-	"k8s.io/ingress-gce/pkg/utils"
 )
 
 // IsUserError checks if given error is caused by User.
 func IsUserError(err error) bool {
-	var userErr *utils.UserError
+	var userErr *l4utils.UserError
 	var firewallErr *firewalls.FirewallXPNError
 
-	return utils.IsNetworkTierError(err) ||
-		utils.IsIPConfigurationError(err) ||
-		utils.IsIPOutOfRangeError(err) ||
-		utils.IsConflictingPortsConfigurationError(err) ||
-		utils.IsInvalidSubnetConfigurationError(err) ||
+	return l4utils.IsNetworkTierError(err) ||
+		l4utils.IsIPConfigurationError(err) ||
+		l4utils.IsIPOutOfRangeError(err) ||
+		l4utils.IsConflictingPortsConfigurationError(err) ||
+		l4utils.IsInvalidSubnetConfigurationError(err) ||
 		l4utils.IsInvalidLoadBalancerSourceRangesSpecError(err) ||
 		l4utils.IsInvalidLoadBalancerSourceRangesAnnotationError(err) ||
-		utils.IsUnsupportedNetworkTierError(err) ||
-		utils.IsConstraintViolationError(err) ||
+		l4utils.IsUnsupportedNetworkTierError(err) ||
+		l4utils.IsConstraintViolationError(err) ||
 		errors.As(err, &firewallErr) ||
 		errors.As(err, &userErr)
 }

--- a/pkg/l4/resources/user_error_test.go
+++ b/pkg/l4/resources/user_error_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/l4/resources"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
-	"k8s.io/ingress-gce/pkg/utils"
 )
 
 func TestIsUserError(t *testing.T) {
@@ -26,15 +25,15 @@ func TestIsUserError(t *testing.T) {
 			want: false,
 		},
 		{
-			err:  utils.NewNetworkTierErr("forwardingRule", "STANDARD", "PREMIUM"),
+			err:  l4utils.NewNetworkTierErr("forwardingRule", "STANDARD", "PREMIUM"),
 			want: true,
 		},
 		{
-			err:  utils.NewUnsupportedNetworkTierErr("forwardingRule", "STANDARD"),
+			err:  l4utils.NewUnsupportedNetworkTierErr("forwardingRule", "STANDARD"),
 			want: true,
 		},
 		{
-			err:  utils.NewUserError(fmt.Errorf("err")),
+			err:  l4utils.NewUserError(fmt.Errorf("err")),
 			want: true,
 		},
 		{
@@ -42,7 +41,7 @@ func TestIsUserError(t *testing.T) {
 			want: true,
 		},
 		{
-			err:  utils.NewIPConfigurationError("123.123.123.456", "bad ip"),
+			err:  l4utils.NewIPConfigurationError("123.123.123.456", "bad ip"),
 			want: true,
 		},
 		{
@@ -54,7 +53,7 @@ func TestIsUserError(t *testing.T) {
 			want: true,
 		},
 		{
-			err:  utils.NewConflictingPortsConfigurationError("8080-8090", "conflicting ports"),
+			err:  l4utils.NewConflictingPortsConfigurationError("8080-8090", "conflicting ports"),
 			want: true,
 		},
 		{

--- a/pkg/l4/utils/errors.go
+++ b/pkg/l4/utils/errors.go
@@ -1,0 +1,174 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	gceutils "k8s.io/ingress-gce/pkg/utils"
+)
+
+var networkTierErrorRegexp = regexp.MustCompile(`The network tier of external IP is STANDARD|PREMIUM, that of Address must be the same.`)
+
+// NetworkTierError is a struct to define error caused by User misconfiguration of Network Tier.
+type NetworkTierError struct {
+	resource   string
+	desiredNT  string
+	receivedNT string
+}
+
+// Error function prints out Network Tier error.
+func (e *NetworkTierError) Error() string {
+	return fmt.Sprintf("Network tier mismatch for resource %s, desired: %s, received: %s", e.resource, e.desiredNT, e.receivedNT)
+}
+
+func NewNetworkTierErr(resourceInErr, desired, received string) *NetworkTierError {
+	return &NetworkTierError{resource: resourceInErr, desiredNT: desired, receivedNT: received}
+}
+
+type UnsupportedNetworkTierError struct {
+	resource      string
+	unsupportedNT string
+}
+
+// Error function prints out Network Tier error.
+func (e *UnsupportedNetworkTierError) Error() string {
+	return fmt.Sprintf("Network tier %s is not supported for %s", e.unsupportedNT, e.resource)
+}
+
+func NewUnsupportedNetworkTierErr(resourceInErr, networkTier string) *UnsupportedNetworkTierError {
+	return &UnsupportedNetworkTierError{resource: resourceInErr, unsupportedNT: networkTier}
+}
+
+// IPConfigurationError is a struct to define error caused by User misconfiguration the Load Balancer IP.
+type IPConfigurationError struct {
+	ip     string
+	reason string
+}
+
+func (e *IPConfigurationError) Error() string {
+	return fmt.Sprintf("IP configuration error: \"%s\" %s", e.ip, e.reason)
+}
+
+func NewIPConfigurationError(ip, reason string) *IPConfigurationError {
+	return &IPConfigurationError{ip: ip, reason: reason}
+}
+
+// ConflictingPortsConfigurationError is a struct to define error caused by User misconfiguration of the LB ports.
+type ConflictingPortsConfigurationError struct {
+	ports  string
+	reason string
+}
+
+func (e *ConflictingPortsConfigurationError) Error() string {
+	return fmt.Sprintf("Conflicting ports configuration error: \"%s\" %s", e.ports, e.reason)
+}
+
+func NewConflictingPortsConfigurationError(ports, reason string) *ConflictingPortsConfigurationError {
+	return &ConflictingPortsConfigurationError{ports: ports, reason: reason}
+}
+
+// InvalidSubnetConfigurationError is a struct to define error caused by User misconfiguration of Load Balancer's subnet.
+type InvalidSubnetConfigurationError struct {
+	projectName string
+	subnetName  string
+}
+
+func (e *InvalidSubnetConfigurationError) Error() string {
+	return fmt.Sprintf("Subnetwork \"%s\" can't be found for project %s", e.subnetName, e.projectName)
+}
+
+func NewInvalidSubnetConfigurationError(projectName, subnetName string) *InvalidSubnetConfigurationError {
+	return &InvalidSubnetConfigurationError{projectName: projectName, subnetName: subnetName}
+}
+
+// IsNetworkTierMismatchGCEError checks if error is a GCE network tier mismatch for external IP
+func IsNetworkTierMismatchGCEError(err error) bool {
+	return networkTierErrorRegexp.MatchString(err.Error())
+}
+
+// IsNetworkTierError checks if wrapped error is a Network Tier Mismatch error
+func IsNetworkTierError(err error) bool {
+	var netTierError *NetworkTierError
+	return errors.As(err, &netTierError)
+}
+
+// IsUnsupportedNetworkTierError checks if wrapped error is an Unsupported Network Tier error
+func IsUnsupportedNetworkTierError(err error) bool {
+	var netTierError *UnsupportedNetworkTierError
+	return errors.As(err, &netTierError)
+}
+
+// IsConstraintViolationError checks if the error is a constraint violation error returned by GCP.
+func IsConstraintViolationError(err error) bool {
+	return gceutils.IsHTTPErrorCode(err, http.StatusPreconditionFailed) && strings.Contains(err.Error(), "Constraint") && strings.Contains(err.Error(), "violated")
+}
+
+// IsIPConfigurationError checks if wrapped error is an IP configuration error.
+func IsIPConfigurationError(err error) bool {
+	var ipConfigError *IPConfigurationError
+	return errors.As(err, &ipConfigError)
+}
+
+// IsIPOutOfRangeError checks if error is a GCE IP out of range error.
+func IsIPOutOfRangeError(err error) bool {
+	return gceutils.IsHTTPErrorCode(err, http.StatusBadRequest) && strings.Contains(err.Error(), "Requested internal IP address is outside the network/subnetwork range")
+}
+
+// IsConflictingPortsConfigurationError checks if wrapped error is an conflicting ports configuration error.
+func IsConflictingPortsConfigurationError(err error) bool {
+	var portsConflictConfigError *ConflictingPortsConfigurationError
+	return errors.As(err, &portsConflictConfigError)
+}
+
+// IsInvalidSubnetConfigurationError checks if wrapped error is an Invalid Subnet Configuration error.
+func IsInvalidSubnetConfigurationError(err error) bool {
+	var invalidSubnetConfigError *InvalidSubnetConfigurationError
+	return errors.As(err, &invalidSubnetConfigError)
+}
+
+// UserError is a struct to define error caused by User misconfiguration.
+type UserError struct {
+	err error
+}
+
+func (e *UserError) Error() string {
+	return e.err.Error()
+}
+
+func NewUserError(err error) *UserError {
+	return &UserError{err}
+}
+
+func GetErrorType(err error) string {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return http.StatusText(gerr.Code)
+	}
+	var k8serr *k8serrors.StatusError
+	if errors.As(err, &k8serr) {
+		return "k8s " + string(k8serrors.ReasonForError(k8serr))
+	}
+	return ""
+}
+
+// IsUnsupportedFeatureError returns true if the error has 400 number,
+// and has information that `featureName` isn't supported
+//
+//	ex: ```Error 400: Invalid value for field
+//	resource.connectionTrackingPolicy.enableStrongAffinity': 'true'.
+//	EnableStrongAffinity is not supported., invalid```
+func IsUnsupportedFeatureError(err error, featureName string) bool {
+	if err == nil {
+		return false
+	}
+	isUnsupported := strings.Contains(err.Error(), "is not supported") && gceutils.IsHTTPErrorCode(err, http.StatusBadRequest)
+	if strings.Contains(err.Error(), featureName) && isUnsupported {
+		return true
+	}
+	return false
+}

--- a/pkg/l4/utils/errors_test.go
+++ b/pkg/l4/utils/errors_test.go
@@ -1,0 +1,184 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsNetworkMismatchGCEError(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want bool
+	}{
+		{
+			err:  fmt.Errorf("The network tier of external IP is STANDARD, that of Address must be the same."),
+			want: true,
+		},
+		{
+			err:  fmt.Errorf("The network tier of external IP is PREMIUM, that of Address must be the same."),
+			want: true,
+		},
+		{
+			err:  fmt.Errorf("The network tier of external IP is , that of Address must be the same."),
+			want: false,
+		},
+		{
+			err:  fmt.Errorf("The network tier of external IP is"),
+			want: false,
+		},
+		{
+			err:  fmt.Errorf("Some dummy string"),
+			want: false,
+		},
+	} {
+		if got := IsNetworkTierMismatchGCEError(tc.err); got != tc.want {
+			t.Errorf("IsNetworkTierMismatchGCEError(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestIsNetworkMismatchError(t *testing.T) {
+	netTierMismatchError := NewNetworkTierErr("forwarding-rule", "premium", "standard")
+	for _, tc := range []struct {
+		description string
+		err         error
+		want        bool
+	}{
+		{
+			description: "Good error is wrapped",
+			err:         fmt.Errorf("err: %w", netTierMismatchError),
+			want:        true,
+		},
+		{
+			description: "Good error is NetworkTierErr type",
+			err:         netTierMismatchError,
+			want:        true,
+		},
+		{
+			description: "Wrong error is not NetworkTierErr type",
+			err:         fmt.Errorf("Wrong error."),
+			want:        false,
+		},
+	} {
+		if got := IsNetworkTierError(tc.err); got != tc.want {
+			t.Errorf("IsNetworkTierError(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestIsConstraintViolationError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			desc: "random error",
+			err:  errors.New("random error"),
+			want: false,
+		},
+		{
+			desc: "other google api error",
+			err: &googleapi.Error{
+				Code:    http.StatusBadRequest,
+				Message: "invalid arguments",
+			},
+			want: false,
+		},
+		{
+			desc: "constraint violation google api error",
+			err: &googleapi.Error{
+				Code:    http.StatusPreconditionFailed,
+				Message: "Constraint constraints/compute.restrictLoadBalancerCreationForTypes violated for projects/cf-gcpai-sales-buddy-l-t4. Forwarding Rule projects/cf-gcpai-sales-buddy-l-t4/regions/europe-west4/forwardingRules/k8s2-tcp-mv3ejptg-anthos-identity-servic-gke-oidc-envo-eswdpmuk of type INTERNAL_TCP_UDP is not allowed.",
+			},
+			want: true,
+		},
+		{
+			desc: "status 412 but not constraint violation",
+			err: &googleapi.Error{
+				Code:    http.StatusPreconditionFailed,
+				Message: "precondition failed for some other reason",
+			},
+			want: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			if got := IsConstraintViolationError(tC.err); got != tC.want {
+				t.Errorf("IsConstraintViolationError(%v) = %v, want %v", tC.err, got, tC.want)
+			}
+		})
+	}
+}
+
+func TestIsIPOutOfRangeError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			desc: "other googleapi error",
+			err:  &googleapi.Error{Code: http.StatusBadRequest, Message: "Some other error"},
+			want: false,
+		},
+		{
+			desc: "not a googleapi error",
+			err:  fmt.Errorf("Requested internal IP address is outside the network/subnetwork range"),
+			want: false,
+		},
+		{
+			desc: "correct googleapi error",
+			err:  &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.ipAddress': '10.24.120.53'. Requested internal IP address is outside the network/subnetwork range., invalid"},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := IsIPOutOfRangeError(tc.err); got != tc.want {
+				t.Errorf("IsIPOutOfRangeError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetErrorType(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc    string
+		err     error
+		errType string
+	}{
+		{desc: "nil error", err: nil},
+		{desc: "Forbidden googleapi error", err: &googleapi.Error{Code: http.StatusForbidden}, errType: http.StatusText(http.StatusForbidden)},
+		{desc: "Forbidden googleapi error wrapped", err: fmt.Errorf("Got error: %w", &googleapi.Error{Code: http.StatusForbidden}), errType: http.StatusText(http.StatusForbidden)},
+		{desc: "k8s notFound error", err: k8serrors.NewNotFound(schema.GroupResource{}, ""), errType: "k8s " + string(v1.StatusReasonNotFound)},
+		{desc: "k8s notFound error wrapped", err: fmt.Errorf("Got error: %w", k8serrors.NewNotFound(schema.GroupResource{}, "")), errType: "k8s " + string(v1.StatusReasonNotFound)},
+		{desc: "k8s notFound error embedded with %v", err: fmt.Errorf("Got error: %v", k8serrors.NewNotFound(schema.GroupResource{}, "")), errType: ""},
+		{desc: "unknown error", err: fmt.Errorf("Got unknown error"), errType: ""},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if errType := GetErrorType(tc.err); errType != tc.errType {
+				t.Errorf("Unexpected errType %q, want %q", errType, tc.errType)
+			}
+		})
+	}
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -26,7 +26,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/ingress-gce/pkg/utils"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/klog/v2"
 )
 
@@ -133,7 +133,7 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 		return nil, err
 	}
 	if !exists {
-		return nil, utils.NewUserError(fmt.Errorf("network %s does not exist", networkName))
+		return nil, l4utils.NewUserError(fmt.Errorf("network %s does not exist", networkName))
 	}
 	network := obj.(*networkv1.Network)
 	if network == nil {
@@ -141,21 +141,21 @@ func (nr *NetworksResolver) ServiceNetwork(service *apiv1.Service) (*NetworkInfo
 	}
 	svcLogger.Info("Found network for service", "network", network.Name)
 	if network.Spec.Type != networkv1.L3NetworkType {
-		return nil, utils.NewUserError(fmt.Errorf("network.Spec.Type=%s is not supported for multinetwork LoadBalancer services, the only supported network type is L3", network.Spec.Type))
+		return nil, l4utils.NewUserError(fmt.Errorf("network.Spec.Type=%s is not supported for multinetwork LoadBalancer services, the only supported network type is L3", network.Spec.Type))
 	}
 	parametersRef := network.Spec.ParametersRef
 	if !refersGKENetworkParamSet(parametersRef) {
-		return nil, utils.NewUserError(fmt.Errorf("network.Spec.ParametersRef does not refer a GKENetworkParamSet resource"))
+		return nil, l4utils.NewUserError(fmt.Errorf("network.Spec.ParametersRef does not refer a GKENetworkParamSet resource"))
 	}
 	if parametersRef.Namespace != nil {
-		return nil, utils.NewUserError(fmt.Errorf("network.Spec.ParametersRef.namespace must not be set for GKENetworkParamSet reference as it is a cluster scope resource"))
+		return nil, l4utils.NewUserError(fmt.Errorf("network.Spec.ParametersRef.namespace must not be set for GKENetworkParamSet reference as it is a cluster scope resource"))
 	}
 	gkeParamsObj, exists, err := nr.gkeNetworkParamSetLister.GetByKey(parametersRef.Name)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, utils.NewUserError(fmt.Errorf("GKENetworkParamSet %s was not found", parametersRef.Name))
+		return nil, l4utils.NewUserError(fmt.Errorf("GKENetworkParamSet %s was not found", parametersRef.Name))
 	}
 	gkeNetworkParamSet := gkeParamsObj.(*networkv1.GKENetworkParamSet)
 	if gkeNetworkParamSet == nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -93,80 +92,6 @@ const (
 	// LabelNodeSubnet specifies the subnet name of this node.
 	LabelNodeSubnet = "cloud.google.com/gke-node-pool-subnet"
 )
-
-var networkTierErrorRegexp = regexp.MustCompile(`The network tier of external IP is STANDARD|PREMIUM, that of Address must be the same.`)
-
-// NetworkTierError is a struct to define error caused by User misconfiguration of Network Tier.
-type NetworkTierError struct {
-	resource   string
-	desiredNT  string
-	receivedNT string
-}
-
-// Error function prints out Network Tier error.
-func (e *NetworkTierError) Error() string {
-	return fmt.Sprintf("Network tier mismatch for resource %s, desired: %s, received: %s", e.resource, e.desiredNT, e.receivedNT)
-}
-
-func NewNetworkTierErr(resourceInErr, desired, received string) *NetworkTierError {
-	return &NetworkTierError{resource: resourceInErr, desiredNT: desired, receivedNT: received}
-}
-
-type UnsupportedNetworkTierError struct {
-	resource      string
-	unsupportedNT string
-}
-
-// Error function prints out Network Tier error.
-func (e *UnsupportedNetworkTierError) Error() string {
-	return fmt.Sprintf("Network tier %s is not supported for %s", e.unsupportedNT, e.resource)
-}
-
-func NewUnsupportedNetworkTierErr(resourceInErr, networkTier string) *UnsupportedNetworkTierError {
-	return &UnsupportedNetworkTierError{resource: resourceInErr, unsupportedNT: networkTier}
-}
-
-// IPConfigurationError is a struct to define error caused by User misconfiguration the Load Balancer IP.
-type IPConfigurationError struct {
-	ip     string
-	reason string
-}
-
-func (e *IPConfigurationError) Error() string {
-	return fmt.Sprintf("IP configuration error: \"%s\" %s", e.ip, e.reason)
-}
-
-func NewIPConfigurationError(ip, reason string) *IPConfigurationError {
-	return &IPConfigurationError{ip: ip, reason: reason}
-}
-
-// ConflictingPortsConfigurationError is a struct to define error caused by User misconfiguration of the LB ports.
-type ConflictingPortsConfigurationError struct {
-	ports  string
-	reason string
-}
-
-func (e *ConflictingPortsConfigurationError) Error() string {
-	return fmt.Sprintf("Conflicting ports configuration error: \"%s\" %s", e.ports, e.reason)
-}
-
-func NewConflictingPortsConfigurationError(ports, reason string) *ConflictingPortsConfigurationError {
-	return &ConflictingPortsConfigurationError{ports: ports, reason: reason}
-}
-
-// InvalidSubnetConfigurationError is a struct to define error caused by User misconfiguration of Load Balancer's subnet.
-type InvalidSubnetConfigurationError struct {
-	projectName string
-	subnetName  string
-}
-
-func (e *InvalidSubnetConfigurationError) Error() string {
-	return fmt.Sprintf("Subnetwork \"%s\" can't be found for project %s", e.subnetName, e.projectName)
-}
-
-func NewInvalidSubnetConfigurationError(projectName, subnetName string) *InvalidSubnetConfigurationError {
-	return &InvalidSubnetConfigurationError{projectName: projectName, subnetName: subnetName}
-}
 
 // L4LBType indicates if L4 LoadBalancer is Internal or External
 type L4LBType int
@@ -251,64 +176,6 @@ func IsMemberAlreadyExistsError(err error) bool {
 	return strings.Contains(apiErr.Error(), "memberAlreadyExists")
 }
 
-// IsNetworkTierMismatchGCEError checks if error is a GCE network tier mismatch for external IP
-func IsNetworkTierMismatchGCEError(err error) bool {
-	return networkTierErrorRegexp.MatchString(err.Error())
-}
-
-// IsNetworkTierError checks if wrapped error is a Network Tier Mismatch error
-func IsNetworkTierError(err error) bool {
-	var netTierError *NetworkTierError
-	return errors.As(err, &netTierError)
-}
-
-// IsUnsupportedNetworkTierError checks if wrapped error is an Unsupported Network Tier error
-func IsUnsupportedNetworkTierError(err error) bool {
-	var netTierError *UnsupportedNetworkTierError
-	return errors.As(err, &netTierError)
-}
-
-// IsConstraintViolationError checks if the error is a constraint violation error returned by GCP.
-func IsConstraintViolationError(err error) bool {
-	return IsHTTPErrorCode(err, http.StatusPreconditionFailed) && strings.Contains(err.Error(), "Constraint") && strings.Contains(err.Error(), "violated")
-}
-
-// IsIPConfigurationError checks if wrapped error is an IP configuration error.
-func IsIPConfigurationError(err error) bool {
-	var ipConfigError *IPConfigurationError
-	return errors.As(err, &ipConfigError)
-}
-
-// IsIPOutOfRangeError checks if error is a GCE IP out of range error.
-func IsIPOutOfRangeError(err error) bool {
-	return IsHTTPErrorCode(err, http.StatusBadRequest) && strings.Contains(err.Error(), "Requested internal IP address is outside the network/subnetwork range")
-}
-
-// IsConflictingPortsConfigurationError checks if wrapped error is an conflicting ports configuration error.
-func IsConflictingPortsConfigurationError(err error) bool {
-	var portsConflictConfigError *ConflictingPortsConfigurationError
-	return errors.As(err, &portsConflictConfigError)
-}
-
-// IsInvalidSubnetConfigurationError checks if wrapped error is an Invalid Subnet Configuration error.
-func IsInvalidSubnetConfigurationError(err error) bool {
-	var invalidSubnetConfigError *InvalidSubnetConfigurationError
-	return errors.As(err, &invalidSubnetConfigError)
-}
-
-// UserError is a struct to define error caused by User misconfiguration.
-type UserError struct {
-	err error
-}
-
-func (e *UserError) Error() string {
-	return e.err.Error()
-}
-
-func NewUserError(err error) *UserError {
-	return &UserError{err}
-}
-
 // IsNotFoundError returns true if the resource does not exist
 func IsNotFoundError(err error) bool {
 	return IsHTTPErrorCode(err, http.StatusNotFound)
@@ -336,18 +203,6 @@ func isGCEError(err error, reason string) bool {
 		}
 	}
 	return false
-}
-
-func GetErrorType(err error) string {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return http.StatusText(gerr.Code)
-	}
-	var k8serr *k8serrors.StatusError
-	if errors.As(err, &k8serr) {
-		return "k8s " + string(k8serrors.ReasonForError(k8serr))
-	}
-	return ""
 }
 
 // IsGCEServerError returns true if the error is GCE server error
@@ -889,23 +744,6 @@ func SubnetHasIPv6Range(cloud *gce.Cloud, subnetName, ipv6AccessType string) (bo
 	isValidStackType := (subnet.StackType == DualStackSubnetStackType) || (subnet.StackType == IPv6SubnetStackType)
 
 	return isValidStackType, nil
-}
-
-// IsUnsupportedFeatureError returns true if the error has 400 number,
-// and has information that `featureName` isn't supported
-//
-//	ex: ```Error 400: Invalid value for field
-//	resource.connectionTrackingPolicy.enableStrongAffinity': 'true'.
-//	EnableStrongAffinity is not supported., invalid```
-func IsUnsupportedFeatureError(err error, featureName string) bool {
-	if err == nil {
-		return false
-	}
-	isUnsupported := strings.Contains(err.Error(), "is not supported") && IsHTTPErrorCode(err, http.StatusBadRequest)
-	if strings.Contains(err.Error(), featureName) && isUnsupported {
-		return true
-	}
-	return false
 }
 
 // GetDomainFromGABasePath takes a GA base path of the form <path>/compute/v1 and returns the path.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -36,7 +36,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
@@ -1069,29 +1068,6 @@ func TestIsQuotaExceededError(t *testing.T) {
 	}
 }
 
-func TestGetErrorType(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		desc    string
-		err     error
-		errType string
-	}{
-		{desc: "nil error", err: nil},
-		{desc: "Forbidden googleapi error", err: &googleapi.Error{Code: http.StatusForbidden}, errType: http.StatusText(http.StatusForbidden)},
-		{desc: "Forbidden googleapi error wrapped", err: fmt.Errorf("Got error: %w", &googleapi.Error{Code: http.StatusForbidden}), errType: http.StatusText(http.StatusForbidden)},
-		{desc: "k8s notFound error", err: k8serrors.NewNotFound(schema.GroupResource{}, ""), errType: "k8s " + string(v1.StatusReasonNotFound)},
-		{desc: "k8s notFound error wrapped", err: fmt.Errorf("Got error: %w", k8serrors.NewNotFound(schema.GroupResource{}, "")), errType: "k8s " + string(v1.StatusReasonNotFound)},
-		{desc: "k8s notFound error embedded with %v", err: fmt.Errorf("Got error: %v", k8serrors.NewNotFound(schema.GroupResource{}, "")), errType: ""},
-		{desc: "unknown error", err: fmt.Errorf("Got unknown error"), errType: ""},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			if errType := utils.GetErrorType(tc.err); errType != tc.errType {
-				t.Errorf("Unexpected errType %q, want %q", errType, tc.errType)
-			}
-		})
-	}
-}
-
 func TestBackendToServicePortID(t *testing.T) {
 	testNS := "test-namespace"
 	for _, tc := range []struct {
@@ -1241,67 +1217,6 @@ func TestMinMaxPortRange(t *testing.T) {
 		portsRange := utils.MinMaxPortRange(tc.svcPorts)
 		if portsRange != tc.expectedRange {
 			t.Errorf("PortRange mismatch %v != %v", tc.expectedRange, portsRange)
-		}
-	}
-}
-
-func TestIsNetworkMismatchGCEError(t *testing.T) {
-	for _, tc := range []struct {
-		err  error
-		want bool
-	}{
-		{
-			err:  fmt.Errorf("The network tier of external IP is STANDARD, that of Address must be the same."),
-			want: true,
-		},
-		{
-			err:  fmt.Errorf("The network tier of external IP is PREMIUM, that of Address must be the same."),
-			want: true,
-		},
-		{
-			err:  fmt.Errorf("The network tier of external IP is , that of Address must be the same."),
-			want: false,
-		},
-		{
-			err:  fmt.Errorf("The network tier of external IP is"),
-			want: false,
-		},
-		{
-			err:  fmt.Errorf("Some dummy string"),
-			want: false,
-		},
-	} {
-		if got := utils.IsNetworkTierMismatchGCEError(tc.err); got != tc.want {
-			t.Errorf("IsNetworkTierMismatchGCEError(%v) = %v, want %v", tc.err, got, tc.want)
-		}
-	}
-}
-
-func TestIsNetworkMismatchError(t *testing.T) {
-	netTierMismatchError := utils.NewNetworkTierErr("forwarding-rule", "premium", "standard")
-	for _, tc := range []struct {
-		description string
-		err         error
-		want        bool
-	}{
-		{
-			description: "Good error is wrapped",
-			err:         fmt.Errorf("err: %w", netTierMismatchError),
-			want:        true,
-		},
-		{
-			description: "Good error is NetworkTierErr type",
-			err:         netTierMismatchError,
-			want:        true,
-		},
-		{
-			description: "Wrong error is not NetworkTierErr type",
-			err:         fmt.Errorf("Wrong error."),
-			want:        false,
-		},
-	} {
-		if got := utils.IsNetworkTierError(tc.err); got != tc.want {
-			t.Errorf("IsNetworkTierError(%v) = %v, want %v", tc.err, got, tc.want)
 		}
 	}
 }
@@ -1560,66 +1475,6 @@ func TestAddIPToLBStatus(t *testing.T) {
 	}
 }
 
-func TestIsUnsupportedFeatureError(t *testing.T) {
-	testCases := []struct {
-		desc                string
-		featureName         string
-		errorMessage        string
-		errorCode           int
-		expectedReturnValue bool
-	}{
-		{
-			desc:                "empty error",
-			featureName:         "randomFeature",
-			errorMessage:        "",
-			errorCode:           200,
-			expectedReturnValue: false,
-		},
-		{
-			desc:                "wrong error code",
-			featureName:         "randomFeature",
-			errorMessage:        "randomFeature is not supported",
-			errorCode:           200,
-			expectedReturnValue: false,
-		},
-		{
-			desc:                "wrong error message",
-			featureName:         "randomFeature",
-			errorMessage:        "randomFeature abc",
-			errorCode:           400,
-			expectedReturnValue: false,
-		},
-		{
-			desc:                "wrong feature name",
-			featureName:         "newFeature",
-			errorMessage:        "randomFeature is not supported",
-			errorCode:           400,
-			expectedReturnValue: false,
-		},
-		{
-			desc:                "feature is not supported",
-			featureName:         "enableStrongAffinity",
-			errorMessage:        "Invalid value for field 'resource.connectionTrackingPolicy.enableStrongAffinity': 'true'. EnableStrongAffinity is not supported., invalid",
-			errorCode:           400,
-			expectedReturnValue: true,
-		},
-	}
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
-
-			err := googleapi.Error{
-				Message: tc.errorMessage,
-				Code:    tc.errorCode,
-			}
-			if utils.IsUnsupportedFeatureError(&err, tc.featureName) != tc.expectedReturnValue {
-				t.Errorf("IsUnsupportedFeatureError returned unexpected result: %v, expectations: %v for error: %v", utils.IsUnsupportedFeatureError(&err, tc.featureName), tc.expectedReturnValue, err)
-			}
-		})
-	}
-}
-
 func TestIsGCEServerError(t *testing.T) {
 	testcases := []struct {
 		desc string
@@ -1863,93 +1718,6 @@ func TestLBBasedOnFinalizer(t *testing.T) {
 
 			if diff := cmp.Diff(tC.want, got); diff != "" {
 				t.Errorf("got != want, diff(-tc.want +got) = %s", diff)
-			}
-		})
-	}
-}
-
-func TestIsConstraintViolationError(t *testing.T) {
-	testCases := []struct {
-		desc string
-		err  error
-		want bool
-	}{
-		{
-			desc: "nil error",
-			err:  nil,
-			want: false,
-		},
-		{
-			desc: "random error",
-			err:  errors.New("random error"),
-			want: false,
-		},
-		{
-			desc: "other google api error",
-			err: &googleapi.Error{
-				Code:    http.StatusBadRequest,
-				Message: "invalid arguments",
-			},
-			want: false,
-		},
-		{
-			desc: "constraint violation google api error",
-			err: &googleapi.Error{
-				Code:    http.StatusPreconditionFailed,
-				Message: "Constraint constraints/compute.restrictLoadBalancerCreationForTypes violated for projects/cf-gcpai-sales-buddy-l-t4. Forwarding Rule projects/cf-gcpai-sales-buddy-l-t4/regions/europe-west4/forwardingRules/k8s2-tcp-mv3ejptg-anthos-identity-servic-gke-oidc-envo-eswdpmuk of type INTERNAL_TCP_UDP is not allowed.",
-			},
-			want: true,
-		},
-		{
-			desc: "status 412 but not constraint violation",
-			err: &googleapi.Error{
-				Code:    http.StatusPreconditionFailed,
-				Message: "precondition failed for some other reason",
-			},
-			want: false,
-		},
-	}
-	for _, tC := range testCases {
-		t.Run(tC.desc, func(t *testing.T) {
-			if got := utils.IsConstraintViolationError(tC.err); got != tC.want {
-				t.Errorf("IsConstraintViolationError(%v) = %v, want %v", tC.err, got, tC.want)
-			}
-		})
-	}
-}
-
-func TestIsIPOutOfRangeError(t *testing.T) {
-	testCases := []struct {
-		desc string
-		err  error
-		want bool
-	}{
-		{
-			desc: "nil error",
-			err:  nil,
-			want: false,
-		},
-		{
-			desc: "other googleapi error",
-			err:  &googleapi.Error{Code: http.StatusBadRequest, Message: "Some other error"},
-			want: false,
-		},
-		{
-			desc: "not a googleapi error",
-			err:  fmt.Errorf("Requested internal IP address is outside the network/subnetwork range"),
-			want: false,
-		},
-		{
-			desc: "correct googleapi error",
-			err:  &googleapi.Error{Code: http.StatusBadRequest, Message: "Invalid value for field 'resource.ipAddress': '10.24.120.53'. Requested internal IP address is outside the network/subnetwork range., invalid"},
-			want: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			if got := utils.IsIPOutOfRangeError(tc.err); got != tc.want {
-				t.Errorf("IsIPOutOfRangeError(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Part two of the ongoing effort to split `pkg/utils`. This extracts all L4-specific error types, error checkers, and their corresponding tests out of `pkg/utils/utils.go` and into a dedicated `pkg/l4/utils/errors.go` file.