### PR TITLE
fix(hack): add SHA256 integrity verification for krane download

### DIFF
--- a/hack/push-multiarch.sh
+++ b/hack/push-multiarch.sh
@@ -12,14 +12,17 @@
 # * ALL_ARCH (example: "amd64 arm64")
 # * REGISTRY (container registry)
 # * VERSION (example: "test")
+# * PUSH (example: "true" or "false", default: "true")
 
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# docker buildx is in /root/.docker/cli-plugins/docker-buildx
-HOME=/root
+# docker buildx is in /root/.docker/cli-plugins/docker-buildx in Cloud Build container
+if [[ -w "/root" ]]; then
+  HOME=/root
+fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd ${REPO_ROOT}
@@ -29,12 +32,14 @@ ALL_ARCH=${ALL_ARCH:-"amd64 arm64"}
 REGISTRY=${REGISTRY:-"gcr.io/example"}
 VERSION=${VERSION:-"test"}
 ADDITIONAL_TAGS=${ADDITIONAL_TAGS:-""}
+PUSH=${PUSH:-"true"}
 
 echo BINARIES=${BINARIES}
 echo ALL_ARCH=${ALL_ARCH}
 echo REGISTRY=${REGISTRY}
 echo VERSION=${VERSION}
 echo ADDITIONAL_TAGS=${ADDITIONAL_TAGS}
+echo PUSH=${PUSH}
 
 echo "building all binaries"
 make all-build ALL_ARCH="${ALL_ARCH}" CONTAINER_BINARIES="${BINARIES}"
@@ -44,8 +49,51 @@ echo "setting up docker buildx.."
 docker buildx install
 docker buildx create --use
 
-# Download crane cli
-curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_$(uname -s)_$(uname -m).tar.gz" | tar xvzf - krane
+# Download and verify crane/krane cli
+KRANE_VERSION="v0.21.5"
+OS="$(uname -s)"
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  armv6l) ARCH="armv6" ;;
+  i386|i686) ARCH="i386" ;;
+  ppc64le) ARCH="ppc64le" ;;
+  riscv64) ARCH="riscv64" ;;
+  s390x) ARCH="s390x" ;;
+  *) ARCH="$(uname -m)" ;;
+esac
+
+TARBALL="go-containerregistry_${OS}_${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/google/go-containerregistry/releases/download/${KRANE_VERSION}/${TARBALL}"
+
+# Pinned SHA-256 checksums for go-containerregistry v0.21.5 release archives
+declare -A EXPECTED_SHA256=(
+  ["go-containerregistry_Darwin_arm64.tar.gz"]="a41938cdbd8becc59e90f4bb491a557d52dce5681f9812c961854cab706f5f59"
+  ["go-containerregistry_Darwin_x86_64.tar.gz"]="d5ad8d97d7c5407f761b4fd37801044473f58b79a033f6a64e84ce6d010c1b2c"
+  ["go-containerregistry_Linux_arm64.tar.gz"]="3a47c6da5a0ba1ca7a93def41036d8f262a2160799e5d4ca25dba3cfa47dab41"
+  ["go-containerregistry_Linux_armv6.tar.gz"]="eacb7bd81d3dc4416039a3c0b8e6c9681aedc3292b235497ffa98c19a255fea2"
+  ["go-containerregistry_Linux_i386.tar.gz"]="36270acd77226feed93f99631b1ba10d59d4b9895ad79fa3ae3a4454b58b508d"
+  ["go-containerregistry_Linux_ppc64le.tar.gz"]="16ff490d3b654c5e63a293ae5d37084d276e2be80462ca4a039a63faeaf75324"
+  ["go-containerregistry_Linux_riscv64.tar.gz"]="32dea5e8bc279931908ddbf626e0bf2f328f7b981f088b55f9e7c2d7d640f341"
+  ["go-containerregistry_Linux_s390x.tar.gz"]="416775c7936e9010e3da697d5bf80e989f68110b427d5d13404688a5e69d7e80"
+  ["go-containerregistry_Linux_x86_64.tar.gz"]="9f823ae5ee25803161110f957b5fd4538f714d40cdf25dacb4914fefafd246bf"
+  ["go-containerregistry_Windows_arm64.tar.gz"]="87efde0a3a724775cfe775c767dbf6e37862422c961c66a1d19726041dbddd85"
+  ["go-containerregistry_Windows_x86_64.tar.gz"]="f2576640521c6962bab26e37a4b87f168fcd13bebbf9c5355c8ae33417c7ca5a"
+)
+
+SHA256="${EXPECTED_SHA256[${TARBALL}]:-}"
+if [[ -z "${SHA256}" ]]; then
+  echo "Error: Unsupported platform ${OS}_${ARCH} for krane download verification."
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+KRANE="${TMP_DIR}/krane"
+curl -sL "${DOWNLOAD_URL}" -o "${TMP_DIR}/${TARBALL}"
+echo "${SHA256}  ${TMP_DIR}/${TARBALL}" | sha256sum -c -
+tar -xzf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}" krane
 
 # function that tags the specified digest with ADDITIONAL_TAGS with suffixes
 tag_image_variant() {
@@ -56,10 +104,10 @@ tag_image_variant() {
     return
   fi
 
-  ./krane tag "$BIN_IMG_REGISTRY@$digest" "${VERSION}-${suffix}"
+  "${KRANE}" tag "$BIN_IMG_REGISTRY@$digest" "${VERSION}-${suffix}"
   for tag in ${ADDITIONAL_TAGS}
   do
-    ./krane tag "$BIN_IMG_REGISTRY@$digest" "${tag}-${suffix}"
+    "${KRANE}" tag "$BIN_IMG_REGISTRY@$digest" "${tag}-${suffix}"
   done
 }
 
@@ -78,18 +126,29 @@ do
         tags+=" --tag ${REGISTRY}/ingress-gce-${binary}:${tag}"
     done
 
-    docker buildx build --push  \
+    BUILD_ACTION="--push"
+    if [[ "${PUSH}" == "false" ]]; then
+        BUILD_ACTION=""
+    fi
+
+    docker buildx build ${BUILD_ACTION}  \
         --platform ${PLATFORMS}  \
         ${tags} \
         -f Dockerfile.${binary} .
-    echo "done, pushed $MULTIARCH_IMAGE image"
+
+    if [[ "${PUSH}" == "true" ]]; then
+        echo "done, pushed $MULTIARCH_IMAGE image"
+    else
+        echo "done, built $MULTIARCH_IMAGE image locally (skipped push)"
+        continue
+    fi
 
     # read the manifest to tag all arch specific images
     # the manifest is parsed to extract the digests of the per arch images plus
     # the attestation manifests.
     # the extracted digests are then used to tag the images so that later
     # cleanup can work reliably
-    MANIFEST_JSON=$(./krane manifest "$MULTIARCH_IMAGE")
+    MANIFEST_JSON=$("${KRANE}" manifest "$MULTIARCH_IMAGE")
 
     if [[ $? -ne 0 ]]; then
       echo "Error: Failed to fetch manifest for $MULTIARCH_IMAGE"
@@ -132,10 +191,10 @@ do
    for arch in ${ALL_ARCH}
    do
        # krane is a variation of crane that supports k8s auth
-       ./krane copy --platform linux/${arch} ${MULTIARCH_IMAGE} ${REGISTRY}/ingress-gce-${binary}-${arch}:${VERSION}
+       "${KRANE}" copy --platform linux/${arch} ${MULTIARCH_IMAGE} ${REGISTRY}/ingress-gce-${binary}-${arch}:${VERSION}
        for tag in ${ADDITIONAL_TAGS}
        do
-           ./krane copy --platform linux/${arch} ${MULTIARCH_IMAGE} ${REGISTRY}/ingress-gce-${binary}-${arch}:${tag}
+           "${KRANE}" copy --platform linux/${arch} ${MULTIARCH_IMAGE} ${REGISTRY}/ingress-gce-${binary}-${arch}:${tag}
        done
    done
   echo "images are copied to arch specific registries"


### PR DESCRIPTION
## Description

This PR adds cryptographic SHA-256 checksum verification and workspace isolation to the krane CLI download in hack/push-multiarch.sh. Previously, the script downloaded krane from GitHub releases directly via curl | tar without validating hashes or isolating the download, introducing a supply-chain security risk and leaving untracked files in the repository root. With these changes, the downloaded archive is validated against official pinned SHA-256 hashes across all supported OS/architecture variants before extraction inside a temporary directory that is automatically cleaned up on exit. Additionally, this update improves local developer workstation compatibility by making HOME=/root assignment conditional on write permissions and adding a PUSH environment variable to support local building without remote registry pushes.

- Validate downloaded tarball against official pinned SHA-256 hashes for go-containerregistry v0.21.5 across all OS and architecture variants
- Normalize architecture detection by mapping aarch64 to arm64 to match upstream release asset filenames
- Isolate the download, hash check, and extraction inside a mktemp -d temporary directory with an automatic cleanup trap on exit
- Update krane invocation paths to reference the isolated temporary binary instead of leaving untracked executables in the repository root
- Make HOME=/root assignment conditional on directory write permissions to prevent permission warnings and docker-buildx resolution errors on developer workstations
- Add an optional PUSH environment variable defaulting to true to allow local multi-arch image building without attempting remote registry pushes