### PR TITLE
feat: add allowGlobalAccess support for gce-internal Ingress

### DIFF
--- a/pkg/annotations/ingress.go
+++ b/pkg/annotations/ingress.go
@@ -87,6 +87,11 @@ const (
 	//     networking.gke.io/v1beta1.FrontendConfig: 'my-frontendconfig'
 	FrontendConfigKey = "networking.gke.io/v1beta1.FrontendConfig"
 
+	// AllowGlobalAccessKey tells the Ingress controller to allow global access
+	// to the internal load balancer forwarding rule from all regions.
+	// Only applies to gce-internal ingress class.
+	AllowGlobalAccessKey = "networking.gke.io/internal-load-balancer-allow-global-access"
+
 	// UrlMapKey is the annotation key used by controller to record GCP URL map.
 	UrlMapKey = StatusPrefix + "/url-map"
 	// UrlMapKey is the annotation key used by controller to record GCP URL map used for Https Redirects only.
@@ -205,4 +210,18 @@ func (ing *Ingress) FrontendConfig() string {
 		return ""
 	}
 	return val
+}
+
+// AllowGlobalAccess returns whether global access is allowed for the internal
+// load balancer forwarding rule. False by default.
+func (ing *Ingress) AllowGlobalAccess() bool {
+	val, ok := ing.v[AllowGlobalAccessKey]
+	if !ok {
+		return false
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return v
 }

--- a/pkg/annotations/ingress_test.go
+++ b/pkg/annotations/ingress_test.go
@@ -25,13 +25,14 @@ import (
 
 func TestIngress(t *testing.T) {
 	for _, tc := range []struct {
-		desc         string
-		ing          *v1.Ingress
-		allowHTTP    bool
-		useNamedTLS  string
-		staticIPName string
-		ingressClass string
-		wantErr      bool
+		desc              string
+		ing               *v1.Ingress
+		allowHTTP         bool
+		useNamedTLS       string
+		staticIPName      string
+		ingressClass      string
+		allowGlobalAccess bool
+		wantErr           bool
 	}{
 		{
 			desc:      "Empty ingress",
@@ -71,6 +72,46 @@ func TestIngress(t *testing.T) {
 			staticIPName: "1.2.3.4",
 			ingressClass: "gce",
 		},
+		{
+			desc: "AllowGlobalAccess set to true",
+			ing: &v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowGlobalAccessKey: "true",
+						IngressClassKey:      GceL7ILBIngressClass,
+					},
+				},
+			},
+			allowHTTP:         true,
+			ingressClass:      GceL7ILBIngressClass,
+			allowGlobalAccess: true,
+		},
+		{
+			desc: "AllowGlobalAccess set to false",
+			ing: &v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowGlobalAccessKey: "false",
+						IngressClassKey:      GceL7ILBIngressClass,
+					},
+				},
+			},
+			allowHTTP:         true,
+			ingressClass:      GceL7ILBIngressClass,
+			allowGlobalAccess: false,
+		},
+		{
+			desc: "AllowGlobalAccess invalid value defaults to false",
+			ing: &v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AllowGlobalAccessKey: "invalid",
+					},
+				},
+			},
+			allowHTTP:         true,
+			allowGlobalAccess: false,
+		},
 	} {
 		ing := FromIngress(tc.ing)
 
@@ -89,6 +130,9 @@ func TestIngress(t *testing.T) {
 		}
 		if x := ing.IngressClass(); x != tc.ingressClass {
 			t.Errorf("ingress %+v; IngressClass() = %v, want %v", tc.ing, x, tc.ingressClass)
+		}
+		if x := ing.AllowGlobalAccess(); x != tc.allowGlobalAccess {
+			t.Errorf("ingress %+v; AllowGlobalAccess() = %v, want %v", tc.ing, x, tc.allowGlobalAccess)
 		}
 	}
 }

--- a/pkg/loadbalancers/forwarding_rules.go
+++ b/pkg/loadbalancers/forwarding_rules.go
@@ -77,11 +77,11 @@ func (l7 *L7) checkForwardingRule(protocol namer.NamerProtocol, name, proxyLink,
 	isL7ILB := utils.IsGCEL7ILBIngress(l7.runtimeInfo.Ingress)
 	isL7XLBRegional := utils.IsGCEL7XLBRegionalIngress(&l7.ingress)
 	tr := translator.NewTranslator(isL7ILB, isL7XLBRegional, l7.namer)
-	env := &translator.Env{VIP: ip, Network: l7.cloud.NetworkURL(), Subnetwork: l7.cloud.SubnetworkURL()}
+	env := &translator.Env{Ing: l7.runtimeInfo.Ingress, VIP: ip, Network: l7.cloud.NetworkURL(), Subnetwork: l7.cloud.SubnetworkURL()}
 	fr := tr.ToCompositeForwardingRule(env, protocol, version, proxyLink, description, l7.runtimeInfo.StaticIPSubnet)
 
 	existing, _ = composite.GetForwardingRule(l7.cloud, key, version, l7.logger)
-	if existing != nil && (fr.IPAddress != "" && existing.IPAddress != fr.IPAddress || existing.PortRange != fr.PortRange) {
+	if existing != nil && (fr.IPAddress != "" && existing.IPAddress != fr.IPAddress || existing.PortRange != fr.PortRange || existing.AllowGlobalAccess != fr.AllowGlobalAccess) {
 		l7.logger.Info("Recreating forwarding rule %v(%v), so it has %v(%v)",
 			"existingIp", existing.IPAddress, "existingPortRange", existing.PortRange,
 			"targetIp", fr.IPAddress, "targetPortRange", fr.PortRange)

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -29,6 +29,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
@@ -286,6 +287,9 @@ func (t *Translator) ToCompositeForwardingRule(env *Env, protocol namer.NamerPro
 			fr.Subnetwork = fwSubnet
 		} else {
 			fr.Subnetwork = env.Subnetwork
+		}
+		if annotations.FromIngress(env.Ing).AllowGlobalAccess() {
+			fr.AllowGlobalAccess = true
 		}
 	} else if t.IsL7XLBRegional {
 		fr.LoadBalancingScheme = "EXTERNAL_MANAGED"

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -30,6 +30,7 @@ import (
 	frontendconfigv1beta1 "k8s.io/ingress-gce/pkg/apis/frontendconfig/v1beta1"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/utils"
 	namer_util "k8s.io/ingress-gce/pkg/utils/namer"
@@ -388,6 +389,7 @@ func TestToForwardingRule(t *testing.T) {
 		isL7XLBRegional bool
 		protocol        namer_util.NamerProtocol
 		ipSubnet        string
+		ing             *v1.Ingress
 		want            *composite.ForwardingRule
 	}{
 		{
@@ -500,12 +502,54 @@ func TestToForwardingRule(t *testing.T) {
 				Subnetwork:          "different-subnet",
 			},
 		},
+		{
+			desc:     "http-ilb with allowGlobalAccess annotation",
+			isL7ILB:  true,
+			protocol: namer_util.HTTPProtocol,
+			ing: &v1.Ingress{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotations.AllowGlobalAccessKey: "true",
+					},
+				},
+			},
+			want: &composite.ForwardingRule{
+				Name:                "foo-fr",
+				IPAddress:           vip,
+				Target:              proxyLink,
+				PortRange:           httpDefaultPortRange,
+				IPProtocol:          "TCP",
+				Description:         description,
+				Version:             version,
+				LoadBalancingScheme: "INTERNAL_MANAGED",
+				Network:             network,
+				Subnetwork:          subnetwork,
+				AllowGlobalAccess:   true,
+			},
+		},
+		{
+			desc:     "http-ilb without allowGlobalAccess annotation defaults to false",
+			isL7ILB:  true,
+			protocol: namer_util.HTTPProtocol,
+			want: &composite.ForwardingRule{
+				Name:                "foo-fr",
+				IPAddress:           vip,
+				Target:              proxyLink,
+				PortRange:           httpDefaultPortRange,
+				IPProtocol:          "TCP",
+				Description:         description,
+				Version:             version,
+				LoadBalancingScheme: "INTERNAL_MANAGED",
+				Network:             network,
+				Subnetwork:          subnetwork,
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			tr := NewTranslator(tc.isL7ILB, tc.isL7XLBRegional, &testNamer{"foo"})
-			env := &Env{VIP: vip, Network: network, Subnetwork: subnetwork}
+			env := &Env{Ing: tc.ing, VIP: vip, Network: network, Subnetwork: subnetwork}
 			got := tr.ToCompositeForwardingRule(env, tc.protocol, version, proxyLink, description, tc.ipSubnet)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatalf("Got diff for ForwardingRule (-want +got):\n%s", diff)


### PR DESCRIPTION
## Problem

The `networking.gke.io/internal-load-balancer-allow-global-access` annotation
allows internal load balancers to accept traffic from all regions. Currently this
annotation is only supported for `type: LoadBalancer` Services via
`cloud-provider-gcp`, but not for `gce-internal` Ingress resources.

Users who need `allowGlobalAccess` on an internal Ingress must manually patch
the GCP forwarding rule after each controller sync, which is not sustainable.

## Solution

Extend the annotation support to `gce-internal` Ingress by reading it in the
translator and setting `AllowGlobalAccess: true` on the forwarding rule when
the annotation is present.

Since `allowGlobalAccess` is immutable in GCP for `INTERNAL_MANAGED` forwarding
rules, the recreate logic in `checkForwardingRule` is also updated to trigger
a delete+recreate when the desired value differs from the existing one.

## Testing

Unit tests added for:
- `AllowGlobalAccess()` annotation helper (`pkg/annotations/ingress_test.go`)
- `ToCompositeForwardingRule()` with annotation set and unset (`pkg/translator/translator_test.go`)

Fixes #1883