### PR TITLE
Fix neg cpu spike

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -486,29 +486,33 @@ func (c *Controller) stop() {
 }
 
 func (c *Controller) endpointWorker() {
-	for {
-		func() {
-			key, quit := c.endpointQueue.Get()
-			if quit {
-				return
-			}
-			c.processEndpoint(key.(string))
-			c.endpointQueue.Done(key)
-		}()
+	for c.processNextEndpointWorkItem() {
 	}
 }
 
-func (c *Controller) nodeWorker() {
-	for {
-		func() {
-			key, quit := c.nodeQueue.Get()
-			if quit {
-				return
-			}
-			c.processNode()
-			c.nodeQueue.Done(key)
-		}()
+func (c *Controller) processNextEndpointWorkItem() bool {
+	key, quit := c.endpointQueue.Get()
+	if quit {
+		return false
 	}
+	defer c.endpointQueue.Done(key)
+	c.processEndpoint(key.(string))
+	return true
+}
+
+func (c *Controller) nodeWorker() {
+	for c.processNextNodeWorkItem() {
+	}
+}
+
+func (c *Controller) processNextNodeWorkItem() bool {
+	key, quit := c.nodeQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.nodeQueue.Done(key)
+	c.processNode()
+	return true
 }
 
 // processNode finds the related syncers and signal it to sync
@@ -549,18 +553,20 @@ func (c *Controller) processEndpoint(key string) {
 }
 
 func (c *Controller) serviceWorker() {
-	for {
-		func() {
-			key, quit := c.serviceQueue.Get()
-			if quit {
-				return
-			}
-			defer c.serviceQueue.Done(key)
-			err := c.processService(key.(string))
-			c.handleErr(err, key)
-			c.negMetrics.PublishNegControllerErrorCountMetrics(err, false)
-		}()
+	for c.processNextServiceWorkItem() {
 	}
+}
+
+func (c *Controller) processNextServiceWorkItem() bool {
+	key, quit := c.serviceQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.serviceQueue.Done(key)
+	err := c.processService(key.(string))
+	c.handleErr(err, key)
+	c.negMetrics.PublishNegControllerErrorCountMetrics(err, false)
+	return true
 }
 
 // processService takes a service and determines whether it needs NEGs or not.
@@ -646,21 +652,23 @@ func (c *Controller) processService(key string) error {
 }
 
 func (c *Controller) nodeTopologyWorker() {
-	for {
-		func() {
-			key, quit := c.nodeTopologyQueue.Get()
-			if quit {
-				return
-			}
-			c.processNodeTopology()
-			// Node Topology CR is a cluster-wide resource, so the key will
-			// always be the same.
-			// Done() ensures that if the item is updated while it is being
-			// process, it will be re-added to the queue for re-processing,
-			// so we won't miss any updates.
-			c.nodeTopologyQueue.Done(key)
-		}()
+	for c.processNextNodeTopologyWorkItem() {
 	}
+}
+
+func (c *Controller) processNextNodeTopologyWorkItem() bool {
+	key, quit := c.nodeTopologyQueue.Get()
+	if quit {
+		return false
+	}
+	// Node Topology CR is a cluster-wide resource, so the key will
+	// always be the same.
+	// Done() ensures that if the item is updated while it is being
+	// process, it will be re-added to the queue for re-processing,
+	// so we won't miss any updates.
+	defer c.nodeTopologyQueue.Done(key)
+	c.processNodeTopology()
+	return true
 }
 
 // processNodeTopology signals all syncers to sync

--- a/pkg/psc/controller.go
+++ b/pkg/psc/controller.go
@@ -192,7 +192,7 @@ func (c *Controller) Run() {
 		c.svcAttachmentQueue.ShutDown()
 	}()
 
-	go wait.Until(func() { c.serviceAttachmentWorker(c.stopCh) }, time.Second, c.stopCh)
+	go wait.Until(c.serviceAttachmentWorker, time.Second, c.stopCh)
 
 	go func() {
 		// Wait a GC period before starting to ensure that resources have enough time to sync
@@ -206,25 +206,20 @@ func (c *Controller) Run() {
 
 // serviceAttachmentWorker keeps processing service attachment keys in the queue
 // until stopChan has been signaled
-func (c *Controller) serviceAttachmentWorker(stopChan <-chan struct{}) {
-	processKey := func() {
-		key, quit := c.svcAttachmentQueue.Get()
-		if quit {
-			return
-		}
-		defer c.svcAttachmentQueue.Done(key)
-		err := c.processServiceAttachment(key.(string))
-		c.handleErr(err, key)
+func (c *Controller) serviceAttachmentWorker() {
+	for c.processNextServiceAttachmentWorkItem() {
 	}
+}
 
-	for {
-		select {
-		case <-stopChan:
-			return
-		default:
-			processKey()
-		}
+func (c *Controller) processNextServiceAttachmentWorkItem() bool {
+	key, quit := c.svcAttachmentQueue.Get()
+	if quit {
+		return false
 	}
+	defer c.svcAttachmentQueue.Done(key)
+	err := c.processServiceAttachment(key.(string))
+	c.handleErr(err, key)
+	return true
 }
 
 // handleErr will check for an error and report it as an event on the provided


### PR DESCRIPTION
Fix a severe 100% CPU lock and goroutine leak issue that occurs when ProviderConfig tenants are deleted in multi-tenant mode.

**Root Cause**
When an active tenant was deleted, uncontrolled CPU starvation caused the Kubernetes Control Plane (KCP) to rapidly and continuously vertically scale (resize) the cluster's master VMs up to enormous sizes. This was triggered by the goroutine Leak in NEG worker loops. The worker polling loops in pkg/neg/controller.go (serviceWorker, endpointWorker, etc.) were wrapped in anonymous functions inside an infinite for loop. When the workqueue was shut down on tenant deletion, the queue's Get() unblocked sending a quit=true flag. The return statement successfully exited the anonymous function, but instantly dropped execution back to the top of the infinite loop—spinning wildly on the shutdown queue without blocking.

**Fixes**
Refactored all NEG worker loops to use canonical Kubernetes processNextWorkItem() bool handler methods. When the workqueue is shut down, false is returned, natively breaking the outer infinite for loop and terminating the goroutine safely.