### PR TITLE
Omit subnet if address is provided when creating Forwarding Rule

### DIFF
--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -201,6 +201,10 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	}
 	frLogger.V(2).Info("ipv6AddressToUse for service", "ipv6AddressToUse", ipv6AddrToUse)
 
+	if ipv6AddressName != "" {
+		subnetworkURL = ""
+	}
+
 	netTier, isFromAnnotation := annotations.NetworkTier(l4netlb.Service)
 	frLogger.V(2).Info("network tier for service", "networkTier", netTier, "isFromAnnotation", isFromAnnotation)
 

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -2231,3 +2231,103 @@ func TestEnsureL4NetLB_L4LBConfigLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureIPv6ExternalLoadBalancerOmittingSubnet(t *testing.T) {
+	t.Parallel()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	ipv6Address := &ga.Address{
+		Name:         "ipv6-address",
+		Address:      "2::2",
+		IpVersion:    "IPV6",
+		PrefixLength: 96,
+	}
+	err := l4NetLB.cloud.ReserveRegionAddress(ipv6Address, l4NetLB.cloud.Region())
+	if err != nil {
+		t.Fatalf("Failed to reserve IPv6 address: %v", err)
+	}
+	svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = "ipv6-address"
+
+	result := l4NetLB.EnsureFrontend(nodeNames, l4NetLB.Service, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	// Because a static IP is configured, ipv6AddressName is not empty,
+	// so the ForwardingRule should have an empty Subnetwork field.
+	ipv6FRName := l4NetLB.ipv6FRName()
+	fr, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(ipv6FRName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to get forwarding rule %s: %v", ipv6FRName, err)
+	}
+
+	if fr.Subnetwork != "" {
+		t.Errorf("Expected ForwardingRule Subnetwork to be empty when a static IPv6 address is specified, got: %q", fr.Subnetwork)
+	}
+}
+
+func TestEnsureIPv6ExternalLoadBalancerUpdatesForwardingRuleSubnet(t *testing.T) {
+	t.Parallel()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	ipv6Address := &ga.Address{
+		Name:         "ipv6-address",
+		Address:      "2::2",
+		IpVersion:    "IPV6",
+		PrefixLength: 96,
+	}
+	err := l4NetLB.cloud.ReserveRegionAddress(ipv6Address, l4NetLB.cloud.Region())
+	if err != nil {
+		t.Fatalf("Failed to reserve IPv6 address: %v", err)
+	}
+	svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = "ipv6-address"
+
+	ipv6FRName := l4NetLB.ipv6FRName()
+
+	// Pre-create an IPv6 forwarding rule with both Subnetwork and IPAddress to simulate
+	// an older GKE version before the fix.
+	err = l4NetLB.cloud.Compute().(*cloud.MockGCE).ForwardingRules().Insert(context.TODO(), meta.RegionalKey(ipv6FRName, l4NetLB.cloud.Region()), &compute.ForwardingRule{
+		Name:                ipv6FRName,
+		IPAddress:           "2::2",
+		IPProtocol:          "TCP",
+		PortRange:           "8080-8080",
+		LoadBalancingScheme: string(cloud.SchemeExternal),
+		BackendService:      "https://www.googleapis.com/compute/v1/projects/test-poject/regions/us-central1/backendServices/bs1",
+		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
+		Subnetwork:          "https://www.googleapis.com/compute/v1/projects/test-poject/regions/us-central1/subnetworks/default-subnet",
+		IpVersion:           "IPV6",
+	})
+	if err != nil {
+		t.Fatalf("Failed to pre-create Forwarding Rule: %v", err)
+	}
+
+	oldFr, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(ipv6FRName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to get forwarding rule %s: %v", ipv6FRName, err)
+	}
+	if oldFr.Subnetwork == "" {
+		t.Errorf("Expected existing ForwardingRule Subnetwork to be non-empty before update")
+	}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, l4NetLB.Service, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	fr, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(ipv6FRName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("Failed to get forwarding rule %s: %v", ipv6FRName, err)
+	}
+
+	if fr.Subnetwork != "" {
+		t.Errorf("Expected ForwardingRule Subnetwork to be cleared upon update, got: %q", fr.Subnetwork)
+	}
+}


### PR DESCRIPTION
GKE is introducing support for [Bring Your Own IP (BYOIP) IPv6](http://go/byoip-ipv6-gke) which allows users to assign external non-Google IPv6 addresses to clusters and load balancers (LBs). However, an issue occurs when assigning a BYOIP address to LBs via the "[networking.gke.io/load-balancer-ip-addresses](https://github.com/kubernetes/ingress-gce/blob/715be1510656acfa825961568f717c2b724147ff/pkg/l4/annotations/l4_static_address.go#L17)" annotation during Forwarding Rule (FR) creation by the L4 load balancer controller. The controller currently defaults to specifying a [subnetwork](https://source.corp.google.com/piper///depot/google3/cloud/cluster/api/mixer_forwarding_rules.proto;bpv=1;bpt=1;rcl=945362573;l=447?gsn=subnetwork&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgoogle3%3Flang%3Dprotobuf%3Fpath%3Dcloud%2Fcluster%2Fapi%2Fmixer_forwarding_rules.proto%234.0.2.15) in the [GCE API call](https://source.corp.google.com/piper///depot/google3/cloud/cluster/manager/networking/shared/api/region_forwarding_rules_service.proto;bpv=1;bpt=1;l=60?q=%2F%2Fdepot%2Fgoogle3%2Fcloud%2Fcluster%2Fmanager%2Fnetworking%2Fshared%2Fapi%2Fregion_forwarding_rules_service.proto%20%20&sq=package:piper%20file:%2F%2Fdepot%2Fgoogle3%20-file:google3%2Fexperimental&gsn=CreateForwardingRule&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgoogle3%3Flang%3Dprotobuf%3Fpath%3Dcloud%2Fcluster%2Fmanager%2Fnetworking%2Fshared%2Fapi%2Fregion_forwarding_rules_service.proto%236.0.2.3) even if none is provided via annotations, causing Forwarding Rule creation to fail in IPv6 clusters with the following error:

```shell
Warning  SyncExternalLoadBalancerFailed  2m11s (x19 over 13m)  loadbalancer-controller  Error ensuring Resource for L4 External LoadBalancer, err: googleapi: Error 400: Invalid value for field 'resource.subnetwork': 'https://www.googleapis.com/compute/v1/projects/***/regions/us-central1/subnetworks/****-subnet'. VM-only subnetwork with IP collection is not allowed for IPv6 forwarding rules., invalid
```

The L4 load balancer controller should not generate or include the cluster's default subnetwork to the request when a user explicitly configures the [load-balancer-ip-addresses](https://github.com/kubernetes/ingress-gce/blob/715be1510656acfa825961568f717c2b724147ff/pkg/l4/annotations/l4_static_address.go#L17) annotation when creating LB and forwarding rule. Defaulting to cluster’s default subnet is a wrong assumption because here the LB’s external IP is not from the subnet.

See: [go/gke-byoipv6lb-omit-subnet](http://goto.google.com/gke-byoipv6lb-omit-subnet) 
