### PR TITLE
Canonicalize IPv6 addresses in L4StandaloneNEG to prevent k8s apiserv…

### DIFF
--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net/netip"
 	"sort"
 	"strings"
 	"time"
@@ -383,6 +384,10 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		for _, a := range addrs {
 			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
 			trimmedIP := strings.Split(a, "/")[0]
+			// And make it canonical to avoid warnings from k8s apiserver
+			if ipAddr, err := netip.ParseAddr(trimmedIP); err == nil {
+				trimmedIP = ipAddr.String()
+			}
 			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
 		}
 	}

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -136,6 +136,41 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			},
 		},
 		{
+			desc: "GCP IPv6 forwarding rule canonicalizes non-standard IPv6 address",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-ipv6-canonical",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-ipv6-noncanonical",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-ipv6-noncanonical": {
+					Name:                "fr-ipv6-noncanonical",
+					IPAddress:           "2600:1900:4000:0001:0000:0000:0000:000A/96",
+					BackendService:      bsURL,
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionGA,
+				},
+			},
+			expectIPs:   []string{"2600:1900:4000:1::a"},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 2600:1900:4000:1::a",
+			},
+		},
+		{
 			desc: "Dual stack forwarding rules (IPv4 and IPv6)",
 			svc: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
…er warnings

It's not released yet so it's a trivial change. For NetLB/ILB we also should do this, but at this point I'm afraid it might break something. The warning comes from https://github.com/kubernetes/kubernetes/blob/74c594bf1a429c0b6cdc33e48a32596c978dfa7b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go#L126