### PR TITLE
BYOIPv6: Read and use IP Collection annotation for LBs

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -160,6 +160,7 @@ var F = struct {
 	// EnableL4DenyFirewallExplicitlySet will be set to true if the argument was explicitly set by the user.
 	EnableL4DenyFirewallExplicitlySet bool
 	EnableL4NetLBRBSByDefault         bool
+	EnableBYOIPv6                     bool
 	// ===============================
 	// DEPRECATED FLAGS
 	// ===============================
@@ -381,6 +382,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NEGLocalIncludeDrainNodes, "enable-l4-neg-local-include-drain-nodes", false, "For L4 LB NEGs with externalTrafficPolicy=Local, keep nodes carrying the GKE drain label in the NEG as long as they still host a backing pod. Unready-node behavior is unchanged.")
 	flag.BoolVar(&F.EnableL4NetLBRBSByDefault, "enable-l4-netlb-rbs-by-default", false, "Enable L4 NetLB Regional Backend Services by default for new L4 NetLB services.")
 	flag.BoolVar(&F.EnableNEGPreprovisioning, "enable-neg-preprovisioning", false, "Enable support for NEG pre-provisioning.")
+	flag.BoolVar(&F.EnableBYOIPv6, "enable-byo-ipv6", false, "Enable Bring Your Own IPv6 (BYOIPv6) feature for ip-collection annotations.")
 }
 
 func Validate() {

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -60,19 +61,25 @@ const (
 
 // Original file in https://github.com/kubernetes/legacy-cloud-providers/blob/6aa80146c33550e908aed072618bd7f9998837f6/gce/gce_address_manager.go
 type Manager struct {
-	svc         gce.CloudAddressService
-	name        string
-	serviceName string
-	addressName string
-	targetIP    string
-	addressType cloud.LbScheme
-	region      string
-	subnetURL   string
-	tryRelease  bool
-	networkTier cloud.NetworkTier
-	ipVersion   IPVersion
+	svc          gce.CloudAddressService
+	name         string
+	serviceName  string
+	addressName  string
+	targetIP     string
+	addressType  cloud.LbScheme
+	region       string
+	subnetURL    string
+	tryRelease   bool
+	networkTier  cloud.NetworkTier
+	ipVersion    IPVersion
+	ipCollection string
 
 	frLogger klog.Logger
+}
+
+// SetIPCollection sets the ipCollection for the manager.
+func (m *Manager) SetIPCollection(ipCollection string) {
+	m.ipCollection = ipCollection
 }
 
 func NewManager(svc gce.CloudAddressService, serviceName, region, subnetURL, name, addressName, targetIP string, addressType cloud.LbScheme, networkTier cloud.NetworkTier, ipVersion IPVersion, frLogger klog.Logger) *Manager {
@@ -261,11 +268,12 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	// Try reserving the IP with controller-owned address name
 	// If am.targetIP is an empty string, a new IP will be created.
 	newAddr := &compute.Address{
-		Name:        m.name,
-		Description: fmt.Sprintf(`{"kubernetes.io/service-name":"%s"}`, m.serviceName),
-		Address:     m.targetIP,
-		AddressType: string(m.addressType),
-		Subnetwork:  m.subnetURL,
+		Name:         m.name,
+		Description:  fmt.Sprintf(`{"kubernetes.io/service-name":"%s"}`, m.serviceName),
+		Address:      m.targetIP,
+		AddressType:  string(m.addressType),
+		Subnetwork:   m.subnetURL,
+		IpCollection: m.ipCollection,
 	}
 	// NetworkTier is supported only for External IP Address
 	if m.addressType == cloud.SchemeExternal {
@@ -386,6 +394,9 @@ func (m *Manager) validateAddress(addr *compute.Address) error {
 	}
 	if addr.NetworkTier != m.networkTier.ToGCEValue() {
 		return l4utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
+	}
+	if flags.F.EnableBYOIPv6 && m.ipCollection != addr.IpCollection {
+		return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
 	}
 	return nil
 }

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -53,7 +53,7 @@ func TestAddressManagerNoRequestedIP(t *testing.T) {
 	targetIP := ""
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -64,7 +64,20 @@ func TestAddressManagerBasic(t *testing.T) {
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
+	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
+}
+
+// TestAddressManagerWithIPCollection tests reserving an address with an IP collection
+func TestAddressManagerWithIPCollection(t *testing.T) {
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	targetIP := "1.1.1.1"
+	ipCollection := "my-ip-collection"
+
+	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium, address.IPv4Version, klog.TODO())
+	mgr.SetIPCollection(ipCollection)
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierPremium.ToGCEValue(), ipCollection)
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -80,7 +93,7 @@ func TestAddressManagerOrphaned(t *testing.T) {
 	require.NoError(t, err)
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -92,7 +105,7 @@ func TestAddressManagerStandardNetworkTier(t *testing.T) {
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeExternal, cloud.NetworkTierStandard, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierStandard.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierStandard.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -103,7 +116,7 @@ func TestAddressManagerStandardNetworkTierNotAvailableForInternalAddress(t *test
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierStandard, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierPremium.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierPremium.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -120,7 +133,7 @@ func TestAddressManagerOutdatedOrphan(t *testing.T) {
 	require.NoError(t, err)
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -310,7 +323,7 @@ func TestAddressManagerIPv6(t *testing.T) {
 			}
 
 			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", tc.targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv6Version, klog.TODO())
-			testHoldAddress(t, mgr, svc, testLBName, vals.Region, tc.targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+			testHoldAddress(t, mgr, svc, testLBName, vals.Region, tc.targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 			testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 		})
 	}
@@ -418,7 +431,7 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 	}
 }
 
-func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
+func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier, ipCollection string) {
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)
 	assert.NotEmpty(t, ipToUse)
@@ -432,6 +445,7 @@ func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressSer
 	}
 	assert.EqualValues(t, scheme, addr.AddressType)
 	assert.EqualValues(t, addr.NetworkTier, netTier)
+	assert.EqualValues(t, ipCollection, addr.IpCollection)
 }
 
 func testReleaseAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region string) {

--- a/pkg/l4/annotations/service.go
+++ b/pkg/l4/annotations/service.go
@@ -110,6 +110,10 @@ const (
 
 	// CustomForwardingRuleKey is the annotation key for custom forwarding rule name.
 	CustomForwardingRuleKey = "networking.gke.io/custom-forwarding-rule"
+
+	// IPCollectionV6AnnotationKey is the annotation key for BYOIP IPv6 IP collection.
+	// The value of this annotation must be a full resource URL.
+	IPCollectionV6AnnotationKey = "networking.gke.io/ip-collection-v6"
 )
 
 // Service represents Service annotations.
@@ -123,6 +127,14 @@ func FromService(obj *v1.Service) *Service {
 		return &Service{}
 	}
 	return &Service{obj.Annotations}
+}
+
+// GetIPCollectionV6 returns the configured IP collection for BYOIP.
+func (svc *Service) GetIPCollectionV6() string {
+	if val, exists := svc.v[IPCollectionV6AnnotationKey]; exists {
+		return val
+	}
+	return ""
 }
 
 // WantsL4ILB checks if the given service requires L4 ILB.

--- a/pkg/l4/annotations/service_test.go
+++ b/pkg/l4/annotations/service_test.go
@@ -380,3 +380,35 @@ func TestWantsL4NetLB(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIPCollection(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		svc  *v1.Service
+		want string
+	}{
+		{
+			desc: "ip-collection annotation not specified",
+			svc:  &v1.Service{},
+			want: "",
+		},
+		{
+			desc: "ip-collection annotation specified",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						IPCollectionV6AnnotationKey: "my-ip-collection",
+					},
+				},
+			},
+			want: "my-ip-collection",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := FromService(tc.svc).GetIPCollectionV6()
+			if got != tc.want {
+				t.Errorf("FromService().GetIPCollection() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/l4/forwardingrules/equal.go
+++ b/pkg/l4/forwardingrules/equal.go
@@ -52,7 +52,8 @@ func EqualIPv6(fr1, fr2 *composite.ForwardingRule) (bool, error) {
 		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
 		fr1.AllPorts == fr2.AllPorts &&
 		fr1.Subnetwork == fr2.Subnetwork &&
-		fr1.NetworkTier == fr2.NetworkTier, nil
+		fr1.NetworkTier == fr2.NetworkTier &&
+		equalResourcePaths(fr1.IpCollection, fr2.IpCollection), nil
 }
 
 // equalPorts compares two port ranges or slices of ports. Before comparison,

--- a/pkg/l4/forwardingrules/equal_test.go
+++ b/pkg/l4/forwardingrules/equal_test.go
@@ -448,6 +448,24 @@ func TestEqualIPv6(t *testing.T) {
 		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
 	}
+	ipCollectionFwdRule1 := &composite.ForwardingRule{
+		Name:                "ip-collection-fwd-rule-1",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		IpCollection:        "my-collection",
+	}
+	ipCollectionFwdRule2 := &composite.ForwardingRule{
+		Name:                "ip-collection-fwd-rule-2",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		IpCollection:        "other-collection",
+	}
 
 	testCases := []struct {
 		desc        string
@@ -502,6 +520,24 @@ func TestEqualIPv6(t *testing.T) {
 			oldFwdRule:  bsLink2PremiumNetworkTierFwdRule,
 			newFwdRule:  bsLink2StandardNetworkTierFwdRule,
 			expectEqual: false,
+		},
+		{
+			desc:        "different ip collection",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  ipCollectionFwdRule2,
+			expectEqual: false,
+		},
+		{
+			desc:        "one has ip collection, one does not",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  tcpFwdRule,
+			expectEqual: false,
+		},
+		{
+			desc:        "same ip collection",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  ipCollectionFwdRule1,
+			expectEqual: true,
 		},
 	}
 

--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -190,6 +190,14 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	if err != nil {
 		return nil, l4utils.ResourceResync, fmt.Errorf("error getting ipv6 forwarding rule subnet: %w", err)
 	}
+
+	var ipCollection string
+	if flags.F.EnableBYOIPv6 {
+		ipCollection = annotations.FromService(l4netlb.Service).GetIPCollectionV6()
+	}
+	if ipCollection != "" {
+		subnetworkURL = ""
+	}
 	frLogger.V(2).Info("subnetworkURL for service", "subnetworkURL", subnetworkURL)
 
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
@@ -199,6 +207,12 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 		frLogger.Error(err, "address.IPv6ToUse for service returned error")
 		return nil, l4utils.ResourceResync, err
 	}
+
+	// If the IP collection changed, we cannot reuse the old forwarding rule's IP.
+	if fwdRuleToDetermineIP != nil && fwdRuleToDetermineIP.IpCollection != ipCollection {
+		ipv6AddrToUse = ""
+	}
+
 	frLogger.V(2).Info("ipv6AddressToUse for service", "ipv6AddressToUse", ipv6AddrToUse)
 
 	netTier, isFromAnnotation := annotations.NetworkTier(l4netlb.Service)
@@ -214,6 +228,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	if !l4netlb.cloud.IsLegacyNetwork() && netTier == cloud.NetworkTierPremium {
 		nm := types.NamespacedName{Namespace: l4netlb.Service.Namespace, Name: l4netlb.Service.Name}.String()
 		addrMgr := address.NewManager(l4netlb.cloud, nm, l4netlb.cloud.Region(), subnetworkURL, expectedIPv6FrName, ipv6AddressName, ipv6AddrToUse, cloud.SchemeExternal, netTier, address.IPv6Version, frLogger)
+		addrMgr.SetIPCollection(ipCollection)
 
 		// If network tier annotation in Service Spec is present
 		// check if it matches network tiers from forwarding rule and external ip Address.
@@ -333,6 +348,11 @@ func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse
 		}
 	}
 
+	var ipCollection string
+	if flags.F.EnableBYOIPv6 {
+		ipCollection = annotations.FromService(l4netlb.Service).GetIPCollectionV6()
+	}
+
 	fr := &composite.ForwardingRule{
 		Name:                frName,
 		Description:         frDesc,
@@ -346,6 +366,7 @@ func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse
 		Subnetwork:          subnetworkURL,
 		AllPorts:            allPorts,
 		Ports:               ports,
+		IpCollection:        ipCollection,
 	}
 
 	return fr, nil

--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -424,6 +424,12 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 	l4.network = *svcNetwork
 
+	// Check if ip-collection is specified for IPv4 service
+	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" && l4utils.NeedsIPv4(svc) {
+		err := fmt.Errorf("%s is currently only supported for IPv6-only external LBs", annotations.IPCollectionV6AnnotationKey)
+		l4.recorder.Event(l4.Service, corev1.EventTypeWarning, "IPCollectionV6Error", err.Error())
+	}
+
 	// If service requires IPv6 LoadBalancer -- verify that Subnet with Internal IPv6 ranges is used.
 	if l4.enableDualStack && l4utils.NeedsIPv6(l4.Service) {
 		err := l4.serviceSubnetHasInternalIPv6Range()
@@ -494,6 +500,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	var ipv6AddressName string
 	if l4.enableDualStack && l4utils.NeedsIPv6(l4.Service) {
 		existingIPv6FR, err = l4.getOldIPv6ForwardingRule(existingBS)
+
 		ipv6AddrToUse, ipv6AddressName, err = address.IPv6ToUse(l4.cloud, l4.Service, existingIPv6FR, subnetworkURL, l4.svcLogger)
 		if err != nil {
 			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: address.IPv6ToUse returned error: %w", err)

--- a/pkg/l4/resources/l4_test.go
+++ b/pkg/l4/resources/l4_test.go
@@ -3439,3 +3439,50 @@ func TestEnsureInternalLoadBalancer_L4LBConfigLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureInternalLoadBalancerIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4ILBService(false, 8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4Params := &L4ILBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4 := NewL4Handler(l4Params, klog.TODO())
+
+	if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
+	if result.Error != nil {
+		t.Errorf("Expected no error for conflicting annotations, but got %v", result.Error)
+	}
+
+	fakeRecorder := l4.recorder.(*record.FakeRecorder)
+	warningFound := false
+	for len(fakeRecorder.Events) > 0 {
+		event := <-fakeRecorder.Events
+		if strings.Contains(event, "Warning IPCollectionV6Error") {
+			warningFound = true
+			break
+		}
+	}
+	if !warningFound {
+		t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+	}
+}

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -271,6 +271,47 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service, 
 
 	l4netlb.networkInfo = *networkInfo
 
+	var ipCollectionV6 string
+	if flags.F.EnableBYOIPv6 {
+		ipCollectionV6 = annotations.FromService(svc).GetIPCollectionV6()
+	}
+	subnet := annotations.FromService(svc).GetExternalLoadBalancerAnnotationSubnet()
+	if ipCollectionV6 != "" && subnet != "" {
+		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.CustomSubnetAnnotationKey, subnet, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check conflicts between spec.loadBalancerIP and ip-collection
+	if ipCollectionV6 != "" && svc.Spec.LoadBalancerIP != "" {
+		err := fmt.Errorf("cannot specify both spec.LoadBalancerIP (%q) and %s (%q) for LoadBalancer", svc.Spec.LoadBalancerIP, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check conflicts between load-balancer-ip-addresses and ip-collection
+	staticL4Addresses := svc.Annotations[annotations.StaticL4AddressesAnnotationKey]
+	if ipCollectionV6 != "" && staticL4Addresses != "" {
+		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.StaticL4AddressesAnnotationKey, staticL4Addresses, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check if ip-collection-v6 is specified for an IPv4 service
+	if ipCollectionV6 != "" && l4utils.NeedsIPv4(svc) {
+		err := fmt.Errorf("%s is currently only supported for IPv6-only Services", annotations.IPCollectionV6AnnotationKey)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
 	// if service requires strong session affinity, check requirements
 	if err := l4netlb.checkStrongSessionAffinityRequirements(); err != nil {
 		result.Error = err

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -1655,6 +1655,10 @@ func assertDualStackNetLBResources(t *testing.T, l4NetLB *L4NetLB, nodeNames []s
 func assertDualStackNetLBResourcesWithCustomIPv6Subnet(t *testing.T, l4NetLB *L4NetLB, nodeNames []string, expectedIPv6Subnet string) {
 	t.Helper()
 
+	if annotations.FromService(l4NetLB.Service).GetIPCollectionV6() != "" {
+		expectedIPv6Subnet = ""
+	}
+
 	// Check that HealthCheck is created
 	healthCheck, err := getAndVerifyNetLBHealthCheck(l4NetLB)
 	if err != nil {
@@ -1744,7 +1748,11 @@ func assertNetLBResourcesIPv6Only(t *testing.T, l4NetLB *L4NetLB, nodeNames []st
 		t.Errorf("getAndVerifyNetLBBackendService(_, %v) = %v, want nil", healthcheck, err)
 	}
 
-	if err := verifyNetLBIPv6ForwardingRule(l4NetLB, backendService.SelfLink, l4NetLB.cloud.SubnetworkURL()); err != nil {
+	expectedIPv6Subnet := l4NetLB.cloud.SubnetworkURL()
+	if annotations.FromService(l4NetLB.Service).GetIPCollectionV6() != "" {
+		expectedIPv6Subnet = ""
+	}
+	if err := verifyNetLBIPv6ForwardingRule(l4NetLB, backendService.SelfLink, expectedIPv6Subnet); err != nil {
 		t.Errorf("verifyNetLBIPv6ForwardingRule() = %v, want nil", err)
 	}
 
@@ -2006,6 +2014,12 @@ func buildExpectedNetLBAnnotations(l4netlb *L4NetLB) map[string]string {
 	if val, ok := l4netlb.Service.Annotations[annotations.NetworkTierAnnotationKey]; ok {
 		expectedAnnotations[annotations.NetworkTierAnnotationKey] = val
 	}
+	if val, ok := l4netlb.Service.Annotations[annotations.RBSAnnotationKey]; ok {
+		expectedAnnotations[annotations.RBSAnnotationKey] = val
+	}
+	if val, ok := l4netlb.Service.Annotations[annotations.IPCollectionV6AnnotationKey]; ok {
+		expectedAnnotations[annotations.IPCollectionV6AnnotationKey] = val
+	}
 	return expectedAnnotations
 }
 
@@ -2229,5 +2243,230 @@ func TestEnsureL4NetLB_L4LBConfigLogging(t *testing.T) {
 				t.Errorf("LogConfig mismatch following reconciliation (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestIPv6OnlyNetLBIPCollectionAnnotation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	for k, v := range result.Annotations {
+		svc.Annotations[k] = v
+	}
+	assertNetLBResourcesIPv6Only(t, l4NetLB, nodeNames)
+
+	// Check IpCollection and Subnetwork on IPv6 Forwarding Rule
+	frName := l4NetLB.ipv6FRName()
+	fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection", fwdRule.IpCollection)
+	}
+	if fwdRule.Subnetwork != "" {
+		t.Errorf("fwdRule.Subnetwork = %v, want empty string", fwdRule.Subnetwork)
+	}
+}
+
+func TestEnsureFrontendConflictingAnnotations(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Annotations[annotations.CustomSubnetAnnotationKey] = "my-subnet"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendConflictingIPAnnotations(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.LoadBalancerIP = "1.2.3.4"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendConflictingIPAddressesAnnotation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = "1.2.3.4"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendIPv4OnlyIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for ip-collection on IPv4 service, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for ip-collection on IPv4 service, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendDualStackIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for ip-collection on dualstack service, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for ip-collection on dualstack service, but got %v", result.Error)
 	}
 }


### PR DESCRIPTION
GKE is introducing support for [Bring Your Own IP (BYOIP) IPv6](http://go/byoip-ipv6-gke) which allows users to assign external non-Google IPv6 addresses to clusters and load balancers (LBs). 

User can specify their BYOIP IPv6 addresses through the "networking.gke.io/ip-collection", the controller reserves an address with it and use it for Forwarding Rule creation.

User will get an error when specifying subnet and IP collection at the same time. When creating Forwarding Rules, the defaulted subnetURL will be omitted if ip-collection annotation is specified.