### PR TITLE
Topology provider negbinding

### DIFF
--- a/pkg/neg/syncers/negbinding_topology.go
+++ b/pkg/neg/syncers/negbinding_topology.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"fmt"
+
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
+)
+
+// NEGBindingTopologyProvider provides subnets and zones where NEGs should be managed
+// based on NetworkEndpointGroupBinding CR
+type NEGBindingTopologyProvider struct {
+	negBindingName   string
+	namespace        string
+	negBindingLister cache.Indexer
+	defaultSubnetID  *cloud.ResourceID
+}
+
+// NewNEGBindingTopologyProvider constructs a new NEGBindingTopologyProvider
+func NewNEGBindingTopologyProvider(namespace, negBindingName string, negBindingLister cache.Indexer, defaultSubnetURL string) (*NEGBindingTopologyProvider, error) {
+	defaultSubnetID, err := cloud.ParseResourceURL(defaultSubnetURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse default subnetwork URL %q: %w", defaultSubnetURL, err)
+	}
+
+	return &NEGBindingTopologyProvider{
+		negBindingName:   negBindingName,
+		namespace:        namespace,
+		negBindingLister: negBindingLister,
+		defaultSubnetID:  defaultSubnetID,
+	}, nil
+}
+
+func (p *NEGBindingTopologyProvider) getBinding() (*negbindingv1beta1.NetworkEndpointGroupBinding, error) {
+	key := fmt.Sprintf("%s/%s", p.namespace, p.negBindingName)
+	obj, exists, err := p.negBindingLister.GetByKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("error getting negbinding from cache: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("negbinding %s is not in store", key)
+	}
+	binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+	if !ok {
+		return nil, fmt.Errorf("cached object %q is of type %T, expected *NetworkEndpointGroupBinding", key, obj)
+	}
+	return binding, nil
+}
+
+// ListSubnetsInDefaultNetwork returns the list of subnets declared inside the NegBinding CR Spec.
+func (p *NEGBindingTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig {
+	binding, err := p.getBinding()
+	if err != nil {
+		logger.Error(err, "Failed to get NegBinding from store", "namespace", p.namespace, "negBindingName", p.negBindingName)
+		return nil
+	}
+
+	configs := make([]nodetopologyv1.SubnetConfig, len(binding.Spec.NetworkEndpointGroups))
+	for i, ref := range binding.Spec.NetworkEndpointGroups {
+		key := &meta.Key{
+			Name:   ref.Subnet,
+			Region: p.defaultSubnetID.Key.Region,
+		}
+		subnetPath := cloud.SelfLink(meta.VersionGA, p.defaultSubnetID.ProjectID, p.defaultSubnetID.Resource, key)
+		configs[i] = nodetopologyv1.SubnetConfig{
+			Name:       ref.Subnet,
+			SubnetPath: subnetPath,
+		}
+	}
+	return configs
+}
+
+// ListZonesPerSubnet returns a map of subnet to zones defined inside the NegBinding CR Spec.
+// NEGBinding contains explicit locations (subnet + zone pairs), where NEG controller is expected to
+// manage NEGs ignoring if any endpoints available there. Therefore ignoring filtering.
+func (p *NEGBindingTopologyProvider) ListZonesPerSubnet(_ zonegetter.Filter, networkInfo network.NetworkInfo, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
+	if !networkInfo.IsDefault {
+		return nil, fmt.Errorf("NEGBinding does not support multi-network mode")
+	}
+
+	binding, err := p.getBinding()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NegBinding from store: %w", err)
+	}
+
+	zonesPerSubnet := make(shared.ZonesPerSubnetMap)
+	for _, ref := range binding.Spec.NetworkEndpointGroups {
+		zonesPerSubnet[ref.Subnet] = sets.New(ref.Zones...)
+	}
+	return zonesPerSubnet, nil
+}

--- a/pkg/neg/syncers/negbinding_topology_test.go
+++ b/pkg/neg/syncers/negbinding_topology_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	fakenegbinding "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
+)
+
+func TestNEGBindingTopologyProvider(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	testCases := []struct {
+		desc            string
+		initialBinding  *negbindingv1beta1.NetworkEndpointGroupBinding
+		expectedSubnets []nodetopologyv1.SubnetConfig
+		expectedZones   shared.ZonesPerSubnetMap
+		updatedBinding  *negbindingv1beta1.NetworkEndpointGroupBinding // optional runtime update
+		updatedSubnets  []nodetopologyv1.SubnetConfig                  // expected after update
+		updatedZones    shared.ZonesPerSubnetMap                       // expected after update
+	}{
+		{
+			desc: "Empty NEG list",
+			initialBinding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{},
+				},
+			},
+			expectedSubnets: []nodetopologyv1.SubnetConfig{},
+			expectedZones:   shared.ZonesPerSubnetMap{},
+		},
+		{
+			desc: "Single subnet with primary default mapping",
+			initialBinding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Name:   "neg-default",
+							Subnet: "default-subnet",
+							Zones:  []string{"us-central1-a", "us-central1-b"},
+						},
+					},
+				},
+			},
+			expectedSubnets: []nodetopologyv1.SubnetConfig{
+				{
+					Name:       "default-subnet",
+					SubnetPath: defaultSubnetURL,
+				},
+			},
+			expectedZones: shared.ZonesPerSubnetMap{
+				"default-subnet": sets.New("us-central1-a", "us-central1-b"),
+			},
+		},
+		{
+			desc: "Multiple subnets and dynamic update verification",
+			initialBinding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Name:   "neg-a",
+							Subnet: "subnet-a",
+							Zones:  []string{"us-central1-a"},
+						},
+					},
+				},
+			},
+			expectedSubnets: []nodetopologyv1.SubnetConfig{
+				{
+					Name:       "subnet-a",
+					SubnetPath: "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/subnet-a",
+				},
+			},
+			expectedZones: shared.ZonesPerSubnetMap{
+				"subnet-a": sets.New("us-central1-a"),
+			},
+			updatedBinding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Name:   "neg-a",
+							Subnet: "subnet-a",
+							Zones:  []string{"us-central1-a", "us-central1-b"},
+						},
+						{
+							Name:   "neg-b",
+							Subnet: "subnet-b",
+							Zones:  []string{"us-central1-c"},
+						},
+					},
+				},
+			},
+			updatedSubnets: []nodetopologyv1.SubnetConfig{
+				{
+					Name:       "subnet-a",
+					SubnetPath: "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/subnet-a",
+				},
+				{
+					Name:       "subnet-b",
+					SubnetPath: "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/subnet-b",
+				},
+			},
+			updatedZones: shared.ZonesPerSubnetMap{
+				"subnet-a": sets.New("us-central1-a", "us-central1-b"),
+				"subnet-b": sets.New("us-central1-c"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeClient := fakenegbinding.NewSimpleClientset()
+			informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
+			negBindingLister := informer.GetIndexer()
+
+			p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+			if err != nil {
+				t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
+			}
+
+			negBindingLister.Add(tc.initialBinding)
+
+			subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+			if !reflect.DeepEqual(subnets, tc.expectedSubnets) {
+				t.Errorf("ListSubnetsInDefaultNetwork() returned %+v, expected %+v", subnets, tc.expectedSubnets)
+			}
+
+			zonesPerSubnet, err := p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+			if err != nil {
+				t.Errorf("ListZonesPerSubnet() returned unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(zonesPerSubnet, tc.expectedZones) {
+				t.Errorf("ListZonesPerSubnet() returned %+v, expected %+v", zonesPerSubnet, tc.expectedZones)
+			}
+
+			if _, ok := zonesPerSubnet["unknown-subnet"]; ok {
+				t.Errorf("ListZonesPerSubnet() returned zones for unknown-subnet, expected it to be absent")
+			}
+
+			if tc.updatedBinding != nil {
+				negBindingLister.Update(tc.updatedBinding)
+
+				subnets = p.ListSubnetsInDefaultNetwork(klog.TODO())
+				if !reflect.DeepEqual(subnets, tc.updatedSubnets) {
+					t.Errorf("ListSubnetsInDefaultNetwork() after update returned %+v, expected %+v", subnets, tc.updatedSubnets)
+				}
+
+				zonesPerSubnet, err = p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+				if err != nil {
+					t.Errorf("ListZonesPerSubnet() after update returned unexpected error: %v", err)
+				}
+				if !reflect.DeepEqual(zonesPerSubnet, tc.updatedZones) {
+					t.Errorf("ListZonesPerSubnet() after update returned %+v, expected %+v", zonesPerSubnet, tc.updatedZones)
+				}
+			}
+		})
+	}
+
+}
+
+func TestNewNEGBindingTopologyProviderInvalidDefaultSubnetURL(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	_, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, "invalid-url-with-no-slashes")
+	if err == nil {
+		t.Error("NewNEGBindingTopologyProvider() with invalid defaultSubnetURL returned no error")
+	} else if expected := `failed to parse default subnetwork URL "invalid-url-with-no-slashes": "invalid-url-with-no-slashes" is not a valid resource URL`; err.Error() != expected {
+		t.Errorf("NewNEGBindingTopologyProvider() returned error %q, expected %q", err.Error(), expected)
+	}
+}
+
+func TestNEGBindingTopologyProviderInvalidTypeInCache(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	if err != nil {
+		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	invalidObj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	negBindingLister.Add(invalidObj)
+
+	subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+	if subnets != nil {
+		t.Errorf("ListSubnetsInDefaultNetwork() returned %v, expected nil when cache has invalid type", subnets)
+	}
+
+	_, err = p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err == nil {
+		t.Errorf("ListZonesPerSubnet() returned no error, expected error when cache has invalid type")
+	} else {
+		expectedErr := fmt.Sprintf(`failed to get NegBinding from store: cached object "%s/%s" is of type *v1.PartialObjectMetadata, expected *NetworkEndpointGroupBinding`, namespace, name)
+		if err.Error() != expectedErr {
+			t.Errorf("ListZonesPerSubnet() returned error %q, expected %q", err.Error(), expectedErr)
+		}
+	}
+}
+
+func TestNEGBindingTopologyProviderNEGBindingNotInStore(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	if err != nil {
+		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+	if subnets != nil {
+		t.Errorf("ListSubnetsInDefaultNetwork() returned %v, expected nil when object is not in store", subnets)
+	}
+
+	_, err = p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err == nil {
+		t.Errorf("ListZonesPerSubnet() returned no error, expected error when object is not in store")
+	} else {
+		expectedErr := fmt.Sprintf("failed to get NegBinding from store: negbinding %s/%s is not in store", namespace, name)
+		if err.Error() != expectedErr {
+			t.Errorf("ListZonesPerSubnet() returned error %q, expected %q", err.Error(), expectedErr)
+		}
+	}
+}
+
+func TestNEGBindingTopologyProviderMultinetError(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	if err != nil {
+		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	multinetInfo := network.NetworkInfo{IsDefault: false}
+	_, err = p.ListZonesPerSubnet(zonegetter.AllNodesFilter, multinetInfo, klog.TODO())
+	if err == nil {
+		t.Errorf("ListZonesPerSubnet() expected error for multi-network mode, got nil")
+	} else if expected := "NEGBinding does not support multi-network mode"; err.Error() != expected {
+		t.Errorf("ListZonesPerSubnet() returned error %q, expected %q", err.Error(), expected)
+	}
+}


### PR DESCRIPTION
`TopologyProvider`'s (https://github.com/kubernetes/ingress-gce/pull/3121) implementation based on the NEGBinding CR (https://github.com/kubernetes/ingress-gce/pull/3103) instead of the SvcNEG.

As NEGBinding's subnets and zones should be managed by the feature's user, it's expected that is location (subnet + zone) is provided in the CR, then controller should expect and manage it there without checking if there are (or are no any) candidate nodes in this location, as adding location to CR is an explicit request to manage NEG there.