### PR TITLE
NEG Binding Core

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -45,6 +45,8 @@ import (
 	l4lbconfigclient "k8s.io/ingress-gce/pkg/l4lbconfig/client/clientset/versioned"
 	multiprojectgce "k8s.io/ingress-gce/pkg/multiproject/common/gce"
 	multiprojectstart "k8s.io/ingress-gce/pkg/multiproject/start"
+	"k8s.io/ingress-gce/pkg/negbinding"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/network"
 	providerconfigclient "k8s.io/ingress-gce/pkg/providerconfig/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/psc"
@@ -170,10 +172,25 @@ func main() {
 		if _, err := crdHandler.EnsureCRD(negCRDMeta, true); err != nil {
 			klog.Fatalf("Failed to ensure ServiceNetworkEndpointGroup CRD: %v", err)
 		}
+
+		if flags.F.EnableNEGBinding {
+			negBindingCRDMeta := negbinding.CRDMeta()
+			if _, err := crdHandler.EnsureCRD(negBindingCRDMeta, true); err != nil {
+				klog.Fatalf("Failed to ensure NetworkEndpointGroupBinding CRD: %v", err)
+			}
+		}
 	}
 	svcNegClient, err := svcnegclient.NewForConfig(kubeConfig)
 	if err != nil {
 		klog.Fatalf("Failed to create NetworkEndpointGroup client: %v", err)
+	}
+
+	var negBindingClient negbindingclient.Interface
+	if flags.F.EnableNEGBinding {
+		negBindingClient, err = negbindingclient.NewForConfig(kubeConfig)
+		if err != nil {
+			klog.Fatalf("Failed to create NetworkEndpointGroupBinding client: %v", err)
+		}
 	}
 
 	var svcAttachmentClient serviceattachmentclient.Interface
@@ -278,6 +295,7 @@ func main() {
 					rootLogger,
 					kubeClient,
 					svcNegClient,
+					negBindingClient,
 					networkClient,
 					nodeTopologyClient,
 					kubeSystemUID,
@@ -297,6 +315,7 @@ func main() {
 					rootLogger,
 					kubeClient,
 					svcNegClient,
+					negBindingClient,
 					networkClient,
 					nodeTopologyClient,
 					kubeSystemUID,
@@ -360,7 +379,7 @@ func main() {
 		ReadOnlyMode:                         flags.F.ReadOnlyMode,
 		EnableL4NetLBRBSByDefault:            flags.F.EnableL4NetLBRBSByDefault,
 	}
-	ctx, err := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, svcAttachmentClient, networkClient, nodeTopologyClient, l4LBConfigClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
+	ctx, err := ingctx.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, firewallCRClient, svcNegClient, negBindingClient, svcAttachmentClient, networkClient, nodeTopologyClient, l4LBConfigClient, eventRecorderKubeClient, cloud, namer, kubeSystemUID, ctxConfig, rootLogger)
 	if err != nil {
 		klog.Fatalf("unable to set up controller context: %v", err)
 	}
@@ -731,6 +750,7 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 	negController, err := neg.NewController(
 		ctx.KubeClient,
 		ctx.SvcNegClient,
+		ctx.NEGBindingClient,
 		ctx.EventRecorderClient,
 		ctx.KubeSystemUID,
 		ctx.IngressInformer,
@@ -739,6 +759,7 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 		ctx.NodeInformer,
 		ctx.EndpointSliceInformer,
 		ctx.SvcNegInformer,
+		ctx.NEGBindingInformer,
 		ctx.NetworkInformer,
 		ctx.GKENetworkParamsInformer,
 		ctx.NodeTopologyInformer,
@@ -761,6 +782,7 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
 		flags.F.EnableNEGsForIngress,
+		flags.F.EnableNEGBinding,
 		flags.F.EnableL4NEGLocalIncludeDrainNodes,
 		stopCh,
 		logger,

--- a/pkg/common/operator/ingress_test.go
+++ b/pkg/common/operator/ingress_test.go
@@ -57,7 +57,7 @@ func TestReferencesSvcNeg(t *testing.T) {
 		HealthCheckPath:               "/",
 		EnableIngressRegionalExternal: true,
 	}
-	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 	if err != nil {
 		t.Fatalf("Failed to initialize controller context: %v", err)
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -45,6 +45,9 @@ import (
 	l4lbconfigclient "k8s.io/ingress-gce/pkg/l4lbconfig/client/clientset/versioned"
 	informerl4lbconfig "k8s.io/ingress-gce/pkg/l4lbconfig/client/informers/externalversions/l4lbconfig/v1"
 	"k8s.io/ingress-gce/pkg/metrics"
+	"k8s.io/ingress-gce/pkg/neg"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
 	"k8s.io/ingress-gce/pkg/recorders"
 	serviceattachmentclient "k8s.io/ingress-gce/pkg/serviceattachment/client/clientset/versioned"
 	informerserviceattachment "k8s.io/ingress-gce/pkg/serviceattachment/client/informers/externalversions/serviceattachment/v1"
@@ -69,6 +72,7 @@ const (
 type ControllerContext struct {
 	KubeClient          kubernetes.Interface
 	SvcNegClient        svcnegclient.Interface
+	NEGBindingClient    negbindingclient.Interface
 	SAClient            serviceattachmentclient.Interface
 	FirewallClient      firewallclient.Interface
 	EventRecorderClient kubernetes.Interface
@@ -91,6 +95,7 @@ type ControllerContext struct {
 	NodeInformer             cache.SharedIndexInformer
 	EndpointSliceInformer    cache.SharedIndexInformer
 	SvcNegInformer           cache.SharedIndexInformer
+	NEGBindingInformer       cache.SharedIndexInformer
 	SAInformer               cache.SharedIndexInformer
 	FirewallInformer         cache.SharedIndexInformer
 	NetworkInformer          cache.SharedIndexInformer
@@ -154,6 +159,7 @@ func NewControllerContext(
 	frontendConfigClient frontendconfigclient.Interface,
 	firewallClient firewallclient.Interface,
 	svcnegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	saClient serviceattachmentclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
@@ -182,6 +188,7 @@ func NewControllerContext(
 		KubeClient:              kubeClient,
 		FirewallClient:          firewallClient,
 		SvcNegClient:            svcnegClient,
+		NEGBindingClient:        negBindingClient,
 		SAClient:                saClient,
 		EventRecorderClient:     eventRecorderClient,
 		NodeTopologyClient:      nodeTopologyClient,
@@ -216,6 +223,11 @@ func NewControllerContext(
 
 	if saClient != nil {
 		context.SAInformer = informerserviceattachment.NewServiceAttachmentInformer(saClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())
+	}
+
+	if negBindingClient != nil {
+		context.NEGBindingInformer = informernegbinding.NewNetworkEndpointGroupBindingInformer(negBindingClient, config.Namespace, config.ResyncPeriod, utils.NewNamespaceIndexer())
+		_ = context.NEGBindingInformer.AddIndexers(cache.Indexers{neg.ServiceKeyIndex: neg.ServiceKeyIndexFunc})
 	}
 
 	if networkClient != nil {
@@ -317,6 +329,9 @@ func (ctx *ControllerContext) HasSynced() bool {
 	if ctx.SAInformer != nil {
 		funcs = append(funcs, ctx.SAInformer.HasSynced)
 	}
+	if ctx.NEGBindingInformer != nil {
+		funcs = append(funcs, ctx.NEGBindingInformer.HasSynced)
+	}
 	if ctx.NetworkInformer != nil {
 		funcs = append(funcs, ctx.NetworkInformer.HasSynced)
 	}
@@ -362,6 +377,9 @@ func (ctx *ControllerContext) Start(stopCh <-chan struct{}) {
 	}
 	if ctx.SAInformer != nil {
 		go ctx.SAInformer.Run(stopCh)
+	}
+	if ctx.NEGBindingInformer != nil {
+		go ctx.NEGBindingInformer.Run(stopCh)
 	}
 	if ctx.NetworkInformer != nil {
 		go ctx.NetworkInformer.Run(stopCh)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -96,7 +96,7 @@ func newLoadBalancerController() (*LoadBalancerController, error) {
 		HealthCheckPath:               "/",
 		EnableIngressRegionalExternal: true,
 	}
-	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, nil, svcNegClient, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, frontendConfigClient, nil, svcNegClient, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controller context")
 	}

--- a/pkg/firewalls/controller_test.go
+++ b/pkg/firewalls/controller_test.go
@@ -57,7 +57,7 @@ func newFirewallController() (*FirewallController, error) {
 		ResyncPeriod:          1 * time.Minute,
 		DefaultBackendSvcPort: test.DefaultBeSvcPort,
 	}
-	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, nil, firewallClient, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, backendConfigClient, nil, firewallClient, nil, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, defaultNamer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controller context: %v", err)
 	}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -112,6 +112,7 @@ var F = struct {
 	EnableL4ILBDualStack                        bool
 	EnableL4NetLBDualStack                      bool
 	EnableNEGController                         bool
+	EnableNEGBinding                            bool
 	EnableL4NEG                                 bool
 	EnableL4NetLBNEG                            bool
 	EnableL4NetLBNEGDefault                     bool
@@ -314,6 +315,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.RunL4StandaloneNEGController, "run-l4-standalone-neg-controller", false, `Optional, if enabled then the Standalone NEG L4 LB controller will be run.`)
 	flag.BoolVar(&F.EnableL4StandaloneNEGs, "enable-l4-standalone-negs", false, `Optional, if enabled the NEG controller will process standalone NEGs for services using the StandalonePassthroughNegLoadBalancerClass.`)
 	flag.BoolVar(&F.EnableNEGController, "enable-neg-controller", true, `Optional, if enabled then the NEG controller will be run.`)
+	flag.BoolVar(&F.EnableNEGBinding, "enable-neg-binding", false, `Optional, if enabled then NEG controller will process NEGBinding CRs.`)
 	flag.BoolVar(&F.EnableL4NEG, "enable-l4-neg", false, `Optional, if enabled then the NEG controller will process L4 NEGs.`)
 	flag.BoolVar(&F.EnableL4NetLBNEG, "enable-l4-netlb-neg", false, `Optional, if enabled then the NetLB controller can create L4 NetLB services with NEG backends.`)
 	flag.BoolVar(&F.EnableL4NetLBNEGDefault, "enable-l4-netlb-neg-default", false, `Optional, if enabled then newly created L4 NetLB services will use NEG backends. Has effect only if '--enable-l4-netlb-neg' is set to true.`)

--- a/pkg/l4/controllers/l4controller_test.go
+++ b/pkg/l4/controllers/l4controller_test.go
@@ -1034,7 +1034,7 @@ func newServiceController(t *testing.T, fakeGCE *gce.Cloud, readOnlyMode bool) (
 		EnableL4ILBDualStack:   true,
 		EnableL4NetLBDualStack: true,
 	}
-	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 	if err != nil {
 		t.Fatalf("failed to initialize controller context: %v", err)
 	}

--- a/pkg/l4/controllers/l4netlbcontroller_test.go
+++ b/pkg/l4/controllers/l4netlbcontroller_test.go
@@ -331,7 +331,7 @@ func buildContext(vals gce.TestClusterValues, readOnlyMode bool, isRBSdefault bo
 		EnableL4NetLBDualStack:    true,
 		EnableL4NetLBRBSByDefault: isRBSdefault,
 	}
-	return ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, networkClient, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
+	return ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, networkClient, nil, nil, kubeClient /*kube client to be used for events*/, fakeGCE, namer, "" /*kubeSystemUID*/, ctxConfig, klog.TODO())
 }
 
 func newL4NetLBServiceController() *L4NetLBController {

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -674,7 +674,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			defer close(stopCh)
 
 			ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
 			if err != nil {
 				t.Fatalf("Failed to create controller context: %v", err)
 			}
@@ -857,7 +857,7 @@ func setupControllerContext(t *testing.T) (*fake.Clientset, *gce.Cloud, *Standal
 	stopCh := make(chan struct{})
 
 	ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
 	if err != nil {
 		t.Fatalf("Failed to create controller context: %v", err)
 	}

--- a/pkg/multiproject/neg/informerset/informerset.go
+++ b/pkg/multiproject/neg/informerset/informerset.go
@@ -12,6 +12,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/ingress-gce/pkg/multiproject/common/filteredinformer"
+	"k8s.io/ingress-gce/pkg/neg"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
+	negbindinginformers "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	svcneginformers "k8s.io/ingress-gce/pkg/svcneg/client/informers/externalversions"
 	"k8s.io/ingress-gce/pkg/utils/endpointslices"
@@ -25,6 +28,7 @@ type InformerSet struct {
 	svcNegFactory       svcneginformers.SharedInformerFactory
 	networkFactory      networkinformers.SharedInformerFactory
 	nodetopologyFactory nodetopologyinformers.SharedInformerFactory
+	negBindingFactory   negbindinginformers.SharedInformerFactory
 
 	// Core Kubernetes informers (always present)
 	Ingress       cache.SharedIndexInformer
@@ -35,6 +39,7 @@ type InformerSet struct {
 
 	// Custom resource informers (may be nil)
 	SvcNeg           cache.SharedIndexInformer // ServiceNetworkEndpointGroups CRD
+	NEGBinding       cache.SharedIndexInformer // NEGBinding CRD
 	Network          cache.SharedIndexInformer // GKE Network CRD
 	GkeNetworkParams cache.SharedIndexInformer // GKENetworkParamSets CRD
 	NodeTopology     cache.SharedIndexInformer // NodeTopology CRD
@@ -49,6 +54,7 @@ type InformerSet struct {
 func NewInformerSet(
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
 	resyncPeriod metav1.Duration,
@@ -64,6 +70,9 @@ func NewInformerSet(
 	}
 	if nodeTopologyClient != nil {
 		infSet.nodetopologyFactory = nodetopologyinformers.NewSharedInformerFactory(nodeTopologyClient, resyncPeriod.Duration)
+	}
+	if negBindingClient != nil {
+		infSet.negBindingFactory = negbindinginformers.NewSharedInformerFactory(negBindingClient, resyncPeriod.Duration)
 	}
 
 	// Create core Kubernetes informers from factory
@@ -93,6 +102,16 @@ func NewInformerSet(
 
 	if infSet.nodetopologyFactory != nil {
 		infSet.NodeTopology = infSet.nodetopologyFactory.Networking().V1().NodeTopologies().Informer()
+	}
+
+	if infSet.negBindingFactory != nil {
+		negBindingInformer := infSet.negBindingFactory.Networking().V1beta1().NetworkEndpointGroupBindings().Informer()
+		if err := negBindingInformer.AddIndexers(cache.Indexers{
+			neg.ServiceKeyIndex: neg.ServiceKeyIndexFunc,
+		}); err != nil {
+			klog.Fatalf("failed to add indexers to NEGBinding informer: %v", err)
+		}
+		infSet.NEGBinding = negBindingInformer
 	}
 	return infSet
 }
@@ -129,6 +148,9 @@ func (i *InformerSet) Start(stopCh <-chan struct{}, logger klog.Logger) error {
 	}
 	if i.nodetopologyFactory != nil {
 		i.nodetopologyFactory.Start(stopCh)
+	}
+	if i.negBindingFactory != nil {
+		i.negBindingFactory.Start(stopCh)
 	}
 
 	i.started = true
@@ -181,6 +203,9 @@ func (i *InformerSet) FilterByProviderConfig(providerConfigName string) *Informe
 	}
 	if i.NodeTopology != nil {
 		filteredInformers.NodeTopology = newProviderConfigFilteredInformer(i.NodeTopology, providerConfigName)
+	}
+	if i.NEGBinding != nil {
+		filteredInformers.NEGBinding = newProviderConfigFilteredInformer(i.NEGBinding, providerConfigName)
 	}
 
 	return filteredInformers
@@ -238,6 +263,9 @@ func (i *InformerSet) hasSyncedFuncs() []func() bool {
 	}
 	if i.NodeTopology != nil {
 		funcs = append(funcs, i.NodeTopology.HasSynced)
+	}
+	if i.NEGBinding != nil {
+		funcs = append(funcs, i.NEGBinding.HasSynced)
 	}
 
 	return funcs

--- a/pkg/multiproject/neg/informerset/informerset_test.go
+++ b/pkg/multiproject/neg/informerset/informerset_test.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
+	negbindingfake "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	svcnegfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/utils/endpointslices"
@@ -31,9 +33,11 @@ func TestNewInformerSet_OptionalClients(t *testing.T) {
 	testCases := []struct {
 		name             string
 		withSvcNeg       bool
+		withNEGBinding   bool
 		withNetwork      bool
 		withNodeTopology bool
 		wantSvcNeg       bool
+		wantNEGBinding   bool
 		wantNetwork      bool
 		wantGKEParams    bool
 		wantNodeTopology bool
@@ -44,9 +48,11 @@ func TestNewInformerSet_OptionalClients(t *testing.T) {
 		{
 			name:             "all-optional-clients",
 			withSvcNeg:       true,
+			withNEGBinding:   true,
 			withNetwork:      true,
 			withNodeTopology: true,
 			wantSvcNeg:       true,
+			wantNEGBinding:   true,
 			wantNetwork:      true,
 			wantGKEParams:    true,
 			wantNodeTopology: true,
@@ -65,6 +71,11 @@ func TestNewInformerSet_OptionalClients(t *testing.T) {
 				svcNegClient = svcnegfake.NewSimpleClientset()
 			}
 
+			var negBindingClient negbindingclient.Interface
+			if tc.withNEGBinding {
+				negBindingClient = negbindingfake.NewSimpleClientset()
+			}
+
 			var netClient networkclient.Interface
 			if tc.withNetwork {
 				netClient = networkfake.NewSimpleClientset()
@@ -75,13 +86,16 @@ func TestNewInformerSet_OptionalClients(t *testing.T) {
 				topoClient = nodetopologyfake.NewSimpleClientset()
 			}
 
-			inf := NewInformerSet(kubeClient, svcNegClient, netClient, topoClient, metav1.Duration{Duration: 0})
+			inf := NewInformerSet(kubeClient, svcNegClient, negBindingClient, netClient, topoClient, metav1.Duration{Duration: 0})
 			if inf == nil {
 				t.Fatalf("NewInformerSet returned nil")
 			}
 
 			if got := inf.SvcNeg != nil; got != tc.wantSvcNeg {
 				t.Errorf("SvcNeg: got %t, want %t", got, tc.wantSvcNeg)
+			}
+			if got := inf.NEGBinding != nil; got != tc.wantNEGBinding {
+				t.Errorf("NEGBinding: got %t, want %t", got, tc.wantNEGBinding)
 			}
 			if got := inf.Network != nil; got != tc.wantNetwork {
 				t.Errorf("Network: got %t, want %t", got, tc.wantNetwork)
@@ -102,7 +116,7 @@ func TestEndpointSlice_HasRequiredIndexers(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := k8sfake.NewSimpleClientset()
-	inf := NewInformerSet(kubeClient, nil, nil, nil, metav1.Duration{Duration: 0})
+	inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
 	if inf == nil {
 		t.Fatalf("NewInformerSet returned nil")
 	}
@@ -147,7 +161,7 @@ func TestStart_Semantics(t *testing.T) {
 			test.PrependBookmarkReactor(&kubeClient.Fake, kubeClient.Tracker(), r.res, r.obj)
 		}
 
-		inf := NewInformerSet(kubeClient, nil, nil, nil, metav1.Duration{Duration: 0})
+		inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
 
 		stop := make(chan struct{})
 		defer close(stop)
@@ -166,7 +180,7 @@ func TestStart_Semantics(t *testing.T) {
 		t.Parallel()
 
 		kubeClient := k8sfake.NewSimpleClientset()
-		inf := NewInformerSet(kubeClient, nil, nil, nil, metav1.Duration{Duration: 0})
+		inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
 
 		stop := make(chan struct{})
 		close(stop)
@@ -198,7 +212,7 @@ func TestStart_Semantics(t *testing.T) {
 		for _, r := range resources {
 			test.PrependBookmarkReactor(&kubeClient.Fake, kubeClient.Tracker(), r.res, r.obj)
 		}
-		inf := NewInformerSet(kubeClient, nil, nil, nil, metav1.Duration{Duration: 0})
+		inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
 
 		stop := make(chan struct{})
 		defer close(stop)
@@ -259,7 +273,7 @@ func TestFilterByProviderConfig_WrappingAndState(t *testing.T) {
 		ObjectMeta: test.DefaultBookmarkObjectMeta,
 	})
 
-	inf := NewInformerSet(kubeClient, svcClient, nil, nil, metav1.Duration{Duration: 0})
+	inf := NewInformerSet(kubeClient, svcClient, nil, nil, nil, metav1.Duration{Duration: 0})
 
 	// Before starting, filtered should mirror started=false.
 	filteredBefore := inf.FilterByProviderConfig("pc-1")
@@ -325,7 +339,7 @@ func TestFilterByProviderConfig_PreservesIndexers(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := k8sfake.NewSimpleClientset()
-	inf := NewInformerSet(kubeClient, nil, nil, nil, metav1.Duration{Duration: 0})
+	inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
 
 	original := inf.EndpointSlice.GetIndexer().GetIndexers()
 	filtered := inf.FilterByProviderConfig("pc-1").EndpointSlice.GetIndexer().GetIndexers()

--- a/pkg/multiproject/neg/neg.go
+++ b/pkg/multiproject/neg/neg.go
@@ -17,6 +17,7 @@ import (
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/network"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -48,6 +49,7 @@ func StartNEGController(
 	kubeClient kubernetes.Interface,
 	eventRecorderClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
 	kubeSystemUID types.UID,
@@ -94,6 +96,7 @@ func StartNEGController(
 	negController, err := createNEGController(
 		kubeClient,
 		svcNegClient,
+		negBindingClient,
 		eventRecorderClient,
 		kubeSystemUID,
 		filteredInformers.Ingress,
@@ -102,6 +105,7 @@ func StartNEGController(
 		filteredInformers.Node,
 		filteredInformers.EndpointSlice,
 		filteredInformers.SvcNeg,
+		filteredInformers.NEGBinding,
 		filteredInformers.Network,
 		filteredInformers.GkeNetworkParams,
 		filteredInformers.NodeTopology,
@@ -128,6 +132,7 @@ func StartNEGController(
 func createNEGController(
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	eventRecorderClient kubernetes.Interface,
 	kubeSystemUID types.UID,
 	ingressInformer cache.SharedIndexInformer,
@@ -136,6 +141,7 @@ func createNEGController(
 	nodeInformer cache.SharedIndexInformer,
 	endpointSliceInformer cache.SharedIndexInformer,
 	svcNegInformer cache.SharedIndexInformer,
+	negBindingInformer cache.SharedIndexInformer,
 	networkInformer cache.SharedIndexInformer,
 	gkeNetworkParamsInformer cache.SharedIndexInformer,
 	nodeTopologyInformer cache.SharedIndexInformer,
@@ -163,6 +169,7 @@ func createNEGController(
 	negController, err := newNEGController(
 		kubeClient,
 		svcNegClient,
+		negBindingClient,
 		eventRecorderClient,
 		kubeSystemUID,
 		ingressInformer,
@@ -171,6 +178,7 @@ func createNEGController(
 		nodeInformer,
 		endpointSliceInformer,
 		svcNegInformer,
+		negBindingInformer,
 		networkInformer,
 		gkeNetworkParamsInformer,
 		nodeTopologyInformer,
@@ -193,6 +201,7 @@ func createNEGController(
 		flags.F.EnableL4NetLBNEG,
 		flags.F.ReadOnlyMode,
 		flags.F.EnableNEGsForIngress,
+		flags.F.EnableNEGBinding,
 		flags.F.EnableL4NEGLocalIncludeDrainNodes,
 		stopCh,
 		logger,

--- a/pkg/multiproject/neg/neg_test.go
+++ b/pkg/multiproject/neg/neg_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 	providerconfig "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
 	svcnegv1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	multiprojectgce "k8s.io/ingress-gce/pkg/multiproject/common/gce"
@@ -20,6 +21,8 @@ import (
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
+	negbindingfake "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	svcnegfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/test"
@@ -37,6 +40,7 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	kubeClient := k8sfake.NewSimpleClientset()
 	svcNegClient := svcnegfake.NewSimpleClientset()
+	negBindingClient := negbindingfake.NewSimpleClientset()
 
 	test.PrependBookmarkReactor(&kubeClient.Fake, kubeClient.Tracker(), "*", &providerconfig.ProviderConfig{
 		ObjectMeta: test.DefaultBookmarkObjectMeta,
@@ -44,8 +48,11 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 	test.PrependBookmarkReactor(&svcNegClient.Fake, svcNegClient.Tracker(), "*", &svcnegv1.ServiceNetworkEndpointGroup{
 		ObjectMeta: test.DefaultBookmarkObjectMeta,
 	})
+	test.PrependBookmarkReactor(&negBindingClient.Fake, negBindingClient.Tracker(), "*", &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
 
-	informers := multiprojectinformers.NewInformerSet(kubeClient, svcNegClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
+	informers := multiprojectinformers.NewInformerSet(kubeClient, svcNegClient, negBindingClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
 
 	// Start base informers; they are not strictly required by our stubbed controller,
 	// but mirrors real startup flow and ensures CombinedHasSynced would be true if used.
@@ -84,16 +91,16 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 	// that can run without panics.
 	var capturedStopCh <-chan struct{}
 	orig := newNEGController
-	newNEGController = func(kc kubernetes.Interface, sc svcnegclient.Interface, ec kubernetes.Interface, uid types.UID,
+	newNEGController = func(kc kubernetes.Interface, sc svcnegclient.Interface, nbc negbindingclient.Interface, ec kubernetes.Interface, uid types.UID,
 		ing cache.SharedIndexInformer, svc cache.SharedIndexInformer, pod cache.SharedIndexInformer, node cache.SharedIndexInformer,
-		es cache.SharedIndexInformer, sn cache.SharedIndexInformer, netInf cache.SharedIndexInformer, gke cache.SharedIndexInformer, nt cache.SharedIndexInformer,
+		es cache.SharedIndexInformer, sn cache.SharedIndexInformer, nbi cache.SharedIndexInformer, netInf cache.SharedIndexInformer, gke cache.SharedIndexInformer, nt cache.SharedIndexInformer,
 		synced func() bool, l4 namer.L4ResourcesNamer, defSP utils.ServicePort, cloud negtypes.NetworkEndpointGroupCloud, zg *zonegetter.ZoneGetter, nm negtypes.NetworkEndpointGroupNamer,
 		resync time.Duration, gc time.Duration, workers int, enableRR bool, runL4 bool, nonGCP bool, dualStack bool, lp labels.PodLabelPropagationConfig,
-		multiNetworking bool, ingressRegional bool, runNetLB bool, readOnly bool, enableNEGsForIngress bool, includeDrainNodesL4Local bool,
+		multiNetworking bool, ingressRegional bool, runNetLB bool, readOnly bool, enableNEGsForIngress bool, enableNEGBinding bool, includeDrainNodesL4Local bool,
 		stopCh <-chan struct{}, l klog.Logger, negMetrics *metrics.NegMetrics, syncerMetrics *syncMetrics.SyncerMetrics) (*neg.Controller, error) {
 		capturedStopCh = stopCh
-		return neg.NewController(kc, sc, ec, uid, ing, svc, pod, node, es, sn, netInf, gke, nt, synced, l4, defSP, cloud, zg, nm,
-			resync, gc, workers, enableRR, runL4, nonGCP, dualStack, lp, multiNetworking, ingressRegional, runNetLB, readOnly, enableNEGsForIngress, includeDrainNodesL4Local, stopCh, l, negMetrics, syncerMetrics)
+		return neg.NewController(kc, sc, nbc, ec, uid, ing, svc, pod, node, es, sn, nbi, netInf, gke, nt, synced, l4, defSP, cloud, zg, nm,
+			resync, gc, workers, enableRR, runL4, nonGCP, dualStack, lp, multiNetworking, ingressRegional, runNetLB, readOnly, enableNEGsForIngress, enableNEGBinding, includeDrainNodesL4Local, stopCh, l, negMetrics, syncerMetrics)
 	}
 	t.Cleanup(func() { newNEGController = orig })
 
@@ -118,7 +125,7 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 				// Wire the join to the real globalStop for this subcase.
 				joinStop = globalStop
 				var err error
-				providerStop, err = StartNEGController(informers, kubeClient, kubeClient, svcnegfake.NewSimpleClientset(), networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, joinStop, logger, pc, syncMetrics.FakeSyncerMetrics())
+				providerStop, err = StartNEGController(informers, kubeClient, kubeClient, svcnegfake.NewSimpleClientset(), negBindingClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, joinStop, logger, pc, syncMetrics.FakeSyncerMetrics())
 				if err != nil {
 					t.Fatalf("StartNEGController: %v", err)
 				}
@@ -128,7 +135,7 @@ func TestStartNEGController_StopJoin(t *testing.T) {
 				js := make(chan struct{})
 				joinStop = js
 				var err error
-				providerStop, err = StartNEGController(informers, kubeClient, kubeClient, svcnegfake.NewSimpleClientset(), networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, joinStop, logger, &providerconfig.ProviderConfig{ObjectMeta: metav1.ObjectMeta{Name: "pc-2"}}, syncMetrics.FakeSyncerMetrics())
+				providerStop, err = StartNEGController(informers, kubeClient, kubeClient, svcnegfake.NewSimpleClientset(), negBindingClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, joinStop, logger, &providerconfig.ProviderConfig{ObjectMeta: metav1.ObjectMeta{Name: "pc-2"}}, syncMetrics.FakeSyncerMetrics())
 				if err != nil {
 					t.Fatalf("StartNEGController (2): %v", err)
 				}
@@ -156,7 +163,11 @@ func TestStartNEGController_NilSvcNegClientErrors(t *testing.T) {
 
 	logger, _ := ktesting.NewTestContext(t)
 	kubeClient := k8sfake.NewSimpleClientset()
-	informers := multiprojectinformers.NewInformerSet(kubeClient, nil, networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
+	negBindingClient := negbindingfake.NewSimpleClientset()
+	test.PrependBookmarkReactor(&negBindingClient.Fake, negBindingClient.Tracker(), "*", &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
+	informers := multiprojectinformers.NewInformerSet(kubeClient, nil, negBindingClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), metav1.Duration{})
 	globalStop := make(chan struct{})
 	t.Cleanup(func() { close(globalStop) })
 	if err := informers.Start(globalStop, logger); err != nil {
@@ -186,7 +197,7 @@ func TestStartNEGController_NilSvcNegClientErrors(t *testing.T) {
 	}
 
 	// newNEGController remains default (neg.NewController), which errors when svcNegClient is nil
-	ch, err := StartNEGController(informers, kubeClient, kubeClient, nil /* svcneg */, networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, globalStop, logger, pc, syncMetrics.FakeSyncerMetrics())
+	ch, err := StartNEGController(informers, kubeClient, kubeClient, nil /* svcneg */, negBindingClient, networkclient.Interface(nil), nodetopologyclient.Interface(nil), kubeSystemUID, rootNamer, l4Namer, lpCfg, cloud, globalStop, logger, pc, syncMetrics.FakeSyncerMetrics())
 	if err == nil {
 		t.Fatalf("expected error from StartNEGController when svcNegClient is nil, got nil and channel=%v", ch)
 	}

--- a/pkg/multiproject/neg/starter.go
+++ b/pkg/multiproject/neg/starter.go
@@ -12,6 +12,7 @@ import (
 	multiprojectinformers "k8s.io/ingress-gce/pkg/multiproject/neg/informerset"
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
@@ -23,6 +24,7 @@ type NEGControllerStarter struct {
 	informers           *multiprojectinformers.InformerSet
 	kubeClient          kubernetes.Interface
 	svcNegClient        svcnegclient.Interface
+	negBindingClient    negbindingclient.Interface
 	networkClient       networkclient.Interface
 	nodetopologyClient  nodetopologyclient.Interface
 	eventRecorderClient kubernetes.Interface
@@ -41,6 +43,7 @@ func NewNEGControllerStarter(
 	informers *multiprojectinformers.InformerSet,
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodetopologyClient nodetopologyclient.Interface,
 	eventRecorderClient kubernetes.Interface,
@@ -57,6 +60,7 @@ func NewNEGControllerStarter(
 		informers:           informers,
 		kubeClient:          kubeClient,
 		svcNegClient:        svcNegClient,
+		negBindingClient:    negBindingClient,
 		networkClient:       networkClient,
 		nodetopologyClient:  nodetopologyClient,
 		eventRecorderClient: eventRecorderClient,
@@ -88,6 +92,7 @@ func (s *NEGControllerStarter) StartController(pc *providerconfig.ProviderConfig
 		s.kubeClient,
 		s.eventRecorderClient,
 		s.svcNegClient,
+		s.negBindingClient,
 		s.networkClient,
 		s.nodetopologyClient,
 		s.kubeSystemUID,

--- a/pkg/multiproject/start/start.go
+++ b/pkg/multiproject/start/start.go
@@ -28,6 +28,7 @@ import (
 	providerconfiginformers "k8s.io/ingress-gce/pkg/providerconfig/client/informers/externalversions"
 	"k8s.io/ingress-gce/pkg/recorders"
 
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
@@ -43,6 +44,7 @@ func StartWithLeaderElection(
 	logger klog.Logger,
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
 	kubeSystemUID types.UID,
@@ -57,7 +59,7 @@ func StartWithLeaderElection(
 
 	recordersManager := recorders.NewManager(eventRecorderKubeClient, logger)
 
-	leConfig, err := makeLeaderElectionConfig(leaderElectKubeClient, hostname, recordersManager, logger, kubeClient, svcNegClient, networkClient, nodeTopologyClient, kubeSystemUID, eventRecorderKubeClient, providerConfigClient, gceCreator, rootNamer, syncerMetrics)
+	leConfig, err := makeLeaderElectionConfig(leaderElectKubeClient, hostname, recordersManager, logger, kubeClient, svcNegClient, negBindingClient, networkClient, nodeTopologyClient, kubeSystemUID, eventRecorderKubeClient, providerConfigClient, gceCreator, rootNamer, syncerMetrics)
 	if err != nil {
 		return err
 	}
@@ -82,6 +84,7 @@ func makeLeaderElectionConfig(
 	logger klog.Logger,
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
 	kubeSystemUID types.UID,
@@ -118,7 +121,7 @@ func makeLeaderElectionConfig(
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				logger.Info("Became leader, starting multi-project controller")
-				Start(logger, kubeClient, svcNegClient, networkClient, nodeTopologyClient, kubeSystemUID, eventRecorderKubeClient, providerConfigClient, gceCreator, rootNamer, ctx.Done(), syncerMetrics)
+				Start(logger, kubeClient, svcNegClient, negBindingClient, networkClient, nodeTopologyClient, kubeSystemUID, eventRecorderKubeClient, providerConfigClient, gceCreator, rootNamer, ctx.Done(), syncerMetrics)
 			},
 			OnStoppedLeading: func() {
 				logger.Info("Stop running multi-project leader election")
@@ -135,6 +138,7 @@ func Start(
 	logger klog.Logger,
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	networkClient networkclient.Interface,
 	nodeTopologyClient nodetopologyclient.Interface,
 	kubeSystemUID types.UID,
@@ -158,6 +162,7 @@ func Start(
 	informers := multiprojectinformers.NewInformerSet(
 		kubeClient,
 		svcNegClient,
+		negBindingClient,
 		networkClient,
 		nodeTopologyClient,
 		metav1.Duration{Duration: flags.F.ResyncPeriod},
@@ -174,6 +179,7 @@ func Start(
 		informers,
 		kubeClient,
 		svcNegClient,
+		negBindingClient,
 		networkClient,
 		nodeTopologyClient,
 		eventRecorderKubeClient,

--- a/pkg/multiproject/start/start_test.go
+++ b/pkg/multiproject/start/start_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	cloudgce "k8s.io/cloud-provider-gcp/providers/gce"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 	providerconfigv1 "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
 	svcnegv1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/flags"
@@ -35,6 +36,7 @@ import (
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/negannotation"
+	negbindingfake "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
 	pcclientfake "k8s.io/ingress-gce/pkg/providerconfig/client/clientset/versioned/fake"
 	svcnegfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/test"
@@ -215,6 +217,7 @@ func TestStartProviderConfigIntegration(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset()
 			pcClient := pcclientfake.NewSimpleClientset()
 			svcNegClient := svcnegfake.NewSimpleClientset()
+			negBindingClient := negbindingfake.NewSimpleClientset()
 			networkClient := networkfake.NewSimpleClientset()
 			nodeTopologyClient := nodetopologyfake.NewSimpleClientset()
 
@@ -237,6 +240,10 @@ func TestStartProviderConfigIntegration(t *testing.T) {
 			})
 
 			test.PrependBookmarkReactor(&svcNegClient.Fake, svcNegClient.Tracker(), "servicenetworkendpointgroups", &svcnegv1.ServiceNetworkEndpointGroup{
+				ObjectMeta: test.DefaultBookmarkObjectMeta,
+			})
+
+			test.PrependBookmarkReactor(&negBindingClient.Fake, negBindingClient.Tracker(), "networkendpointgroupbindings", &negbindingv1beta1.NetworkEndpointGroupBinding{
 				ObjectMeta: test.DefaultBookmarkObjectMeta,
 			})
 
@@ -276,6 +283,7 @@ func TestStartProviderConfigIntegration(t *testing.T) {
 					logger,
 					kubeClient,
 					svcNegClient,
+					negBindingClient,
 					networkClient,
 					nodeTopologyClient,
 					kubeSystemUID,
@@ -370,6 +378,7 @@ func TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	pcClient := pcclientfake.NewSimpleClientset()
 	svcNegClient := svcnegfake.NewSimpleClientset()
+	negBindingClient := negbindingfake.NewSimpleClientset()
 	networkClient := networkfake.NewSimpleClientset()
 	nodeTopoClient := nodetopologyfake.NewSimpleClientset()
 
@@ -392,6 +401,10 @@ func TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking(t *testing.T) {
 	})
 
 	test.PrependBookmarkReactor(&svcNegClient.Fake, svcNegClient.Tracker(), "servicenetworkendpointgroups", &svcnegv1.ServiceNetworkEndpointGroup{
+		ObjectMeta: test.DefaultBookmarkObjectMeta,
+	})
+
+	test.PrependBookmarkReactor(&negBindingClient.Fake, negBindingClient.Tracker(), "networkendpointgroupbindings", &negbindingv1beta1.NetworkEndpointGroupBinding{
 		ObjectMeta: test.DefaultBookmarkObjectMeta,
 	})
 
@@ -424,7 +437,7 @@ func TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking(t *testing.T) {
 
 	// Start multiproject manager (this starts shared factories once with globalStop).
 	go Start(
-		logger, kubeClient, svcNegClient, networkClient, nodeTopoClient,
+		logger, kubeClient, svcNegClient, negBindingClient, networkClient, nodeTopoClient,
 		kubeSystemUID, kubeClient, pcClient,
 		gceCreator, rootNamer, globalStop, syncMetrics.FakeSyncerMetrics(),
 	)
@@ -1036,6 +1049,7 @@ func TestProviderConfigErrorCases(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset()
 			pcClient := pcclientfake.NewSimpleClientset()
 			svcNegClient := svcnegfake.NewSimpleClientset()
+			negBindingClient := negbindingfake.NewSimpleClientset()
 			networkClient := networkfake.NewSimpleClientset()
 			nodeTopologyClient := nodetopologyfake.NewSimpleClientset()
 
@@ -1058,6 +1072,10 @@ func TestProviderConfigErrorCases(t *testing.T) {
 			})
 
 			test.PrependBookmarkReactor(&svcNegClient.Fake, svcNegClient.Tracker(), "servicenetworkendpointgroups", &svcnegv1.ServiceNetworkEndpointGroup{
+				ObjectMeta: test.DefaultBookmarkObjectMeta,
+			})
+
+			test.PrependBookmarkReactor(&negBindingClient.Fake, negBindingClient.Tracker(), "networkendpointgroupbindings", &negbindingv1beta1.NetworkEndpointGroupBinding{
 				ObjectMeta: test.DefaultBookmarkObjectMeta,
 			})
 
@@ -1094,6 +1112,7 @@ func TestProviderConfigErrorCases(t *testing.T) {
 					logger,
 					kubeClient,
 					svcNegClient,
+					negBindingClient,
 					networkClient,
 					nodeTopologyClient,
 					kubeSystemUID,

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/annotations"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 	svcnegv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/controller/translator"
 	"k8s.io/ingress-gce/pkg/flags"
@@ -48,6 +50,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/negannotation"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/network"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -61,14 +64,15 @@ import (
 // Controller is network endpoint group controller.
 // It determines whether NEG for a service port is needed, then signals NegSyncerManager to sync it.
 type Controller struct {
-	manager         negtypes.NegSyncerManager
-	gcPeriod        time.Duration
-	recorder        record.EventRecorder
-	namer           negtypes.NetworkEndpointGroupNamer
-	l4Namer         namer.L4ResourcesNamer
-	zoneGetter      *zonegetter.ZoneGetter
-	networkResolver network.Resolver
-	cloud           negtypes.NetworkEndpointGroupCloud
+	manager           negtypes.NegSyncerManager
+	negBindingManager *negBindingManager
+	gcPeriod          time.Duration
+	recorder          record.EventRecorder
+	namer             negtypes.NetworkEndpointGroupNamer
+	l4Namer           namer.L4ResourcesNamer
+	zoneGetter        *zonegetter.ZoneGetter
+	networkResolver   network.Resolver
+	cloud             negtypes.NetworkEndpointGroupCloud
 
 	hasSynced             func() bool
 	ingressLister         cache.Indexer
@@ -85,6 +89,7 @@ type Controller struct {
 	// nodeTopologyQueue acts as an intermeidate queue to trigger sync on all
 	// syncers on Node Topology resource updates.
 	nodeTopologyQueue workqueue.RateLimitingInterface
+	negBindingQueue   workqueue.RateLimitingInterface
 
 	// syncTracker tracks the latest time that service and endpoint changes are processed
 	syncTracker utils.TimeTracker
@@ -116,6 +121,9 @@ type Controller struct {
 
 	// enableNEGsForIngress indicates whether the NEG controller will create NEGs for Ingress services
 	enableNEGsForIngress bool
+
+	// enableNEGBinding indicates whether the controller should process NEGBinding CRs
+	enableNEGBinding bool
 
 	// includeDrainNodesL4Local indicates whether to include draining nodes for NEGs with L4Local mode
 	includeDrainNodesL4Local bool
@@ -171,6 +179,7 @@ func (c *Controller) nodeUpdateRequiresResync(oldNode, currentNode *apiv1.Node) 
 func NewController(
 	kubeClient kubernetes.Interface,
 	svcNegClient svcnegclient.Interface,
+	negBindingClient negbindingclient.Interface,
 	eventRecorderClient kubernetes.Interface,
 	kubeSystemUID types.UID,
 	ingressInformer cache.SharedIndexInformer,
@@ -179,6 +188,7 @@ func NewController(
 	nodeInformer cache.SharedIndexInformer,
 	endpointSliceInformer cache.SharedIndexInformer,
 	svcNegInformer cache.SharedIndexInformer,
+	negBindingInformer cache.SharedIndexInformer,
 	networkInformer cache.SharedIndexInformer,
 	gkeNetworkParamSetInformer cache.SharedIndexInformer,
 	nodeTopologyInformer cache.SharedIndexInformer,
@@ -201,6 +211,7 @@ func NewController(
 	runL4ForNetLB bool,
 	readOnlyMode bool,
 	enableNEGsForIngress bool,
+	enableNEGBinding bool,
 	includeDrainNodesL4Local bool,
 	stopCh <-chan struct{},
 	logger klog.Logger,
@@ -227,6 +238,13 @@ func NewController(
 	if err != nil {
 		logger.Error(err, "Errored adding NEG CRD scheme to event recorder")
 		negMetrics.PublishNegControllerErrorCountMetrics(err, true)
+	}
+	if enableNEGBinding {
+		err = negbindingv1beta1.AddToScheme(negScheme)
+		if err != nil {
+			logger.Error(err, "Errored adding NEGBinding CRD scheme to event recorder")
+			negMetrics.PublishNegControllerErrorCountMetrics(err, true)
+		}
 	}
 	recorder := eventBroadcaster.NewRecorder(negScheme,
 		apiv1.EventSource{Component: "neg-controller"})
@@ -282,10 +300,34 @@ func NewController(
 		gkeNetworkParamSetIndexer = gkeNetworkParamSetInformer.GetIndexer()
 	}
 	enableMultiSubnetClusterPhase1 := flags.F.EnableMultiSubnetClusterPhase1
+	netResolver := network.NewNetworksResolver(networkIndexer, gkeNetworkParamSetIndexer, cloud, enableMultiNetworking, logger)
+
+	var negBindingMgr *negBindingManager
+	if enableNEGBinding {
+		negBindingMgr = newNEGBindingManager(
+			negBindingClient,
+			negBindingInformer.GetIndexer(),
+			podInformer.GetIndexer(),
+			serviceInformer.GetIndexer(),
+			endpointSliceInformer.GetIndexer(),
+			nodeInformer.GetIndexer(),
+			zoneGetter,
+			netResolver,
+			cloud,
+			recorder,
+			namer,
+			negMetrics,
+			syncerMetrics,
+			reflector,
+			kubeSystemUID,
+			logger,
+		)
+	}
 
 	negController := &Controller{
 		client:                         kubeClient,
 		manager:                        manager,
+		negBindingManager:              negBindingMgr,
 		cloud:                          cloud,
 		gcPeriod:                       gcPeriod,
 		recorder:                       recorder,
@@ -296,7 +338,7 @@ func NewController(
 		hasSynced:                      hasSynced,
 		ingressLister:                  ingressInformer.GetIndexer(),
 		serviceLister:                  serviceInformer.GetIndexer(),
-		networkResolver:                network.NewNetworksResolver(networkIndexer, gkeNetworkParamSetIndexer, cloud, enableMultiNetworking, logger),
+		networkResolver:                netResolver,
 		serviceQueue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_service_queue"),
 		endpointQueue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_endpoint_queue"),
 		nodeQueue:                      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_node_queue"),
@@ -309,11 +351,15 @@ func NewController(
 		runL4ForNetLB:                  runL4ForNetLB,
 		readOnlyMode:                   readOnlyMode,
 		enableNEGsForIngress:           enableNEGsForIngress,
+		enableNEGBinding:               enableNEGBinding,
 		includeDrainNodesL4Local:       includeDrainNodesL4Local,
 		nodeMembershipFilters:          buildNodeMembershipFilters(includeDrainNodesL4Local),
 		stopCh:                         stopCh,
 		logger:                         logger,
 		negMetrics:                     negMetrics,
+	}
+	if enableNEGBinding {
+		negController.negBindingQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_binding_queue")
 	}
 	if enableMultiSubnetClusterPhase1 {
 		negController.nodeTopologyQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "neg_node_topology_queue")
@@ -427,6 +473,15 @@ func NewController(
 			},
 		})
 	}
+	if enableNEGBinding {
+		negBindingInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    negController.enqueueNEGBinding,
+			DeleteFunc: negController.enqueueNEGBinding,
+			UpdateFunc: func(old, cur interface{}) {
+				negController.enqueueNEGBinding(cur)
+			},
+		})
+	}
 	return negController, nil
 }
 
@@ -448,6 +503,9 @@ func (c *Controller) Run() {
 	go wait.Until(c.serviceWorker, time.Second, c.stopCh)
 	go wait.Until(c.endpointWorker, time.Second, c.stopCh)
 	go wait.Until(c.nodeWorker, time.Second, c.stopCh)
+	if c.enableNEGBinding {
+		go wait.Until(c.negBindingWorker, time.Second, c.stopCh)
+	}
 	if c.enableMultiSubnetClusterPhase1 {
 		go wait.Until(c.nodeTopologyWorker, time.Second, c.stopCh)
 	}
@@ -479,10 +537,16 @@ func (c *Controller) stop() {
 	c.serviceQueue.ShutDown()
 	c.endpointQueue.ShutDown()
 	c.nodeQueue.ShutDown()
+	if c.enableNEGBinding {
+		c.negBindingQueue.ShutDown()
+	}
 	if c.enableMultiSubnetClusterPhase1 {
 		c.nodeTopologyQueue.ShutDown()
 	}
 	c.manager.ShutDown()
+	if c.enableNEGBinding {
+		c.negBindingManager.ShutDown()
+	}
 }
 
 func (c *Controller) endpointWorker() {
@@ -546,6 +610,9 @@ func (c *Controller) processEndpoint(key string) {
 		return
 	}
 	c.manager.Sync(namespace, name)
+	if c.enableNEGBinding {
+		_ = c.negBindingManager.EnsureSyncersForService(namespace, name)
+	}
 }
 
 func (c *Controller) serviceWorker() {
@@ -591,49 +658,58 @@ func (c *Controller) processService(key string) error {
 	if !exists {
 		c.syncerMetrics.DeleteNegService(key)
 		c.manager.StopSyncer(namespace, name)
+		if c.enableNEGBinding {
+			c.negBindingManager.ProcessServiceDeletion(namespace, name)
+		}
 		return nil
 	}
 	service := obj.(*apiv1.Service)
 	if service == nil {
 		return fmt.Errorf("cannot convert to Service (%T)", obj)
 	}
+
+	var bindingErr error
+	if c.enableNEGBinding {
+		bindingErr = c.negBindingManager.EnsureSyncersForService(namespace, name)
+	}
+
 	negUsage := metricscollector.NegServiceState{}
 	svcPortInfoMap := make(negtypes.PortInfoMap)
 	networkInfo, err := c.networkResolver.ServiceNetwork(service)
 	if err != nil {
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	if err := c.mergeDefaultBackendServicePortInfoMap(key, service, svcPortInfoMap, networkInfo); err != nil {
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	negUsage.IngressNeg = len(svcPortInfoMap)
 	if err := c.mergeIngressPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, networkInfo); err != nil {
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	negUsage.IngressNeg = len(svcPortInfoMap)
 	if err := c.mergeStandaloneNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, &negUsage, networkInfo); err != nil {
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	negUsage.StandaloneNeg = len(svcPortInfoMap) - negUsage.IngressNeg
 
 	// Create L4 PortInfo if ILB subsetting is enabled or a NetLB service needs NEG backends.
 	if err := c.mergeVmIpNEGsPortInfo(service, types.NamespacedName{Namespace: namespace, Name: name}, svcPortInfoMap, &negUsage, networkInfo); err != nil {
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	if len(svcPortInfoMap) != 0 {
 		c.logger.V(2).Info("Syncing service", "service", key)
 		if !flags.F.EnableIPV6OnlyNEG {
 			if service.Spec.Type != apiv1.ServiceTypeLoadBalancer && isSingleStackIPv6Service(service) {
-				return fmt.Errorf("NEG is not supported for ipv6 only service (%T)", service)
+				return utilerrors.NewAggregate([]error{fmt.Errorf("NEG is not supported for ipv6 only service (%T)", service), bindingErr})
 			}
 		}
 
 		if err = c.syncNegStatusAnnotation(namespace, name, svcPortInfoMap); err != nil {
-			return err
+			return utilerrors.NewAggregate([]error{err, bindingErr})
 		}
 		negUsage.SuccessfulNeg, negUsage.ErrorNeg, err = c.manager.EnsureSyncers(namespace, name, svcPortInfoMap)
 		c.syncerMetrics.SetNegService(key, negUsage)
-		return err
+		return utilerrors.NewAggregate([]error{err, bindingErr})
 	}
 	// do not need Neg
 	c.logger.V(3).Info("Service does not need any NEG. Skipping", "service", key)
@@ -642,7 +718,10 @@ func (c *Controller) processService(key string) error {
 	c.manager.StopSyncer(namespace, name)
 
 	// delete the annotation
-	return c.syncNegStatusAnnotation(namespace, name, make(negtypes.PortInfoMap))
+	if err := c.syncNegStatusAnnotation(namespace, name, make(negtypes.PortInfoMap)); err != nil {
+		return utilerrors.NewAggregate([]error{err, bindingErr})
+	}
+	return bindingErr
 }
 
 func (c *Controller) nodeTopologyWorker() {
@@ -674,6 +753,9 @@ func (c *Controller) processNodeTopology() {
 		return
 	}
 	c.manager.SyncAllSyncers()
+	if c.enableNEGBinding {
+		c.negBindingManager.SyncAllSyncers()
+	}
 }
 
 // mergeIngressPortInfo merges Ingress PortInfo into portInfoMap if the service has Enable Ingress annotation.
@@ -958,6 +1040,30 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	c.serviceQueue.AddRateLimited(key)
 }
 
+func (c *Controller) handleNEGBindingErr(err error, key interface{}) {
+	if !c.enableNEGBinding {
+		return
+	}
+	if err == nil {
+		c.negBindingQueue.Forget(key)
+		return
+	}
+
+	msg := fmt.Sprintf("error processing NEGBinding %q: %v", key, err)
+	c.logger.Error(err, "Error processing NEGBinding", "binding", key)
+	if c.negBindingManager != nil {
+		if obj, exists, getErr := c.negBindingManager.negBindingLister.GetByKey(key.(string)); getErr == nil && exists {
+			binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+			if !ok {
+				c.logger.Error(nil, "Unexpected object type in negBindingLister during error handling", "type", fmt.Sprintf("%T", obj))
+			} else {
+				c.recorder.Event(binding, apiv1.EventTypeWarning, "ProcessNEGBindingFailed", msg)
+			}
+		}
+	}
+	c.negBindingQueue.AddRateLimited(key)
+}
+
 func (c *Controller) enqueueEndpointSlice(obj interface{}) {
 	endpointSlice, ok := obj.(*discovery.EndpointSlice)
 	if !ok {
@@ -1093,6 +1199,76 @@ func getIngressServicesFromStore(store cache.Store, svc *apiv1.Service) (ings []
 
 	}
 	return
+}
+
+func (c *Controller) negBindingWorker() {
+	for {
+		func() {
+			key, quit := c.negBindingQueue.Get()
+			if quit {
+				return
+			}
+			defer c.negBindingQueue.Done(key)
+			err := c.processNEGBinding(key.(string))
+			c.handleNEGBindingErr(err, key)
+			c.negMetrics.PublishNegControllerErrorCountMetrics(err, false)
+		}()
+	}
+}
+
+func (c *Controller) processNEGBinding(key string) error {
+	if !c.enableNEGBinding {
+		return nil
+	}
+	c.logger.V(3).Info("Processing NEGBinding", "binding", key)
+	defer func() {
+		now := c.syncTracker.Track()
+		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.logger.V(3).Info("Finished processing NEGBinding", "binding", key)
+	}()
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	if c.readOnlyMode {
+		c.negBindingManager.StopSyncer(namespace, name)
+		return nil
+	}
+
+	obj, exists, err := c.negBindingManager.negBindingLister.GetByKey(key)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		c.negBindingManager.StopSyncer(namespace, name)
+		return nil
+	}
+
+	binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+	if !ok {
+		return fmt.Errorf("cannot convert to NetworkEndpointGroupBinding (%T)", obj)
+	}
+
+	if binding.DeletionTimestamp != nil {
+		c.negBindingManager.StopSyncer(namespace, name)
+		return nil
+	}
+
+	return c.negBindingManager.EnsureSyncerForNEGBinding(binding)
+}
+
+func (c *Controller) enqueueNEGBinding(obj interface{}) {
+	if !c.enableNEGBinding {
+		return
+	}
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		c.logger.Error(err, "Failed to get key for NEGBinding object", "object", obj)
+		return
+	}
+	c.negBindingQueue.Add(key)
 }
 
 // isSingleStackIPv6Service returns true if the given service is a single stack ipv6 service

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -42,12 +42,15 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/annotations"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 	"k8s.io/ingress-gce/pkg/flags"
 	l4annotations "k8s.io/ingress-gce/pkg/l4/annotations"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/negannotation"
+	negbindingfake "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
 	"k8s.io/ingress-gce/pkg/network"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -133,6 +136,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 	return NewController(
 		kubeClient,
 		testContext.SvcNegClient,
+		nil,
 		kubeClient,
 		testContext.KubeSystemUID,
 		testContext.IngressInformer,
@@ -141,6 +145,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		testContext.NodeInformer,
 		testContext.EndpointSliceInformer,
 		testContext.SvcNegInformer,
+		nil,
 		testContext.NetworkInformer,
 		testContext.GKENetworkParamSetInformer,
 		testContext.NodeTopologyInformer,
@@ -164,6 +169,7 @@ func newTestControllerWithParamsAndContext(kubeClient kubernetes.Interface, test
 		false,
 		readOnlyMode,
 		true,  // enableNEGsForIngress
+		false, // enableNEGBinding
 		false, // includeDrainNodesL4Local
 		make(<-chan struct{}),
 		klog.TODO(),
@@ -2532,6 +2538,7 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 	controller, err := NewController(
 		kubeClient,
 		testContext.SvcNegClient,
+		nil,
 		kubeClient,
 		testContext.KubeSystemUID,
 		testContext.IngressInformer,
@@ -2540,6 +2547,7 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 		testContext.NodeInformer, // use the testContext node informer
 		testContext.EndpointSliceInformer,
 		testContext.SvcNegInformer,
+		nil,
 		testContext.NetworkInformer,
 		testContext.GKENetworkParamSetInformer,
 		testContext.NodeTopologyInformer,
@@ -2562,6 +2570,7 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 		false,
 		false, // readOnlyMode
 		true,  // enableNEGsForIngress
+		false, // enableNEGBinding
 		true,  // includeDrainNodesL4Local = true
 		make(<-chan struct{}),
 		klog.TODO(),
@@ -2678,4 +2687,132 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 	// stays false→false (drain label still present). The enqueue must happen via the
 	// drain filter — if that filter were missing from the set the queue would stay empty.
 	ensureNodeEnqueue(t, "drain-excluded-node", controller)
+}
+
+func TestControllerNEGBinding(t *testing.T) {
+	oldFlag := flags.F.EnableMultiSubnetClusterPhase1
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+	defer func() { flags.F.EnableMultiSubnetClusterPhase1 = oldFlag }()
+
+	kubeClient := fake.NewSimpleClientset()
+	fakeNBClient := negbindingfake.NewSimpleClientset()
+	testContext := negtypes.NewTestContextWithKubeClient(kubeClient)
+
+	negBindingInformer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, utils.NewNamespaceIndexer())
+	_ = negBindingInformer.AddIndexers(cache.Indexers{ServiceKeyIndex: ServiceKeyIndexFunc})
+
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(testContext.NodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to create fake zone getter: %v", err)
+	}
+
+	controller, err := NewController(
+		kubeClient,
+		testContext.SvcNegClient,
+		fakeNBClient,
+		kubeClient,
+		testContext.KubeSystemUID,
+		testContext.IngressInformer,
+		testContext.ServiceInformer,
+		testContext.PodInformer,
+		testContext.NodeInformer,
+		testContext.EndpointSliceInformer,
+		testContext.SvcNegInformer,
+		negBindingInformer,
+		testContext.NetworkInformer,
+		testContext.GKENetworkParamSetInformer,
+		testContext.NodeTopologyInformer,
+		func() bool { return true },
+		testContext.L4Namer,
+		defaultBackend,
+		negtypes.NewAdapterWithNetwork(testContext.Cloud, "default-network", defaultTestSubnetURL, testContext.NegMetrics),
+		zoneGetter,
+		testContext.NegNamer,
+		testContext.ResyncPeriod,
+		testContext.ResyncPeriod,
+		testContext.NumGCWorkers,
+		false, false, false,
+		testContext.EnableDualStackNEG,
+		labels.PodLabelPropagationConfig{},
+		true, false, false, false, true, true, false,
+		make(<-chan struct{}),
+		klog.TODO(),
+		testContext.NegMetrics,
+		metricscollector.FakeSyncerMetrics(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create test controller: %v", err)
+	}
+
+	svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "svc1"},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}},
+		},
+	}
+	_ = testContext.ServiceInformer.GetIndexer().Add(svc)
+	_, _ = kubeClient.CoreV1().Services("ns1").Create(context.Background(), svc, metav1.CreateOptions{})
+
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "binding1"},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: "svc1",
+				Port: 80,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}},
+			},
+		},
+	}
+	_ = negBindingInformer.GetIndexer().Add(binding)
+	_, err = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings("ns1").Create(context.Background(), binding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding in fake client: %v", err)
+	}
+
+	err = controller.processNEGBinding("ns1/binding1")
+	if err != nil {
+		t.Fatalf("processNEGBinding failed: %v", err)
+	}
+
+	if controller.negBindingManager == nil {
+		t.Fatalf("expected negBindingManager to be initialized")
+	}
+
+	controller.negBindingManager.mu.Lock()
+	syncerCount := len(controller.negBindingManager.syncerMap)
+	controller.negBindingManager.mu.Unlock()
+
+	if syncerCount != 1 {
+		t.Errorf("expected 1 syncer in negBindingManager, got %d", syncerCount)
+	}
+
+	// Update service to have standalone NEG annotations and process service update
+	svcWithNEG := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "ns1",
+			Name:        "svc1",
+			Annotations: map[string]string{negannotation.NEGAnnotationKey: `{"exposed_ports":{"80":{}}}`},
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}},
+		},
+	}
+	_ = testContext.ServiceInformer.GetIndexer().Update(svcWithNEG)
+	_, _ = kubeClient.CoreV1().Services("ns1").Update(context.Background(), svcWithNEG, metav1.UpdateOptions{})
+
+	err = controller.processService("ns1/svc1")
+	if err != nil {
+		t.Fatalf("processService failed for service with standalone NEG: %v", err)
+	}
+
+	controller.negBindingManager.mu.Lock()
+	syncerCount = len(controller.negBindingManager.syncerMap)
+	controller.negBindingManager.mu.Unlock()
+
+	if syncerCount != 1 {
+		t.Errorf("expected 1 syncer in negBindingManager after processService on standalone NEG service, got %d", syncerCount)
+	}
 }

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -1,0 +1,548 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
+	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
+	"k8s.io/ingress-gce/pkg/neg/readiness"
+	negsyncer "k8s.io/ingress-gce/pkg/neg/syncers"
+	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
+	"k8s.io/ingress-gce/pkg/neg/syncers/negstatushandler"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/patch"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// ServiceKeyIndex is the name of the index that maps service key (namespace/name) to NEGBinding.
+	ServiceKeyIndex = "serviceKey"
+)
+
+var (
+	ErrNEGBindingMultiNetworkNotSupported = errors.New("NEGBinding does not support multi-network")
+	ErrServiceNotFound                    = errors.New("service not found in cache")
+	ErrInvalidBackendRef                  = errors.New("BackendRef is nil")
+	ErrInvalidBackendRefKind              = errors.New("unsupported BackendRef Kind")
+)
+
+// ServiceKeyIndexFunc maps NEGBinding to its backend service key if kind is Service.
+func ServiceKeyIndexFunc(obj interface{}) ([]string, error) {
+	binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+	if !ok {
+		return []string{}, fmt.Errorf("unexpected object type %T", obj)
+	}
+	if binding.Spec.BackendRef != nil && binding.Spec.BackendRef.Kind == negbindingv1beta1.ServiceKind {
+		return []string{fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)}, nil
+	}
+	return []string{}, nil
+}
+
+type syncerConfig struct {
+	portTuple   negtypes.SvcPortTuple
+	networkInfo network.NetworkInfo
+}
+
+func (c syncerConfig) Equals(other syncerConfig) bool {
+	return c.portTuple.Port == other.portTuple.Port &&
+		c.portTuple.Name == other.portTuple.Name &&
+		c.portTuple.TargetPort == other.portTuple.TargetPort &&
+		c.networkInfo.IsDefault == other.networkInfo.IsDefault &&
+		c.networkInfo.NetworkURL == other.networkInfo.NetworkURL &&
+		c.networkInfo.SubnetworkURL == other.networkInfo.SubnetworkURL &&
+		c.networkInfo.K8sNetwork == other.networkInfo.K8sNetwork
+}
+
+// negBindingManager manages the lifecycle of syncers associated with NEGBinding CRs.
+type negBindingManager struct {
+	negBindingClient negbindingclient.Interface
+	negBindingLister cache.Indexer
+
+	// Listers needed for syncer
+	podLister           cache.Indexer
+	serviceLister       cache.Indexer
+	endpointSliceLister cache.Indexer
+	nodeLister          cache.Indexer
+
+	zoneGetter      *zonegetter.ZoneGetter
+	networkResolver network.Resolver
+	cloud           negtypes.NetworkEndpointGroupCloud
+	recorder        record.EventRecorder
+	namer           negtypes.NetworkEndpointGroupNamer
+
+	// Syncers map keyed by binding namespace/name (bindingKey)
+	mu            sync.Mutex
+	syncerMap     map[string]negtypes.NegSyncer
+	syncerConfigs map[string]syncerConfig
+
+	// Metrics
+	negMetrics    *metrics.NegMetrics
+	syncerMetrics *metricscollector.SyncerMetrics
+
+	reflector     readiness.Reflector
+	kubeSystemUID types.UID
+
+	logger klog.Logger
+}
+
+// newNEGBindingManager constructs a new negBindingManager.
+func newNEGBindingManager(
+	negBindingClient negbindingclient.Interface,
+	negBindingLister cache.Indexer,
+	podLister cache.Indexer,
+	serviceLister cache.Indexer,
+	endpointSliceLister cache.Indexer,
+	nodeLister cache.Indexer,
+	zoneGetter *zonegetter.ZoneGetter,
+	networkResolver network.Resolver,
+	cloud negtypes.NetworkEndpointGroupCloud,
+	recorder record.EventRecorder,
+	namer negtypes.NetworkEndpointGroupNamer,
+	negMetrics *metrics.NegMetrics,
+	syncerMetrics *metricscollector.SyncerMetrics,
+	reflector readiness.Reflector,
+	kubeSystemUID types.UID,
+	logger klog.Logger,
+) *negBindingManager {
+	m := &negBindingManager{
+		negBindingClient:    negBindingClient,
+		negBindingLister:    negBindingLister,
+		podLister:           podLister,
+		serviceLister:       serviceLister,
+		endpointSliceLister: endpointSliceLister,
+		nodeLister:          nodeLister,
+		zoneGetter:          zoneGetter,
+		networkResolver:     networkResolver,
+		cloud:               cloud,
+		recorder:            recorder,
+		namer:               namer,
+		syncerMap:           make(map[string]negtypes.NegSyncer),
+		syncerConfigs:       make(map[string]syncerConfig),
+		negMetrics:          negMetrics,
+		syncerMetrics:       syncerMetrics,
+		reflector:           reflector,
+		kubeSystemUID:       kubeSystemUID,
+		logger:              logger.WithName("NEGBindingManager"),
+	}
+	return m
+}
+
+// EnsureSyncerForNEGBinding ensures corresponding syncer is started for the binding.
+func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	err := m.validateBackendRef(binding)
+	if err != nil {
+		_ = m.updateBackendRefCondition(binding, err)
+		return err
+	}
+
+	svcName := binding.Spec.BackendRef.Name
+	svcKey := fmt.Sprintf("%s/%s", binding.Namespace, svcName)
+	svc, err := m.getServiceFromCache(svcKey)
+	if err != nil {
+		_ = m.updateBackendRefCondition(binding, ErrServiceNotFound)
+		return err
+	}
+
+	networkInfo, err := m.getAndVerifyNetworkInfo(svc)
+	if err != nil {
+		_ = m.updateBackendRefCondition(binding, err)
+		return err
+	}
+
+	syncer, err := m.ensureSyncerForNEGBinding(binding, svc, networkInfo)
+	if err != nil {
+		return err
+	}
+
+	if syncer != nil {
+		syncer.Sync()
+	}
+	return nil
+}
+
+// EnsureSyncersForService ensures syncers for all bindings referencing the given service.
+func (m *negBindingManager) EnsureSyncersForService(svcNamespace, svcName string) error {
+	svcKey := fmt.Sprintf("%s/%s", svcNamespace, svcName)
+	svc, err := m.getServiceFromCache(svcKey)
+	if err != nil {
+		return err
+	}
+
+	objs, err := m.negBindingLister.ByIndex(ServiceKeyIndex, svcKey)
+	if err != nil {
+		return fmt.Errorf("failed to list bindings for service %s from index: %w", svcKey, err)
+	}
+
+	networkInfo, networkInfoErr := m.getAndVerifyNetworkInfo(svc)
+
+	var errs []error
+	for _, obj := range objs {
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			errs = append(errs, fmt.Errorf("unexpected object type %T in binding index for service %s", obj, svcKey))
+			continue
+		}
+
+		err := m.validateBackendRef(binding)
+		if err != nil {
+			_ = m.updateBackendRefCondition(binding, err)
+			return err
+		}
+
+		if networkInfoErr != nil {
+			_ = m.updateBackendRefCondition(binding, networkInfoErr)
+			continue
+		}
+
+		syncer, err := m.ensureSyncerForNEGBinding(binding, svc, networkInfo)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		if syncer != nil {
+			_ = syncer.Sync()
+		}
+	}
+
+	if networkInfoErr != nil {
+		errs = append(errs, networkInfoErr)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (m *negBindingManager) ensureSyncerForNEGBinding(
+	binding *negbindingv1beta1.NetworkEndpointGroupBinding,
+	svc *apiv1.Service,
+	networkInfo *network.NetworkInfo,
+) (negtypes.NegSyncer, error) {
+	svcName := binding.Spec.BackendRef.Name
+	svcPort := binding.Spec.BackendRef.Port
+
+	portTuple, err := m.getPortTuple(svc, svcPort)
+	if err != nil {
+		_ = m.updateBackendRefCondition(binding, err)
+		return nil, err
+	}
+
+	if err := m.updateBackendRefCondition(binding, nil); err != nil {
+		return nil, err
+	}
+
+	bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+	if len(binding.Spec.NetworkEndpointGroups) == 0 {
+		m.logger.Info("NEGBinding has no NEGs defined", "binding", bindingKey)
+		m.StopSyncer(binding.Namespace, binding.Name)
+		return nil, nil
+	}
+
+	newConfig := syncerConfig{portTuple: portTuple, networkInfo: *networkInfo}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	syncer, ok := m.syncerMap[bindingKey]
+	if ok {
+		oldConfig, hasConfig := m.syncerConfigs[bindingKey]
+		if !hasConfig || !oldConfig.Equals(newConfig) {
+			m.logger.Info("Configuration changed for NEGBinding syncer, recreating", "binding", bindingKey, "old", oldConfig, "new", newConfig)
+			syncer.Stop()
+			delete(m.syncerMap, bindingKey)
+			delete(m.syncerConfigs, bindingKey)
+			// Proceed to create new syncer
+		} else {
+			if syncer.IsStopped() {
+				if err := syncer.Start(); err != nil {
+					return nil, fmt.Errorf("failed to start existing syncer for binding %s: %w", bindingKey, err)
+				}
+			}
+			return syncer, nil
+		}
+	}
+
+	defaultSubnetURL := networkInfo.SubnetworkURL
+
+	syncerKey := negtypes.NegSyncerKey{
+		Namespace:        binding.Namespace,
+		Name:             svcName,
+		NEGBindingName:   binding.Name,
+		PortTuple:        portTuple,
+		NegType:          negtypes.VmIpPortEndpointType,
+		EpCalculatorMode: negtypes.L7Mode,
+	}
+
+	tp, err := negsyncer.NewNEGBindingTopologyProvider(binding.Namespace, binding.Name, m.negBindingLister, defaultSubnetURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create topology provider: %w", err)
+	}
+
+	statusHandler := negstatushandler.NewNEGBindingStatusHandler(
+		binding.Name,
+		binding.Namespace,
+		m.negBindingClient,
+		m.negBindingLister,
+		m.negMetrics,
+		m.logger,
+	)
+
+	epc := negsyncer.GetEndpointsCalculator(
+		m.podLister,
+		m.nodeLister,
+		m.serviceLister,
+		m.zoneGetter,
+		syncerKey,
+		negtypes.L7Mode,
+		m.logger.WithValues("service", klog.KRef(syncerKey.Namespace, syncerKey.Name), "negBindingName", syncerKey.NEGBindingName),
+		false,
+		m.syncerMetrics,
+		networkInfo,
+		"",
+		m.negMetrics,
+	)
+
+	nbNamer := namer.NewNegBindingNamer(binding.Namespace, binding.Name, m.negBindingLister)
+
+	syncer = negsyncer.NewTransactionSyncer(
+		syncerKey,
+		m.recorder,
+		m.cloud,
+		tp,
+		m.podLister,
+		m.serviceLister,
+		m.endpointSliceLister,
+		m.nodeLister,
+		statusHandler,
+		m.reflector,
+		epc,
+		string(m.kubeSystemUID),
+		m.syncerMetrics,
+		false,
+		false,
+		m.logger,
+		labels.PodLabelPropagationConfig{},
+		false,
+		*networkInfo,
+		nbNamer,
+		m.negMetrics,
+	)
+
+	if err := syncer.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start syncer for binding %s: %w", bindingKey, err)
+	}
+
+	m.syncerMap[bindingKey] = syncer
+	m.syncerConfigs[bindingKey] = newConfig
+	return syncer, nil
+}
+
+// ProcessServiceDeletion handles service deletion by stopping syncers for referencing bindings.
+func (m *negBindingManager) ProcessServiceDeletion(svcNamespace, svcName string) {
+	svcKey := fmt.Sprintf("%s/%s", svcNamespace, svcName)
+	objs, err := m.negBindingLister.ByIndex(ServiceKeyIndex, svcKey)
+	if err != nil {
+		m.logger.Error(err, "failed to list bindings for service from index during deletion processing", "service", svcKey)
+		return
+	}
+	for _, obj := range objs {
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			m.logger.Error(nil, "Unexpected object type in negBindingLister during service deletion processing", "type", fmt.Sprintf("%T", obj))
+			continue
+		}
+		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		m.logger.Info("Service deleted, stopping syncer for binding", "binding", bindingKey, "service", svcKey)
+		m.StopSyncer(binding.Namespace, binding.Name)
+		_ = m.updateBackendRefCondition(binding, fmt.Errorf("%w: %s/%s", ErrServiceNotFound, svcNamespace, svcName))
+	}
+}
+
+// StopSyncer stops the syncer associated with the binding and removes it from the map.
+func (m *negBindingManager) StopSyncer(namespace, name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	bindingKey := fmt.Sprintf("%s/%s", namespace, name)
+	if syncer, ok := m.syncerMap[bindingKey]; ok {
+		syncer.Stop()
+		delete(m.syncerMap, bindingKey)
+		delete(m.syncerConfigs, bindingKey)
+	}
+}
+
+// Sync triggers a sync for the syncer associated with the binding.
+func (m *negBindingManager) Sync(namespace, name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	bindingKey := fmt.Sprintf("%s/%s", namespace, name)
+	if syncer, ok := m.syncerMap[bindingKey]; ok {
+		if !syncer.IsStopped() {
+			syncer.Sync()
+		}
+	}
+}
+
+// ShutDown stops all running syncers managed by this manager.
+func (m *negBindingManager) ShutDown() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, syncer := range m.syncerMap {
+		syncer.Stop()
+	}
+	m.syncerMap = make(map[string]negtypes.NegSyncer)
+	m.syncerConfigs = make(map[string]syncerConfig)
+}
+
+func (m *negBindingManager) getServiceFromCache(svcKey string) (*apiv1.Service, error) {
+	svcObj, exists, err := m.serviceLister.GetByKey(svcKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s from cache: %w", svcKey, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", ErrServiceNotFound, svcKey)
+	}
+	svc, ok := svcObj.(*apiv1.Service)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object type %T in service cache for %s", svcObj, svcKey)
+	}
+	return svc, nil
+}
+
+func (m *negBindingManager) getAndVerifyNetworkInfo(svc *apiv1.Service) (*network.NetworkInfo, error) {
+	networkInfo, err := m.networkResolver.ServiceNetwork(svc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get network info for service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	if !networkInfo.IsDefault {
+		return nil, fmt.Errorf("%w, service: %s/%s", ErrNEGBindingMultiNetworkNotSupported, svc.Namespace, svc.Name)
+	}
+	return networkInfo, nil
+}
+
+// SyncAllSyncers triggers sync for all running syncers managed by this manager.
+func (m *negBindingManager) SyncAllSyncers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, syncer := range m.syncerMap {
+		if !syncer.IsStopped() {
+			syncer.Sync()
+		}
+	}
+}
+
+func (m *negBindingManager) getPortTuple(svc *apiv1.Service, port int32) (negtypes.SvcPortTuple, error) {
+	for _, sp := range svc.Spec.Ports {
+		if sp.Port == port {
+			portTuple := negtypes.SvcPortTuple{
+				Port:       sp.Port,
+				Name:       sp.Name,
+				TargetPort: sp.TargetPort.String(),
+			}
+			return portTuple, nil
+		}
+	}
+	return negtypes.SvcPortTuple{}, fmt.Errorf("port %d not found in service %s/%s spec", port, svc.Namespace, svc.Name)
+}
+
+func (m *negBindingManager) validateBackendRef(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	if binding.Spec.BackendRef == nil {
+		return ErrInvalidBackendRef
+	}
+	if binding.Spec.BackendRef.Kind != negbindingv1beta1.ServiceKind {
+		return fmt.Errorf("%w: unsupported Kind %q", ErrInvalidBackendRefKind, binding.Spec.BackendRef.Kind)
+	}
+	return nil
+}
+
+func (m *negBindingManager) updateBackendRefCondition(binding *negbindingv1beta1.NetworkEndpointGroupBinding, validationErr error) error {
+	cond := negbindingv1beta1.Condition{
+		Type:               "BackendRef",
+		LastTransitionTime: metav1.Now(),
+	}
+	if validationErr == nil {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "BackendRefValid"
+	} else {
+		cond.Status = metav1.ConditionFalse
+		cond.Message = validationErr.Error()
+		if errors.Is(validationErr, ErrInvalidBackendRefKind) {
+			cond.Reason = "InvalidBackendRefKind"
+		} else if errors.Is(validationErr, ErrServiceNotFound) {
+			cond.Reason = "ServiceNotFound"
+		} else if errors.Is(validationErr, ErrInvalidBackendRef) {
+			cond.Reason = "InvalidBackendRef"
+		} else {
+			cond.Reason = "InvalidBackendRef" // Default
+		}
+	}
+
+	origBinding := binding.DeepCopy()
+	m.ensureCondition(binding, cond)
+
+	patchBytes, err := patch.MergePatchBytes(negbindingv1beta1.NetworkEndpointGroupBinding{Status: origBinding.Status}, negbindingv1beta1.NetworkEndpointGroupBinding{Status: binding.Status})
+	if err != nil {
+		return fmt.Errorf("failed to prepare patch bytes for status update: %w", err)
+	}
+
+	if string(patchBytes) == "{}" {
+		return nil
+	}
+
+	start := time.Now()
+	_, err = m.negBindingClient.NetworkingV1beta1().NetworkEndpointGroupBindings(binding.Namespace).Patch(context.Background(), binding.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	m.negMetrics.PublishK8sRequestCountMetrics(start, metrics.PatchRequest, err)
+	return err
+}
+
+func (m *negBindingManager) ensureCondition(binding *negbindingv1beta1.NetworkEndpointGroupBinding, expectedCondition negbindingv1beta1.Condition) {
+	var index int
+	var found bool
+	for i, condition := range binding.Status.Conditions {
+		if condition.Type == expectedCondition.Type {
+			index = i
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		binding.Status.Conditions = append(binding.Status.Conditions, expectedCondition)
+		return
+	}
+
+	condition := binding.Status.Conditions[index]
+	if condition.Status == expectedCondition.Status {
+		expectedCondition.LastTransitionTime = condition.LastTransitionTime
+	}
+
+	binding.Status.Conditions[index] = expectedCondition
+}

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -1,0 +1,495 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
+	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
+	"k8s.io/ingress-gce/pkg/neg/readiness"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	fakenegbinding "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/utils/zonegetter"
+	"k8s.io/klog/v2"
+)
+
+func TestNEGBindingManager(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+
+	// Create test Service
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      svcName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       svcPort,
+					TargetPort: intstr.FromString(targetPort),
+				},
+			},
+		},
+	}
+	_, err := kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	// Create test Binding
+	bindingName := "test-binding"
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      bindingName,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: svcName,
+				Port: svcPort,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-1",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+			},
+		},
+	}
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	_, err = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding: %v", err)
+	}
+
+	// Listers with custom Indexer
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	err = negBindingLister.Add(testBinding)
+	if err != nil {
+		t.Fatalf("failed to add binding to lister: %v", err)
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	err = serviceLister.Add(testSvc)
+	if err != nil {
+		t.Fatalf("failed to add service to lister: %v", err)
+	}
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	// Test EnsureSyncerForNEGBinding
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+	}
+
+	// Verify BackendRef condition is True
+	updatedBinding, err := fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), bindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get updated binding: %v", err)
+	}
+	cond, found := findCondition(updatedBinding.Status.Conditions, "BackendRef")
+	if !found {
+		t.Fatalf("Condition BackendRef not found")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected BackendRef condition status True, got %s", cond.Status)
+	}
+	if cond.Reason != "BackendRefValid" {
+		t.Errorf("Expected BackendRef condition reason BackendRefValid, got %s", cond.Reason)
+	}
+
+	// Verify syncer is created and running
+	bindingKey := fmt.Sprintf("%s/%s", namespace, bindingName)
+	syncer, ok := m.syncerMap[bindingKey]
+	if !ok {
+		t.Fatalf("Syncer not found in map for key %s", bindingKey)
+	}
+	if syncer.IsStopped() {
+		t.Errorf("Expected syncer to be running, but it is stopped")
+	}
+
+	// Test EnsureSyncersForService
+	// First stop it
+	m.StopSyncer(namespace, bindingName)
+	if _, ok := m.syncerMap[bindingKey]; ok {
+		t.Fatalf("Syncer should have been removed from map")
+	}
+
+	// Now ensure via service
+	err = m.EnsureSyncersForService(namespace, svcName)
+	if err != nil {
+		t.Fatalf("EnsureSyncersForService failed: %v", err)
+	}
+
+	// Verify syncer is back
+	syncer, ok = m.syncerMap[bindingKey]
+	if !ok {
+		t.Fatalf("Syncer not found in map after service ensure")
+	}
+	if syncer.IsStopped() {
+		t.Errorf("Expected syncer to be running, but it is stopped")
+	}
+
+	// Test updating binding to have no NEGs
+	testBindingNoNEGs := testBinding.DeepCopy()
+	testBindingNoNEGs.Spec.NetworkEndpointGroups = []negbindingv1beta1.SpecNegRef{}
+	err = m.EnsureSyncerForNEGBinding(testBindingNoNEGs)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding with empty NEGs failed: %v", err)
+	}
+	if _, ok := m.syncerMap[bindingKey]; ok {
+		t.Fatalf("Syncer should have been removed from map when binding has no NEGs")
+	}
+
+	// Restore syncer for subsequent tests
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding restore failed: %v", err)
+	}
+
+	// Simulate service deletion from cache
+	err = serviceLister.Delete(testSvc)
+	if err != nil {
+		t.Fatalf("failed to delete service from lister: %v", err)
+	}
+
+	// Test ProcessServiceDeletion (should stop and remove syncer)
+	m.ProcessServiceDeletion(namespace, svcName)
+	if _, ok := m.syncerMap[bindingKey]; ok {
+		t.Fatalf("Syncer should be removed from map after ProcessServiceDeletion")
+	}
+	if _, ok := m.syncerConfigs[bindingKey]; ok {
+		t.Errorf("Expected config to be removed from syncerConfigs after ProcessServiceDeletion")
+	}
+
+	// Call EnsureSyncerForNEGBinding (which simulates reconciliation)
+	// Since Service is missing, it should fail with ErrServiceNotFound.
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if !errors.Is(err, ErrServiceNotFound) {
+		t.Fatalf("Expected EnsureSyncerForNEGBinding to fail with ErrServiceNotFound, got: %v", err)
+	}
+
+	// Shutdown
+	m.ShutDown()
+	if len(m.syncerMap) != 0 {
+		t.Errorf("Expected syncerMap to be empty after ShutDown, got size %d", len(m.syncerMap))
+	}
+}
+
+func TestNEGBindingManagerErrorCases(t *testing.T) {
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      svcName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       svcPort,
+					TargetPort: intstr.FromString("8080"),
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc           string
+		addService     bool
+		isMultiNet     bool
+		binding        *negbindingv1beta1.NetworkEndpointGroupBinding
+		expectedErr    string
+		expectedStatus metav1.ConditionStatus
+		expectedReason string
+	}{
+		{
+			desc:       "BackendRef is nil",
+			addService: false,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-nil-ref"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef:            nil,
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}}},
+				},
+			},
+			expectedErr:    ErrInvalidBackendRef.Error(),
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "InvalidBackendRef",
+		},
+		{
+			desc:       "BackendRef Kind is invalid",
+			addService: false,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-invalid-kind"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: "InvalidKind",
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}}},
+				},
+			},
+			expectedErr:    fmt.Sprintf("%v: unsupported Kind %q", ErrInvalidBackendRefKind, "InvalidKind"),
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "InvalidBackendRefKind",
+		},
+		{
+			desc:       "Service does not exist",
+			addService: false,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-no-svc"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: negbindingv1beta1.ServiceKind,
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}}},
+				},
+			},
+			expectedErr:    fmt.Sprintf("%v: %s/%s", ErrServiceNotFound, namespace, svcName),
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "ServiceNotFound",
+		},
+		{
+			desc:       "Service port mismatch",
+			addService: true,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-2"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: negbindingv1beta1.ServiceKind,
+						Name: svcName,
+						Port: int32(9999),
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}},
+					},
+				},
+			},
+			expectedErr:    fmt.Sprintf("port 9999 not found in service %s/%s spec", namespace, svcName),
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "InvalidBackendRef",
+		},
+		{
+			desc:       "Empty NEGs in binding spec",
+			addService: true,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-3"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: negbindingv1beta1.ServiceKind,
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{},
+				},
+			},
+			expectedErr:    "",
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: "BackendRefValid",
+		},
+		{
+			desc:       "Multi-network service unsupported",
+			addService: true,
+			isMultiNet: true,
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-multinet"},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: negbindingv1beta1.ServiceKind,
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{Name: "neg-1", Subnet: "custom-subnet", Zones: []string{"us-central1-a"}},
+					},
+				},
+			},
+			expectedErr:    fmt.Sprintf("NEGBinding does not support multi-network, service: %s/%s", namespace, svcName),
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "InvalidBackendRef",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+			fakeNBClient := fakenegbinding.NewSimpleClientset()
+			indexers := cache.Indexers{
+				cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+				ServiceKeyIndex:      ServiceKeyIndexFunc,
+			}
+			negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+			_ = negBindingLister.Add(tc.binding)
+			_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(tc.binding.Namespace).Create(context.TODO(), tc.binding, metav1.CreateOptions{})
+
+			serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.addService {
+				serviceLister.Add(testSvc)
+			}
+			podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+			nodeInformer := zonegetter.FakeNodeInformer()
+			zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+			zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+			if err != nil {
+				t.Fatalf("failed to create zone getter: %v", err)
+			}
+
+			clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+			negMetrics := metrics.NewNegMetrics()
+			syncerMetrics := metricscollector.FakeSyncerMetrics()
+			defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+			cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+			fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: !tc.isMultiNet, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+			m := newNEGBindingManager(
+				fakeNBClient,
+				negBindingLister,
+				podLister,
+				serviceLister,
+				endpointSliceLister,
+				nodeLister,
+				zoneGetter,
+				fakeNetworkResolver,
+				cloudAdapter,
+				record.NewFakeRecorder(100),
+				clusterNamer,
+				negMetrics,
+				syncerMetrics,
+				&readiness.NoopReflector{},
+				"kube-system-uid",
+				klog.TODO(),
+			)
+
+			err = m.EnsureSyncerForNEGBinding(tc.binding)
+			if tc.expectedErr != "" {
+				if err == nil {
+					t.Fatalf("EnsureSyncerForNEGBinding() expected error %q, got nil", tc.expectedErr)
+				}
+				if err.Error() != tc.expectedErr {
+					t.Errorf("EnsureSyncerForNEGBinding() returned error %q, expected %q", err.Error(), tc.expectedErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("EnsureSyncerForNEGBinding() expected no error, got: %v", err)
+				}
+			}
+
+			// Verify that no syncer is created for error/empty cases
+			if len(m.syncerMap) != 0 {
+				t.Errorf("Expected syncerMap to be empty, got size %d", len(m.syncerMap))
+			}
+
+			// Assert condition in fake client
+			updatedBinding, err := fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(tc.binding.Namespace).Get(context.TODO(), tc.binding.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get updated binding: %v", err)
+			}
+
+			cond, found := findCondition(updatedBinding.Status.Conditions, "BackendRef")
+			if !found {
+				t.Fatalf("Condition %s not found in updated status", "BackendRef")
+			}
+
+			if cond.Status != tc.expectedStatus {
+				t.Errorf("Condition %s status got %s, expected %s", "BackendRef", cond.Status, tc.expectedStatus)
+			}
+			if cond.Reason != tc.expectedReason {
+				t.Errorf("Condition %s reason got %s, expected %s", "BackendRef", cond.Reason, tc.expectedReason)
+			}
+		})
+	}
+}
+
+func findCondition(conditions []negbindingv1beta1.Condition, conditionType string) (negbindingv1beta1.Condition, bool) {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition, true
+		}
+	}
+	return negbindingv1beta1.Condition{}, false
+}

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -1089,6 +1089,12 @@ func (s *transactionSyncer) computeEPSStaleness(endpointSlices []*discovery.Endp
 
 // getNEGName returns the name of the NEG for the given subnet.
 func (s *transactionSyncer) getNEGName(subnet string) (string, error) {
+	// NEG name for binding syncer should be get from namer only, as there might not be name for default network
+	// or it can be changed during the syncer lifecycle.
+	if s.NegSyncerKey.IsBindingKey() {
+		return s.getNonDefaultSubnetNEGName(subnet)
+	}
+
 	// For multi-net or in case multi-subnet is disabled - default NEG name used (as there is only single subnet then, therefore no need for multiple NEG names)
 	if !flags.F.EnableMultiSubnetClusterPhase1 || !s.networkInfo.IsDefault {
 		return s.NegSyncerKey.NegName, nil

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -492,22 +492,21 @@ func (s *transactionSyncer) generateSubnetToNegNameMap(subnetConfigs []nodetopol
 	// neg naming which differs from how multi subnet cluster non default NEG names are
 	// handled.
 	if !s.networkInfo.IsDefault {
-		subnetToNegMapping[defaultSubnet] = s.NegSyncerKey.NegName
+		negName, err := s.getNEGName(defaultSubnet)
+		if err != nil {
+			return nil, err
+		}
+		subnetToNegMapping[defaultSubnet] = negName
 		return subnetToNegMapping, nil
 	}
 
 	for _, subnetConfig := range subnetConfigs {
-		// negs in default subnet have a different naming scheme from other subnets
-		if subnetConfig.Name == defaultSubnet {
-			subnetToNegMapping[defaultSubnet] = s.NegSyncerKey.NegName
-			continue
-		}
-		nonDefaultNegName, err := s.getNonDefaultSubnetNEGName(subnetConfig.Name)
+		negName, err := s.getNEGName(subnetConfig.Name)
 		if err != nil {
-			s.logger.Error(err, "Errored when getting NEG name from non-default subnets when retrieving existing endpoints")
+			s.logger.Error(err, "Errored when getting NEG name when retrieving existing endpoints", "subnet", subnetConfig.Name)
 			return nil, err
 		}
-		subnetToNegMapping[subnetConfig.Name] = nonDefaultNegName
+		subnetToNegMapping[subnetConfig.Name] = negName
 	}
 
 	return subnetToNegMapping, nil
@@ -635,17 +634,15 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 			// Therefore this condition should be true only for multi-networking where we don't want NEGs in default subnet
 			continue
 		}
-		negName := s.NegSyncerKey.NegName
+		negName, err := s.getNEGName(subnetConfig.Name)
+		if err != nil {
+			s.logger.Error(err, "Unable to get the name of the NEG based on the subnet name", "subnetName", subnetConfig.Name)
+			errList = append(errList, err)
+			continue
+		}
 		networkInfo := s.networkInfo
 
 		if subnetConfig.Name != defaultSubnet {
-			// Determine the NEG name for the non-default subnet NEGs.
-			negName, err = s.getNonDefaultSubnetNEGName(subnetConfig.Name)
-			if err != nil {
-				s.logger.Error(err, "Unable to get the name of the additional NEG based on the subnet name", "subnetName", subnetConfig.Name)
-				errList = append(errList, err)
-				continue
-			}
 
 			// Determine the networkInfo for the non-default subnet NEGs.
 			resourceID, err := cloud.ParseResourceURL(subnetConfig.SubnetPath)
@@ -797,26 +794,10 @@ func (s *transactionSyncer) operationInternal(operation transactionOp, negLocati
 		networkEndpoints = append(networkEndpoints, ne)
 	}
 	zone := negLocation.Zone
-	negName := s.NegSyncerKey.NegName
-	if flags.F.EnableMultiSubnetClusterPhase1 {
-		defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
-		if err != nil {
-			s.logger.Error(err, "Errored getting default subnet from NetworkInfo when updating NEG endpoints")
-			return err
-		}
-
-		// In the case where this is the default network of the cluster
-		// (s.networkInfo.IsDefault) but the subnet of the NEG
-		// (epGroupInfo.Subnet) is not the defaultSubnet, we are dealing with
-		// the Multi-Subnet Cluster use case, wherein the name of the NEG would
-		// need to be different.
-		if s.networkInfo.IsDefault && negLocation.Subnet != defaultSubnet {
-			negName, err = s.getNonDefaultSubnetNEGName(negLocation.Subnet)
-			if err != nil {
-				s.logger.Error(err, "Errored getting non-default subnet NEG name when updating NEG endpoints")
-				return err
-			}
-		}
+	negName, err := s.getNEGName(negLocation.Subnet)
+	if err != nil {
+		s.logger.Error(err, "Errored getting NEG name when updating NEG endpoints", "subnet", negLocation.Subnet)
+		return err
 	}
 	if operation == attachOp {
 		err = s.cloud.AttachNetworkEndpoints(negName, zone, networkEndpoints, s.NegSyncerKey.GetAPIVersion(), logger)
@@ -948,25 +929,13 @@ func (s *transactionSyncer) commitPods(endpointMap map[negtypes.NEGLocation]negt
 			}
 			zoneEndpointMap[endpoint] = podName
 		}
-		negName := s.NegSyncerKey.NegName
-		syncerKey := s.NegSyncerKey
-		if flags.F.EnableMultiSubnetClusterPhase1 {
-			defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
-			if err != nil {
-				s.logger.Error(err, "Errored getting default subnet from NetworkInfo when committing pods")
-				continue
-			}
-
-			if negLocation.Subnet != defaultSubnet {
-				negName, err = s.getNonDefaultSubnetNEGName(negLocation.Subnet)
-				if err != nil {
-					s.logger.Error(err, "Errored getting non-default subnet NEG name when committing pods")
-					continue
-				}
-			}
-			// To ensure syncerKey has the same information as the passed in NEG name.
-			syncerKey.NegName = negName
+		negName, err := s.getNEGName(negLocation.Subnet)
+		if err != nil {
+			s.logger.Error(err, "Errored getting NEG name when committing pods", "subnet", negLocation.Subnet)
+			continue
 		}
+		syncerKey := s.NegSyncerKey
+		syncerKey.NegName = negName
 		s.reflector.CommitPods(syncerKey, negName, negLocation.Zone, zoneEndpointMap)
 	}
 }
@@ -1106,6 +1075,25 @@ func (s *transactionSyncer) computeEPSStaleness(endpointSlices []*discovery.Endp
 		s.negMetrics.PublishNegEPSStalenessMetrics(epsStaleness)
 		s.logger.V(3).Info("Endpoint slice syncs", "Namespace", endpointSlice.Namespace, "Name", endpointSlice.Name, "staleness", epsStaleness)
 	}
+}
+
+// getNEGName returns the name of the NEG for the given subnet.
+func (s *transactionSyncer) getNEGName(subnet string) (string, error) {
+	// For multi-net or in case multi-subnet is disabled - default NEG name used (as there is only single subnet then, therefore no need for multiple NEG names)
+	if !flags.F.EnableMultiSubnetClusterPhase1 || !s.networkInfo.IsDefault {
+		return s.NegSyncerKey.NegName, nil
+	}
+
+	defaultSubnet, err := utils.KeyName(s.networkInfo.SubnetworkURL)
+	if err != nil {
+		return "", err
+	}
+
+	// For non-binding syncer namer used for non-default subnet only; NEG name for default is stored in syncer key
+	if subnet != defaultSubnet {
+		return s.getNonDefaultSubnetNEGName(subnet)
+	}
+	return s.NegSyncerKey.NegName, nil
 }
 
 // getNonDefaultSubnetNEGName returns the name of the NEG based on the subnet name.

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -164,7 +164,12 @@ func NewTransactionSyncer(
 	negMetrics *metrics.NegMetrics,
 ) negtypes.NegSyncer {
 
-	logger := log.WithName("Syncer").WithValues("service", klog.KRef(negSyncerKey.Namespace, negSyncerKey.Name), "primaryNEGName", negSyncerKey.NegName)
+	logger := log.WithName("Syncer").WithValues("service", klog.KRef(negSyncerKey.Namespace, negSyncerKey.Name))
+	if negSyncerKey.IsBindingKey() {
+		logger = logger.WithValues("negBindingName", negSyncerKey.NEGBindingName)
+	} else {
+		logger = logger.WithValues("primaryNEGName", negSyncerKey.NegName)
+	}
 
 	// TransactionSyncer implements the syncer core
 	ts := &transactionSyncer{

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -569,6 +569,11 @@ func (s *transactionSyncer) listTargetZonesPerSubnet() (shared.ZonesPerSubnetMap
 		return nil, err
 	}
 
+	// All zones to manage should be set in NEGBinding CR directly
+	if s.NegSyncerKey.IsBindingKey() {
+		return zonesPerSubnet, nil
+	}
+
 	if !flags.F.EnableNEGPreprovisioning {
 		return zonesPerSubnet, nil
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -5158,6 +5158,69 @@ func TestNEGPreprovisioningTransition(t *testing.T) {
 	}
 }
 
+func TestListTargetZonesPerSubnet(t *testing.T) {
+	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
+	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(defaultTestSubnetURL, testNetwork)
+	testNegType := negtypes.VmIpPortEndpointType
+
+	prevEnableMultiSubnetClusterPhase1 := flags.F.EnableMultiSubnetClusterPhase1
+	prevNodeTopologyCRName := flags.F.NodeTopologyCRName
+	prevEnableNEGPreprovisioning := flags.F.EnableNEGPreprovisioning
+	defer func() {
+		flags.F.EnableMultiSubnetClusterPhase1 = prevEnableMultiSubnetClusterPhase1
+		flags.F.NodeTopologyCRName = prevNodeTopologyCRName
+		flags.F.EnableNEGPreprovisioning = prevEnableNEGPreprovisioning
+	}()
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+	flags.F.NodeTopologyCRName = "default"
+	flags.F.EnableNEGPreprovisioning = true
+
+	_, ts, err := newTestTransactionSyncer(fakeCloud, testNegType, "")
+	if err != nil {
+		t.Fatalf("failed to initialize transaction syncer: %v", err)
+	}
+
+	// Mock the zoneGetter to return only zone1 (TestZone1)
+	zonegetter.DeleteFakeNodesInZone(t, negtypes.TestZone2, ts.topologyProvider.(*zonegetter.ZoneGetter))
+	zonegetter.DeleteFakeNodesInZone(t, negtypes.TestZone4, ts.topologyProvider.(*zonegetter.ZoneGetter))
+
+	// Setup Service with preprovisioning annotation for zone2
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ts.Name,
+			Namespace: ts.Namespace,
+			Annotations: map[string]string{
+				negannotation.NEGAnnotationKey: `{"exposed_ports":{"80":{}},"zones":["zone2"]}`,
+			},
+		},
+	}
+	ts.serviceLister.Add(svc)
+
+	// Case 1: Standard NEG Syncer (IsBindingKey() == false).
+	// Pre-provisioning zones from the service annotation SHOULD be merged into zonesPerSubnet.
+	ts.NegSyncerKey.NEGBindingName = ""
+	zonesMap, err := ts.listTargetZonesPerSubnet()
+	if err != nil {
+		t.Fatalf("listTargetZonesPerSubnet failed for standard syncer: %v", err)
+	}
+	expectedStandardZones := sets.New("zone1", "zone2")
+	if !zonesMap[defaultTestSubnet].Equal(expectedStandardZones) {
+		t.Errorf("listTargetZonesPerSubnet() for standard syncer = %v, expected %v", zonesMap[defaultTestSubnet].UnsortedList(), expectedStandardZones.UnsortedList())
+	}
+
+	// Case 2: NEGBinding Syncer (IsBindingKey() == true).
+	// Pre-provisioning zones from the service annotation MUST NOT be merged, returning only zones from topologyProvider.
+	ts.NegSyncerKey.NEGBindingName = "test-neg-binding"
+	zonesMapBinding, err := ts.listTargetZonesPerSubnet()
+	if err != nil {
+		t.Fatalf("listTargetZonesPerSubnet failed for NEGBinding syncer: %v", err)
+	}
+	expectedBindingZones := sets.New("zone1")
+	if !zonesMapBinding[defaultTestSubnet].Equal(expectedBindingZones) {
+		t.Errorf("listTargetZonesPerSubnet() for NEGBinding syncer = %v, expected %v", zonesMapBinding[defaultTestSubnet].UnsortedList(), expectedBindingZones.UnsortedList())
+	}
+}
+
 func TestSyncNEGsPartialFailure(t *testing.T) {
 	testCases := []struct {
 		desc              string

--- a/pkg/neg/types/types.go
+++ b/pkg/neg/types/types.go
@@ -281,6 +281,8 @@ type NegSyncerKey struct {
 	Name string
 	// Name of neg
 	NegName string
+	// Name of NEGBinding (populated only for negBindingManager, where NegName is omitted)
+	NEGBindingName string
 	// PortTuple is the port tuple of the service backing the NEG
 	PortTuple SvcPortTuple
 
@@ -309,11 +311,20 @@ type NegSyncerKey struct {
 }
 
 func (key NegSyncerKey) String() string {
-	s := fmt.Sprintf("%s/%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	var s string
+	if key.IsBindingKey() {
+		s = fmt.Sprintf("%s/%s-binding-%s-%s-%s-%s", key.Namespace, key.Name, key.NEGBindingName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	} else {
+		s = fmt.Sprintf("%s/%s-%s-%s-%s-%s", key.Namespace, key.Name, key.NegName, key.PortTuple.String(), string(key.NegType), key.EpCalculatorMode)
+	}
 	if key.IncludeDrainNodesL4Local {
 		s += "-includeDrainNodesL4Local=true"
 	}
 	return s
+}
+
+func (key NegSyncerKey) IsBindingKey() bool {
+	return key.NEGBindingName != ""
 }
 
 // GetAPIVersion returns the compute API version to be used in order

--- a/pkg/neg/types/types_test.go
+++ b/pkg/neg/types/types_test.go
@@ -804,3 +804,35 @@ func CheckIfAddressIsPresentInData(addressData []AddressData, ready bool, addres
 	}
 	return false
 }
+
+func TestNegSyncerKeyString(t *testing.T) {
+	t.Parallel()
+
+	keyWithNEGName := NegSyncerKey{
+		Namespace:        "ns",
+		Name:             "svc",
+		NegName:          "negName",
+		PortTuple:        SvcPortTuple{Name: "portName", Port: 80},
+		NegType:          VmIpPortEndpointType,
+		EpCalculatorMode: L7Mode,
+	}
+
+	negBindingKey := NegSyncerKey{
+		Namespace:        "ns",
+		Name:             "svc",
+		NEGBindingName:   "negBindingName",
+		PortTuple:        SvcPortTuple{Name: "portName", Port: 80},
+		NegType:          VmIpPortEndpointType,
+		EpCalculatorMode: L7Mode,
+	}
+
+	want := "ns/svc-negName-portName/80--GCE_VM_IP_PORT-L7"
+	if keyWithNEGName.String() != want {
+		t.Errorf("key1.String() = %q, want %q", keyWithNEGName.String(), want)
+	}
+
+	want = "ns/svc-binding-negBindingName-portName/80--GCE_VM_IP_PORT-L7"
+	if negBindingKey.String() != want {
+		t.Errorf("key2.String() = %q, want %q", negBindingKey.String(), want)
+	}
+}

--- a/pkg/psc/controller_test.go
+++ b/pkg/psc/controller_test.go
@@ -1607,7 +1607,7 @@ func newTestController(clusterType string, readOnlyMode bool) (*Controller, erro
 
 	flags.F.GKEClusterName = ClusterName
 	flags.F.GKEClusterType = clusterType
-	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, nil, saClient, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, resourceNamer, kubeSystemUID, ctxConfig, klog.TODO())
+	ctx, err := context.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, saClient, nil, nil, nil, kubeClient /*kube client to be used for events*/, gceClient, resourceNamer, kubeSystemUID, ctxConfig, klog.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controller context")
 	}

--- a/pkg/utils/namer/negbinding_namer.go
+++ b/pkg/utils/namer/negbinding_namer.go
@@ -76,7 +76,7 @@ func (n *NegBindingNamer) negNameForSubnet(subnet, namespace, svcName string, po
 		binding.Spec.BackendRef.Name != svcName ||
 		binding.Spec.BackendRef.Port != port {
 		gotRef := fmt.Sprintf("%s/%s:%v", namespace, svcName, port)
-		expectedRef := fmt.Sprintf("%s/%s:%v", binding.Namespace, binding.Spec.BackendRef.Name, port)
+		expectedRef := fmt.Sprintf("%s/%s:%v", binding.Namespace, binding.Spec.BackendRef.Name, binding.Spec.BackendRef.Port)
 		return "", fmt.Errorf("%w: backendRef %s, negBinding.Spec.BackendRef %s", ErrNBNamerInvalidBackendRef, gotRef, expectedRef)
 	}
 


### PR DESCRIPTION
Core functionality for NEG binding - if NEGBinding CR is created and references existing service and existing NEGs - manage NEGs' endpoints (sync them with service's ones).

Not covered by core, but will be in further PRs:
* Conflicts resolving (force only one NB CR to manage single NEG name) (https://github.com/kubernetes/ingress-gce/pull/3177)
* Cleanup (if NEG was managed by NB CR, but not anymore - remove all endpoints) (https://github.com/kubernetes/ingress-gce/pull/3180)
* Verifying NEGs' description
* Reporting bound NEGs' number in metrics
* Readiness gate of the pods, which are added to NEGs using binding feature

Feature is disabled by default using `enable-neg-binding` flag.