### PR TITLE
Check for address in forwarding rules before reserving it.

### DIFF
--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -20,11 +20,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"k8s.io/ingress-gce/pkg/composite"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -168,7 +172,6 @@ func (m *Manager) ReleaseAddress() error {
 }
 
 func (m *Manager) removeAddress(name, reason string) error {
-
 	m.frLogger.V(2).Info("Releasing existing address", "name", name, "reason", reason)
 	err := m.svc.DeleteRegionAddress(name, m.region)
 	if err != nil {
@@ -180,6 +183,26 @@ func (m *Manager) removeAddress(name, reason string) error {
 	}
 	m.frLogger.V(4).Info("Successfully released address", "addressName", name)
 	return nil
+}
+
+// DecompressIPv6 re-adds ommited hextets in IPv6 address.
+// For example, running the function with argument "2001:db8::ff00:42:8329"
+// returns "2001:db8:0:0:0:ff00:42:8329".
+func DecompressIPv6(addr string) string {
+	if !strings.Contains(addr, "::") {
+		// no compression
+		return addr
+	}
+	hextets := strings.Split(addr, ":")
+	toAdd := 9 - len(hextets)
+	expanded := strings.Repeat(":0", toAdd) + ":"
+	if strings.HasPrefix(addr, "::") {
+		expanded = "0" + expanded
+	}
+	if strings.HasSuffix(addr, "::") {
+		expanded += "0"
+	}
+	return strings.Replace(addr, "::", expanded, 1)
 }
 
 // ensureAddressReservation reserves ip address and returns address as a string,
@@ -270,6 +293,34 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 		return "", IPAddrUndefined, fmt.Errorf("failed to reserve address %q with no specific IP, err: %v", m.name, reserveErr)
 	}
 
+	// Check if the address is in forwarding rules. If it is, we don't need to reserve it.
+	if gceCloud, ok := m.svc.(*gce.Cloud); ok {
+		// Create a filter for the IPAddress.
+		// ForwardingRules keep IP addresses in expanded form, mask may be included.
+		ipFilter := filter.Regexp("IPAddress", DecompressIPv6(m.targetIP)+"(/\\d+)?")
+		key := meta.RegionalKey("", m.region)
+
+		// List regional forwarding rules to determine if the target IP is already in use.
+		frList, err := composite.ListForwardingRules(gceCloud, key, meta.VersionGA, m.frLogger, ipFilter)
+		if err != nil {
+			return "", IPAddrUndefined, fmt.Errorf("failed to lookup forwarding rules, err: %v", err)
+		} else {
+			for _, fr := range frList {
+				var desc utils.L4LBResourceDescription
+				descErr := desc.Unmarshal(fr.Description)
+				if descErr != nil {
+					return "", IPAddrUndefined, l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("failed to unmarshal forwarding rule, err: %v", err))
+				}
+				// If the forwarding rule is used by a different service, return a configuration error.
+				if desc.ServiceName != m.serviceName {
+					return "", IPAddrUndefined, l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("is already in use by forwarding rule %s of service %s", fr.Name, desc.ServiceName))
+				}
+				m.frLogger.V(4).Info("Successfully found IP in forwarding rules", "ip", m.targetIP, "forwarding rule", fr.Name)
+				return m.targetIP, IPAddrManaged, nil
+			}
+		}
+	}
+
 	// Reserving the address failed due to a conflict or bad request. The address manager just checked that no address
 	// exists with the name, so it may belong to the user.
 	addr, err := m.svc.GetRegionAddressByIP(m.region, m.targetIP)
@@ -295,7 +346,6 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	m.frLogger.V(4).Info("Address was already reserved with name: %q, description: %q", "ip", m.targetIP, "addressName", addr.Name, "addressDescription", addr.Description)
 	m.tryRelease = false
 	return addr.Address, IPAddrUnmanaged, nil
-
 }
 
 func (m *Manager) validateAddress(addr *compute.Address) error {

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/filter"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
@@ -185,10 +185,10 @@ func (m *Manager) removeAddress(name, reason string) error {
 	return nil
 }
 
-// DecompressIPv6 re-adds ommited hextets in IPv6 address.
+// DecompressAddr re-adds ommited hextets in IPv6 address.
 // For example, running the function with argument "2001:db8::ff00:42:8329"
 // returns "2001:db8:0:0:0:ff00:42:8329".
-func DecompressIPv6(addr string) string {
+func DecompressAddr(addr string) string {
 	if !strings.Contains(addr, "::") {
 		// no compression
 		return addr
@@ -203,6 +203,39 @@ func DecompressIPv6(addr string) string {
 		expanded += "0"
 	}
 	return strings.Replace(addr, "::", expanded, 1)
+}
+
+func (m *Manager) isAddressInForwardingRules() error {
+	// Check if the address is in forwarding rules. If it is, we don't need to reserve it.
+	if gceCloud, ok := m.svc.(*gce.Cloud); ok {
+		key := meta.RegionalKey(m.name, m.region)
+		fr, err := composite.GetForwardingRule(gceCloud, key, meta.VersionGA, m.frLogger)
+		if err != nil {
+			return fmt.Errorf("failed to lookup forwarding rules, err: %v", err)
+		} else {
+			// We might need to match de-compressed address with mask.
+			ok, err := regexp.MatchString(DecompressAddr(m.targetIP)+"(/\\d+)?", fr.IPAddress)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("forwarding rule IP %q doesn't match requested IP %q", fr.IPAddress, m.targetIP)
+			}
+
+			// If the forwarding rule service name matches.
+			var desc utils.L4LBResourceDescription
+			descErr := desc.Unmarshal(fr.Description)
+			if descErr != nil {
+				return l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("failed to unmarshal forwarding rule, err: %v", err))
+			}
+			if desc.ServiceName != m.serviceName {
+				return l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("is already in use by forwarding rule %s of service %s", fr.Name, desc.ServiceName))
+			}
+			m.frLogger.V(4).Info("Successfully found IP in forwarding rules", "ip", m.targetIP, "forwarding rule", fr.Name)
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to convert provider")
 }
 
 // ensureAddressReservation reserves ip address and returns address as a string,
@@ -246,6 +279,7 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	}
 
 	reserveErr := m.svc.ReserveRegionAddress(newAddr, m.region)
+
 	if reserveErr == nil {
 		if newAddr.Address != "" {
 			m.frLogger.V(4).Info("Successfully reserved IP", "ip", newAddr.Address, "addressName", newAddr.Name)
@@ -293,32 +327,11 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 		return "", IPAddrUndefined, fmt.Errorf("failed to reserve address %q with no specific IP, err: %v", m.name, reserveErr)
 	}
 
-	// Check if the address is in forwarding rules. If it is, we don't need to reserve it.
-	if gceCloud, ok := m.svc.(*gce.Cloud); ok {
-		// Create a filter for the IPAddress.
-		// ForwardingRules keep IP addresses in expanded form, mask may be included.
-		ipFilter := filter.Regexp("IPAddress", DecompressIPv6(m.targetIP)+"(/\\d+)?")
-		key := meta.RegionalKey("", m.region)
-
-		// List regional forwarding rules to determine if the target IP is already in use.
-		frList, err := composite.ListForwardingRules(gceCloud, key, meta.VersionGA, m.frLogger, ipFilter)
-		if err != nil {
-			return "", IPAddrUndefined, fmt.Errorf("failed to lookup forwarding rules, err: %v", err)
-		} else {
-			for _, fr := range frList {
-				var desc utils.L4LBResourceDescription
-				descErr := desc.Unmarshal(fr.Description)
-				if descErr != nil {
-					return "", IPAddrUndefined, l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("failed to unmarshal forwarding rule, err: %v", err))
-				}
-				// If the forwarding rule is used by a different service, return a configuration error.
-				if desc.ServiceName != m.serviceName {
-					return "", IPAddrUndefined, l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("is already in use by forwarding rule %s of service %s", fr.Name, desc.ServiceName))
-				}
-				m.frLogger.V(4).Info("Successfully found IP in forwarding rules", "ip", m.targetIP, "forwarding rule", fr.Name)
-				return m.targetIP, IPAddrManaged, nil
-			}
-		}
+	err := m.isAddressInForwardingRules()
+	if err == nil {
+		return m.targetIP, IPAddrManaged, nil
+	} else {
+		m.frLogger.V(4).Info("IP not found in forwarding rules", "ip", m.targetIP, "err", err)
 	}
 
 	// Reserving the address failed due to a conflict or bad request. The address manager just checked that no address

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -205,37 +205,43 @@ func DecompressAddr(addr string) string {
 	return strings.Replace(addr, "::", expanded, 1)
 }
 
-func (m *Manager) isAddressInForwardingRules() error {
+func (m *Manager) IsAddressInForwardingRules() bool {
 	// Check if the address is in forwarding rules. If it is, we don't need to reserve it.
 	if gceCloud, ok := m.svc.(*gce.Cloud); ok {
 		key := meta.RegionalKey(m.name, m.region)
 		fr, err := composite.GetForwardingRule(gceCloud, key, meta.VersionGA, m.frLogger)
 		if err != nil {
-			return fmt.Errorf("failed to lookup forwarding rules, err: %v", err)
-		} else {
-			// We might need to match de-compressed address with mask.
-			ok, err := regexp.MatchString(DecompressAddr(m.targetIP)+"(/\\d+)?", fr.IPAddress)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return fmt.Errorf("forwarding rule IP %q doesn't match requested IP %q", fr.IPAddress, m.targetIP)
-			}
-
-			// If the forwarding rule service name matches.
-			var desc utils.L4LBResourceDescription
-			descErr := desc.Unmarshal(fr.Description)
-			if descErr != nil {
-				return l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("failed to unmarshal forwarding rule, err: %v", err))
-			}
-			if desc.ServiceName != m.serviceName {
-				return l4utils.NewIPConfigurationError(m.targetIP, fmt.Sprintf("is already in use by forwarding rule %s of service %s", fr.Name, desc.ServiceName))
-			}
-			m.frLogger.V(4).Info("Successfully found IP in forwarding rules", "ip", m.targetIP, "forwarding rule", fr.Name)
-			return nil
+			m.frLogger.V(4).Info("failed to lookup forwarding rules, err: %v", err)
+			return false
 		}
+		// We might need to match de-compressed address with mask.
+		pattern := DecompressAddr(m.targetIP) + "(/\\d+)?"
+		ok, err := regexp.MatchString(pattern, fr.IPAddress)
+		if err != nil {
+			m.frLogger.V(4).Info("failed to regexp match %v in %v", pattern, fr.IPAddress)
+			return false
+		}
+		if !ok {
+			m.frLogger.V(4).Info("forwarding rule IP %q doesn't match requested IP %q", fr.IPAddress, m.targetIP)
+			return false
+		}
+
+		// If the forwarding rule service name matches.
+		var desc utils.L4LBResourceDescription
+		descErr := desc.Unmarshal(fr.Description)
+		if descErr != nil {
+			m.frLogger.V(4).Info(m.targetIP, fmt.Sprintf("failed to unmarshal forwarding rule, err: %v", err))
+			return false
+		}
+		if desc.ServiceName != m.serviceName {
+			m.frLogger.V(4).Info(m.targetIP, fmt.Sprintf("is already in use by forwarding rule %s of service %s", fr.Name, desc.ServiceName))
+			return false
+		}
+		m.frLogger.V(4).Info("Successfully found IP in forwarding rules", "ip", m.targetIP, "forwarding rule", fr.Name)
+		return true
 	}
-	return fmt.Errorf("failed to convert provider")
+	m.frLogger.V(4).Info("failed to convert provider")
+	return false
 }
 
 // ensureAddressReservation reserves ip address and returns address as a string,
@@ -327,11 +333,10 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 		return "", IPAddrUndefined, fmt.Errorf("failed to reserve address %q with no specific IP, err: %v", m.name, reserveErr)
 	}
 
-	err := m.isAddressInForwardingRules()
-	if err == nil {
+	if ok := m.IsAddressInForwardingRules(); ok {
 		return m.targetIP, IPAddrManaged, nil
 	} else {
-		m.frLogger.V(4).Info("IP not found in forwarding rules", "ip", m.targetIP, "err", err)
+		m.frLogger.V(4).Info("IP not found in forwarding rules", "ip", m.targetIP)
 	}
 
 	// Reserving the address failed due to a conflict or bad request. The address manager just checked that no address

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -189,12 +189,23 @@ func (m *Manager) removeAddress(name, reason string) error {
 // For example, running the function with argument "2001:db8::ff00:42:8329"
 // returns "2001:db8:0:0:0:ff00:42:8329".
 func DecompressAddr(addr string) string {
+	const hextetsInIPv6 = 8
 	if !strings.Contains(addr, "::") {
 		// no compression
 		return addr
 	}
 	hextets := strings.Split(addr, ":")
-	toAdd := 9 - len(hextets)
+	numOfHextets := len(hextets)
+	if numOfHextets < 3 || numOfHextets > 9 {
+		// Address not in a valid compressed form (shortest: "::" (3), longest: one hextet skipped
+		// at beginning or end (9)), returning without any changes.
+		return addr
+	}
+	// To calculate number of missing hextets, we subtract the number of hextets from number of
+	// hextets in IPv6 (8) + 1, since compressed hextets will be represented by one empty item.
+	// Note that it will be decompressed using strings.Replace, so we don't have to worry about
+	// addresses without compression.
+	toAdd := hextetsInIPv6 + 1 - numOfHextets
 	expanded := strings.Repeat(":0", toAdd) + ":"
 	if strings.HasPrefix(addr, "::") {
 		expanded = "0" + expanded
@@ -334,7 +345,7 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	}
 
 	if ok := m.IsAddressInForwardingRules(); ok {
-		return m.targetIP, IPAddrManaged, nil
+		return m.targetIP, IPAddrUnmanaged, nil
 	} else {
 		m.frLogger.V(4).Info("IP not found in forwarding rules", "ip", m.targetIP)
 	}

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -22,13 +22,14 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
+	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
-	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	compute "google.golang.org/api/compute/v1"
@@ -315,73 +316,103 @@ func TestAddressManagerIPv6(t *testing.T) {
 	}
 }
 
-// TestAddressManagerForwardingRuleConflict tests if reserving the IP fails when the IP
-// is already in use by a Forwarding Rule of another service.
-func TestAddressManagerForwardingRuleConflict(t *testing.T) {
-	t.Parallel()
-
+func TestIsAddressInForwardingRules(t *testing.T) {
 	testCases := []struct {
-		desc        string
-		serviceName string
-		hasConflict bool
+		desc           string
+		address        string
+		ipVersion      address.IPVersion
+		forwardingRule *composite.ForwardingRule
+		serviceName    string
+		wantResult     bool
 	}{
 		{
-			desc:        "No conflict, forwarding rule belongs to the same service",
-			serviceName: testSvcName,
-			hasConflict: false,
+			desc:      "match",
+			address:   "35.190.1.1",
+			ipVersion: address.IPv4Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
 		},
 		{
-			desc:        "Conflict, forwarding rule belongs to a different service",
-			serviceName: "different-service",
-			hasConflict: true,
+			desc:      "match IPv6",
+			address:   "1111:2222:3333:4444:5555::",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "1111:2222:3333:4444:5555:0:0:0", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
+		},
+		{
+			desc:      "IP addres not matching",
+			address:   "35.190.1.3",
+			ipVersion: address.IPv4Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: false,
+		},
+		{desc: "IP addres not matching IPv6",
+			address:   "2222:2222:3333:4444:5555::",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "1111:2222:3333:4444:5555:0:0:0", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: false,
+		},
+		{
+			desc:      "service name not matching",
+			address:   "35.190.1.3",
+			ipVersion: address.IPv4Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.3", Name: testLBName,
+			},
+			serviceName: "wrong-svc-name",
+			wantResult:  false,
+		},
+		{
+			desc:           "no forwarding rule",
+			address:        "35.190.1.1",
+			ipVersion:      address.IPv4Version,
+			forwardingRule: nil,
+			wantResult:     false,
+		},
+		{
+			desc:      "empty address string",
+			address:   "",
+			ipVersion: address.IPv4Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", ServiceName: testLBName,
+			},
+			wantResult: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
-
 			svc, err := fakeGCECloud(vals)
-			require.NoError(t, err)
-
-			targetIP := "10.0.0.1"
-
-			// Force a reservation conflict by pre-reserving the IP under a different address name.
-			conflictingAddr := &compute.Address{
-				Name:        "other-addr",
-				Address:     targetIP,
-				AddressType: string(cloud.SchemeInternal),
+			if err != nil {
+				t.Fatalf("fakeGCECloud(%v) returned error %v", vals, err)
 			}
-			err = svc.ReserveRegionAddress(conflictingAddr, vals.Region)
-			require.NoError(t, err)
-
-			// Create a forwarding rule associated with the target IP.
-			mockGCE := svc.Compute().(*cloud.MockGCE)
-			frName := "conflicting-fr"
-			frDesc, err := utils.MakeL4LBServiceDescription(tc.serviceName, targetIP, meta.VersionGA, false, utils.ILB)
-			require.NoError(t, err)
-
-			frKey := meta.RegionalKey(frName, vals.Region)
-			mockGCE.MockForwardingRules.Objects[*frKey] = &cloud.MockForwardingRulesObj{
-				Obj: &compute.ForwardingRule{
-					Name:        frName,
-					IPAddress:   targetIP,
-					Description: frDesc,
-				},
+			svcName := testSvcName
+			if tc.serviceName != "" {
+				svcName = tc.serviceName
 			}
 
-			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-			_, _, err = mgr.HoldAddress()
+			desc, err := utils.MakeL4LBServiceDescription(svcName, tc.address, meta.VersionGA, false, utils.ILB)
+			if err != nil {
+				t.Fatalf("MakeL4LBServiceDescription returned err %v", desc)
+			}
+			if tc.forwardingRule != nil {
+				tc.forwardingRule.Description = desc
+				mustCreateForwardingRules(t, svc, []*composite.ForwardingRule{tc.forwardingRule})
+			}
 
-			if tc.hasConflict {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "is already in use by forwarding rule")
-			} else {
-				// No conflict is returned because the forwarding rule belongs to the same service.
-				// However, since we pre-reserved the address under "other-addr" name, HoldAddress will get it, validate it,
-				// and return it as IPAddrUnmanaged.
-				assert.NoError(t, err)
+			m := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", tc.address, cloud.SchemeInternal, cloud.NetworkTierPremium, tc.ipVersion, klog.TODO())
+			got := m.IsAddressInForwardingRules()
+			if got != tc.wantResult {
+				t.Errorf("IsAddressInForwardingRules() unexpectet result, want = %v, got=%v, svc=%+v", tc.wantResult, tc.address, svc)
 			}
 		})
 	}
@@ -489,5 +520,22 @@ func TestDecompressIPv6(t *testing.T) {
 				t.Errorf("DecompressIPv6(%q) = %q; want %q", tc.addr, actual, tc.expected)
 			}
 		})
+	}
+}
+
+func mustCreateForwardingRules(t *testing.T, cloud *gce.Cloud, frs []*composite.ForwardingRule) {
+	t.Helper()
+	for _, fr := range frs {
+		mustCreateForwardingRule(t, cloud, fr)
+	}
+}
+
+func mustCreateForwardingRule(t *testing.T, cloud *gce.Cloud, fr *composite.ForwardingRule) {
+	t.Helper()
+
+	key := meta.RegionalKey(fr.Name, cloud.Region())
+	err := composite.CreateForwardingRule(cloud, key, fr, klog.TODO())
+	if err != nil {
+		t.Fatalf("composite.CreateForwardingRule(_, %s, %v) returned error %v, want nil", key, fr, err)
 	}
 }

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -484,7 +484,7 @@ func TestDecompressIPv6(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := address.DecompressIPv6(tc.addr)
+			actual := address.DecompressAddr(tc.addr)
 			if actual != tc.expected {
 				t.Errorf("DecompressIPv6(%q) = %q; want %q", tc.addr, actual, tc.expected)
 			}

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -339,7 +339,7 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 			address:   "1111:2222:3333:4444:5555::",
 			ipVersion: address.IPv6Version,
 			forwardingRule: &composite.ForwardingRule{
-				IPAddress: "1111:2222:3333:4444:5555:0:0:0", Name: testLBName, ServiceName: testSvcName,
+				IPAddress: "1111:2222:3333:4444:5555:0:0:0/96", Name: testLBName, ServiceName: testSvcName,
 			},
 			wantResult: true,
 		},

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	compute "google.golang.org/api/compute/v1"
@@ -314,6 +315,78 @@ func TestAddressManagerIPv6(t *testing.T) {
 	}
 }
 
+// TestAddressManagerForwardingRuleConflict tests if reserving the IP fails when the IP
+// is already in use by a Forwarding Rule of another service.
+func TestAddressManagerForwardingRuleConflict(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		serviceName string
+		hasConflict bool
+	}{
+		{
+			desc:        "No conflict, forwarding rule belongs to the same service",
+			serviceName: testSvcName,
+			hasConflict: false,
+		},
+		{
+			desc:        "Conflict, forwarding rule belongs to a different service",
+			serviceName: "different-service",
+			hasConflict: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			svc, err := fakeGCECloud(vals)
+			require.NoError(t, err)
+
+			targetIP := "10.0.0.1"
+
+			// Force a reservation conflict by pre-reserving the IP under a different address name.
+			conflictingAddr := &compute.Address{
+				Name:        "other-addr",
+				Address:     targetIP,
+				AddressType: string(cloud.SchemeInternal),
+			}
+			err = svc.ReserveRegionAddress(conflictingAddr, vals.Region)
+			require.NoError(t, err)
+
+			// Create a forwarding rule associated with the target IP.
+			mockGCE := svc.Compute().(*cloud.MockGCE)
+			frName := "conflicting-fr"
+			frDesc, err := utils.MakeL4LBServiceDescription(tc.serviceName, targetIP, meta.VersionGA, false, utils.ILB)
+			require.NoError(t, err)
+
+			frKey := meta.RegionalKey(frName, vals.Region)
+			mockGCE.MockForwardingRules.Objects[*frKey] = &cloud.MockForwardingRulesObj{
+				Obj: &compute.ForwardingRule{
+					Name:        frName,
+					IPAddress:   targetIP,
+					Description: frDesc,
+				},
+			}
+
+			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
+			_, _, err = mgr.HoldAddress()
+
+			if tc.hasConflict {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "is already in use by forwarding rule")
+			} else {
+				// No conflict is returned because the forwarding rule belongs to the same service.
+				// However, since we pre-reserved the address under "other-addr" name, HoldAddress will get it, validate it,
+				// and return it as IPAddrUnmanaged.
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)
@@ -349,4 +422,72 @@ func fakeGCECloud(vals gce.TestClusterValues) (*gce.Cloud, error) {
 	mockGCE.MockAlphaAddresses.X = mock.AddressAttributes{}
 	mockGCE.MockAddresses.X = mock.AddressAttributes{}
 	return gce, nil
+}
+
+func TestDecompressIPv6(t *testing.T) {
+	testCases := []struct {
+		name     string
+		addr     string
+		expected string
+	}{
+		{
+			name:     "No compression",
+			addr:     "2001:db8:1:2:3:ff00:42:8329",
+			expected: "2001:db8:1:2:3:ff00:42:8329",
+		},
+		{
+			name:     "Compression in middle",
+			addr:     "2001:db8::ff00:42:8329",
+			expected: "2001:db8:0:0:0:ff00:42:8329",
+		},
+		{
+			name:     "Compression in middle (Short)",
+			addr:     "1:2::3",
+			expected: "1:2:0:0:0:0:0:3",
+		},
+		{
+			name:     "Compression in middle (single hextet)",
+			addr:     "1:2:3:4::6:7:8",
+			expected: "1:2:3:4:0:6:7:8",
+		},
+		{
+			name:     "Match-all",
+			addr:     "::",
+			expected: "0:0:0:0:0:0:0:0",
+		},
+		{
+			name:     "Loopback",
+			addr:     "::1",
+			expected: "0:0:0:0:0:0:0:1",
+		},
+		{
+			name:     "Compression at beginning",
+			addr:     "::ff00:42:8329",
+			expected: "0:0:0:0:0:ff00:42:8329",
+		},
+		{
+			name:     "Compression at end",
+			addr:     "2001:db8::",
+			expected: "2001:db8:0:0:0:0:0:0",
+		},
+		{
+			name:     "Compression at beginning (single hextet)",
+			addr:     "::db8:1:2:3:ff00:42:8329",
+			expected: "0:db8:1:2:3:ff00:42:8329",
+		},
+		{
+			name:     "Compression at end (single hextet)",
+			addr:     "2001:db8:1:2:3:ff00:42::",
+			expected: "2001:db8:1:2:3:ff00:42:0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := address.DecompressIPv6(tc.addr)
+			if actual != tc.expected {
+				t.Errorf("DecompressIPv6(%q) = %q; want %q", tc.addr, actual, tc.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This change aims to improve static IP assignment by avoiding triggering quota `filtered_list_cost_overhead_per_region` (https://docs.cloud.google.com/compute/api-quota).