### PR TITLE
fix: sanitize INI values to prevent CRLF injection in GCE provider configuration

### DIFF
--- a/pkg/multiproject/common/gce/gce.go
+++ b/pkg/multiproject/common/gce/gce.go
@@ -83,7 +83,8 @@ func generateConfigForProviderConfig(defaultConfigContent string, providerConfig
 
 	// Update ProjectID
 	projectIDKey := "project-id"
-	globalSection.Key(projectIDKey).SetValue(providerConfig.Spec.ProjectID)
+	projectID := sanitizeINIValue(providerConfig.Spec.ProjectID)
+	globalSection.Key(projectIDKey).SetValue(projectID)
 
 	// Update TokenURL
 	tokenURLKey := "token-url"
@@ -112,7 +113,7 @@ func generateConfigForProviderConfig(defaultConfigContent string, providerConfig
 	if len(networkParts) > 1 {
 		networkName = networkParts[len(networkParts)-1]
 	}
-	globalSection.Key(networkNameKey).SetValue(networkName)
+	globalSection.Key(networkNameKey).SetValue(sanitizeINIValue(networkName))
 
 	subnetworkNameKey := "subnetwork-name"
 	// Subnetwork name is the last part of the subnetwork path
@@ -122,7 +123,7 @@ func generateConfigForProviderConfig(defaultConfigContent string, providerConfig
 	if len(subnetworkParts) > 1 {
 		subnetworkName = subnetworkParts[len(subnetworkParts)-1]
 	}
-	globalSection.Key(subnetworkNameKey).SetValue(subnetworkName)
+	globalSection.Key(subnetworkNameKey).SetValue(sanitizeINIValue(subnetworkName))
 
 	// Write the modified config content to a string with custom options
 	var modifiedConfigContent bytes.Buffer
@@ -150,7 +151,7 @@ func tokenURLForProviderConfig(existingTokenURL string, providerConfig *v1.Provi
 	baseURL := tokenURLParts[0]
 	// Format: {BASE_URL}/projects/{TENANT_PROJECT_NUMBER}/locations/{TENANT_LOCATION}/tenants/{TENANT_ID}:generateTenantToken"
 	formatString := "%s/projects/%d/locations/%s/tenants/%s:generateTenantToken"
-	tokenURL := fmt.Sprintf(formatString, baseURL, providerConfig.Spec.ProjectNumber, location, providerConfig.Name)
+	tokenURL := fmt.Sprintf(formatString, baseURL, providerConfig.Spec.ProjectNumber, location, sanitizeINIValue(providerConfig.Name))
 	return tokenURL, nil
 }
 
@@ -205,4 +206,9 @@ func extractLocationFromTokenURL(tokenURL string) string {
 		}
 	}
 	return ""
+}
+
+// sanitizeINIValue removes carriage returns and newlines to prevent CRLF injection
+func sanitizeINIValue(val string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(val, "\r", ""), "\n", "")
 }

--- a/pkg/multiproject/common/gce/gce_test.go
+++ b/pkg/multiproject/common/gce/gce_test.go
@@ -503,3 +503,51 @@ func mustNormalizeJSON(t *testing.T, jsonString string) string {
 
 	return normalizedString
 }
+
+func TestSanitizeINIValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "No newlines",
+			input:    "regular-string",
+			expected: "regular-string",
+		},
+		{
+			name:     "Carriage return only",
+			input:    "string\rwith\rcr",
+			expected: "stringwithcr",
+		},
+		{
+			name:     "Newline only",
+			input:    "string\nwith\nnl",
+			expected: "stringwithnl",
+		},
+		{
+			name:     "CRLF",
+			input:    "string\r\nwith\r\ncrlf",
+			expected: "stringwithcrlf",
+		},
+		{
+			name:     "Multiple newlines at end",
+			input:    "string\n\n\r\n",
+			expected: "string",
+		},
+		{
+			name:     "Malicious INI injection attempt",
+			input:    "project\n[malicious_section]\nkey=value",
+			expected: "project[malicious_section]key=value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sanitizeINIValue(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduced a sanitizeINIValue(val string) string helper function in pkg/multiproject/common/gce/gce.go that strips all carriage return (\r) and newline (\n) characters from the input.
Wrapped the user-supplied values with the new sanitizeINIValue function before writing them to the INI parser. This was applied to ProjectID, networkName, subnetworkName, and providerConfig.Name.
Added TestSanitizeINIValue in pkg/multiproject/common/gce/gce_test.go to verify the sanitization logic against various payloads, including a malicious INI injection attempt.