### PR TITLE
fix(l4): add nil check for sessionAffinityConfig in L4NetLB

### DIFF
--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -198,11 +198,11 @@ func (l4netlb *L4NetLB) createKey(name string) (*meta.Key, error) {
 	return composite.CreateKey(l4netlb.cloud, name, l4netlb.scope)
 }
 
-// isSessionAffinityConfigEmpty checks if Session Affinity Config doesn't have:
+// isSessionAffinityConfigEmpty checks if Session Affinity Config is nil or doesn't have:
 //   - ClientIP or
 //   - ClientIP.TimeoutSeconds specified
 func isSessionAffinityConfigEmpty(sessionAffinityConfig *corev1.SessionAffinityConfig) bool {
-	return sessionAffinityConfig.ClientIP == nil || sessionAffinityConfig.ClientIP.TimeoutSeconds == nil
+	return sessionAffinityConfig == nil || sessionAffinityConfig.ClientIP == nil || sessionAffinityConfig.ClientIP.TimeoutSeconds == nil
 }
 
 // checkStrongSessionAffinityRequirements returns an error if Strong Session Affinity (SSA) was enabled:

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -1315,6 +1315,16 @@ func TestCheckStrongSessionAffinityRequirements(t *testing.T) {
 			expectError:           true,
 		},
 		{
+			desc:                        "strong session affinity has nil SessionAffinityConfig",
+			enableStrongSessionAffinity: true,
+			serviceAnnotations: map[string]string{
+				annotations.StrongSessionAffinityAnnotationKey: annotations.StrongSessionAffinityEnabled,
+			},
+			sessionAffinityType:   v1.ServiceAffinityClientIP,
+			sessionAffinityConfig: nil,
+			expectError:           true,
+		},
+		{
 			desc:                        "strong session affinity set up is correct",
 			enableStrongSessionAffinity: true,
 			serviceAnnotations: map[string]string{


### PR DESCRIPTION
## Description
In Kubernetes Service specifications, `sessionAffinityConfig` is an optional pointer field that may be omitted by users even when session affinity is enabled. In the existing L4NetLB resource evaluation logic, `isSessionAffinityConfigEmpty` accessed nested fields within the configuration structure without verifying that the top-level pointer itself was non-nil. This change adds a defensive null pointer check to ensure the configuration structure is present before inspecting its contents.

## Notable Changes
Added a non-nil check for `sessionAffinityConfig` in `isSessionAffinityConfigEmpty` within `pkg/l4/resources/l4netlb.go` before evaluating `ClientIP` and `TimeoutSeconds`.