### PR TITLE
fix: handle tombstone objects in isObjectInProviderConfig to prevent filtering errors during deletion events

### DIFF
--- a/pkg/multiproject/common/filteredinformer/helpers.go
+++ b/pkg/multiproject/common/filteredinformer/helpers.go
@@ -2,11 +2,15 @@ package filteredinformer
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/flags"
 )
 
 // isObjectInProviderConfig checks if an object belongs to a specific provider config.
 func isObjectInProviderConfig(obj interface{}, providerConfigName string) bool {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
 	metaObj, err := meta.Accessor(obj)
 	if err != nil {
 		return false

--- a/pkg/multiproject/common/filteredinformer/helpers_test.go
+++ b/pkg/multiproject/common/filteredinformer/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/flags"
 )
 
@@ -40,6 +41,15 @@ func TestIsObjectInProviderConfig(t *testing.T) {
 			providerConfigName: "p123456-abc",
 			object:             "invalid-object",
 			expectedToMatch:    false,
+		},
+		{
+			desc:               "Tombstone object in provider config should return true",
+			providerConfigName: "p123456-abc",
+			object: cache.DeletedFinalStateUnknown{
+				Key: "some-key",
+				Obj: &metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
+			},
+			expectedToMatch: true,
 		},
 	}
 


### PR DESCRIPTION
This PR addresses a logic flaw where cache.DeletedFinalStateUnknown tombstone events were being silently dropped during cache disruptions.
Previously, dropping these events caused the controller's internal state to permanently drift from the actual Kubernetes cluster state.
The fix updates the isObjectInProviderConfig function in pkg/multiproject/common/filteredinformer/helpers.go to correctly unwrap cache.DeletedFinalStateUnknown objects before attempting to access their metadata.
This PR includes new test cases in pkg/multiproject/common/filteredinformer/helpers_test.go to ensure that a tombstone object belonging to a provider config correctly evaluates to true and is processed properly.