### PR TITLE
Enhance L4 Standalone NEG controller observability and sync tracking

### DIFF
--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -396,6 +396,7 @@ func main() {
 		logger.Info("Start running the enabled controllers",
 			"L4 controller", flags.F.RunL4Controller,
 			"L4 NetLB controller", flags.F.RunL4NetLBController,
+			"L4 Standalone NEG LB controller", flags.F.RunL4StandaloneNEGController,
 			"InstanceGroup controller", flags.F.EnableIGController,
 			"PSC controller", flags.F.EnablePSC,
 		)
@@ -446,6 +447,7 @@ func main() {
 			logger.Info("Start running L4 leader election",
 				"L4 controller", flags.F.RunL4Controller,
 				"L4 NetLB controller", flags.F.RunL4NetLBController,
+				"L4 Standalone NEG LB controller", flags.F.RunL4StandaloneNEGController,
 				"InstanceGroup controller", flags.F.EnableIGController,
 				"PSC controller", flags.F.EnablePSC,
 			)

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -41,6 +42,10 @@ import (
 )
 
 const (
+	StandaloneNEGLBControllerName = "standalone-neg-lb-controller"
+
+	defaultNumWorkers = 1
+
 	// ExternalIPProgrammed Condition Type
 	ExternalIPProgrammed = "ExternalIPProgrammed"
 
@@ -107,7 +112,7 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 		hasSynced: ctx.HasSynced,
 		logger:    logger,
 	}
-	lc.svcQueue = utils.NewPeriodicTaskQueueWithMultipleWorkers("standalone-l4-neg-lb", "services", 1, lc.sync, logger)
+	lc.svcQueue = utils.NewPeriodicTaskQueueWithMultipleWorkers("standalone-l4-neg-lb", "services", defaultNumWorkers, lc.syncWrapper, logger)
 
 	ctx.ServiceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -167,7 +172,7 @@ func (lc *StandaloneNEGLBController) enqueue(svc *v1.Service) {
 }
 
 func (lc *StandaloneNEGLBController) Run() {
-	lc.logger.Info("Starting StandaloneNEGLBController")
+	lc.logger.Info("Starting StandaloneNEGLBController", "numWorkers", defaultNumWorkers)
 
 	err := wait.PollUntilContextCancel(wait.ContextForChannel(lc.stopCh), 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		lc.logger.V(2).Info("Waiting for initial cache sync before starting L4 Standalone NEG controller")
@@ -184,23 +189,43 @@ func (lc *StandaloneNEGLBController) Run() {
 	<-lc.stopCh
 }
 
-func (lc *StandaloneNEGLBController) sync(key string) error {
+func (lc *StandaloneNEGLBController) syncWrapper(key string) (err error) {
+	syncTrackingId := rand.Int31()
+	svcLogger := lc.logger.WithValues("serviceKey", key, "syncId", syncTrackingId)
+
+	defer func() {
+		if r := recover(); r != nil {
+			errMessage := fmt.Sprintf("Panic in L4 Standalone NEG LB sync worker goroutine: %v", r)
+			svcLogger.Error(nil, errMessage)
+			l4metrics.PublishL4ControllerPanicCount(StandaloneNEGLBControllerName)
+			err = fmt.Errorf("%s", errMessage)
+		}
+	}()
+	syncErr := lc.sync(key, svcLogger)
+	return syncErr
+}
+
+func (lc *StandaloneNEGLBController) sync(key string, svcLogger klog.Logger) error {
+	l4metrics.PublishL4controllerLastSyncTime(StandaloneNEGLBControllerName)
+
 	obj, exists, err := lc.ctx.ServiceInformer.GetIndexer().GetByKey(key)
 	if err != nil {
 		return fmt.Errorf("failed to lookup service for key %s: %w", key, err)
 	}
 	if !exists || obj == nil {
+		svcLogger.V(3).Info("Ignoring sync of non-existent service")
 		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
 		return nil
 	}
 	svc := obj.(*v1.Service)
-	svcLogger := lc.logger.WithValues("service", klog.KObj(svc))
 
 	if svc.DeletionTimestamp != nil {
+		svcLogger.V(3).Info("Ignoring sync of service undergoing deletion")
 		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
 		return nil
 	}
 	if !lc.shouldProcess(svc) {
+		svcLogger.V(3).Info("Ignoring sync: service does not match standalone LB criteria")
 		lc.ctx.L4Metrics.DeleteL4StandaloneNEGService(key)
 		if err := lc.clearStatusIngressIP(svc, svcLogger); err != nil {
 			return err

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -687,7 +687,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			kubeClient.CoreV1().Services(tc.svc.Namespace).Create(context.TODO(), tc.svc, metav1.CreateOptions{})
 
 			key := tc.svc.Namespace + "/" + tc.svc.Name
-			err = lc.sync(key)
+			err = lc.syncWrapper(key)
 			if (err != nil) != tc.expectError {
 				t.Errorf("sync() error = %v, expectError %v", err, tc.expectError)
 			}
@@ -916,7 +916,7 @@ func TestStandaloneNEGLBControllerMetrics_Success(t *testing.T) {
 
 	svcKey := svc.Namespace + "/" + svc.Name
 
-	err = lc.sync(svcKey)
+	err = lc.syncWrapper(svcKey)
 	if err != nil {
 		t.Fatalf("sync() error = %v", err)
 	}
@@ -982,7 +982,7 @@ func TestStandaloneNEGLBControllerMetrics_UserError(t *testing.T) {
 
 	svcKey := svc.Namespace + "/" + svc.Name
 
-	err = lc.sync(svcKey)
+	err = lc.syncWrapper(svcKey)
 	if err == nil {
 		t.Fatalf("Expected sync to fail")
 	}
@@ -1036,7 +1036,7 @@ func TestStandaloneNEGLBControllerMetrics_SystemError(t *testing.T) {
 
 	svcKey := svc.Namespace + "/" + svc.Name
 
-	err = lc.sync(svcKey)
+	err = lc.syncWrapper(svcKey)
 	if err == nil {
 		t.Fatalf("Expected sync to fail due to GCE error")
 	}
@@ -1104,7 +1104,7 @@ func TestStandaloneNEGLBControllerMetrics_Deletion(t *testing.T) {
 	svcKey := svc.Namespace + "/" + svc.Name
 
 	// Initial sync to establish state in metrics
-	err = lc.sync(svcKey)
+	err = lc.syncWrapper(svcKey)
 	if err != nil {
 		t.Fatalf("sync() error = %v", err)
 	}
@@ -1120,7 +1120,7 @@ func TestStandaloneNEGLBControllerMetrics_Deletion(t *testing.T) {
 	}
 	lc.ctx.ServiceInformer.GetIndexer().Delete(svc)
 
-	err = lc.sync(svcKey)
+	err = lc.syncWrapper(svcKey)
 	if err != nil {
 		t.Fatalf("sync() error = %v", err)
 	}


### PR DESCRIPTION
Adds a syncWrapper to process queue tasks uniformly alongside L4 NetLB and ILB. Injects syncTrackingId and service keys into the core logger for traceable pipelines, and wires worker panic recoveries into standard L4 metrics.