### PR TITLE
Standalone L4 NEG controller metrics

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -340,6 +340,7 @@ func main() {
 		MaxIGSize:                            flags.F.MaxIGSize,
 		RunL4ILBController:                   flags.F.RunL4Controller,
 		RunL4NetLBController:                 flags.F.RunL4NetLBController,
+		RunL4StandaloneNEGController:         flags.F.RunL4StandaloneNEGController,
 		EnableL4ILBDualStack:                 flags.F.EnableL4ILBDualStack,
 		EnableL4NetLBDualStack:               flags.F.EnableL4NetLBDualStack,
 		EnableL4StrongSessionAffinity:        flags.F.EnableL4StrongSessionAffinity,
@@ -371,7 +372,7 @@ func main() {
 		id: fmt.Sprintf("%v_%x", hostname, rand.Intn(1e6)),
 	}
 
-	enableL4Controllers := flags.F.RunL4Controller || flags.F.RunL4NetLBController || flags.F.EnableIGController || flags.F.EnablePSC
+	enableL4Controllers := flags.F.RunL4Controller || flags.F.RunL4NetLBController || flags.F.EnableIGController || flags.F.EnablePSC || flags.F.RunL4StandaloneNEGController
 	runNEG := func() {
 		logger := rootLogger.WithName("NEGController")
 		logger.Info("Start running the enabled controllers",
@@ -619,7 +620,7 @@ func runIngressControllers(ctx *ingctx.ControllerContext, systemHealth *systemhe
 }
 
 func runL4Controllers(ctx *ingctx.ControllerContext, systemHealth *systemhealth.SystemHealth, option runOption, leOption leaderElectionOption, logger klog.Logger) {
-	if !flags.F.RunL4Controller && !flags.F.EnablePSC && !flags.F.EnableIGController && !flags.F.RunL4NetLBController {
+	if !flags.F.RunL4Controller && !flags.F.EnablePSC && !flags.F.EnableIGController && !flags.F.RunL4NetLBController && !flags.F.RunL4StandaloneNEGController {
 		return
 	}
 
@@ -663,7 +664,7 @@ func runL4Controllers(ctx *ingctx.ControllerContext, systemHealth *systemhealth.
 		logger.V(0).Info("L4NetLB controller started")
 	}
 
-	if flags.F.RunL4StandaloneNEGLBController {
+	if flags.F.RunL4StandaloneNEGController {
 		standaloneNEGLBController := controllers.NewStandaloneNEGLBController(ctx, option.stopCh, logger)
 		runWithWg(standaloneNEGLBController.Run, option.wg)
 		logger.V(0).Info("L4 Standalone NEG LB controller started")

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -127,6 +127,7 @@ type ControllerContextConfig struct {
 	MaxIGSize                            int
 	RunL4ILBController                   bool
 	RunL4NetLBController                 bool
+	RunL4StandaloneNEGController         bool
 	EnableL4ILBDualStack                 bool
 	EnableL4NetLBDualStack               bool
 	EnableL4StrongSessionAffinity        bool
@@ -374,7 +375,7 @@ func (ctx *ControllerContext) Start(stopCh <-chan struct{}) {
 	// Export ingress usage metrics.
 	go ctx.ControllerMetrics.Run(stopCh)
 
-	if runL4 := ctx.RunL4ILBController || ctx.RunL4NetLBController; runL4 {
+	if runL4 := ctx.RunL4ILBController || ctx.RunL4NetLBController || ctx.RunL4StandaloneNEGController; runL4 {
 		// Export L4LB usage metrics
 		go ctx.L4Metrics.Run(stopCh)
 	}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -56,45 +56,45 @@ const (
 
 // F are global flags for the controller.
 var F = struct {
-	APIServerHost                  string
-	ClusterName                    string
-	ConfigFilePath                 string
-	DefaultSvc                     string
-	DefaultSvcHealthCheckPath      string
-	DefaultSvcPortName             string
-	GCEOperationPollInterval       time.Duration
-	GCERateLimit                   RateLimitSpecs
-	GCERateLimitScale              float64
-	GKEClusterName                 string
-	GKEClusterHash                 string
-	GKEClusterType                 string
-	HealthCheckPath                string
-	HealthzPort                    int
-	THCPort                        int
-	InCluster                      bool
-	IngressClass                   string
-	KubeConfigFile                 string
-	NegGCPeriod                    time.Duration
-	NumNegGCWorkers                int
-	NodePortRanges                 PortRanges
-	ResyncPeriod                   time.Duration
-	L4NetLBProvisionDeadline       time.Duration
-	NumL4Workers                   int
-	NumL4NetLBWorkers              int
-	NumIngressWorkers              int
-	RunIngressController           bool
-	RunL4Controller                bool
-	RunL4NetLBController           bool
-	RunL4StandaloneNEGLBController bool
-	EnableIGController             bool
-	Version                        bool
-	WatchNamespace                 string
-	LeaderElection                 LeaderElectionConfiguration
-	MetricsExportInterval          time.Duration
-	NegMetricsExportInterval       time.Duration
-	KubeClientQPS                  float32
-	KubeClientBurst                int
-	ReadOnlyMode                   bool
+	APIServerHost                string
+	ClusterName                  string
+	ConfigFilePath               string
+	DefaultSvc                   string
+	DefaultSvcHealthCheckPath    string
+	DefaultSvcPortName           string
+	GCEOperationPollInterval     time.Duration
+	GCERateLimit                 RateLimitSpecs
+	GCERateLimitScale            float64
+	GKEClusterName               string
+	GKEClusterHash               string
+	GKEClusterType               string
+	HealthCheckPath              string
+	HealthzPort                  int
+	THCPort                      int
+	InCluster                    bool
+	IngressClass                 string
+	KubeConfigFile               string
+	NegGCPeriod                  time.Duration
+	NumNegGCWorkers              int
+	NodePortRanges               PortRanges
+	ResyncPeriod                 time.Duration
+	L4NetLBProvisionDeadline     time.Duration
+	NumL4Workers                 int
+	NumL4NetLBWorkers            int
+	NumIngressWorkers            int
+	RunIngressController         bool
+	RunL4Controller              bool
+	RunL4NetLBController         bool
+	RunL4StandaloneNEGController bool
+	EnableIGController           bool
+	Version                      bool
+	WatchNamespace               string
+	LeaderElection               LeaderElectionConfiguration
+	MetricsExportInterval        time.Duration
+	NegMetricsExportInterval     time.Duration
+	KubeClientQPS                float32
+	KubeClientBurst              int
+	ReadOnlyMode                 bool
 
 	// Feature flags should be named Enablexxx.
 	EnableNonGCPMode                            bool
@@ -309,7 +309,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunIngressController, "run-ingress-controller", true, `Optional, if enabled then the ingress controller will be run.`)
 	flag.BoolVar(&F.RunL4Controller, "run-l4-controller", false, `Optional, whether or not to run L4 Service Controller as part of glbc. If set to true, services of Type:LoadBalancer with Internal annotation will be processed by this controller.`)
 	flag.BoolVar(&F.RunL4NetLBController, "run-l4-netlb-controller", false, `Optional, if enabled then the L4NetLbController will be run.`)
-	flag.BoolVar(&F.RunL4StandaloneNEGLBController, "run-l4-standalone-neg-controller", false, `Optional, if enabled then the Standalone NEG L4 LB controller will be run.`)
+	flag.BoolVar(&F.RunL4StandaloneNEGController, "run-l4-standalone-neg-controller", false, `Optional, if enabled then the Standalone NEG L4 LB controller will be run.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
 	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
 	flag.BoolVar(&F.EnableL4NetLBNEG, "enable-l4-netlb-neg", false, `Optional, if enabled then the NetLB controller can create L4 NetLB services with NEG backends.`)

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -25,15 +25,44 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/composite"
 	ccontext "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
+	l4metrics "k8s.io/ingress-gce/pkg/l4/metrics"
+	"k8s.io/ingress-gce/pkg/l4/resources"
+	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
 )
+
+var (
+	// supportedLBSchemes is a list of supported LB schemes. Only Forwarding rules
+	// with these schemes can be referenced in a L4 standalone NEG service.
+	supportedLBSchemes = []string{
+		string(cloud.SchemeExternal),
+		"EXTERNAL_PASSTHROUGH",
+	}
+	// supportedFRProtocols is a list of supported protocols. Only Forwarding
+	// rules with these protocols can be referenced in a L4 standalone NEG
+	// service.
+	supportedFRProtocols = []string{
+		"TCP",
+		"UDP",
+		"L3_DEFAULT",
+	}
+)
+
+func isSchemeSupported(lbScheme string) bool {
+	return slices.Contains(supportedLBSchemes, lbScheme)
+}
+
+func isFRProtocolSupported(protocol string) bool {
+	return slices.Contains(supportedFRProtocols, protocol)
+}
 
 type parsedForwardingRule struct {
 	key     *meta.Key
@@ -62,15 +91,40 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 
 	ctx.ServiceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			svc := obj.(*v1.Service)
+			svc, ok := obj.(*v1.Service)
+			if !ok {
+				return
+			}
 			if lc.shouldProcess(svc) {
 				lc.enqueue(svc)
 			}
 		},
 		UpdateFunc: func(old, cur interface{}) {
-			curSvc := cur.(*v1.Service)
-			if lc.shouldProcess(curSvc) {
+			curSvc, ok := cur.(*v1.Service)
+			if !ok {
+				return
+			}
+			oldSvc, okOld := old.(*v1.Service)
+			if okOld && lc.shouldProcess(oldSvc) || lc.shouldProcess(curSvc) {
 				lc.enqueue(curSvc)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc, ok := obj.(*v1.Service)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					logger.Error(nil, "unexpected object type in DeleteFunc", "type", fmt.Sprintf("%T", obj))
+					return
+				}
+				svc, ok = tombstone.Obj.(*v1.Service)
+				if !ok {
+					logger.Error(nil, "unexpected object type in tombstone in DeleteFunc", "type", fmt.Sprintf("%T", tombstone.Obj))
+					return
+				}
+			}
+			if lc.shouldProcess(svc) {
+				lc.enqueue(svc)
 			}
 		},
 	})
@@ -79,6 +133,9 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 }
 
 func (lc *StandaloneNEGLBController) shouldProcess(svc *v1.Service) bool {
+	if svc == nil {
+		return false
+	}
 	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
 	}
@@ -113,18 +170,27 @@ func (lc *StandaloneNEGLBController) sync(key string) error {
 		return fmt.Errorf("failed to lookup service for key %s: %w", key, err)
 	}
 	if !exists || obj == nil {
+		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
 		return nil
 	}
 	svc := obj.(*v1.Service)
+	svcLogger := lc.logger.WithValues("service", klog.KObj(svc))
+
 	if svc.DeletionTimestamp != nil {
+		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
 		return nil
 	}
 	if !lc.shouldProcess(svc) {
+		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
+		if err := lc.clearStatusIngressIP(svc, svcLogger); err != nil {
+			return err
+		}
 		return nil
 	}
-	svcLogger := lc.logger.WithValues("service", klog.KObj(svc))
 
-	return lc.syncStandaloneNEGLB(svc, svcLogger)
+	schemes, err := lc.syncStandaloneNEGLB(svc, svcLogger)
+	lc.publishMetrics(key, schemes, err)
+	return err
 }
 
 func (lc *StandaloneNEGLBController) parseForwardingRuleKeys(frNamesStr string, svcLogger klog.Logger) ([]parsedForwardingRule, []error) {
@@ -158,30 +224,33 @@ func (lc *StandaloneNEGLBController) parseForwardingRuleKeys(frNamesStr string, 
 }
 
 func validateForwardingRule(fr *composite.ForwardingRule, frName string) error {
-	if fr.LoadBalancingScheme != string(cloud.SchemeExternal) {
-		return fmt.Errorf("forwarding rule %s has unsupported load balancing scheme: %s", frName, fr.LoadBalancingScheme)
+	var errs []error
+	if !isSchemeSupported(fr.LoadBalancingScheme) {
+		errs = append(errs, fmt.Errorf("forwarding rule %s has unsupported load balancing scheme: %s, supported schemes are: %s", frName, fr.LoadBalancingScheme, strings.Join(supportedLBSchemes, ", ")))
 	}
-	if fr.IPProtocol != "TCP" && fr.IPProtocol != "UDP" && fr.IPProtocol != "L3_DEFAULT" {
-		return fmt.Errorf("forwarding rule %s has unsupported protocol: %s", frName, fr.IPProtocol)
+	if !isFRProtocolSupported(fr.IPProtocol) {
+		errs = append(errs, fmt.Errorf("forwarding rule %s has unsupported protocol: %s, supported protocols are: %s", frName, fr.IPProtocol, strings.Join(supportedFRProtocols, ", ")))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
-func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) error {
+func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) (lbSchemes []string, err error) {
 	frNamesStr, ok := svc.Annotations[annotations.CustomForwardingRuleKey]
 	if !ok || frNamesStr == "" {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
 		svcLogger.V(4).Info("Service has no forwarding rule reference, skipping")
 		err := lc.clearStatusIngressIP(svc, svcLogger)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+		return nil, l4utils.NewUserError(fmt.Errorf("service has no forwarding rule reference annotation %s", annotations.CustomForwardingRuleKey))
 	}
 
 	parsedRules, parseErrs := lc.parseForwardingRuleKeys(frNamesStr, svcLogger)
 	var errs []error
-	errs = append(errs, parseErrs...)
+	for _, parseErr := range parseErrs {
+		errs = append(errs, l4utils.NewUserError(parseErr))
+	}
 
 	if len(parsedRules) == 0 {
 		err := lc.clearStatusIngressIP(svc, svcLogger)
@@ -190,31 +259,36 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		}
 		if len(errs) > 0 {
 			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule %s", errors.Join(errs...).Error())
-			return errors.Join(errs...)
+			return nil, errors.Join(errs...)
 		}
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
-		return nil
+		return nil, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation"))
 	}
 
 	var lbIngresses []v1.LoadBalancerIngress
 	vipMode := v1.LoadBalancerIPModeVIP
+	var schemes []string
 
 	for _, parsed := range parsedRules {
 		fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsed.key, meta.VersionGA, svcLogger)
 		if err != nil {
 			svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
+			if utils.IsNotFoundError(err) {
+				err = l4utils.NewUserError(err)
+			}
 			errs = append(errs, err)
 			continue
 		}
 
+		schemes = append(schemes, fr.LoadBalancingScheme)
+
 		if err := validateForwardingRule(fr, parsed.rawName); err != nil {
 			svcLogger.Error(err, "invalid forwarding rule", "frName", parsed.rawName)
-			errs = append(errs, err)
+			errs = append(errs, l4utils.NewUserError(err))
 			continue
 		}
 
 		lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: fr.IPAddress, IPMode: &vipMode})
-
 	}
 
 	if len(errs) > 0 {
@@ -227,7 +301,7 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		if err != nil {
 			errs = append(errs, err)
 		}
-		return errors.Join(errs...)
+		return schemes, errors.Join(errs...)
 	}
 
 	newStatus := &v1.LoadBalancerStatus{
@@ -235,13 +309,13 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	}
 
 	if err := updateServiceStatus(lc.ctx, svc, newStatus, nil, svcLogger); err != nil {
-		return err
+		return schemes, err
 	}
 
 	if len(errs) > 0 {
-		return errors.Join(errs...)
+		return schemes, errors.Join(errs...)
 	}
-	return nil
+	return schemes, nil
 }
 
 func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {
@@ -256,4 +330,25 @@ func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLo
 		return err
 	}
 	return nil
+}
+
+func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string, syncErr error) {
+	state := l4metrics.L4StandaloneNEGServiceState{
+		Status: l4metrics.StatusSuccess,
+	}
+	if syncErr != nil {
+		if resources.IsUserError(syncErr) {
+			state.Status = l4metrics.StatusUserError
+		} else {
+			state.Status = l4metrics.StatusError
+			now := time.Now()
+			state.FirstSyncErrorTime = &now
+		}
+	}
+
+	state.LBSchemeExternal = slices.Contains(schemes, "EXTERNAL")
+	state.LBSchemeExternalPassthrough = slices.Contains(schemes, "EXTERNAL_PASSTHROUGH")
+	state.LBSchemeInternal = slices.Contains(schemes, "INTERNAL")
+
+	lc.ctx.L4Metrics.SetL4StandaloneNEGService(key, state)
 }

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -22,15 +22,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
+	l4metrics "k8s.io/ingress-gce/pkg/l4/metrics"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
@@ -306,6 +309,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					LoadBalancerClass: &lbClass,
 				},
 			},
+			expectError:        true,
 			expectEventReasons: []string{"NoForwardingRuleRef"},
 		},
 		{
@@ -323,6 +327,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					LoadBalancerClass: &lbClass,
 				},
 			},
+			expectError:        true,
 			expectEventReasons: []string{"NoForwardingRuleRef"},
 		},
 		{
@@ -340,6 +345,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					LoadBalancerClass: &lbClass,
 				},
 			},
+			expectError:        true,
 			expectEventReasons: []string{"NoForwardingRuleRef"},
 		},
 		{
@@ -361,7 +367,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			expectEventReasons: []string{"ForwardingRuleUnusable"},
 		},
 		{
-			desc: "Service with Type != ServiceTypeLoadBalancer is ignored",
+			desc: "Clear status ingress IP when Service type is not LoadBalancer",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc-not-lb",
@@ -393,7 +399,6 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					Version:             meta.VersionGA,
 				},
 			},
-			expectIPs:   []string{"1.2.3.4"},
 			expectError: false,
 		},
 		{
@@ -416,6 +421,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				},
 			},
 			expectIPs:          nil,
+			expectError:        true,
 			expectEventReasons: []string{"NoForwardingRuleRef"},
 		},
 		{
@@ -478,6 +484,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				},
 			},
 			expectIPs:          nil,
+			expectError:        true,
 			expectEventReasons: []string{"NoForwardingRuleRef"},
 		},
 		{
@@ -621,14 +628,23 @@ func TestValidateForwardingRule(t *testing.T) {
 			expectError: false,
 		},
 		{
-			desc: "Internal scheme unsupported",
+			desc: "Internal scheme not supported",
 			fr: &composite.ForwardingRule{
 				LoadBalancingScheme: "INTERNAL",
 				IPProtocol:          "TCP",
 			},
 			frName:         "internal-scheme",
 			expectError:    true,
-			expectErrorMsg: "forwarding rule internal-scheme has unsupported load balancing scheme: INTERNAL",
+			expectErrorMsg: "forwarding rule internal-scheme has unsupported load balancing scheme: INTERNAL, supported schemes are: EXTERNAL, EXTERNAL_PASSTHROUGH",
+		},
+		{
+			desc: "Valid EXTERNAL_PASSTHROUGH rule",
+			fr: &composite.ForwardingRule{
+				LoadBalancingScheme: "EXTERNAL_PASSTHROUGH",
+				IPProtocol:          "TCP",
+			},
+			frName:      "valid-ext-passthrough",
+			expectError: false,
 		},
 		{
 			desc: "Unsupported scheme",
@@ -638,7 +654,7 @@ func TestValidateForwardingRule(t *testing.T) {
 			},
 			frName:         "invalid-scheme",
 			expectError:    true,
-			expectErrorMsg: "forwarding rule invalid-scheme has unsupported load balancing scheme: INTERNAL_SELF_MANAGED",
+			expectErrorMsg: "forwarding rule invalid-scheme has unsupported load balancing scheme: INTERNAL_SELF_MANAGED, supported schemes are: EXTERNAL, EXTERNAL_PASSTHROUGH",
 		},
 		{
 			desc: "Unsupported protocol",
@@ -648,7 +664,7 @@ func TestValidateForwardingRule(t *testing.T) {
 			},
 			frName:         "invalid-protocol",
 			expectError:    true,
-			expectErrorMsg: "forwarding rule invalid-protocol has unsupported protocol: ESP",
+			expectErrorMsg: "forwarding rule invalid-protocol has unsupported protocol: ESP, supported protocols are: TCP, UDP, L3_DEFAULT",
 		},
 	}
 
@@ -662,5 +678,451 @@ func TestValidateForwardingRule(t *testing.T) {
 				t.Errorf("validateForwardingRule() error message = %q, expected = %q", err.Error(), tc.expectErrorMsg)
 			}
 		})
+	}
+}
+
+func setupControllerContext(t *testing.T) (*fake.Clientset, *gce.Cloud, *StandaloneNEGLBController, chan struct{}) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
+	namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
+
+	stopCh := make(chan struct{})
+
+	ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
+	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to create controller context: %v", err)
+	}
+
+	lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
+	return kubeClient, fakeGCE, lc, stopCh
+}
+
+func TestStandaloneNEGLBControllerMetrics_Success(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+	frName := "custom-fr"
+	frIP := "10.0.0.100"
+	project := "test-project"
+	region := "us-central1"
+	bsURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs1", project, region)
+
+	kubeClient, fakeGCE, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	// Create a valid forwarding rule
+	key, err := composite.CreateKey(fakeGCE, frName, meta.Regional)
+	if err != nil {
+		t.Fatalf("Failed to create key for forwarding rule: %v", err)
+	}
+	fr := &composite.ForwardingRule{
+		Name:                frName,
+		IPAddress:           frIP,
+		BackendService:      bsURL,
+		LoadBalancingScheme: "EXTERNAL",
+		IPProtocol:          "TCP",
+		Scope:               meta.Regional,
+		Version:             meta.VersionGA,
+	}
+	err = composite.CreateForwardingRule(fakeGCE, key, fr, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to create forwarding rule: %v", err)
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.CustomForwardingRuleKey: frName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	// Add service to informer and fake kube client
+	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
+	kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	err = lc.sync(svcKey)
+	if err != nil {
+		t.Fatalf("sync() error = %v", err)
+	}
+
+	state, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+	if !ok {
+		t.Fatalf("Expected service %s in metrics map", svcKey)
+	}
+	if state.Status != l4metrics.StatusSuccess {
+		t.Errorf("Expected status %s, got %s", l4metrics.StatusSuccess, state.Status)
+	}
+	if !state.LBSchemeExternal {
+		t.Errorf("Expected LBSchemeExternal to be true")
+	}
+}
+
+func TestStandaloneNEGLBControllerMetrics_UserError(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+	frName := "custom-fr"
+	frIP := "10.0.0.100"
+	project := "test-project"
+	region := "us-central1"
+	bsURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs1", project, region)
+
+	kubeClient, fakeGCE, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	// Create a forwarding rule with invalid scheme
+	key, err := composite.CreateKey(fakeGCE, frName, meta.Regional)
+	if err != nil {
+		t.Fatalf("Failed to create key for forwarding rule: %v", err)
+	}
+	fr := &composite.ForwardingRule{
+		Name:                frName,
+		IPAddress:           frIP,
+		BackendService:      bsURL,
+		LoadBalancingScheme: "INTERNAL_SELF_MANAGED", // Invalid
+		IPProtocol:          "TCP",
+		Scope:               meta.Regional,
+		Version:             meta.VersionGA,
+	}
+	err = composite.CreateForwardingRule(fakeGCE, key, fr, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to create forwarding rule: %v", err)
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.CustomForwardingRuleKey: frName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
+	kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	err = lc.sync(svcKey)
+	if err == nil {
+		t.Fatalf("Expected sync to fail")
+	}
+
+	state, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+	if !ok {
+		t.Fatalf("Expected service %s in metrics map", svcKey)
+	}
+	if state.Status != l4metrics.StatusUserError {
+		t.Errorf("Expected status %s, got %s", l4metrics.StatusUserError, state.Status)
+	}
+}
+
+func TestStandaloneNEGLBControllerMetrics_SystemError(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+	frName := "custom-fr"
+
+	kubeClient, fakeGCE, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	// Create a valid forwarding rule key
+	key, err := composite.CreateKey(fakeGCE, frName, meta.Regional)
+	if err != nil {
+		t.Fatalf("Failed to create key for forwarding rule: %v", err)
+	}
+
+	// Inject GCE error
+	mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+	if mockGCE.MockForwardingRules.GetError == nil {
+		mockGCE.MockForwardingRules.GetError = make(map[meta.Key]error)
+	}
+	mockGCE.MockForwardingRules.GetError[*key] = fmt.Errorf("internal GCE error")
+	defer delete(mockGCE.MockForwardingRules.GetError, *key)
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.CustomForwardingRuleKey: frName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
+	kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	err = lc.sync(svcKey)
+	if err == nil {
+		t.Fatalf("Expected sync to fail due to GCE error")
+	}
+
+	state, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+	if !ok {
+		t.Fatalf("Expected service %s in metrics map", svcKey)
+	}
+	if state.Status != l4metrics.StatusError {
+		t.Errorf("Expected status %s, got %s", l4metrics.StatusError, state.Status)
+	}
+	if state.FirstSyncErrorTime == nil {
+		t.Errorf("Expected FirstSyncErrorTime to be set for system error")
+	}
+}
+
+func TestStandaloneNEGLBControllerMetrics_Deletion(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+	frName := "custom-fr"
+	frIP := "10.0.0.100"
+	project := "test-project"
+	region := "us-central1"
+	bsURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs1", project, region)
+
+	kubeClient, fakeGCE, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	// Create a valid forwarding rule
+	key, err := composite.CreateKey(fakeGCE, frName, meta.Regional)
+	if err != nil {
+		t.Fatalf("Failed to create key for forwarding rule: %v", err)
+	}
+	fr := &composite.ForwardingRule{
+		Name:                frName,
+		IPAddress:           frIP,
+		BackendService:      bsURL,
+		LoadBalancingScheme: "EXTERNAL",
+		IPProtocol:          "TCP",
+		Scope:               meta.Regional,
+		Version:             meta.VersionGA,
+	}
+	err = composite.CreateForwardingRule(fakeGCE, key, fr, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to create forwarding rule: %v", err)
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.CustomForwardingRuleKey: frName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	// Add service to informer and fake kube client
+	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
+	kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	// Initial sync to establish state in metrics
+	err = lc.sync(svcKey)
+	if err != nil {
+		t.Fatalf("sync() error = %v", err)
+	}
+	_, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+	if !ok {
+		t.Fatalf("Expected service %s in metrics map", svcKey)
+	}
+
+	// Act - Deletion
+	err = kubeClient.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete service: %v", err)
+	}
+	lc.ctx.ServiceInformer.GetIndexer().Delete(svc)
+
+	err = lc.sync(svcKey)
+	if err != nil {
+		t.Fatalf("sync() error = %v", err)
+	}
+
+	// Assert
+	_, ok = lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+	if ok {
+		t.Errorf("Expected service %s to be removed from metrics map", svcKey)
+	}
+}
+
+func TestStandaloneNEGLBControllerEventHandlers_Add(t *testing.T) {
+	kubeClient, _, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	// Start the informer
+	go lc.ctx.ServiceInformer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, lc.ctx.ServiceInformer.HasSynced) {
+		t.Fatalf("Failed to sync cache")
+	}
+
+	// Start the queue workers
+	go lc.svcQueue.Run()
+	defer lc.svcQueue.Shutdown()
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: new(annotations.StandalonePassthroughNegLoadBalancerClass),
+		},
+	}
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	// Act
+	_, err := kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Assert - Wait for metrics to be updated (should be UserError because no annotation)
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		state, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+		return ok && state.Status == l4metrics.StatusUserError, nil
+	})
+	if err != nil {
+		t.Errorf("Failed to verify AddFunc via metrics: %v", err)
+	}
+}
+
+func TestStandaloneNEGLBControllerEventHandlers_Update(t *testing.T) {
+	kubeClient, _, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: new(annotations.StandalonePassthroughNegLoadBalancerClass),
+		},
+	}
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	// Setup initial state (service exists and is enqueued/processed once)
+	_, err := kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Start the informer
+	go lc.ctx.ServiceInformer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, lc.ctx.ServiceInformer.HasSynced) {
+		t.Fatalf("Failed to sync cache")
+	}
+
+	// Start the queue workers
+	go lc.svcQueue.Run()
+	defer lc.svcQueue.Shutdown()
+
+	// Wait for initial metrics to be created
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		_, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+		return ok, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to establish initial metrics state: %v", err)
+	}
+
+	// Act - Modify to not match shouldProcess (remove load balancer class)
+	currentSvc, err := kubeClient.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get service: %v", err)
+	}
+	currentSvc.Spec.LoadBalancerClass = nil
+	_, err = kubeClient.CoreV1().Services(svc.Namespace).Update(context.TODO(), currentSvc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update service: %v", err)
+	}
+
+	// Assert - Wait for metrics to be deleted
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		_, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+		return !ok, nil
+	})
+	if err != nil {
+		t.Errorf("Failed to verify UpdateFunc (non-matching) via metrics: %v", err)
+	}
+}
+
+func TestStandaloneNEGLBControllerEventHandlers_Delete(t *testing.T) {
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
+
+	kubeClient, _, lc, stopCh := setupControllerContext(t)
+	defer close(stopCh)
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+	svcKey := svc.Namespace + "/" + svc.Name
+
+	// Setup initial state
+	_, err := kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Start the informer
+	go lc.ctx.ServiceInformer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, lc.ctx.ServiceInformer.HasSynced) {
+		t.Fatalf("Failed to sync cache")
+	}
+
+	// Start the queue workers
+	go lc.svcQueue.Run()
+	defer lc.svcQueue.Shutdown()
+
+	// Wait for initial metrics to be created
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		_, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+		return ok, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to establish initial metrics state: %v", err)
+	}
+
+	// Act - Delete service
+	err = kubeClient.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete service: %v", err)
+	}
+
+	// Assert - Wait for metrics to be deleted
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		_, ok := lc.ctx.L4Metrics.StandaloneNEGServiceState(svcKey)
+		return !ok, nil
+	})
+	if err != nil {
+		t.Errorf("Failed to verify DeleteFunc via metrics: %v", err)
 	}
 }

--- a/pkg/l4/metrics/collector.go
+++ b/pkg/l4/metrics/collector.go
@@ -20,6 +20,8 @@ type Collector struct {
 	l4ILBServiceMap map[string]L4ServiceState
 	// l4NetLBServiceMap is a map between service key and L4 NetLB service state.
 	l4NetLBServiceMap map[string]L4ServiceState
+	// l4StandaloneNEGServiceMap is a map between service key and L4 Standalone NEG service state.
+	l4StandaloneNEGServiceMap map[string]L4StandaloneNEGServiceState
 
 	sync.Mutex
 
@@ -40,6 +42,7 @@ func NewCollector(exportInterval, l4NetLBProvisionDeadline time.Duration, enable
 		l4NetLBServiceLegacyMap:                 make(map[string]L4NetLBServiceLegacyState),
 		l4ILBServiceMap:                         make(map[string]L4ServiceState),
 		l4NetLBServiceMap:                       make(map[string]L4ServiceState),
+		l4StandaloneNEGServiceMap:               make(map[string]L4StandaloneNEGServiceState),
 		l4NetLBProvisionDeadlineForLegacyMetric: l4NetLBProvisionDeadline,
 		enableILBDualStack:                      enableILBDualStack,
 		enableNetLBDualStack:                    enableNetLBDualStack,
@@ -78,4 +81,5 @@ func (c *Collector) export() {
 	c.exportIPv4()
 	c.exportDualStack()
 	c.exportLegacy()
+	c.exportStandaloneNEG()
 }

--- a/pkg/l4/metrics/metrics.go
+++ b/pkg/l4/metrics/metrics.go
@@ -247,6 +247,8 @@ func init() {
 	prometheus.MustRegister(l4ILBCount)
 	klog.V(3).Infof("Registering L4 NetLB usage metrics %v", l4NetLBCount)
 	prometheus.MustRegister(l4NetLBCount)
+	klog.V(3).Infof("Registering L4 Standalone NEG usage metrics %v", l4StandaloneNEGCount)
+	prometheus.MustRegister(l4StandaloneNEGCount)
 }
 
 // PublishILBSyncMetrics exports metrics related to the L4 ILB sync.

--- a/pkg/l4/metrics/standalone_neg_metrics.go
+++ b/pkg/l4/metrics/standalone_neg_metrics.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+)
+
+// L4StandaloneNEGServiceState tracks the state of an L4 Standalone NEG Service.
+type L4StandaloneNEGServiceState struct {
+	Status                      L4ServiceStatus
+	LBSchemeExternal            bool
+	LBSchemeExternalPassthrough bool
+	LBSchemeInternal            bool
+	FirstSyncErrorTime          *time.Time
+}
+
+var (
+	l4StandaloneNEGCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "l4_standalone_neg_lbs_count",
+			Help: "Metric containing the number of L4 Standalone NEG LBs that can be filtered by scheme labels and status",
+		},
+		[]string{"status", "lb_scheme_external", "lb_scheme_external_passthrough", "lb_scheme_internal"},
+	)
+)
+
+// SetL4StandaloneNEGService adds/updates L4 Standalone NEG service state for given service key.
+func (c *Collector) SetL4StandaloneNEGService(svcKey string, state L4StandaloneNEGServiceState) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.l4StandaloneNEGServiceMap == nil {
+		klog.Fatalf("L4 Standalone NEG Metrics failed to initialize correctly.")
+	}
+
+	if state.Status == StatusError {
+		if previousState, ok := c.l4StandaloneNEGServiceMap[svcKey]; ok && previousState.FirstSyncErrorTime != nil {
+			// If service is in Error state and retry timestamp was set then do not update it.
+			state.FirstSyncErrorTime = previousState.FirstSyncErrorTime
+		}
+	}
+	c.l4StandaloneNEGServiceMap[svcKey] = state
+}
+
+// DeleteL4StandaloneNEGService removes the given L4 Standalone NEG service key.
+func (c *Collector) DeleteL4StandaloneNEGService(svcKey string) {
+	c.Lock()
+	defer c.Unlock()
+
+	delete(c.l4StandaloneNEGServiceMap, svcKey)
+}
+
+// StandaloneNEGServiceState returns the state of the given service key (used for testing).
+func (c *Collector) StandaloneNEGServiceState(svcKey string) (L4StandaloneNEGServiceState, bool) {
+	c.Lock()
+	defer c.Unlock()
+
+	state, ok := c.l4StandaloneNEGServiceMap[svcKey]
+	return state, ok
+}
+
+func (c *Collector) exportStandaloneNEG() {
+	c.Lock()
+	defer c.Unlock()
+	c.logger.V(3).Info("Exporting L4 Standalone NEG usage metrics for services", "serviceCount", len(c.l4StandaloneNEGServiceMap))
+	l4StandaloneNEGCount.Reset()
+	for _, svcState := range c.l4StandaloneNEGServiceMap {
+		l4StandaloneNEGCount.With(prometheus.Labels{
+			"status":                         string(getStandaloneStatusConsideringPersistentError(&svcState)),
+			"lb_scheme_external":             strconv.FormatBool(svcState.LBSchemeExternal),
+			"lb_scheme_external_passthrough": strconv.FormatBool(svcState.LBSchemeExternalPassthrough),
+			"lb_scheme_internal":             strconv.FormatBool(svcState.LBSchemeInternal),
+		}).Inc()
+	}
+	c.logger.V(3).Info("L4 Standalone NEG usage metrics exported")
+}
+
+func getStandaloneStatusConsideringPersistentError(state *L4StandaloneNEGServiceState) L4ServiceStatus {
+	if state.Status == StatusError &&
+		state.FirstSyncErrorTime != nil &&
+		time.Since(*state.FirstSyncErrorTime) >= persistentErrorThresholdTime {
+		return StatusPersistentError
+	}
+	return state.Status
+}

--- a/pkg/l4/metrics/standalone_neg_metrics_test.go
+++ b/pkg/l4/metrics/standalone_neg_metrics_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestExportStandaloneNEGMetric_Success(t *testing.T) {
+	newMetrics := NewFakeCollector()
+
+	newMetrics.SetL4StandaloneNEGService("svc-success-external", L4StandaloneNEGServiceState{
+		Status:           StatusSuccess,
+		LBSchemeExternal: true,
+	})
+	newMetrics.SetL4StandaloneNEGService("svc-success-external-passthrough", L4StandaloneNEGServiceState{
+		Status:                      StatusSuccess,
+		LBSchemeExternalPassthrough: true,
+	})
+	newMetrics.SetL4StandaloneNEGService("svc-success-internal", L4StandaloneNEGServiceState{
+		Status:           StatusSuccess,
+		LBSchemeInternal: true,
+	})
+	newMetrics.SetL4StandaloneNEGService("svc-success-multiple-schemes", L4StandaloneNEGServiceState{
+		Status:           StatusSuccess,
+		LBSchemeExternal: true,
+		LBSchemeInternal: true,
+	})
+
+	newMetrics.exportStandaloneNEG()
+
+	verifyL4StandaloneNEGMetric(t, 1, StatusSuccess, "true", "false", "false")
+	verifyL4StandaloneNEGMetric(t, 1, StatusSuccess, "false", "true", "false")
+	verifyL4StandaloneNEGMetric(t, 1, StatusSuccess, "false", "false", "true")
+	verifyL4StandaloneNEGMetric(t, 1, StatusSuccess, "true", "false", "true")
+}
+
+func TestExportStandaloneNEGMetric_UserError(t *testing.T) {
+	newMetrics := NewFakeCollector()
+
+	newMetrics.SetL4StandaloneNEGService("svc-user-error", L4StandaloneNEGServiceState{
+		Status:           StatusUserError,
+		LBSchemeExternal: true,
+	})
+
+	newMetrics.exportStandaloneNEG()
+
+	verifyL4StandaloneNEGMetric(t, 1, StatusUserError, "true", "false", "false")
+}
+
+func TestExportStandaloneNEGMetric_Error(t *testing.T) {
+	newMetrics := NewFakeCollector()
+	notExceedingPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime + 5*time.Minute)
+
+	newMetrics.SetL4StandaloneNEGService("svc-error", L4StandaloneNEGServiceState{
+		Status:             StatusError,
+		LBSchemeExternal:   true,
+		FirstSyncErrorTime: &notExceedingPersistentErrorThresholdTime,
+	})
+
+	newMetrics.exportStandaloneNEG()
+
+	verifyL4StandaloneNEGMetric(t, 1, StatusError, "true", "false", "false")
+}
+
+func TestExportStandaloneNEGMetric_PersistentError(t *testing.T) {
+	newMetrics := NewFakeCollector()
+	pastPersistentErrorThresholdTime := time.Now().Add(-1*persistentErrorThresholdTime - time.Minute)
+
+	newMetrics.SetL4StandaloneNEGService("svc-persistent-error", L4StandaloneNEGServiceState{
+		Status:             StatusError,
+		LBSchemeExternal:   true,
+		FirstSyncErrorTime: &pastPersistentErrorThresholdTime,
+	})
+
+	newMetrics.exportStandaloneNEG()
+
+	verifyL4StandaloneNEGMetric(t, 1, StatusPersistentError, "true", "false", "false")
+}
+
+func TestExportStandaloneNEGMetric_Deletion(t *testing.T) {
+	newMetrics := NewFakeCollector()
+
+	// Setup initial state
+	newMetrics.SetL4StandaloneNEGService("svc-success-external", L4StandaloneNEGServiceState{
+		Status:           StatusSuccess,
+		LBSchemeExternal: true,
+	})
+	newMetrics.exportStandaloneNEG()
+	verifyL4StandaloneNEGMetric(t, 1, StatusSuccess, "true", "false", "false")
+
+	// Act
+	newMetrics.DeleteL4StandaloneNEGService("svc-success-external")
+	newMetrics.exportStandaloneNEG()
+
+	// Assert
+	verifyL4StandaloneNEGMetric(t, 0, StatusSuccess, "true", "false", "false")
+}
+
+func verifyL4StandaloneNEGMetric(t *testing.T, expectedCount int, status L4ServiceStatus, external, externalPassthrough, internal string) {
+	countFloat := testutil.ToFloat64(l4StandaloneNEGCount.With(prometheus.Labels{
+		"status":                         string(status),
+		"lb_scheme_external":             external,
+		"lb_scheme_external_passthrough": externalPassthrough,
+		"lb_scheme_internal":             internal,
+	}))
+	actualCount := int(math.Round(countFloat))
+	if expectedCount != actualCount {
+		t.Errorf("expected value %d but got %d for status: %q, external: %q, externalPassthrough: %q, internal: %q",
+			expectedCount, actualCount, status, external, externalPassthrough, internal)
+	}
+}

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -744,7 +744,7 @@ func (c *Controller) mergeStandaloneNEGsPortInfo(service *apiv1.Service, name ty
 // mergeVmIpNEGsPortInfo merges the PortInfo for ILB, multinet NetLB and NetLB V3 (variant with NEG default) services using GCE_VM_IP NEGs into portInfoMap
 func (c *Controller) mergeVmIpNEGsPortInfo(service *apiv1.Service, name types.NamespacedName, portInfoMap negtypes.PortInfoMap, negUsage *metricscollector.NegServiceState, networkInfo *network.NetworkInfo) error {
 	wantsILB, _ := l4annotations.WantsL4ILB(service)
-	wantsStandaloneNEGLB := flags.F.RunL4StandaloneNEGLBController && l4annotations.HasLoadBalancerClass(service, l4annotations.StandalonePassthroughNegLoadBalancerClass)
+	wantsStandaloneNEGLB := flags.F.RunL4StandaloneNEGController && l4annotations.HasLoadBalancerClass(service, l4annotations.StandalonePassthroughNegLoadBalancerClass)
 	needsNEGForILB := c.runL4ForILB && wantsILB
 	needsNEGForNetLB := c.netLBServiceNeedsNEG(service, networkInfo)
 	if !needsNEGForILB && !needsNEGForNetLB && !wantsStandaloneNEGLB {

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -1294,11 +1294,11 @@ func TestMergeDefaultBackendServicePortInfoMap(t *testing.T) {
 }
 
 func TestMergeVmIpNEGsPortInfo(t *testing.T) {
-	oldRunL4StandaloneNEGLBController := flags.F.RunL4StandaloneNEGLBController
+	oldRunL4StandaloneNEGController := flags.F.RunL4StandaloneNEGController
 
-	flags.F.RunL4StandaloneNEGLBController = true
+	flags.F.RunL4StandaloneNEGController = true
 	defer func() {
-		flags.F.RunL4StandaloneNEGLBController = oldRunL4StandaloneNEGLBController
+		flags.F.RunL4StandaloneNEGController = oldRunL4StandaloneNEGController
 	}()
 
 	controller, err := newTestController(fake.NewSimpleClientset())


### PR DESCRIPTION
Added a metric `l4_standalone_neg_count` that tracks the number of standalone NEG services. The metric can be broken down by the type of FR attached and the status. The status could be success, user error (bad configuration) or system error (mainly problems reaching GCE API).