### PR TITLE
NEGBinding - NEGs ownership

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -491,6 +491,12 @@ func (c *Controller) Run() {
 		return c.hasSynced(), nil
 	}, c.stopCh)
 
+	if c.enableNEGBinding {
+		if err := c.negBindingManager.InitializeOwnershipRegistry(); err != nil {
+			c.logger.Error(err, "Failed to initialize NEG ownership registry")
+		}
+	}
+
 	c.logger.V(2).Info("Starting network endpoint group controller")
 	activecontrollermetrics.RecordRunningController(activecontrollermetrics.NEGControllerLabel)
 	defer func() {

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -308,11 +308,13 @@ func (m *negBindingManager) EnsureSyncersForService(svcNamespace, svcName string
 			errs = append(errs, fmt.Errorf("unexpected object type %T in binding index for service %s", obj, svcKey))
 			continue
 		}
+		binding = binding.DeepCopy()
 
 		err := m.validateBackendRef(binding)
 		if err != nil {
 			_ = m.updateBackendRefCondition(binding, err)
-			return err
+			errs = append(errs, err)
+			continue
 		}
 
 		if networkInfoErr != nil {
@@ -635,10 +637,10 @@ func (m *negBindingManager) updateBackendRefCondition(binding *negbindingv1beta1
 		}
 	}
 
-	origBinding := binding.DeepCopy()
-	m.ensureCondition(binding, cond)
+	newBinding := binding.DeepCopy()
+	m.ensureCondition(newBinding, cond)
 
-	patchBytes, err := patch.MergePatchBytes(negbindingv1beta1.NetworkEndpointGroupBinding{Status: origBinding.Status}, negbindingv1beta1.NetworkEndpointGroupBinding{Status: binding.Status})
+	patchBytes, err := patch.MergePatchBytes(negbindingv1beta1.NetworkEndpointGroupBinding{Status: binding.Status}, negbindingv1beta1.NetworkEndpointGroupBinding{Status: newBinding.Status})
 	if err != nil {
 		return fmt.Errorf("failed to prepare patch bytes for status update: %w", err)
 	}

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -408,6 +408,7 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 		m.negBindingClient,
 		m.negBindingLister,
 		m.negMetrics,
+		m.ownershipRegistry,
 		m.logger,
 	)
 

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
@@ -82,6 +83,95 @@ func (c syncerConfig) Equals(other syncerConfig) bool {
 		c.networkInfo.NetworkURL == other.networkInfo.NetworkURL &&
 		c.networkInfo.SubnetworkURL == other.networkInfo.SubnetworkURL &&
 		c.networkInfo.K8sNetwork == other.networkInfo.K8sNetwork
+}
+
+// negOwnershipRegistry allows to track which NEGBinding CR's syncer has rights to modify endpoints of the NEGs based on their name.
+type negOwnershipRegistry struct {
+	mu sync.Mutex
+
+	// Important: owners and ownedNEGs should be changed only using setOwnerLocked and unsetOwnerLocked to make sure these are consistent
+	owners    map[string]string           // negName -> ownerKey
+	ownedNEGs map[string]sets.Set[string] // ownerKey -> set of NEG names
+
+	onRelease func(negNames []string)
+}
+
+// newNEGOwnershipRegistry constructs a new negOwnershipRegistry.
+func newNEGOwnershipRegistry(onRelease func([]string)) *negOwnershipRegistry {
+	return &negOwnershipRegistry{
+		owners:    make(map[string]string),
+		ownedNEGs: make(map[string]sets.Set[string]),
+		onRelease: onRelease,
+	}
+}
+
+// Acquire tries to get exclusive ownership of NEGs with name negName for owner
+func (r *negOwnershipRegistry) Acquire(negName string, owner string) (bool, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	currentOwner, ok := r.owners[negName]
+	if !ok {
+		r.setOwnerLocked(negName, owner)
+		return true, ""
+	}
+	if currentOwner == owner {
+		return true, ""
+	}
+	return false, currentOwner
+}
+
+// ReleaseAllOwnedExcept releases all owned by owner NEG names, except ones in keep set
+func (r *negOwnershipRegistry) ReleaseAllOwnedExcept(owner string, keep sets.Set[string]) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if keep == nil {
+		keep = sets.New[string]()
+	}
+
+	released := []string{}
+	for negName := range r.ownedNEGs[owner] {
+		if !keep.Has(negName) {
+			r.unsetOwnerLocked(negName)
+			released = append(released, negName)
+		}
+	}
+
+	if len(released) > 0 && r.onRelease != nil {
+		go r.onRelease(released)
+	}
+}
+
+// setOwnerLocked ensures that owners and ownedNEGs are consistent when acquiring ownership of NEG for binding. Should have lock when called.
+func (r *negOwnershipRegistry) setOwnerLocked(negName, owner string) {
+	r.owners[negName] = owner
+	if _, ok := r.ownedNEGs[owner]; !ok {
+		r.ownedNEGs[owner] = sets.New[string]()
+	}
+	r.ownedNEGs[owner].Insert(negName)
+}
+
+// setOwnerLocked ensures that owners and ownedNEGs are consistent when releasing NEG ownership. Should have lock when called.
+func (r *negOwnershipRegistry) unsetOwnerLocked(negName string) {
+	owner, ok := r.owners[negName]
+	if !ok {
+		return
+	}
+	delete(r.owners, negName)
+	if _, ok := r.ownedNEGs[owner]; ok {
+		r.ownedNEGs[owner].Delete(negName)
+		if r.ownedNEGs[owner].Len() == 0 {
+			delete(r.ownedNEGs, owner)
+		}
+	}
+}
+
+// GetOwner gets current owner of the NEG name
+func (r *negOwnershipRegistry) GetOwner(negName string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.owners[negName]
 }
 
 // negBindingManager manages the lifecycle of syncers associated with NEGBinding CRs.

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -203,6 +203,8 @@ type negBindingManager struct {
 	reflector     readiness.Reflector
 	kubeSystemUID types.UID
 
+	ownershipRegistry *negOwnershipRegistry
+
 	logger klog.Logger
 }
 
@@ -245,11 +247,13 @@ func newNEGBindingManager(
 		kubeSystemUID:       kubeSystemUID,
 		logger:              logger.WithName("NEGBindingManager"),
 	}
+	m.ownershipRegistry = newNEGOwnershipRegistry(m.tryAssignReleasedNEGs)
 	return m
 }
 
 // EnsureSyncerForNEGBinding ensures corresponding syncer is started for the binding.
 func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	m.acquireNEGsForBinding(binding)
 	err := m.validateBackendRef(binding)
 	if err != nil {
 		_ = m.updateBackendRefCondition(binding, err)
@@ -368,6 +372,7 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 		if !hasConfig || !oldConfig.Equals(newConfig) {
 			m.logger.Info("Configuration changed for NEGBinding syncer, recreating", "binding", bindingKey, "old", oldConfig, "new", newConfig)
 			syncer.Stop()
+			m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
 			delete(m.syncerMap, bindingKey)
 			delete(m.syncerConfigs, bindingKey)
 			// Proceed to create new syncer
@@ -392,7 +397,7 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 		EpCalculatorMode: negtypes.L7Mode,
 	}
 
-	tp, err := negsyncer.NewNEGBindingTopologyProvider(binding.Namespace, binding.Name, m.negBindingLister, defaultSubnetURL)
+	tp, err := negsyncer.NewNEGBindingTopologyProvider(binding.Namespace, binding.Name, m.negBindingLister, defaultSubnetURL, m.ownershipRegistry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create topology provider: %w", err)
 	}
@@ -484,6 +489,7 @@ func (m *negBindingManager) StopSyncer(namespace, name string) {
 	bindingKey := fmt.Sprintf("%s/%s", namespace, name)
 	if syncer, ok := m.syncerMap[bindingKey]; ok {
 		syncer.Stop()
+		m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
 		delete(m.syncerMap, bindingKey)
 		delete(m.syncerConfigs, bindingKey)
 	}
@@ -635,4 +641,60 @@ func (m *negBindingManager) ensureCondition(binding *negbindingv1beta1.NetworkEn
 	}
 
 	binding.Status.Conditions[index] = expectedCondition
+}
+
+// tryAssignReleasedNEGs is a callback for released NEGs. In case any other NEGBinding CR refers to any released NEG name, its syncer will be ensured and synced.
+func (m *negBindingManager) tryAssignReleasedNEGs(negNames []string) {
+	if len(negNames) == 0 {
+		return
+	}
+
+	releasedSet := sets.New(negNames...)
+	objs := m.negBindingLister.List()
+	for _, obj := range objs {
+		if len(releasedSet) == 0 {
+			break
+		}
+
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			continue
+		}
+
+		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		acquiredNEGs := []string{}
+		for _, ref := range binding.Spec.NetworkEndpointGroups {
+			if releasedSet.Has(ref.Name) {
+				acquired, _ := m.ownershipRegistry.Acquire(ref.Name, bindingKey)
+				if acquired {
+					acquiredNEGs = append(acquiredNEGs, ref.Name)
+					releasedSet.Delete(ref.Name)
+				}
+			}
+		}
+
+		if len(acquiredNEGs) > 0 {
+			binding = binding.DeepCopy()
+			if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
+				m.logger.Error(err, "Failed to ensure syncer for binding after released by other binding NEGs acquired", "binding", bindingKey, "negName", acquiredNEGs)
+			}
+		}
+	}
+}
+
+// acquireNEGsForBinding tries to acquire ownership for NEGBinding based on its Spec.
+func (m *negBindingManager) acquireNEGsForBinding(binding *negbindingv1beta1.NetworkEndpointGroupBinding) {
+	bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+	acquiredNEGs := sets.New[string]()
+	for _, specRef := range binding.Spec.NetworkEndpointGroups {
+		acquired, currentOwner := m.ownershipRegistry.Acquire(specRef.Name, bindingKey)
+		if acquired {
+			acquiredNEGs.Insert(specRef.Name)
+			m.logger.Info("Acquired NEG ownership from spec", "negName", specRef.Name, "owner", bindingKey)
+		} else {
+			m.logger.Info("Conflict acquiring NEG ownership from spec", "negName", specRef.Name, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
+		}
+	}
+
+	m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, acquiredNEGs)
 }

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -568,6 +569,38 @@ func (m *negBindingManager) getPortTuple(svc *apiv1.Service, port int32) (negtyp
 		}
 	}
 	return negtypes.SvcPortTuple{}, fmt.Errorf("port %d not found in service %s/%s spec", port, svc.Namespace, svc.Name)
+}
+
+// InitializeOwnershipRegistry reads NEG names from existing NEGBinding CRs' statuses and acquires them.
+// In case same NEG name found in multiple CRs, only one selected.
+func (m *negBindingManager) InitializeOwnershipRegistry() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bindings := m.negBindingLister.List()
+	for _, obj := range bindings {
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			m.logger.Error(nil, "Unexpected object type in negBindingLister during registry init", "type", fmt.Sprintf("%T", obj))
+			continue
+		}
+		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		for _, statusRef := range binding.Status.NetworkEndpointGroups {
+			negID, err := cloud.ParseResourceURL(statusRef.ResourceURL)
+			if err != nil {
+				m.logger.Error(err, "Failed to parse NEG URL from status during registry init", "binding", bindingKey, "url", statusRef.ResourceURL)
+				continue
+			}
+			negName := negID.Key.Name
+			acquired, currentOwner := m.ownershipRegistry.Acquire(negName, bindingKey)
+			if acquired {
+				m.logger.Info("Acquired NEG ownership from status during registry init", "negName", negName, "owner", bindingKey)
+			} else {
+				m.logger.Info("Conflict acquiring NEG ownership from status during registry init", "negName", negName, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
+			}
+		}
+	}
+	return nil
 }
 
 func (m *negBindingManager) validateBackendRef(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -40,6 +40,7 @@ import (
 	fakenegbinding "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
 	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
 	"k8s.io/ingress-gce/pkg/network"
+	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
@@ -497,6 +498,75 @@ func findCondition(conditions []negbindingv1beta1.Condition, conditionType strin
 		}
 	}
 	return negbindingv1beta1.Condition{}, false
+}
+
+func TestInitializeOwnershipRegistry(t *testing.T) {
+	namespace := "test-namespace"
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	binding1 := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-1"},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: "svc-1", Port: 80},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/neg-1",
+					SubnetURL:   defaultTestSubnetURL,
+				},
+			},
+		},
+	}
+	binding2 := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-2"},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: "svc-2", Port: 80},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-b/networkEndpointGroups/neg-2",
+					SubnetURL:   defaultTestSubnetURL,
+				},
+			},
+		},
+	}
+
+	negBindingLister.Add(binding1)
+	negBindingLister.Add(binding2)
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		metrics.NewNegMetrics(),
+		metricscollector.FakeSyncerMetrics(),
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	registry := m.ownershipRegistry
+
+	err := m.InitializeOwnershipRegistry()
+	if err != nil {
+		t.Fatalf("InitializeRegistry failed: %v", err)
+	}
+
+	expectedOwner1 := "test-namespace/binding-1"
+	if registry.GetOwner("neg-1") != expectedOwner1 {
+		t.Errorf("neg-1 should be owned by %q, got %q", expectedOwner1, registry.GetOwner("neg-1"))
+	}
+
+	expectedOwner2 := "test-namespace/binding-2"
+	if registry.GetOwner("neg-2") != expectedOwner2 {
+		t.Errorf("neg-2 should be owned by %q, got %q", expectedOwner2, registry.GetOwner("neg-2"))
+	}
 }
 
 func TestNEGBindingManagerConflictResolution(t *testing.T) {

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -21,15 +21,18 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
@@ -209,6 +212,7 @@ func TestNEGBindingManager(t *testing.T) {
 	// Test updating binding to have no NEGs
 	testBindingNoNEGs := testBinding.DeepCopy()
 	testBindingNoNEGs.Spec.NetworkEndpointGroups = []negbindingv1beta1.SpecNegRef{}
+	negBindingLister.Update(testBindingNoNEGs)
 	err = m.EnsureSyncerForNEGBinding(testBindingNoNEGs)
 	if err != nil {
 		t.Fatalf("EnsureSyncerForNEGBinding with empty NEGs failed: %v", err)
@@ -218,6 +222,7 @@ func TestNEGBindingManager(t *testing.T) {
 	}
 
 	// Restore syncer for subsequent tests
+	negBindingLister.Update(testBinding)
 	err = m.EnsureSyncerForNEGBinding(testBinding)
 	if err != nil {
 		t.Fatalf("EnsureSyncerForNEGBinding restore failed: %v", err)
@@ -492,4 +497,135 @@ func findCondition(conditions []negbindingv1beta1.Condition, conditionType strin
 		}
 	}
 	return negbindingv1beta1.Condition{}, false
+}
+
+func TestNEGBindingManagerConflictResolution(t *testing.T) {
+	oldFlag := flags.F.EnableMultiSubnetClusterPhase1
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+	defer func() { flags.F.EnableMultiSubnetClusterPhase1 = oldFlag }()
+
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: svcName},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{{Port: svcPort, TargetPort: intstr.FromString(targetPort)}},
+		},
+	}
+	_, _ = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+
+	// B1 wants neg-1
+	b1 := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "b1"},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: svcName, Port: svcPort},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}},
+			},
+		},
+	}
+
+	// B2 wants neg-1
+	b2 := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "b2"},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: svcName, Port: svcPort},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}},
+			},
+		},
+	}
+
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), b1, metav1.CreateOptions{})
+	_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), b2, metav1.CreateOptions{})
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	_ = negBindingLister.Add(b1)
+	_ = negBindingLister.Add(b2)
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = serviceLister.Add(testSvc)
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, _ := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	// 1. Ensure B1. B1 should acquire neg-1.
+	err := m.EnsureSyncerForNEGBinding(b1)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding(b1) failed: %v", err)
+	}
+	var owner string
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		owner = m.ownershipRegistry.GetOwner("neg-1")
+		return owner == "test-ns/b1", nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for B1 to acquire neg-1, current owner: %s", owner)
+	}
+
+	// 2. Ensure B2. B2 should try to acquire neg-1 but fail due to conflict.
+	err = m.EnsureSyncerForNEGBinding(b2)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding(b2) failed: %v", err)
+	}
+	// Verify B1 is still owner
+	owner = m.ownershipRegistry.GetOwner("neg-1")
+	if owner != "test-ns/b1" {
+		t.Errorf("Expected owner of neg-1 to remain test-ns/b1, got %s", owner)
+	}
+
+	// Delete B1 from cache to simulate deletion before stopping syncer
+	_ = negBindingLister.Delete(b1)
+
+	// 3. Stop B1 (simulate deletion). This should release neg-1 and trigger sync of B2.
+	m.StopSyncer("test-ns", "b1")
+
+	// Verify B2 acquires neg-1. Since sync is async (runs in syncer goroutine), we poll.
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		owner = m.ownershipRegistry.GetOwner("neg-1")
+		return owner == "test-ns/b2", nil
+	})
+	if err != nil {
+		t.Errorf("Timed out waiting for B2 to acquire neg-1, current owner: %s", owner)
+	}
 }

--- a/pkg/neg/syncers/negbinding_topology.go
+++ b/pkg/neg/syncers/negbinding_topology.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type negOwnershipRegistry interface {
+	GetOwner(negName string) string
+}
+
 // NEGBindingTopologyProvider provides subnets and zones where NEGs should be managed
 // based on NetworkEndpointGroupBinding CR
 type NEGBindingTopologyProvider struct {
@@ -38,10 +42,11 @@ type NEGBindingTopologyProvider struct {
 	namespace        string
 	negBindingLister cache.Indexer
 	defaultSubnetID  *cloud.ResourceID
+	registry         negOwnershipRegistry
 }
 
 // NewNEGBindingTopologyProvider constructs a new NEGBindingTopologyProvider
-func NewNEGBindingTopologyProvider(namespace, negBindingName string, negBindingLister cache.Indexer, defaultSubnetURL string) (*NEGBindingTopologyProvider, error) {
+func NewNEGBindingTopologyProvider(namespace, negBindingName string, negBindingLister cache.Indexer, defaultSubnetURL string, registry negOwnershipRegistry) (*NEGBindingTopologyProvider, error) {
 	defaultSubnetID, err := cloud.ParseResourceURL(defaultSubnetURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse default subnetwork URL %q: %w", defaultSubnetURL, err)
@@ -52,6 +57,7 @@ func NewNEGBindingTopologyProvider(namespace, negBindingName string, negBindingL
 		namespace:        namespace,
 		negBindingLister: negBindingLister,
 		defaultSubnetID:  defaultSubnetID,
+		registry:         registry,
 	}, nil
 }
 
@@ -71,6 +77,22 @@ func (p *NEGBindingTopologyProvider) getBinding() (*negbindingv1beta1.NetworkEnd
 	return binding, nil
 }
 
+// getOwnedSpecNEGRefs returns owned NEG Refs subset of NEGBinding.Spec.
+func (p *NEGBindingTopologyProvider) getOwnedSpecNEGRefs(binding *negbindingv1beta1.NetworkEndpointGroupBinding, logger klog.Logger) []negbindingv1beta1.SpecNegRef {
+	ownerKey := fmt.Sprintf("%s/%s", p.namespace, p.negBindingName)
+
+	var acquiredRefs []negbindingv1beta1.SpecNegRef
+	for _, ref := range binding.Spec.NetworkEndpointGroups {
+		currentOwner := p.registry.GetOwner(ref.Name)
+		if currentOwner == ownerKey {
+			acquiredRefs = append(acquiredRefs, ref)
+		} else {
+			logger.Info("NEG name is owned by another binding, skipping", "negName", ref.Name, "owner", ownerKey, "currentOwner", currentOwner)
+		}
+	}
+	return acquiredRefs
+}
+
 // ListSubnetsInDefaultNetwork returns the list of subnets declared inside the NegBinding CR Spec.
 func (p *NEGBindingTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig {
 	binding, err := p.getBinding()
@@ -79,17 +101,24 @@ func (p *NEGBindingTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Log
 		return nil
 	}
 
-	configs := make([]nodetopologyv1.SubnetConfig, len(binding.Spec.NetworkEndpointGroups))
-	for i, ref := range binding.Spec.NetworkEndpointGroups {
+	// Return only subnets where NEGs are owned
+	subnets := sets.New[string]()
+	ownedSpecRefs := p.getOwnedSpecNEGRefs(binding, logger)
+	for _, ref := range ownedSpecRefs {
+		subnets.Insert(ref.Subnet)
+	}
+
+	configs := []nodetopologyv1.SubnetConfig{}
+	for subnet := range subnets {
 		key := &meta.Key{
-			Name:   ref.Subnet,
+			Name:   subnet,
 			Region: p.defaultSubnetID.Key.Region,
 		}
 		subnetPath := cloud.SelfLink(meta.VersionGA, p.defaultSubnetID.ProjectID, p.defaultSubnetID.Resource, key)
-		configs[i] = nodetopologyv1.SubnetConfig{
-			Name:       ref.Subnet,
+		configs = append(configs, nodetopologyv1.SubnetConfig{
+			Name:       subnet,
 			SubnetPath: subnetPath,
-		}
+		})
 	}
 	return configs
 }
@@ -107,8 +136,10 @@ func (p *NEGBindingTopologyProvider) ListZonesPerSubnet(_ zonegetter.Filter, net
 		return nil, fmt.Errorf("failed to get NegBinding from store: %w", err)
 	}
 
+	// Return only zones of subnets, where NEGs are owned
+	ownedSpecRefs := p.getOwnedSpecNEGRefs(binding, logger)
 	zonesPerSubnet := make(shared.ZonesPerSubnetMap)
-	for _, ref := range binding.Spec.NetworkEndpointGroups {
+	for _, ref := range ownedSpecRefs {
 		zonesPerSubnet[ref.Subnet] = sets.New(ref.Zones...)
 	}
 	return zonesPerSubnet, nil

--- a/pkg/neg/syncers/negbinding_topology_test.go
+++ b/pkg/neg/syncers/negbinding_topology_test.go
@@ -19,6 +19,7 @@ package syncers
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -35,6 +36,37 @@ import (
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 )
+
+type mockRegistry struct {
+	owners map[string]string
+}
+
+func newMockRegistry() *mockRegistry {
+	return &mockRegistry{owners: make(map[string]string)}
+}
+
+func (r *mockRegistry) Acquire(negName string, owner string) (bool, string) {
+	if current, ok := r.owners[negName]; ok {
+		if current == owner {
+			return true, ""
+		}
+		return false, current
+	}
+	r.owners[negName] = owner
+	return true, ""
+}
+
+func (r *mockRegistry) ReleaseAllOwnedExcept(owner string, keep sets.Set[string]) {
+	for k, v := range r.owners {
+		if v == owner && !keep.Has(k) {
+			delete(r.owners, k)
+		}
+	}
+}
+
+func (r *mockRegistry) GetOwner(negName string) string {
+	return r.owners[negName]
+}
 
 func TestNEGBindingTopologyProvider(t *testing.T) {
 	namespace := "test-namespace"
@@ -160,14 +192,20 @@ func TestNEGBindingTopologyProvider(t *testing.T) {
 			informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
 			negBindingLister := informer.GetIndexer()
 
-			p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+			registry := newMockRegistry()
+			p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
 			if err != nil {
-				t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
+				t.Fatalf("NewNEGBindingTopologyProvider() failed unexpectedly: %v", err)
 			}
 
 			negBindingLister.Add(tc.initialBinding)
+			for _, ref := range tc.initialBinding.Spec.NetworkEndpointGroups {
+				registry.Acquire(ref.Name, fmt.Sprintf("%s/%s", namespace, name))
+			}
 
 			subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+			sortSubnetConfigs(subnets)
+			sortSubnetConfigs(tc.expectedSubnets)
 			if !reflect.DeepEqual(subnets, tc.expectedSubnets) {
 				t.Errorf("ListSubnetsInDefaultNetwork() returned %+v, expected %+v", subnets, tc.expectedSubnets)
 			}
@@ -186,8 +224,14 @@ func TestNEGBindingTopologyProvider(t *testing.T) {
 
 			if tc.updatedBinding != nil {
 				negBindingLister.Update(tc.updatedBinding)
+				registry.ReleaseAllOwnedExcept(fmt.Sprintf("%s/%s", namespace, name), sets.New[string]())
+				for _, ref := range tc.updatedBinding.Spec.NetworkEndpointGroups {
+					registry.Acquire(ref.Name, fmt.Sprintf("%s/%s", namespace, name))
+				}
 
 				subnets = p.ListSubnetsInDefaultNetwork(klog.TODO())
+				sortSubnetConfigs(subnets)
+				sortSubnetConfigs(tc.updatedSubnets)
 				if !reflect.DeepEqual(subnets, tc.updatedSubnets) {
 					t.Errorf("ListSubnetsInDefaultNetwork() after update returned %+v, expected %+v", subnets, tc.updatedSubnets)
 				}
@@ -213,7 +257,8 @@ func TestNewNEGBindingTopologyProviderInvalidDefaultSubnetURL(t *testing.T) {
 	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
 	negBindingLister := informer.GetIndexer()
 
-	_, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, "invalid-url-with-no-slashes")
+	registry := newMockRegistry()
+	_, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, "invalid-url-with-no-slashes", registry)
 	if err == nil {
 		t.Error("NewNEGBindingTopologyProvider() with invalid defaultSubnetURL returned no error")
 	} else if expected := `failed to parse default subnetwork URL "invalid-url-with-no-slashes": "invalid-url-with-no-slashes" is not a valid resource URL`; err.Error() != expected {
@@ -230,7 +275,8 @@ func TestNEGBindingTopologyProviderInvalidTypeInCache(t *testing.T) {
 	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
 	negBindingLister := informer.GetIndexer()
 
-	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	registry := newMockRegistry()
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
 	if err != nil {
 		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
 	}
@@ -268,7 +314,8 @@ func TestNEGBindingTopologyProviderNEGBindingNotInStore(t *testing.T) {
 	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
 	negBindingLister := informer.GetIndexer()
 
-	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	registry := newMockRegistry()
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
 	if err != nil {
 		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
 	}
@@ -298,7 +345,8 @@ func TestNEGBindingTopologyProviderMultinetError(t *testing.T) {
 	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", time.Second, utils.NewNamespaceIndexer())
 	negBindingLister := informer.GetIndexer()
 
-	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL)
+	registry := newMockRegistry()
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
 	if err != nil {
 		t.Fatalf("NewNegBindingTopologyProvider() failed unexpectedly: %v", err)
 	}
@@ -310,4 +358,110 @@ func TestNEGBindingTopologyProviderMultinetError(t *testing.T) {
 	} else if expected := "NEGBinding does not support multi-network mode"; err.Error() != expected {
 		t.Errorf("ListZonesPerSubnet() returned error %q, expected %q", err.Error(), expected)
 	}
+}
+
+func TestNEGBindingTopologyProviderOwnership(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	registry := newMockRegistry()
+	ownerKey := fmt.Sprintf("%s/%s", namespace, name)
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
+	if err != nil {
+		t.Fatalf("NewNEGBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	// 1. Pre-acquire "neg-shared" by another owner
+	otherOwner := "test-namespace/other-binding"
+	acquired, _ := registry.Acquire("neg-shared", otherOwner)
+	if !acquired {
+		t.Fatalf("Failed to pre-acquire lock")
+	}
+
+	// 2. Create binding spec referencing "neg-shared" (subnet-1) and "neg-unique" (subnet-2)
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-shared",
+					Subnet: "subnet-1",
+					Zones:  []string{"zone-a"},
+				},
+				{
+					Name:   "neg-unique",
+					Subnet: "subnet-2",
+					Zones:  []string{"zone-b"},
+				},
+			},
+		},
+	}
+	negBindingLister.Add(binding)
+	registry.Acquire("neg-unique", ownerKey)
+
+	// 3. Call ListZonesPerSubnet. It should only return "subnet-2"
+	zones, err := p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err != nil {
+		t.Errorf("ListZonesPerSubnet() returned unexpected error: %v", err)
+	}
+	expectedZones := shared.ZonesPerSubnetMap{
+		"subnet-2": sets.New("zone-b"),
+	}
+	if !reflect.DeepEqual(zones, expectedZones) {
+		t.Errorf("ListZonesPerSubnet() returned %+v, expected %+v", zones, expectedZones)
+	}
+
+	// 4. Verify locks in registry
+	if registry.GetOwner("neg-unique") != ownerKey {
+		t.Errorf("neg-unique should be owned by %q, got %q", ownerKey, registry.GetOwner("neg-unique"))
+	}
+	if registry.GetOwner("neg-shared") != otherOwner {
+		t.Errorf("neg-shared should still be owned by %q, got %q", otherOwner, registry.GetOwner("neg-shared"))
+	}
+
+	// 5. Call ListSubnetsInDefaultNetwork. It should only return "subnet-2"
+	subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+	if len(subnets) != 1 || subnets[0].Name != "subnet-2" {
+		t.Errorf("ListSubnetsInDefaultNetwork() returned %+v, expected subnet-2 only", subnets)
+	}
+
+	// 6. Update binding spec to remove "neg-unique" (so "neg-unique" is no longer desired)
+	bindingUpdated := binding.DeepCopy()
+	bindingUpdated.Spec.NetworkEndpointGroups = []negbindingv1beta1.SpecNegRef{
+		{
+			Name:   "neg-shared",
+			Subnet: "subnet-1",
+			Zones:  []string{"zone-a"},
+		},
+	}
+	negBindingLister.Update(bindingUpdated)
+	registry.ReleaseAllOwnedExcept(ownerKey, sets.New[string]())
+
+	// 7. Call ListZonesPerSubnet again. It should return empty map (since "neg-shared" is still locked by other)
+	zones, err = p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err != nil {
+		t.Errorf("ListZonesPerSubnet() returned unexpected error: %v", err)
+	}
+	if len(zones) != 0 {
+		t.Errorf("ListZonesPerSubnet() returned %+v, expected empty", zones)
+	}
+
+	// 8. Verify "neg-unique" lock was RELEASED
+	if registry.GetOwner("neg-unique") != "" {
+		t.Errorf("neg-unique should be released, but is still owned by %q", registry.GetOwner("neg-unique"))
+	}
+}
+
+func sortSubnetConfigs(configs []nodetopologyv1.SubnetConfig) {
+	sort.Slice(configs, func(i, j int) bool {
+		return configs[i].Name < configs[j].Name
+	})
 }

--- a/pkg/neg/syncers/negstatushandler/negbinding.go
+++ b/pkg/neg/syncers/negstatushandler/negbinding.go
@@ -19,6 +19,7 @@ package negstatushandler
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -36,9 +37,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	NEGsAttached = "NEGsAttached"
+type negOwnershipRegistry interface {
+	GetOwner(negName string) string
+}
 
+const (
+	ManagedCondition = "Managed"
+	NEGsAttached     = "NEGsAttached"
+
+	NEGOwnershipNoConflicts  = "NEGOwnershipNoConflicts"
+	NEGOwnershipConflict     = "NEGOwnershipConflict"
 	NEGsAttachmentSuccessful = "NEGsAttachmentSuccessful"
 	NEGsAttachmentFailed     = "NEGsAttachmentFailed"
 )
@@ -50,6 +58,7 @@ type NEGBindingStatusHandler struct {
 	negBindingClient negbindingclient.Interface
 	negBindingLister cache.Indexer
 	negMetrics       *metrics.NegMetrics
+	registry         negOwnershipRegistry
 	logger           klog.Logger
 }
 
@@ -60,6 +69,7 @@ func NewNEGBindingStatusHandler(
 	negBindingClient negbindingclient.Interface,
 	negBindingLister cache.Indexer,
 	negMetrics *metrics.NegMetrics,
+	registry negOwnershipRegistry,
 	logger klog.Logger,
 ) *NEGBindingStatusHandler {
 	return &NEGBindingStatusHandler{
@@ -68,6 +78,7 @@ func NewNEGBindingStatusHandler(
 		negBindingClient: negBindingClient,
 		negBindingLister: negBindingLister,
 		negMetrics:       negMetrics,
+		registry:         registry,
 		logger:           logger.WithName("NEGBindingStatusHandler").WithValues("binding", fmt.Sprintf("%s/%s", namespace, negBindingName)),
 	}
 }
@@ -140,6 +151,9 @@ func (h *NEGBindingStatusHandler) ReportStatus(negs []*composite.NetworkEndpoint
 	binding := origBinding.DeepCopy()
 	binding.Status.NetworkEndpointGroups = statusNegs
 
+	managedCond := h.getManagedCondition(binding)
+	h.ensureCondition(binding, managedCond)
+
 	attachedCondition := h.getAttachedCondition(utilerrors.NewAggregate(errList))
 	finalCondition := h.ensureCondition(binding, attachedCondition)
 	h.negMetrics.PublishNegInitializationMetrics(finalCondition.LastTransitionTime.Sub(origBinding.GetCreationTimestamp().Time))
@@ -171,6 +185,7 @@ func (h *NEGBindingStatusHandler) ReportSyncStatus(syncErr error) (bool, error) 
 	}
 	h.negMetrics.PublishNegSyncerStalenessMetrics(ts.Sub(binding.Status.LastSyncTime.Time))
 
+	h.ensureCondition(binding, h.getManagedCondition(binding))
 	h.ensureCondition(binding, h.getAttachedCondition(syncErr))
 	binding.Status.LastSyncTime = ts
 
@@ -255,4 +270,33 @@ func (h *NEGBindingStatusHandler) patchNegBindingStatus(oldStatus, newStatus neg
 	_, err = h.negBindingClient.NetworkingV1beta1().NetworkEndpointGroupBindings(h.namespace).Patch(context.Background(), h.negBindingName, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	h.negMetrics.PublishK8sRequestCountMetrics(start, metrics.PatchRequest, err)
 	return err
+}
+
+func (h *NEGBindingStatusHandler) getManagedCondition(binding *negbindingv1beta1.NetworkEndpointGroupBinding) negbindingv1beta1.Condition {
+	ownerKey := fmt.Sprintf("%s/%s", h.namespace, h.negBindingName)
+	var conflicts []string
+	for _, ref := range binding.Spec.NetworkEndpointGroups {
+		owner := h.registry.GetOwner(ref.Name)
+		if owner != "" && owner != ownerKey {
+			conflicts = append(conflicts, fmt.Sprintf("NEG %q is owned by %q", ref.Name, owner))
+		}
+	}
+	if len(conflicts) == 0 {
+		return negbindingv1beta1.Condition{
+			Type:               ManagedCondition,
+			Status:             metav1.ConditionTrue,
+			Reason:             NEGOwnershipNoConflicts,
+			LastTransitionTime: metav1.Now(),
+			Message:            "All NEGs from Spec currently managed",
+		}
+	}
+
+	message := strings.Join(conflicts, "; ")
+	return negbindingv1beta1.Condition{
+		Type:               ManagedCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             NEGOwnershipConflict,
+		LastTransitionTime: metav1.Now(),
+		Message:            message,
+	}
 }

--- a/pkg/neg/syncers/negstatushandler/negbinding_test.go
+++ b/pkg/neg/syncers/negstatushandler/negbinding_test.go
@@ -35,6 +35,37 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type mockRegistry struct {
+	owners map[string]string
+}
+
+func newMockRegistry() *mockRegistry {
+	return &mockRegistry{owners: make(map[string]string)}
+}
+
+func (r *mockRegistry) Acquire(negName string, owner string) (bool, string) {
+	if current, ok := r.owners[negName]; ok {
+		if current == owner {
+			return true, ""
+		}
+		return false, current
+	}
+	r.owners[negName] = owner
+	return true, ""
+}
+
+func (r *mockRegistry) ReleaseAllOwnedExcept(owner string, keep sets.Set[string]) {
+	for k, v := range r.owners {
+		if v == owner && !keep.Has(k) {
+			delete(r.owners, k)
+		}
+	}
+}
+
+func (r *mockRegistry) GetOwner(negName string) string {
+	return r.owners[negName]
+}
+
 func TestReportStatus(t *testing.T) {
 	namespace := "test-namespace"
 	name := "test-binding"
@@ -175,7 +206,8 @@ func TestReportStatus(t *testing.T) {
 			fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), defaultBinding.DeepCopy(), metav1.CreateOptions{})
 
 			negMetrics := metrics.NewNegMetrics()
-			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+			registry := newMockRegistry()
+			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 			err := h.ReportStatus(tc.negs, tc.errList)
 			if err != nil {
@@ -374,7 +406,8 @@ func TestReportSyncStatus(t *testing.T) {
 			fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), binding.DeepCopy(), metav1.CreateOptions{})
 
 			negMetrics := metrics.NewNegMetrics()
-			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+			registry := newMockRegistry()
+			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 			gotNeedInit, err := h.ReportSyncStatus(tc.syncErr)
 			if err != nil {
@@ -479,7 +512,8 @@ func TestSubnetToZonesMap(t *testing.T) {
 			indexer.Add(tc.binding.DeepCopy())
 
 			negMetrics := metrics.NewNegMetrics()
-			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+			registry := newMockRegistry()
+			h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 			gotMap, err := h.SubnetToZonesMap()
 			if err != nil {
@@ -501,7 +535,8 @@ func TestSubnetToZonesMapInvalidTypeInCache(t *testing.T) {
 	indexer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer()).GetIndexer()
 
 	negMetrics := metrics.NewNegMetrics()
-	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+	registry := newMockRegistry()
+	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 	invalidObj := &metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{
@@ -530,7 +565,8 @@ func TestSubnetToZonesMapNotInStore(t *testing.T) {
 	indexer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer()).GetIndexer()
 
 	negMetrics := metrics.NewNegMetrics()
-	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+	registry := newMockRegistry()
+	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 	_, err := h.SubnetToZonesMap()
 	if err == nil {
@@ -570,7 +606,8 @@ func TestPatchStatusNoChanges(t *testing.T) {
 	fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), defaultBinding.DeepCopy(), metav1.CreateOptions{})
 
 	negMetrics := metrics.NewNegMetrics()
-	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, klog.TODO())
+	registry := newMockRegistry()
+	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, negMetrics, registry, klog.TODO())
 
 	negs := []*composite.NetworkEndpointGroup{
 		{
@@ -649,5 +686,124 @@ func TestPatchStatusNoChanges(t *testing.T) {
 	actions = fakeClient.Actions()
 	if len(actions) != 0 {
 		t.Errorf("Expected 0 actions on second ReportStatus with same data, got %d: %+v", len(actions), actions)
+	}
+}
+
+func TestNEGBindingStatusHandlerOwnership(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	indexer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer()).GetIndexer()
+
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: "test-svc", Port: 80},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-1", Subnet: "subnet-1"},
+				{Name: "neg-2", Subnet: "subnet-2"},
+			},
+		},
+	}
+	indexer.Add(binding)
+	fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), binding, metav1.CreateOptions{})
+
+	registry := newMockRegistry()
+	ownerKey := fmt.Sprintf("%s/%s", namespace, name)
+	h := NewNEGBindingStatusHandler(name, namespace, fakeClient, indexer, metrics.NewNegMetrics(), registry, klog.TODO())
+
+	// Case 1: No conflicts. ReportStatus should succeed normally (Attached=True)
+	registry.Acquire("neg-1", ownerKey)
+	registry.Acquire("neg-2", ownerKey)
+
+	negs := []*composite.NetworkEndpointGroup{
+		{SelfLink: "url-1", Subnetwork: "subnet-url-1"},
+		{SelfLink: "url-2", Subnetwork: "subnet-url-2"},
+	}
+	err := h.ReportStatus(negs, nil)
+	if err != nil {
+		t.Fatalf("ReportStatus failed: %v", err)
+	}
+
+	updatedBinding, _ := fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	cond, _, found := h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected NEGsAttached=True, got: %+v", cond)
+	}
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, ManagedCondition)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected Managed=True, got: %+v", cond)
+	}
+	if cond.Reason != NEGOwnershipNoConflicts {
+		t.Errorf("Expected Reason=%s, got %q", NEGOwnershipNoConflicts, cond.Reason)
+	}
+
+	// Case 2: "neg-1" is stolen by other owner
+	registry.ReleaseAllOwnedExcept(ownerKey, sets.New("neg-2"))
+	otherOwner := "test-namespace/other-binding"
+	registry.Acquire("neg-1", otherOwner)
+
+	err = h.ReportStatus(negs, nil)
+	if err != nil {
+		t.Fatalf("ReportStatus failed: %v", err)
+	}
+
+	updatedBinding, _ = fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, ManagedCondition)
+	if !found || cond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected Managed=False, got: %+v", cond)
+	}
+	if cond.Reason != NEGOwnershipConflict {
+		t.Errorf("Expected Reason=NEGOwnershipConflict, got %q", cond.Reason)
+	}
+	expectedMessage := `NEG "neg-1" is owned by "test-namespace/other-binding"`
+	if cond.Message != expectedMessage {
+		t.Errorf("Expected Message %q, got %q", expectedMessage, cond.Message)
+	}
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected NEGsAttached=True on conflict (no sync error), got: %+v", cond)
+	}
+
+	// Case 3: ReportSyncStatus with conflict
+	_, err = h.ReportSyncStatus(nil)
+	if err != nil {
+		t.Fatalf("ReportSyncStatus failed: %v", err)
+	}
+	updatedBinding, _ = fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, ManagedCondition)
+	if !found || cond.Status != metav1.ConditionFalse || cond.Reason != NEGOwnershipConflict {
+		t.Errorf("Expected Managed=False due to conflict in ReportSyncStatus, got: %+v", cond)
+	}
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected NEGsAttached=True due to conflict in ReportSyncStatus (no sync error), got: %+v", cond)
+	}
+
+	// Case 4: Conflict resolved. ReportStatus should set Managed=True and NEGsAttached=True
+	registry.ReleaseAllOwnedExcept(otherOwner, sets.New[string]()) // release from otherOwner
+	registry.Acquire("neg-1", ownerKey)                            // acquire back
+	registry.Acquire("neg-2", ownerKey)
+
+	err = h.ReportStatus(negs, nil)
+	if err != nil {
+		t.Fatalf("ReportStatus failed: %v", err)
+	}
+
+	updatedBinding, _ = fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, ManagedCondition)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected Managed=True after conflict resolved, got: %+v", cond)
+	}
+	if cond.Reason != NEGOwnershipNoConflicts {
+		t.Errorf("Expected Reason=%s after conflict resolved, got %q", NEGOwnershipNoConflicts, cond.Reason)
+	}
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	if !found || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Expected NEGsAttached=True after conflict resolved, got: %+v", cond)
 	}
 }


### PR DESCRIPTION
Forcing controller to manage single NEG by at most single NEGBinding-based syncer based on NEG name.

If multiple NEGBinding CRs will specify the same NEG name (subnets/zones are not verified there), then only one will have the ability to attach/detach endpoints from all NEGs with this name.