### PR TITLE
Topology provider fix for multinet

### DIFF
--- a/pkg/neg/syncers/negstatushandler/svcneg.go
+++ b/pkg/neg/syncers/negstatushandler/svcneg.go
@@ -136,7 +136,7 @@ func (h *SvcNegStatusHandler) ReportStatus(negs []*composite.NetworkEndpointGrou
 
 	svcNeg := origSvcNeg.DeepCopy()
 	if flags.F.EnableMultiSubnetClusterPhase1 {
-		nonActiveNegRefs := h.getNonActiveNegRefs(origSvcNeg.Status.NetworkEndpointGroups, negObjRefs, h.zoneGetter.ListSubnets(h.logger), h.networkInfo.SubnetworkURL)
+		nonActiveNegRefs := h.getNonActiveNegRefs(origSvcNeg.Status.NetworkEndpointGroups, negObjRefs, h.zoneGetter.ListSubnetsInDefaultNetwork(h.logger), h.networkInfo.SubnetworkURL)
 		negObjRefs = append(negObjRefs, nonActiveNegRefs...)
 	}
 	svcNeg.Status.NetworkEndpointGroups = negObjRefs

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -295,7 +295,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	}
 	s.logger.V(2).Info("Sync NEG", "negSyncerKey", s.NegSyncerKey.String(), "endpointsCalculatorMode", s.endpointsCalculator.Mode())
 
-	subnetConfigs := s.topologyProvider.ListSubnets(s.logger)
+	subnetConfigs := s.topologyProvider.ListSubnetsInDefaultNetwork(s.logger)
 	subnetToNegMapping, err := s.generateSubnetToNegNameMap(subnetConfigs)
 	if err != nil {
 		s.logger.Error(err, "failed to generate subnet to neg name mapping")
@@ -551,7 +551,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 		// zoneGetter.
 
 		// List all existing subnets from the cluster.
-		subnetConfigs = s.topologyProvider.ListSubnets(s.logger)
+		subnetConfigs = s.topologyProvider.ListSubnetsInDefaultNetwork(s.logger)
 	} else {
 		// This is the multi-networking case where the VPC under consideration
 		// is not the default. Use the pre configured subnet from the
@@ -568,7 +568,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	for _, subnetConfig := range subnetConfigs {
 		zones, ok := zonesPerSubnet[subnetConfig.Name]
 		if !ok {
-			// s.topologyProvider.ListSubnets and s.topologyProvider.ListZonesPerSubnet should return same set of subnets.
+			// s.topologyProvider.ListSubnetsInDefaultNetwork and s.topologyProvider.ListZonesPerSubnet should return same set of subnets.
 			// Therefore this condition should be true only for multi-networking where we don't want NEGs in default subnet
 			continue
 		}

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -302,7 +302,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		return err
 	}
 
-	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
+	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.endpointsCalculator.Mode(), s.enableDualStackNEG, s.networkInfo, s.logger, s.negMetrics, needInitDrainStatus, s.NegSyncerKey.IncludeDrainNodesL4Local)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -527,7 +527,7 @@ func (s *transactionSyncer) candidateNodeFilter() zonegetter.Filter {
 // ensureNetworkEndpointGroups ensures NEGs are created and configured correctly in the corresponding zones.
 func (s *transactionSyncer) ensureNetworkEndpointGroups() error {
 	// NEGs should be created in zones with candidate nodes only.
-	zonesPerSubnet, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
+	zonesPerSubnet, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.networkInfo, s.logger)
 	if err != nil {
 		return err
 	}
@@ -913,7 +913,7 @@ func (s *transactionSyncer) isTopologyChange() bool {
 		return false
 	}
 
-	wantSubnetZones, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.logger)
+	wantSubnetZones, err := s.topologyProvider.ListZonesPerSubnet(s.candidateNodeFilter(), s.networkInfo, s.logger)
 	if err != nil {
 		s.logger.Error(err, "unable to list zones")
 		s.negMetrics.PublishNegControllerErrorCountMetrics(err, true)

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -3177,7 +3177,7 @@ func TestUnknownNodes(t *testing.T) {
 	}
 
 	// Check that unknown zone did not cause endpoints to be removed
-	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
+	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
 	if err != nil {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
@@ -3480,7 +3480,7 @@ func TestEnableDegradedMode(t *testing.T) {
 			tc.modify(s)
 
 			subnetToNegMapping := map[string]string{defaultTestSubnet: tc.negName}
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints")
 			}
@@ -3493,7 +3493,7 @@ func TestEnableDegradedMode(t *testing.T) {
 				t.Errorf("syncInternal returned %v, expected %v", err, tc.expectErr)
 			}
 			err = wait.PollImmediate(time.Second, 3*time.Second, func() (bool, error) {
-				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, klog.TODO(), s.negMetrics, false, false)
+				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L7Mode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, false)
 				if err != nil {
 					return false, nil
 				}
@@ -4209,7 +4209,7 @@ func TestSyncL4NEGs(t *testing.T) {
 			// give a little time for the syncer attach/detach goroutines to finish
 			time.Sleep(50 * time.Millisecond)
 
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), s.negMetrics, false, s.NegSyncerKey.IncludeDrainNodesL4Local)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, s.networkInfo, klog.TODO(), s.negMetrics, false, s.NegSyncerKey.IncludeDrainNodesL4Local)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints: %v", err)
 			}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -687,18 +687,18 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter negtypes.TopologyProvider, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, zoneGetter negtypes.TopologyProvider, cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, mode negtypes.EndpointsCalculatorMode, enableDualStackNEG bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool, includeDrainNodesL4Local bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
 	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	drainingEndpoints := make(map[negtypes.NetworkEndpoint]string)
 
 	// Include zones that have non-candidate nodes currently. It is possible that NEGs were created in those zones previously and the endpoints now became non-candidates.
 	// Endpoints in those NEGs now need to be removed. This mostly applies to VM_IP_NEGs where the endpoints are nodes.
-	allZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(zonegetter.AllNodesFilter, logger)
+	allZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(zonegetter.AllNodesFilter, networkInfo, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	candidateZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), logger)
+	candidateZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(negtypes.NodeFilterForEndpointCalculatorMode(mode, includeDrainNodesL4Local), networkInfo, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -1398,7 +1398,8 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 	for _, tc := range testCases {
 		tc.mutate(negCloud)
 		// tc.mode of "" will result in the default node predicate being selected, which is ok for this test.
-		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, negCloud, meta.VersionGA, tc.mode, tc.enableDualStackNEG, klog.TODO(), metrics.NewNegMetrics(), false, false)
+		defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
+		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, negCloud, meta.VersionGA, tc.mode, tc.enableDualStackNEG, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, false)
 
 		if tc.expectErr {
 			if err == nil {
@@ -1570,8 +1571,9 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 			}
 
 			subnetToNegMapping := map[string]string{defaultTestSubnet: negName}
+			defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
 
-			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus, false)
+			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus, false)
 			if err != nil {
 				t.Fatalf("retrieveExistingZoneNetworkEndpointMap: %v", err)
 			}
@@ -1649,7 +1651,8 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 
 	// With includeDrainNodesL4Local=false: zone4 has no NEG but is not a
 	// candidate zone, so the NotFound is suppressed and no error is returned.
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, false)
+	defaultNetInfo := network.NetworkInfo{IsDefault: true, SubnetworkURL: defaultTestSubnetURL}
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, false)
 	if err != nil {
 		t.Errorf("expected no error with includeDrainNodesL4Local=false and missing zone4 NEG, got: %v", err)
 	}
@@ -1658,7 +1661,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	// NEG yet. The NotFound is not suppressed, so an error is returned.
 	// This is the plausible race documented in the review: if ensureNetworkEndpointGroups
 	// silently failed for zone4, the subsequent retrieve would fail here.
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, true)
 	if err == nil {
 		t.Errorf("expected error with includeDrainNodesL4Local=true and missing zone4 NEG, got nil")
 	}
@@ -1668,7 +1671,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	drainEndpoint := &composite.NetworkEndpoint{IpAddress: "10.0.4.1", Instance: "upgrade-instance1"}
 	fakeCloud.AttachNetworkEndpoints(negName, negtypes.TestZone4, []*composite.NetworkEndpoint{drainEndpoint}, meta.VersionGA, klog.TODO())
 
-	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, klog.TODO(), metrics.NewNegMetrics(), false, true)
+	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, fakeCloud, meta.VersionGA, negtypes.L4LocalMode, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false, true)
 	if err != nil {
 		t.Fatalf("retrieveExistingZoneNetworkEndpointMap(drain=true, NEG exists): %v", err)
 	}

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
@@ -106,7 +107,7 @@ type NetworkEndpointsCalculator interface {
 // It helps to determine GCE locations (subnets and zones) where NEGs should be created and/or synced.
 type TopologyProvider interface {
 	ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig
-	ListZonesPerSubnet(filter zonegetter.Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error)
+	ListZonesPerSubnet(filter zonegetter.Filter, networkInfo network.NetworkInfo, logger klog.Logger) (shared.ZonesPerSubnetMap, error)
 }
 
 // NEGStatusHandler defines interface for reporting NEG syncer status.

--- a/pkg/neg/types/interfaces.go
+++ b/pkg/neg/types/interfaces.go
@@ -105,7 +105,7 @@ type NetworkEndpointsCalculator interface {
 // TopologyProvider is an interface for looking up zone and subnet information for NEG syncer.
 // It helps to determine GCE locations (subnets and zones) where NEGs should be created and/or synced.
 type TopologyProvider interface {
-	ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConfig
+	ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig
 	ListZonesPerSubnet(filter zonegetter.Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error)
 }
 

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -241,7 +241,7 @@ func (z *ZoneGetter) ListZonesInDefaultSubnet(filter Filter, logger klog.Logger)
 
 // ListZonesPerSubnet returns a list of zones containing nodes that satisfy the given node filtering mode per subnet.
 func (z *ZoneGetter) ListZonesPerSubnet(filter Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
-	subnetConfigs := z.ListSubnets(logger)
+	subnetConfigs := z.ListSubnetsInDefaultNetwork(logger)
 	if subnetConfigs == nil {
 		return shared.ZonesPerSubnetMap{}, nil
 	}
@@ -293,13 +293,13 @@ func (z *ZoneGetter) listZones(filter Filter, defaultSubnetOnly bool, logger klo
 	return zones.List(), nil
 }
 
-// ListSubnets returns the lists of subnets in the cluster based on the
+// ListSubnetsInDefaultNetwork returns the lists of subnets in the cluster based on the
 // NodeTopology CR.
-// If the CR does not exist or it is not ready, ListSubnets will return only the
+// If the CR does not exist or it is not ready, ListSubnetsInDefaultNetwork will return only the
 // default subnet.
-func (z *ZoneGetter) ListSubnets(logger klog.Logger) []nodetopologyv1.SubnetConfig {
+func (z *ZoneGetter) ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig {
 	if z.mode == Legacy {
-		logger.V(4).Info("ListSubnets is being called with legacy zone getter. Returning empty list of subnets")
+		logger.V(4).Info("ListSubnetsInDefaultNetwork is being called with legacy zone getter. Returning empty list of subnets")
 		return nil
 	}
 

--- a/pkg/utils/zonegetter/zone_getter.go
+++ b/pkg/utils/zonegetter/zone_getter.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -240,19 +241,25 @@ func (z *ZoneGetter) ListZonesInDefaultSubnet(filter Filter, logger klog.Logger)
 }
 
 // ListZonesPerSubnet returns a list of zones containing nodes that satisfy the given node filtering mode per subnet.
-func (z *ZoneGetter) ListZonesPerSubnet(filter Filter, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
+func (z *ZoneGetter) ListZonesPerSubnet(filter Filter, networkInfo network.NetworkInfo, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
+	zones, err := z.ListZones(filter, logger)
+	// Don't return subnets with empty zones set. As ZoneGetter returns all zones per all subnets - don't return any.
+	if err != nil || len(zones) == 0 {
+		return shared.ZonesPerSubnetMap{}, err
+	}
+
+	// Multi-Net
+	if !networkInfo.IsDefault {
+		subnetName, err := utils.KeyName(networkInfo.SubnetworkURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse subnet name from SubnetworkURL %q: %w", networkInfo.SubnetworkURL, err)
+		}
+		return shared.ZonesPerSubnetMap{subnetName: sets.New(zones...)}, nil
+	}
+
+	// Multi-Subnet
 	subnetConfigs := z.ListSubnetsInDefaultNetwork(logger)
 	if subnetConfigs == nil {
-		return shared.ZonesPerSubnetMap{}, nil
-	}
-
-	zones, err := z.ListZones(filter, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	// Don't return subnets with empty zones set. As ZoneGetter returns all zones per all subnets - don't return any.
-	if len(zones) == 0 {
 		return shared.ZonesPerSubnetMap{}, nil
 	}
 

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
+	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -748,7 +749,7 @@ func TestNonGCPZoneGetter(t *testing.T) {
 	}
 
 	// ListZonesPerSubnet
-	retPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, klog.TODO())
+	retPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
 	if err != nil {
 		t.Errorf("expect err = nil for ListZonesPerSubnet, but got %v", err)
 	}
@@ -1671,7 +1672,7 @@ func TestLegacyListZonesPerSubnet(t *testing.T) {
 	PopulateFakeNodeInformer(nodeInformer, true)
 	zoneGetter := NewLegacyZoneGetter(nodeInformer, FakeNodeTopologyInformer())
 
-	zonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, klog.TODO())
+	zonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
 	if err != nil {
 		t.Errorf("expect err = nil for ListZonesPerSubnet, but got %v", err)
 	}
@@ -1758,7 +1759,7 @@ func TestListZonesPerSubnet(t *testing.T) {
 		for _, onlyIncludeDefaultSubnetNodes := range []bool{true, false} {
 			t.Run(tc.desc, func(t *testing.T) {
 				zoneGetter.onlyIncludeDefaultSubnetNodes = onlyIncludeDefaultSubnetNodes
-				gotZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(tc.filter, klog.TODO())
+				gotZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(tc.filter, network.NetworkInfo{IsDefault: true}, klog.TODO())
 				if err != nil {
 					t.Errorf("expect err = nil, but got %v", err)
 				}
@@ -1773,5 +1774,36 @@ func TestListZonesPerSubnet(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestListZonesPerSubnetMultinet(t *testing.T) {
+	t.Parallel()
+
+	nodeInformer := FakeNodeInformer()
+	PopulateFakeNodeInformer(nodeInformer, true)
+	zoneGetter, err := NewFakeZoneGetter(nodeInformer, FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to initialize zone getter: %v", err)
+	}
+
+	multinetworkInfo := network.NetworkInfo{
+		IsDefault:     false,
+		K8sNetwork:    "secondary-network",
+		NetworkURL:    "https://www.googleapis.com/compute/v1/projects/proj/global/networks/secondary-net",
+		SubnetworkURL: "https://www.googleapis.com/compute/v1/projects/proj/regions/us-central1/subnetworks/custom-multinet-subnet",
+	}
+
+	gotZonesPerSubnet, err := zoneGetter.ListZonesPerSubnet(AllNodesFilter, multinetworkInfo, klog.TODO())
+	if err != nil {
+		t.Fatalf("ListZonesPerSubnet() unexpected error: %v", err)
+	}
+
+	wantZonesPerSubnet := shared.ZonesPerSubnetMap{
+		"custom-multinet-subnet": sets.New("zone1", "zone2", "zone3", "zone4", "zone5", "zone6"),
+	}
+
+	if diff := cmp.Diff(wantZonesPerSubnet, gotZonesPerSubnet); diff != "" {
+		t.Errorf("ListZonesPerSubnet() multinet mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/utils/zonegetter/zone_getter_test.go
+++ b/pkg/utils/zonegetter/zone_getter_test.go
@@ -1555,7 +1555,7 @@ func TestIsNodeInDefaultSubnet_forLegacyVPCAllNodesAreAssumedInDefaultSubnet(t *
 	}
 }
 
-func TestListSubnets(t *testing.T) {
+func TestListSubnetsInDefaultNetwork(t *testing.T) {
 	prevTopologyCRName := flags.F.NodeTopologyCRName
 	defer func() {
 		flags.F.NodeTopologyCRName = prevTopologyCRName
@@ -1643,7 +1643,7 @@ func TestListSubnets(t *testing.T) {
 				fakeTopologyInformer.GetIndexer().Add(tc.existingTopologyCR)
 			}
 
-			gotSubnets := zoneGetter.ListSubnets(klog.TODO())
+			gotSubnets := zoneGetter.ListSubnetsInDefaultNetwork(klog.TODO())
 
 			if diff := cmp.Diff(gotSubnets, tc.wantSubnets); diff != "" {
 				t.Errorf("Got mismatch for List Subnets (-got, +want)= %s", diff)
@@ -1652,15 +1652,15 @@ func TestListSubnets(t *testing.T) {
 	}
 }
 
-func TestLegacyListSubnets(t *testing.T) {
+func TestLegacyListSubnetsInDefaultNetwork(t *testing.T) {
 	nodeInformer := FakeNodeInformer()
 	// In production clusters nodes will not be part of different subnets. However to test that Legacy Zone Getter
 	// does not check subnets at all, set true.
 	PopulateFakeNodeInformer(nodeInformer, true)
 	zoneGetter := NewLegacyZoneGetter(nodeInformer, FakeNodeTopologyInformer())
-	subnets := zoneGetter.ListSubnets(klog.TODO())
+	subnets := zoneGetter.ListSubnetsInDefaultNetwork(klog.TODO())
 	if len(subnets) != 0 {
-		t.Errorf("In legacy mode, ListSubnets() returned %d, expected 0 subnets", len(subnets))
+		t.Errorf("In legacy mode, ListSubnetsInDefaultNetwork() returned %d, expected 0 subnets", len(subnets))
 	}
 }
 


### PR DESCRIPTION
Introduced in https://github.com/kubernetes/ingress-gce/pull/3121 `TopologyProvider.ListZonesPerSubnet`  in case when Multi-Net feature is used still returned zones for primary network's subnets, which resulted in empty zones set for non-primary networks' subnets. Making this receiver aware of which feature is used: Multi-Subnet or Multi-Net - and build `ZonesPerSubnet` map accordingly.

Also renamed `ListSubnets` into `ListSubnetsInDefaultNetwork` as it's better describes what it does.