### PR TITLE
Strip /96 prefix from GCP IPv6 forwarding rule IPAddresses

### DIFF
--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -380,7 +380,9 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 
 		addrs := frAddresses(fr)
 		for _, a := range addrs {
-			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: a, IPMode: &vipMode})
+			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
+			trimmedIP := strings.Split(a, "/")[0]
+			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
 		}
 	}
 

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -101,6 +101,120 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			},
 		},
 		{
+			desc: "GCP IPv6 forwarding rule strips /96 from IPAddress string",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-ipv6-strip",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-ipv6",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-ipv6": {
+					Name:                "fr-ipv6",
+					IPAddress:           "2600:1900:4000:1::/96",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{"2600:1900:4000:1::"},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 2600:1900:4000:1::",
+			},
+		},
+		{
+			desc: "Dual stack forwarding rules (IPv4 and IPv6)",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-dual-stack",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-ipv4,fr-ipv6",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-ipv4": {
+					Name:                "fr-ipv4",
+					IPAddress:           "34.1.2.3",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+				"fr-ipv6": {
+					Name:                "fr-ipv6",
+					IPAddress:           "2600:1900:4000:1::/96",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{"34.1.2.3", "2600:1900:4000:1::"},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 34.1.2.3, 2600:1900:4000:1::",
+			},
+		},
+		{
+			desc: "Forwarding rule with empty IPAddress does not panic on split",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-empty-ip",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-empty",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-empty": {
+					Name:                "fr-empty",
+					IPAddress:           "",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{""},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: ",
+			},
+		},
+		{
 			desc: "Multiple forwarding rules, all missing, error",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Validates properly handling IPv6 CIDR outputs from GCP Forwarding Rules bytruncating trailing subnets to adhere to strict K8s Service Status validation. Adds unit assertions covering Pure IPv6, Edge-cases, and Dual-Stack aggregations.