### PR TITLE
NEGBinding - Cleanup

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -1266,8 +1266,7 @@ func (c *Controller) processNEGBinding(key string) error {
 	}
 
 	if binding.DeletionTimestamp != nil {
-		c.negBindingManager.StopSyncer(namespace, name)
-		return nil
+		return c.negBindingManager.ReconcileDeletion(binding)
 	}
 
 	return c.negBindingManager.EnsureSyncerForNEGBinding(binding)

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -864,6 +864,9 @@ func (m *negBindingManager) tryAssignReleasedNEGs(negNames []string) {
 		if !ok {
 			continue
 		}
+		if binding.DeletionTimestamp != nil {
+			continue
+		}
 
 		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
 		subnetsInStatus := sets.New[string]()
@@ -927,17 +930,19 @@ func (m *negBindingManager) acquireNEGsForBinding(binding *negbindingv1beta1.Net
 		subnetsInStatus.Insert(subnetID.Key.Name)
 	}
 
-	for _, specRef := range binding.Spec.NetworkEndpointGroups {
-		if subnetsInStatus.Has(specRef.Subnet) {
-			continue
-		}
+	if binding.DeletionTimestamp == nil {
+		for _, specRef := range binding.Spec.NetworkEndpointGroups {
+			if subnetsInStatus.Has(specRef.Subnet) {
+				continue
+			}
 
-		acquired, currentOwner := m.ownershipRegistry.Acquire(specRef.Name, bindingKey)
-		if acquired {
-			acquiredNEGs.Insert(specRef.Name)
-			m.logger.Info("Acquired NEG ownership from spec", "negName", specRef.Name, "owner", bindingKey)
-		} else {
-			m.logger.Info("Conflict acquiring NEG ownership from spec", "negName", specRef.Name, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
+			acquired, currentOwner := m.ownershipRegistry.Acquire(specRef.Name, bindingKey)
+			if acquired {
+				acquiredNEGs.Insert(specRef.Name)
+				m.logger.Info("Acquired NEG ownership from spec", "negName", specRef.Name, "owner", bindingKey)
+			} else {
+				m.logger.Info("Conflict acquiring NEG ownership from spec", "negName", specRef.Name, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
+			}
 		}
 	}
 

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -43,6 +44,7 @@ import (
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/patch"
+	"k8s.io/ingress-gce/pkg/utils/slice"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 )
@@ -50,6 +52,9 @@ import (
 const (
 	// ServiceKeyIndex is the name of the index that maps service key (namespace/name) to NEGBinding.
 	ServiceKeyIndex = "serviceKey"
+
+	// NEGBindingFinalizer is the finalizer key used to block NEGBinding deletion until NEGs are drained.
+	NEGBindingFinalizer = "networking.gke.io/negbinding-cleanup"
 )
 
 var (
@@ -265,7 +270,19 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 	svcKey := fmt.Sprintf("%s/%s", binding.Namespace, svcName)
 	svc, err := m.getServiceFromCache(svcKey)
 	if err != nil {
-		_ = m.updateBackendRefCondition(binding, ErrServiceNotFound)
+		_ = m.updateBackendRefCondition(binding, err)
+		if errors.Is(err, ErrServiceNotFound) {
+			bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+			m.logger.Info("Service not found for NEGBinding, ensuring cleanup syncer", "binding", bindingKey, "serviceKey", svcKey)
+			syncer, err := m.ensureCleanupSyncer(binding)
+			if err != nil {
+				return err
+			}
+			if syncer != nil {
+				syncer.Sync()
+			}
+			return nil
+		}
 		return err
 	}
 
@@ -284,6 +301,73 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 		syncer.Sync()
 	}
 	return nil
+}
+
+func (m *negBindingManager) ensureCleanupSyncer(binding *negbindingv1beta1.NetworkEndpointGroupBinding) (negtypes.NegSyncer, error) {
+	svcName := binding.Spec.BackendRef.Name
+	svcPort := binding.Spec.BackendRef.Port
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+	syncer, ok := m.syncerMap[bindingKey]
+	if ok {
+		_, hasConfig := m.syncerConfigs[bindingKey]
+		if !hasConfig {
+			// No config - it's cleanup syncer, starting it instead of recreation
+			if syncer.IsStopped() {
+				if err := syncer.Start(); err != nil {
+					return nil, fmt.Errorf("failed to start existing cleanup syncer for binding %s: %w", bindingKey, err)
+				}
+			}
+			return syncer, nil
+		}
+
+		m.logger.Info("Service deleted, replacing transaction syncer with cleanup syncer", "binding", bindingKey)
+		syncer.Stop()
+		delete(m.syncerMap, bindingKey)
+		delete(m.syncerConfigs, bindingKey)
+	}
+
+	portTuple := negtypes.SvcPortTuple{
+		Port:       svcPort,
+		Name:       "",
+		TargetPort: fmt.Sprintf("%d", svcPort),
+	}
+	syncerKey := negtypes.NegSyncerKey{
+		Namespace:        binding.Namespace,
+		Name:             svcName,
+		NEGBindingName:   binding.Name,
+		PortTuple:        portTuple,
+		NegType:          negtypes.VmIpPortEndpointType,
+		EpCalculatorMode: negtypes.L7Mode,
+	}
+
+	statusHandler := negstatushandler.NewNEGBindingStatusHandler(
+		binding.Name,
+		binding.Namespace,
+		m.negBindingClient,
+		m.negBindingLister,
+		m.negMetrics,
+		m.ownershipRegistry,
+		m.logger,
+	)
+
+	cleanupSyncer := negsyncer.NewCleanupSyncer(
+		syncerKey,
+		m.cloud,
+		statusHandler,
+		m.negBindingLister,
+		m.logger,
+	)
+
+	if err := cleanupSyncer.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start cleanup syncer for binding %s: %w", bindingKey, err)
+	}
+
+	m.syncerMap[bindingKey] = cleanupSyncer
+	return cleanupSyncer, nil
 }
 
 // EnsureSyncersForService ensures syncers for all bindings referencing the given service.
@@ -344,6 +428,10 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 	svc *apiv1.Service,
 	networkInfo *network.NetworkInfo,
 ) (negtypes.NegSyncer, error) {
+	if err := m.ensureFinalizer(binding); err != nil {
+		return nil, fmt.Errorf("failed to ensure finalizer: %w", err)
+	}
+
 	svcName := binding.Spec.BackendRef.Name
 	svcPort := binding.Spec.BackendRef.Port
 
@@ -465,7 +553,7 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 	return syncer, nil
 }
 
-// ProcessServiceDeletion handles service deletion by stopping syncers for referencing bindings.
+// ProcessServiceDeletion handles service deletion by ensuring cleanup syncer for referencing bindings.
 func (m *negBindingManager) ProcessServiceDeletion(svcNamespace, svcName string) {
 	svcKey := fmt.Sprintf("%s/%s", svcNamespace, svcName)
 	objs, err := m.negBindingLister.ByIndex(ServiceKeyIndex, svcKey)
@@ -480,9 +568,13 @@ func (m *negBindingManager) ProcessServiceDeletion(svcNamespace, svcName string)
 			continue
 		}
 		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
-		m.logger.Info("Service deleted, stopping syncer for binding", "binding", bindingKey, "service", svcKey)
-		m.StopSyncer(binding.Namespace, binding.Name)
+		m.logger.Info("Service deleted, ensuring cleanup syncer for binding", "binding", bindingKey, "service", svcKey)
 		_ = m.updateBackendRefCondition(binding, fmt.Errorf("%w: %s/%s", ErrServiceNotFound, svcNamespace, svcName))
+
+		// Will ensure cleanup syncer, as there is no service, which needed for normal syncer
+		if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
+			m.logger.Error(err, "Failed to ensure syncer for binding after service deletion", "binding", bindingKey)
+		}
 	}
 }
 
@@ -603,6 +695,82 @@ func (m *negBindingManager) InitializeOwnershipRegistry() error {
 		}
 	}
 	return nil
+}
+
+// ReconcileDeletion ensures NEGBinding CR's NEGs are cleaned up before CR is removed
+func (m *negBindingManager) ReconcileDeletion(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+
+	m.mu.Lock()
+	syncer, ok := m.syncerMap[bindingKey]
+	m.mu.Unlock()
+
+	if !ok {
+		if len(binding.Status.NetworkEndpointGroups) == 0 {
+			m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
+			return m.removeFinalizer(binding)
+		}
+		if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
+			return fmt.Errorf("failed to start syncer for draining: %w", err)
+		}
+		return nil
+	}
+
+	if len(binding.Status.NetworkEndpointGroups) == 0 {
+		m.logger.Info("Draining complete for NEGBinding, removing finalizer", "binding", bindingKey)
+		syncer.Stop()
+		m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
+
+		func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			delete(m.syncerMap, bindingKey)
+			delete(m.syncerConfigs, bindingKey)
+		}()
+
+		return m.removeFinalizer(binding)
+	}
+
+	syncer.Sync()
+	m.logger.Info("NEGBinding is still draining", "binding", bindingKey, "remainingNEGs", len(binding.Status.NetworkEndpointGroups))
+	return nil
+}
+
+func (m *negBindingManager) ensureFinalizer(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	if slices.Contains(binding.Finalizers, NEGBindingFinalizer) {
+		return nil
+	}
+	updated := binding.DeepCopy()
+	updated.Finalizers = append(updated.Finalizers, NEGBindingFinalizer)
+
+	m.logger.Info("Adding finalizer to NEGBinding", "binding", klog.KObj(binding))
+	return m.patchObjectMetadata(binding, updated.ObjectMeta)
+}
+
+func (m *negBindingManager) removeFinalizer(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {
+	if !slices.Contains(binding.Finalizers, NEGBindingFinalizer) {
+		return nil
+	}
+	updated := binding.DeepCopy()
+	updated.Finalizers = slice.RemoveString(updated.Finalizers, NEGBindingFinalizer, nil)
+
+	m.logger.Info("Removing finalizer from NEGBinding", "binding", klog.KObj(binding))
+	return m.patchObjectMetadata(binding, updated.ObjectMeta)
+}
+
+func (m *negBindingManager) patchObjectMetadata(old *negbindingv1beta1.NetworkEndpointGroupBinding, newMeta metav1.ObjectMeta) error {
+	updated := old.DeepCopy()
+	updated.ObjectMeta = newMeta
+	patchBytes, err := patch.MergePatchBytes(old, updated)
+	if err != nil {
+		return err
+	}
+	if string(patchBytes) == "{}" {
+		return nil
+	}
+	_, err = m.negBindingClient.NetworkingV1beta1().NetworkEndpointGroupBindings(old.Namespace).Patch(
+		context.Background(), old.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
 }
 
 func (m *negBindingManager) validateBackendRef(binding *negbindingv1beta1.NetworkEndpointGroupBinding) error {

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -698,8 +698,20 @@ func (m *negBindingManager) tryAssignReleasedNEGs(negNames []string) {
 		}
 
 		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		subnetsInStatus := sets.New[string]()
+		for _, statusRef := range binding.Status.NetworkEndpointGroups {
+			subnetID, err := cloud.ParseResourceURL(statusRef.SubnetURL)
+			if err != nil {
+				continue
+			}
+			subnetsInStatus.Insert(subnetID.Key.Name)
+		}
+
 		acquiredNEGs := []string{}
 		for _, ref := range binding.Spec.NetworkEndpointGroups {
+			if subnetsInStatus.Has(ref.Subnet) {
+				continue
+			}
 			if releasedSet.Has(ref.Name) {
 				acquired, _ := m.ownershipRegistry.Acquire(ref.Name, bindingKey)
 				if acquired {
@@ -718,11 +730,40 @@ func (m *negBindingManager) tryAssignReleasedNEGs(negNames []string) {
 	}
 }
 
-// acquireNEGsForBinding tries to acquire ownership for NEGBinding based on its Spec.
+// acquireNEGsForBinding tries to acquire ownership for NEGBinding based on its Status and Spec.
 func (m *negBindingManager) acquireNEGsForBinding(binding *negbindingv1beta1.NetworkEndpointGroupBinding) {
 	bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
 	acquiredNEGs := sets.New[string]()
+
+	subnetsInStatus := sets.New[string]()
+	for _, statusRef := range binding.Status.NetworkEndpointGroups {
+		negID, err := cloud.ParseResourceURL(statusRef.ResourceURL)
+		if err != nil {
+			m.logger.Error(err, "Failed to parse NEG URL from status", "binding", bindingKey, "url", statusRef.ResourceURL)
+			continue
+		}
+		subnetID, err := cloud.ParseResourceURL(statusRef.SubnetURL)
+		if err != nil {
+			m.logger.Error(err, "Failed to parse NEG's subnet URL from status", "binding", bindingKey, "url", statusRef.SubnetURL)
+			continue
+		}
+
+		negName := negID.Key.Name
+		acquired, currentOwner := m.ownershipRegistry.Acquire(negName, bindingKey)
+		if acquired {
+			acquiredNEGs.Insert(negName)
+			m.logger.Info("Acquired NEG ownership from status", "negName", negName, "owner", bindingKey)
+		} else {
+			m.logger.Info("Conflict acquiring NEG ownership from status", "negName", negName, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
+		}
+		subnetsInStatus.Insert(subnetID.Key.Name)
+	}
+
 	for _, specRef := range binding.Spec.NetworkEndpointGroups {
+		if subnetsInStatus.Has(specRef.Subnet) {
+			continue
+		}
+
 		acquired, currentOwner := m.ownershipRegistry.Acquire(specRef.Name, bindingKey)
 		if acquired {
 			acquiredNEGs.Insert(specRef.Name)

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -1171,3 +1171,64 @@ func TestRestartScenarioNoService(t *testing.T) {
 		t.Errorf("Expected NEG 'neg-1' to be owned by %s after ensuring syncer, got %s", bindingKey, owner)
 	}
 }
+
+func TestNEGBindingManagerDeletionNoAcquireReleased(t *testing.T) {
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	namespace := "test-ns"
+	bindingName := "deleting-binding"
+	now := metav1.Now()
+
+	deletingBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              bindingName,
+			DeletionTimestamp: &now,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: "test-svc",
+				Port: 80,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-released",
+					Subnet: "default",
+				},
+			},
+		},
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	negBindingLister.Add(deletingBinding)
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		klog.TODO(),
+	)
+
+	m.tryAssignReleasedNEGs([]string{"neg-released"})
+
+	owner := m.ownershipRegistry.GetOwner("neg-released")
+	if owner != "" {
+		t.Errorf("Expected released NEG 'neg-released' not to be acquired by deleting binding, got owner %s", owner)
+	}
+}

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -699,3 +699,89 @@ func TestNEGBindingManagerConflictResolution(t *testing.T) {
 		t.Errorf("Timed out waiting for B2 to acquire neg-1, current owner: %s", owner)
 	}
 }
+
+func TestNEGBindingManagerStatusPriorityOverSpec(t *testing.T) {
+	negBindingClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(negBindingClient, "", time.Second, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-svc",
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{Port: 80, TargetPort: intstr.FromInt(8080)},
+			},
+		},
+	}
+	_ = serviceLister.Add(svc)
+
+	b1 := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "b1",
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: "test-svc", Port: 80},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-status-existing", Subnet: "default-subnet", Zones: []string{"us-central1-a"}},
+				{Name: "neg-spec-candidate", Subnet: "default-subnet", Zones: []string{"us-central1-a"}},
+			},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/networkEndpointGroups/neg-status-existing",
+					SubnetURL:   "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet",
+				},
+			},
+		},
+	}
+	_ = negBindingLister.Add(b1)
+
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+	clusterNamer := namer.NewNamer("cluster-id", "fw-name", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+
+	m := newNEGBindingManager(
+		negBindingClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		nil,
+		fakeNetworkResolver,
+		nil,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	m.acquireNEGsForBinding(b1)
+
+	// Verify that neg-status-existing is owned by b1
+	owner := m.ownershipRegistry.GetOwner("neg-status-existing")
+	if owner != "test-ns/b1" {
+		t.Errorf("Expected neg-status-existing to be owned by test-ns/b1, got %q", owner)
+	}
+
+	// Verify that neg-spec-candidate was NOT acquired because status already covered default-subnet
+	ownerSpec := m.ownershipRegistry.GetOwner("neg-spec-candidate")
+	if ownerSpec != "" {
+		t.Errorf("Expected neg-spec-candidate to not be owned (status priority over spec), got %q", ownerSpec)
+	}
+}

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -18,8 +18,8 @@ package neg
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -229,26 +229,56 @@ func TestNEGBindingManager(t *testing.T) {
 		t.Fatalf("EnsureSyncerForNEGBinding restore failed: %v", err)
 	}
 
+	// Manually acquire ownership to simulate it was acquired during normal sync
+	acquired, currentOwner := m.ownershipRegistry.Acquire("neg-1", bindingKey)
+	if !acquired {
+		t.Fatalf("Failed to manually acquire ownership: current owner is %s", currentOwner)
+	}
+
 	// Simulate service deletion from cache
 	err = serviceLister.Delete(testSvc)
 	if err != nil {
 		t.Fatalf("failed to delete service from lister: %v", err)
 	}
 
-	// Test ProcessServiceDeletion (should stop and remove syncer)
+	// Test ProcessServiceDeletion
 	m.ProcessServiceDeletion(namespace, svcName)
-	if _, ok := m.syncerMap[bindingKey]; ok {
-		t.Fatalf("Syncer should be removed from map after ProcessServiceDeletion")
+	if _, ok := m.syncerMap[bindingKey]; !ok {
+		t.Fatalf("Syncer should still be in map after ProcessServiceDeletion")
 	}
-	if _, ok := m.syncerConfigs[bindingKey]; ok {
+
+	// Verify config already removed from syncerConfigs (indicating it transitioned to cleanup syncer)
+	_, ok = m.syncerConfigs[bindingKey]
+	if ok {
 		t.Errorf("Expected config to be removed from syncerConfigs after ProcessServiceDeletion")
 	}
 
 	// Call EnsureSyncerForNEGBinding (which simulates reconciliation)
-	// Since Service is missing, it should fail with ErrServiceNotFound.
+	// Since Service is missing, it should keep/re-ensure cleanup syncer.
 	err = m.EnsureSyncerForNEGBinding(testBinding)
-	if !errors.Is(err, ErrServiceNotFound) {
-		t.Fatalf("Expected EnsureSyncerForNEGBinding to fail with ErrServiceNotFound, got: %v", err)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+	}
+
+	// It should STILL be in the map
+	if _, ok := m.syncerMap[bindingKey]; !ok {
+		t.Fatalf("Syncer should still be in map after EnsureSyncerForNEGBinding with missing service")
+	}
+
+	// Verify config is still not in syncerConfigs
+	_, ok = m.syncerConfigs[bindingKey]
+	if ok {
+		t.Errorf("Expected config to remain removed from syncerConfigs")
+	}
+
+	// Verify ownership is STILL held
+	m.ownershipRegistry.mu.Lock()
+	owner, ok := m.ownershipRegistry.owners["neg-1"]
+	m.ownershipRegistry.mu.Unlock()
+	if !ok {
+		t.Errorf("Expected NEG 'neg-1' to be owned by %s, but it was not found in registry", bindingKey)
+	} else if owner != bindingKey {
+		t.Errorf("Expected NEG 'neg-1' to be owned by %s, got %s", bindingKey, owner)
 	}
 
 	// Shutdown
@@ -318,24 +348,6 @@ func TestNEGBindingManagerErrorCases(t *testing.T) {
 			expectedErr:    fmt.Sprintf("%v: unsupported Kind %q", ErrInvalidBackendRefKind, "InvalidKind"),
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: "InvalidBackendRefKind",
-		},
-		{
-			desc:       "Service does not exist",
-			addService: false,
-			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-no-svc"},
-				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
-					BackendRef: &negbindingv1beta1.BackendRefConfig{
-						Kind: negbindingv1beta1.ServiceKind,
-						Name: svcName,
-						Port: svcPort,
-					},
-					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}}},
-				},
-			},
-			expectedErr:    fmt.Sprintf("%v: %s/%s", ErrServiceNotFound, namespace, svcName),
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "ServiceNotFound",
 		},
 		{
 			desc:       "Service port mismatch",
@@ -555,7 +567,7 @@ func TestInitializeOwnershipRegistry(t *testing.T) {
 
 	err := m.InitializeOwnershipRegistry()
 	if err != nil {
-		t.Fatalf("InitializeRegistry failed: %v", err)
+		t.Fatalf("InitializeOwnershipRegistry failed: %v", err)
 	}
 
 	expectedOwner1 := "test-namespace/binding-1"
@@ -566,6 +578,150 @@ func TestInitializeOwnershipRegistry(t *testing.T) {
 	expectedOwner2 := "test-namespace/binding-2"
 	if registry.GetOwner("neg-2") != expectedOwner2 {
 		t.Errorf("neg-2 should be owned by %q, got %q", expectedOwner2, registry.GetOwner("neg-2"))
+	}
+}
+
+func TestNEGBindingManagerFinalizer(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: svcName},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{{Port: svcPort, TargetPort: intstr.FromString(targetPort)}},
+		},
+	}
+	_, _ = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+
+	bindingName := "test-binding"
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: bindingName},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{Kind: negbindingv1beta1.ServiceKind, Name: svcName, Port: svcPort},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}},
+			},
+		},
+	}
+
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	_ = negBindingLister.Add(testBinding)
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = serviceLister.Add(testSvc)
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, _ := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	// 1. Test EnsureSyncerForNEGBinding adds finalizer
+	err := m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+	}
+
+	// Verify finalizer in fake client
+	updatedBinding, err := fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), bindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get binding: %v", err)
+	}
+	if !slices.Contains(updatedBinding.Finalizers, NEGBindingFinalizer) {
+		t.Errorf("Expected finalizer %s to be added, got %v", NEGBindingFinalizer, updatedBinding.Finalizers)
+	}
+
+	// 2. Test ReconcileDeletion when status is not empty (still draining)
+	// Simulate status has NEG
+	updatedBinding.Status.NetworkEndpointGroups = []negbindingv1beta1.StatusNegRef{
+		{ResourceURL: "neg-1-url", SubnetURL: "subnet-url"},
+	}
+	// Set DeletionTimestamp
+	now := metav1.Now()
+	updatedBinding.DeletionTimestamp = &now
+	// Update in fake client and lister
+	_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Update(context.TODO(), updatedBinding, metav1.UpdateOptions{})
+	_ = negBindingLister.Update(updatedBinding)
+
+	// Call ReconcileDeletion
+	err = m.ReconcileDeletion(updatedBinding)
+	if err != nil {
+		t.Fatalf("Expected ReconcileDeletion to return nil (waiting for drain), got: %v", err)
+	}
+
+	// Verify finalizer is STILL there
+	updatedBinding, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), bindingName, metav1.GetOptions{})
+	if !slices.Contains(updatedBinding.Finalizers, NEGBindingFinalizer) {
+		t.Errorf("Expected finalizer to be kept during drain, but it was removed")
+	}
+
+	// Verify syncer is still running
+	bindingKey := fmt.Sprintf("%s/%s", namespace, bindingName)
+	syncer, ok := m.syncerMap[bindingKey]
+	if !ok {
+		t.Fatalf("Syncer should still exist")
+	}
+	if syncer.IsStopped() {
+		t.Errorf("Syncer should still be running during drain")
+	}
+
+	// 3. Test ReconcileDeletion when status is empty (drained)
+	updatedBinding.Status.NetworkEndpointGroups = []negbindingv1beta1.StatusNegRef{}
+	_, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Update(context.TODO(), updatedBinding, metav1.UpdateOptions{})
+	_ = negBindingLister.Update(updatedBinding)
+
+	err = m.ReconcileDeletion(updatedBinding)
+	if err != nil {
+		t.Fatalf("ReconcileDeletion failed: %v", err)
+	}
+
+	// Verify finalizer is removed
+	updatedBinding, _ = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), bindingName, metav1.GetOptions{})
+	if slices.Contains(updatedBinding.Finalizers, NEGBindingFinalizer) {
+		t.Errorf("Expected finalizer to be removed after drain, but it is still there")
+	}
+
+	// Verify syncer is stopped and removed
+	if _, ok := m.syncerMap[bindingKey]; ok {
+		t.Errorf("Syncer should have been removed from map after drain")
 	}
 }
 
@@ -783,5 +939,235 @@ func TestNEGBindingManagerStatusPriorityOverSpec(t *testing.T) {
 	ownerSpec := m.ownershipRegistry.GetOwner("neg-spec-candidate")
 	if ownerSpec != "" {
 		t.Errorf("Expected neg-spec-candidate to not be owned (status priority over spec), got %q", ownerSpec)
+	}
+}
+
+func TestEnsureSyncerForNEGBindingDeletionNoService(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+
+	namespace := "test-ns"
+	bindingName := "test-binding"
+	svcName := "non-existent-svc"
+	svcPort := int32(80)
+
+	// Create test Binding with DeletionTimestamp and Finalizer
+	now := metav1.Now()
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              bindingName,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{NEGBindingFinalizer},
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: svcName,
+				Port: svcPort,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-1",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+			},
+		},
+	}
+
+	_, err := fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding: %v", err)
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	err = negBindingLister.Add(testBinding)
+	if err != nil {
+		t.Fatalf("failed to add binding to lister: %v", err)
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}) // Empty service lister
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	// Test EnsureSyncerForNEGBinding should succeed despite missing service
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed unexpectedly: %v", err)
+	}
+
+	// Verify syncer is created and running
+	bindingKey := fmt.Sprintf("%s/%s", namespace, bindingName)
+	syncer, ok := m.syncerMap[bindingKey]
+	if !ok {
+		t.Fatalf("Syncer not found in map for key %s", bindingKey)
+	}
+	if syncer.IsStopped() {
+		t.Errorf("Expected syncer to be running")
+	}
+}
+
+func TestRestartScenarioNoService(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+
+	namespace := "test-ns"
+	bindingName := "test-binding"
+	svcName := "non-existent-svc"
+	svcPort := int32(80)
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+
+	// Create test Binding with NEGs in Status, but Service does not exist
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      bindingName,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: svcName,
+				Port: svcPort,
+			},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/neg-1",
+					SubnetURL:   defaultTestSubnetURL,
+				},
+			},
+		},
+	}
+
+	_, err := fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding: %v", err)
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	err = negBindingLister.Add(testBinding)
+	if err != nil {
+		t.Fatalf("failed to add binding to lister: %v", err)
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}) // Empty service lister
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), defaultTestSubnetURL, false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	// 1. Initialize Registry (simulates restore on restart)
+	err = m.InitializeOwnershipRegistry()
+	if err != nil {
+		t.Fatalf("InitializeOwnershipRegistry failed: %v", err)
+	}
+
+	// Verify ownership is restored
+	bindingKey := fmt.Sprintf("%s/%s", namespace, bindingName)
+	owner := m.ownershipRegistry.GetOwner("neg-1")
+	if owner != bindingKey {
+		t.Errorf("Expected NEG 'neg-1' to be owned by %s after init, got %s", bindingKey, owner)
+	}
+
+	// 2. Ensure Syncer (should start cleanup syncer since service is missing)
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed unexpectedly: %v", err)
+	}
+
+	// Verify syncer is created and running
+	syncer, ok := m.syncerMap[bindingKey]
+	if !ok {
+		t.Fatalf("Syncer not found in map for key %s", bindingKey)
+	}
+	if syncer.IsStopped() {
+		t.Errorf("Expected syncer to be running")
+	}
+
+	// Verify config is removed from syncerConfigs (indicating it is a cleanup syncer)
+	_, ok = m.syncerConfigs[bindingKey]
+	if ok {
+		t.Errorf("Expected config to be removed from syncerConfigs for cleanup syncer")
+	}
+
+	// Verify ownership is STILL held after syncer is ensured
+	owner = m.ownershipRegistry.GetOwner("neg-1")
+	if owner != bindingKey {
+		t.Errorf("Expected NEG 'neg-1' to be owned by %s after ensuring syncer, got %s", bindingKey, owner)
 	}
 }

--- a/pkg/neg/syncers/cleanup_syncer.go
+++ b/pkg/neg/syncers/cleanup_syncer.go
@@ -1,0 +1,200 @@
+package syncers
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/neg/syncers/negstatushandler"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
+)
+
+type cleanupSyncer struct {
+	negtypes.NegSyncerKey
+	cloud         negtypes.NetworkEndpointGroupCloud
+	statusHandler *negstatushandler.NEGBindingStatusHandler
+	bindingLister cache.Indexer
+	logger        klog.Logger
+
+	syncCh chan struct{}
+	stopCh chan struct{}
+
+	stateLock  sync.Mutex
+	stopped    bool
+	retryDelay time.Duration
+}
+
+// NewCleanupSyncer creates a new syncer that only detaches endpoints from NEGs listed in status.
+func NewCleanupSyncer(
+	negSyncerKey negtypes.NegSyncerKey,
+	cloud negtypes.NetworkEndpointGroupCloud,
+	statusHandler *negstatushandler.NEGBindingStatusHandler,
+	bindingLister cache.Indexer,
+	logger klog.Logger,
+) negtypes.NegSyncer {
+	return &cleanupSyncer{
+		NegSyncerKey:  negSyncerKey,
+		cloud:         cloud,
+		statusHandler: statusHandler,
+		bindingLister: bindingLister,
+		logger:        logger.WithName("CleanupSyncer"),
+		syncCh:        make(chan struct{}, 1),
+		stopCh:        make(chan struct{}),
+		stopped:       true,
+		retryDelay:    minRetryDelay,
+	}
+}
+
+func (s *cleanupSyncer) Start() error {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	if !s.stopped {
+		return nil
+	}
+	s.stopped = false
+	s.stopCh = make(chan struct{})
+	s.syncCh = make(chan struct{}, 1)
+	go s.loop()
+	return nil
+}
+
+func (s *cleanupSyncer) Stop() {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	if !s.stopped {
+		s.stopped = true
+		close(s.stopCh)
+	}
+}
+
+func (s *cleanupSyncer) Sync() bool {
+	if s.IsStopped() {
+		return false
+	}
+	select {
+	case s.syncCh <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *cleanupSyncer) IsStopped() bool {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	return s.stopped
+}
+
+func (s *cleanupSyncer) IsShuttingDown() bool {
+	return false
+}
+
+func (s *cleanupSyncer) loop() {
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-s.syncCh:
+			err := s.cleanUp()
+			_, reportErr := s.statusHandler.ReportSyncStatus(err)
+			if reportErr != nil {
+				s.logger.Error(reportErr, "Failed to report sync status")
+			}
+			if err != nil {
+				s.logger.Error(err, "Cleanup failed, will retry", "delay", s.retryDelay)
+				time.AfterFunc(s.retryDelay, func() { s.Sync() })
+				s.retryDelay = s.retryDelay * 2
+				if s.retryDelay > maxRetryDelay {
+					s.retryDelay = maxRetryDelay
+				}
+			} else {
+				s.retryDelay = minRetryDelay
+				s.logger.Info("Cleanup successful")
+				s.Stop()
+			}
+		}
+	}
+}
+
+func (s *cleanupSyncer) cleanUp() error {
+	bindingKey := fmt.Sprintf("%s/%s", s.Namespace, s.NEGBindingName)
+	bindingObj, exists, err := s.bindingLister.GetByKey(bindingKey)
+	if err != nil {
+		return fmt.Errorf("failed to get NEGBinding from lister: %w", err)
+	}
+	if !exists {
+		s.logger.Info("NEGBinding no longer exists, stopping cleanup", "binding", bindingKey)
+		s.Stop()
+		return nil
+	}
+	binding := bindingObj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+
+	var errs []error
+	for _, ref := range binding.Status.NetworkEndpointGroups {
+		err := s.cleanUpNEG(ref.ResourceURL)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) == 0 && binding.DeletionTimestamp != nil {
+		s.logger.Info("Binding is deleting and cleanup succeeded, clearing status NEGs to trigger finalizer removal")
+		err := s.statusHandler.ReportStatus(nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to clear status NEGs: %w", err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func (s *cleanupSyncer) cleanUpNEG(negURL string) error {
+	negID, err := cloud.ParseResourceURL(negURL)
+	if err != nil {
+		s.logger.Error(err, "Failed to parse NEG URL, assuming already cleaned up", "negURL", negURL)
+		return nil
+	}
+
+	negName := negID.Key.Name
+	zone := negID.Key.Zone
+	apiVersion := s.GetAPIVersion()
+
+	s.logger.Info("Cleaning up endpoints in NEG", "neg", negName, "zone", zone)
+
+	endpointsWithStatus, err := s.cloud.ListNetworkEndpoints(negName, zone, false, apiVersion, s.logger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			s.logger.Info("NEG was not found during cleanup, assuming already cleaned up", "neg", negName, "zone", zone)
+			return nil
+		}
+		return fmt.Errorf("failed to list endpoints for NEG %q in zone %q: %w", negName, zone, err)
+	}
+
+	if len(endpointsWithStatus) == 0 {
+		s.logger.V(3).Info("NEG is already empty", "neg", negName, "zone", zone)
+		return nil
+	}
+
+	endpoints := []*composite.NetworkEndpoint{}
+	for _, ep := range endpointsWithStatus {
+		endpoints = append(endpoints, ep.NetworkEndpoint)
+	}
+
+	s.logger.Info("Detaching endpoints from NEG during cleanup", "count", len(endpoints), "neg", negName, "zone", zone)
+	err = s.cloud.DetachNetworkEndpoints(negName, zone, endpoints, apiVersion, s.logger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			s.logger.Info("NEG was not found during detach, assuming already cleaned up", "neg", negName, "zone", zone)
+			return nil
+		}
+		return fmt.Errorf("failed to detach endpoints from NEG %q in zone %q: %w", negName, zone, err)
+	}
+
+	return nil
+}

--- a/pkg/neg/syncers/cleanup_syncer_test.go
+++ b/pkg/neg/syncers/cleanup_syncer_test.go
@@ -1,0 +1,110 @@
+package syncers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/cloud-provider-gcp/providers/gce"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
+	"k8s.io/ingress-gce/pkg/neg/syncers/negstatushandler"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	fakenegbinding "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
+	"k8s.io/klog/v2"
+)
+
+func TestCleanupSyncerNEGNotFound(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+
+	namespace := "test-ns"
+	bindingName := "test-binding"
+	now := metav1.Now()
+
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              bindingName,
+			DeletionTimestamp: &now,
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/non-existent-neg",
+					SubnetURL:   "https://www.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/subnetworks/default",
+				},
+			},
+		},
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	}
+	bindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	bindingLister.Add(binding)
+
+	statusHandler := negstatushandler.NewNEGBindingStatusHandler(
+		bindingName,
+		namespace,
+		fakeNBClient,
+		bindingLister,
+		nil,
+		nil,
+		klog.TODO(),
+	)
+
+	syncerKey := negtypes.NegSyncerKey{
+		Namespace:      namespace,
+		Name:           "test-svc",
+		NEGBindingName: bindingName,
+	}
+
+	negMetrics := metrics.NewNegMetrics()
+	cloudAdapter := negtypes.NewAdapter(fakeGCE, negMetrics)
+	syncer := NewCleanupSyncer(syncerKey, cloudAdapter, statusHandler, bindingLister, klog.TODO()).(*cleanupSyncer)
+
+	err := syncer.cleanUpNEG("https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/non-existent-neg")
+	if err != nil {
+		t.Errorf("Expected cleanUpNEG to return nil for non-existent NEG (404), got %v", err)
+	}
+}
+
+func TestCleanupSyncerInvalidURL(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+
+	namespace := "test-ns"
+	bindingName := "test-binding-invalid"
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	}
+	bindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+
+	statusHandler := negstatushandler.NewNEGBindingStatusHandler(
+		bindingName,
+		namespace,
+		fakeNBClient,
+		bindingLister,
+		nil,
+		nil,
+		klog.TODO(),
+	)
+
+	syncerKey := negtypes.NegSyncerKey{
+		Namespace:      namespace,
+		Name:           "test-svc",
+		NEGBindingName: bindingName,
+	}
+
+	negMetrics := metrics.NewNegMetrics()
+	cloudAdapter := negtypes.NewAdapter(fakeGCE, negMetrics)
+	syncer := NewCleanupSyncer(syncerKey, cloudAdapter, statusHandler, bindingLister, klog.TODO()).(*cleanupSyncer)
+
+	err := syncer.cleanUpNEG("invalid-url-string")
+	if err != nil {
+		t.Errorf("Expected cleanUpNEG to return nil for unparseable NEG URL, got %v", err)
+	}
+}

--- a/pkg/neg/syncers/negbinding_topology.go
+++ b/pkg/neg/syncers/negbinding_topology.go
@@ -79,6 +79,9 @@ func (p *NEGBindingTopologyProvider) getBinding() (*negbindingv1beta1.NetworkEnd
 
 // getOwnedSpecNEGRefs returns owned NEG Refs subset of NEGBinding.Spec.
 func (p *NEGBindingTopologyProvider) getOwnedSpecNEGRefs(binding *negbindingv1beta1.NetworkEndpointGroupBinding, logger klog.Logger) []negbindingv1beta1.SpecNegRef {
+	if binding.DeletionTimestamp != nil {
+		return nil
+	}
 	ownerKey := fmt.Sprintf("%s/%s", p.namespace, p.negBindingName)
 
 	var acquiredRefs []negbindingv1beta1.SpecNegRef
@@ -168,6 +171,10 @@ func (p *NEGBindingTopologyProvider) ListZonesPerSubnet(_ zonegetter.Filter, net
 	binding, err := p.getBinding()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get NegBinding from store: %w", err)
+	}
+
+	if binding.DeletionTimestamp != nil {
+		return make(shared.ZonesPerSubnetMap), nil
 	}
 
 	zonesPerSubnet := make(shared.ZonesPerSubnetMap)

--- a/pkg/neg/syncers/negbinding_topology.go
+++ b/pkg/neg/syncers/negbinding_topology.go
@@ -93,6 +93,35 @@ func (p *NEGBindingTopologyProvider) getOwnedSpecNEGRefs(binding *negbindingv1be
 	return acquiredRefs
 }
 
+// getOwnedStatusNEGTopology returns subnet to zone mappings for owned NEGs in Status.
+func (p *NEGBindingTopologyProvider) getOwnedStatusNEGTopology(binding *negbindingv1beta1.NetworkEndpointGroupBinding, logger klog.Logger) shared.ZonesPerSubnetMap {
+	ownerKey := fmt.Sprintf("%s/%s", p.namespace, p.negBindingName)
+	zonesBySubnet := make(shared.ZonesPerSubnetMap)
+
+	for _, statusRef := range binding.Status.NetworkEndpointGroups {
+		negID, err := cloud.ParseResourceURL(statusRef.ResourceURL)
+		if err != nil {
+			logger.Error(err, "Failed to parse NEG URL from status", "url", statusRef.ResourceURL)
+			continue
+		}
+		subnetID, err := cloud.ParseResourceURL(statusRef.SubnetURL)
+		if err != nil {
+			logger.Error(err, "Failed to parse subnet URL from status", "url", statusRef.SubnetURL)
+			continue
+		}
+
+		if p.registry.GetOwner(negID.Key.Name) == ownerKey {
+			subnetName := subnetID.Key.Name
+			if existing, ok := zonesBySubnet[subnetName]; ok {
+				existing.Insert(negID.Key.Zone)
+			} else {
+				zonesBySubnet[subnetName] = sets.New(negID.Key.Zone)
+			}
+		}
+	}
+	return zonesBySubnet
+}
+
 // ListSubnetsInDefaultNetwork returns the list of subnets declared inside the NegBinding CR Spec.
 func (p *NEGBindingTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig {
 	binding, err := p.getBinding()
@@ -101,11 +130,16 @@ func (p *NEGBindingTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Log
 		return nil
 	}
 
-	// Return only subnets where NEGs are owned
+	// Return subnets where NEGs are owned
 	subnets := sets.New[string]()
 	ownedSpecRefs := p.getOwnedSpecNEGRefs(binding, logger)
 	for _, ref := range ownedSpecRefs {
 		subnets.Insert(ref.Subnet)
+	}
+
+	ownedStatusTopology := p.getOwnedStatusNEGTopology(binding, logger)
+	for subnet := range ownedStatusTopology {
+		subnets.Insert(subnet)
 	}
 
 	configs := []nodetopologyv1.SubnetConfig{}
@@ -136,11 +170,11 @@ func (p *NEGBindingTopologyProvider) ListZonesPerSubnet(_ zonegetter.Filter, net
 		return nil, fmt.Errorf("failed to get NegBinding from store: %w", err)
 	}
 
-	// Return only zones of subnets, where NEGs are owned
-	ownedSpecRefs := p.getOwnedSpecNEGRefs(binding, logger)
 	zonesPerSubnet := make(shared.ZonesPerSubnetMap)
+	ownedSpecRefs := p.getOwnedSpecNEGRefs(binding, logger)
 	for _, ref := range ownedSpecRefs {
 		zonesPerSubnet[ref.Subnet] = sets.New(ref.Zones...)
 	}
+
 	return zonesPerSubnet, nil
 }

--- a/pkg/neg/syncers/negbinding_topology_test.go
+++ b/pkg/neg/syncers/negbinding_topology_test.go
@@ -465,3 +465,67 @@ func sortSubnetConfigs(configs []nodetopologyv1.SubnetConfig) {
 		return configs[i].Name < configs[j].Name
 	})
 }
+
+func TestNEGBindingTopologyProviderStatusCoverage(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	registry := newMockRegistry()
+	ownerKey := fmt.Sprintf("%s/%s", namespace, name)
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
+	if err != nil {
+		t.Fatalf("NewNEGBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	// 1. Pre-acquire "neg-old" for this binding
+	acquired, _ := registry.Acquire("neg-old", ownerKey)
+	if !acquired {
+		t.Fatalf("Failed to pre-acquire lock")
+	}
+
+	// 2. Create binding with "neg-old" in status and "neg-new" in spec
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-new",
+					Subnet: "default-subnet",
+					Zones:  []string{"us-central1-a"},
+				},
+			},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-b/networkEndpointGroups/neg-old",
+					SubnetURL:   defaultSubnetURL,
+				},
+			},
+		},
+	}
+	negBindingLister.Add(binding)
+
+	// 3. Verify ListSubnetsInDefaultNetwork returns default-subnet from status even when neg-new is not acquired
+	subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+	if len(subnets) != 1 || subnets[0].Name != "default-subnet" {
+		t.Errorf("ListSubnetsInDefaultNetwork() returned %+v, expected default-subnet from status", subnets)
+	}
+
+	// 4. Verify ListZonesPerSubnet returns empty map when Spec NEG is not acquired (so Status NEG is drained)
+	zones, err := p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err != nil {
+		t.Errorf("ListZonesPerSubnet() returned unexpected error: %v", err)
+	}
+	if len(zones) != 0 {
+		t.Errorf("ListZonesPerSubnet() returned %+v, expected empty map when Spec NEG is unacquired", zones)
+	}
+}

--- a/pkg/neg/syncers/negbinding_topology_test.go
+++ b/pkg/neg/syncers/negbinding_topology_test.go
@@ -529,3 +529,65 @@ func TestNEGBindingTopologyProviderStatusCoverage(t *testing.T) {
 		t.Errorf("ListZonesPerSubnet() returned %+v, expected empty map when Spec NEG is unacquired", zones)
 	}
 }
+
+func TestNEGBindingTopologyProviderDeletion(t *testing.T) {
+	namespace := "test-namespace"
+	name := "test-binding"
+	defaultSubnetURL := "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/default-subnet"
+
+	fakeClient := fakenegbinding.NewSimpleClientset()
+	informer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeClient, "", 0, utils.NewNamespaceIndexer())
+	negBindingLister := informer.GetIndexer()
+
+	registry := newMockRegistry()
+	ownerKey := fmt.Sprintf("%s/%s", namespace, name)
+	p, err := NewNEGBindingTopologyProvider(namespace, name, negBindingLister, defaultSubnetURL, registry)
+	if err != nil {
+		t.Fatalf("NewNEGBindingTopologyProvider() failed unexpectedly: %v", err)
+	}
+
+	registry.Acquire("neg-1", ownerKey)
+	now := metav1.Now()
+	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              name,
+			DeletionTimestamp: &now,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-1",
+					Subnet: "subnet-1",
+					Zones:  []string{"zone-a"},
+				},
+			},
+		},
+		Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+			NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+				{
+					ResourceURL: "https://www.googleapis.com/compute/v1/projects/test-project/zones/zone-a/networkEndpointGroups/neg-1",
+					SubnetURL:   "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/subnet-1",
+				},
+			},
+		},
+	}
+	negBindingLister.Add(binding)
+
+	zones, err := p.ListZonesPerSubnet(zonegetter.AllNodesFilter, network.NetworkInfo{IsDefault: true}, klog.TODO())
+	if err != nil {
+		t.Fatalf("ListZonesPerSubnet() returned error: %v", err)
+	}
+	if len(zones) != 0 {
+		t.Errorf("Expected 0 zones when DeletionTimestamp is set, got %v", zones)
+	}
+
+	subnets := p.ListSubnetsInDefaultNetwork(klog.TODO())
+	if len(subnets) != 1 || subnets[0].Name != "subnet-1" {
+		t.Errorf("Expected subnet-1 from status in ListSubnetsInDefaultNetwork, got %v", subnets)
+	}
+
+	if registry.GetOwner("neg-1") != ownerKey {
+		t.Errorf("neg-1 in status should remain owned during draining, got %q", registry.GetOwner("neg-1"))
+	}
+}

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -708,6 +708,10 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 		}
 	}
 
+	oldNegs, oldNegErrs := s.getNEGsToKeepInStatus(ensuredSubnetZones)
+	negObjs = append(negObjs, oldNegs...)
+	errList = append(errList, oldNegErrs...)
+
 	if updateNEGStatus {
 		if err := s.statusHandler.ReportStatus(negObjs, errList); err != nil {
 			s.logger.Error(err, "Failed to report ensured NEGs on Status reporter")
@@ -1216,4 +1220,101 @@ func collectLabelStats(currentPodLabelMap, addPodLabelMap labels.EndpointPodLabe
 		}
 	}
 	return labelPropagationStats
+}
+
+// getNEGsToKeepInStatus returns a list of NEGs that should be kept in status even though are not in target topology.
+// Mainly used to keep track of NEGs which are currently cleaned up as part of NEGBinding flow.
+func (s *transactionSyncer) getNEGsToKeepInStatus(ensuredSubnetZones shared.ZonesPerSubnetMap) ([]*composite.NetworkEndpointGroup, []error) {
+	var negObjs []*composite.NetworkEndpointGroup
+	var errList []error
+
+	if !s.NegSyncerKey.IsBindingKey() {
+		return nil, nil
+	}
+
+	existingZones, err := s.statusHandler.SubnetToZonesMap()
+	if err != nil {
+		s.logger.Error(err, "Failed to get subnet to zones map from status handler")
+		return nil, []error{err}
+	}
+
+	for subnet, zones := range existingZones {
+		for zone := range zones {
+			// Still desired NEG - will be left in status by standard flow
+			if desiredZones, ok := ensuredSubnetZones[subnet]; ok && desiredZones.Has(zone) {
+				continue
+			}
+
+			negName, err := s.getNEGName(subnet)
+			if err != nil {
+				s.logger.Error(err, "Failed to get NEG name for subnet", "subnet", subnet)
+				errList = append(errList, err)
+				continue
+			}
+
+			hasOngoingTransactions := s.hasTransactions(subnet, zone)
+			hasEndpoints, err := s.hasEndpoints(negName, zone)
+			if err != nil {
+				s.logger.Error(err, "Failed to check if NEG has endpoints", "neg", negName, "zone", zone)
+				errList = append(errList, err)
+				hasEndpoints = true // Keep in status to be safe on error
+			}
+
+			// NEG not cleaned up - should be preserved in status if still exists (if not - it's treated as cleaned up)
+			if hasOngoingTransactions || hasEndpoints {
+				s.logger.Info("Including old NEG in status as it still has endpoints or pending transactions", "neg", negName, "zone", zone, "hasEndpoints", hasEndpoints, "hasTransactions", hasOngoingTransactions)
+				negObj, err := s.cloud.GetNetworkEndpointGroup(negName, zone, s.NegSyncerKey.GetAPIVersion(), s.logger)
+				if err != nil {
+					if utils.IsNotFoundError(err) {
+						s.logger.Info("Previously managed NEG not found in GCE, treating as cleaned up", "neg", negName, "zone", zone)
+						continue
+					}
+					s.logger.Error(err, "Failed to retrieve previously managed NEG from GCE", "neg", negName, "zone", zone)
+					errList = append(errList, err)
+
+					// Try to still preserve NEG in case of error (if not 404)
+					resourceID, parseErr := cloud.ParseResourceURL(s.networkInfo.SubnetworkURL)
+					if parseErr != nil {
+						s.logger.Error(parseErr, "Failed to parse subnetwork URL when constructing fallback NEG descriptor", "subnetURL", s.networkInfo.SubnetworkURL)
+						continue
+					}
+					s.logger.Info("Preserving previously managed NEG in status after retrieval error", "neg", negName, "zone", zone)
+					negObj = &composite.NetworkEndpointGroup{
+						Name:       negName,
+						Zone:       zone,
+						SelfLink:   cloud.SelfLink(s.NegSyncerKey.GetAPIVersion(), resourceID.ProjectID, "networkEndpointGroups", meta.ZonalKey(negName, zone)),
+						Subnetwork: s.networkInfo.SubnetworkURL,
+					}
+				}
+				negObjs = append(negObjs, negObj)
+			} else {
+				s.logger.Info("Excluding previously managed NEG from status as it has no endpoints and no pending transactions", "neg", negName, "zone", zone)
+			}
+		}
+	}
+	return negObjs, errList
+}
+
+// hasEndpoints returns true if the NEG has any endpoints attached in GCE.
+func (s *transactionSyncer) hasEndpoints(negName, zone string) (bool, error) {
+	endpoints, err := s.cloud.ListNetworkEndpoints(negName, zone, false, s.NegSyncerKey.GetAPIVersion(), s.logger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(endpoints) > 0, nil
+}
+
+// hasTransactions returns true if there are any pending transactions (attach/detach) for the given subnet and zone.
+func (s *transactionSyncer) hasTransactions(subnet, zone string) bool {
+	for _, key := range s.transactions.Keys() {
+		if entry, ok := s.transactions.Get(key); ok {
+			if entry.Subnet == subnet && entry.Zone == zone {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -333,7 +333,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 		return err
 	}
 
-	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, ensuredSubnetZones, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.enableDualStackNEG, s.networkInfo, s.logger, s.negMetrics, needInitDrainStatus)
+	currentMap, currentPodLabelMap, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, s.topologyProvider, s.statusHandler, ensuredSubnetZones, s.cloud, s.NegSyncerKey.GetAPIVersion(), s.enableDualStackNEG, s.networkInfo, s.logger, s.negMetrics, needInitDrainStatus)
 	if err != nil {
 		return fmt.Errorf("%w: %w", negtypes.ErrCurrentNegEPNotFound, err)
 	}
@@ -398,6 +398,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 
 	// Filter out locations without NEGs to prevent attaching endpoints in locations where is no NEG
 	targetMap = s.dropLocationsWithoutNEGs(targetMap, currentMap)
+	targetMap = s.cleanOldNEGs(targetMap)
 
 	// When the flags are not enabled, error state should be reset when no
 	// error occurs in the sync.
@@ -981,6 +982,28 @@ func (s *transactionSyncer) dropLocationsWithoutNEGs(targetMap, currentMap map[n
 		}
 	}
 	return filteredMap
+}
+
+// cleanOldNEGs filters the targetMap and forces 0 desired endpoints for locations
+// that are no longer desired (i.e. not in the spec or not owned due to conflict).
+func (s *transactionSyncer) cleanOldNEGs(targetMap map[negtypes.NEGLocation]negtypes.NetworkEndpointSet) map[negtypes.NEGLocation]negtypes.NetworkEndpointSet {
+	desiredZones, err := s.listTargetZonesPerSubnet()
+	if err != nil {
+		s.logger.Error(err, "Failed to list target zones per subnet, skipping cleanOldNEGs")
+		return targetMap
+	}
+
+	resultMap := make(map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, len(targetMap))
+	for loc, endpoints := range targetMap {
+		zones, ok := desiredZones[loc.Subnet]
+		if ok && zones.Has(loc.Zone) {
+			resultMap[loc] = endpoints
+		} else {
+			s.logger.Info("Location is not desired, forcing empty endpoints to trigger drain", "location", loc)
+			resultMap[loc] = negtypes.NewNetworkEndpointSet()
+		}
+	}
+	return resultMap
 }
 
 // filterEndpointByTransaction removes the all endpoints from endpoint map if they exists in the transaction table

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -3193,7 +3193,7 @@ func TestUnknownNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get subnet to zones map: %v", err)
 	}
-	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
+	out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testNegName}, zoneGetter, s.statusHandler, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 	if err != nil {
 		t.Errorf("errored retrieving existing network endpoints")
 	}
@@ -3499,7 +3499,7 @@ func TestEnableDegradedMode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get subnet to zones map: %v", err)
 			}
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, s.statusHandler, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints")
 			}
@@ -3516,7 +3516,7 @@ func TestEnableDegradedMode(t *testing.T) {
 				if statusErr != nil {
 					return false, nil
 				}
-				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
+				out, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, s.statusHandler, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 				if err != nil {
 					return false, nil
 				}
@@ -4244,7 +4244,7 @@ func TestSyncL4NEGs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get subnet to zones map: %v", err)
 			}
-			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
+			out, _, _, err := retrieveExistingZoneNetworkEndpointMap(map[string]string{defaultTestSubnet: testL4NegName}, zoneGetter, s.statusHandler, ensuredZones, fakeCloud, meta.VersionGA, false, s.networkInfo, klog.TODO(), s.negMetrics, false)
 			if err != nil {
 				t.Errorf("errored retrieving existing network endpoints: %v", err)
 			}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -43,9 +43,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
@@ -53,11 +55,14 @@ import (
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/negannotation"
+	fakenegbinding "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
+	informernegbinding "k8s.io/ingress-gce/pkg/negbinding/client/informers/externalversions/negbinding/v1beta1"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/nodetopology"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/endpointslices"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -82,6 +87,28 @@ const (
 	secondaryTestSubnet1 = "secondary1"
 	secondaryTestSubnet2 = "secondary2"
 )
+
+type fakeTopologyProvider struct {
+	subnets []nodetopologyv1.SubnetConfig
+	zones   shared.ZonesPerSubnetMap
+	err     error
+}
+
+func (f *fakeTopologyProvider) ListSubnetsInDefaultNetwork(logger klog.Logger) []nodetopologyv1.SubnetConfig {
+	return f.subnets
+}
+
+func (f *fakeTopologyProvider) ListZonesPerSubnet(filter zonegetter.Filter, networkInfo network.NetworkInfo, logger klog.Logger) (shared.ZonesPerSubnetMap, error) {
+	return f.zones, f.err
+}
+
+type testNegBindingRegistry struct {
+	owners map[string]string
+}
+
+func (r *testNegBindingRegistry) GetOwner(negName string) string {
+	return r.owners[negName]
+}
 
 func TestTransactionSyncNetworkEndpoints(t *testing.T) {
 	t.Parallel()
@@ -5381,5 +5408,288 @@ func TestSyncNEGsPartialFailure(t *testing.T) {
 				t.Errorf("endpoints in zone2 were synced, expected empty: %+v", endpointsZone2)
 			}
 		})
+	}
+}
+
+func TestEnsureNetworkEndpointGroupsForNEGBinding(t *testing.T) {
+	// Save and restore flags
+	oldEnableMultiSubnet := flags.F.EnableMultiSubnetClusterPhase1
+	flags.F.EnableMultiSubnetClusterPhase1 = true
+	defer func() {
+		flags.F.EnableMultiSubnetClusterPhase1 = oldEnableMultiSubnet
+	}()
+
+	testNetwork := cloud.ResourcePath("network", &meta.Key{Name: "test-network"})
+	testSubnetwork := defaultTestSubnetURL
+	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+
+	bindingName := "test-binding"
+	namespace := "test-ns"
+	subnetName := "default"
+	negName := "neg-default"
+
+	testCases := []struct {
+		desc              string
+		attachEndpoints   bool
+		addTransactions   bool
+		expectOldInStatus bool
+	}{
+		{
+			desc:              "Old NEG has endpoints, should keep in status",
+			attachEndpoints:   true,
+			addTransactions:   false,
+			expectOldInStatus: true,
+		},
+		{
+			desc:              "Old NEG has no endpoints and no transactions, should remove from status",
+			attachEndpoints:   false,
+			addTransactions:   false,
+			expectOldInStatus: false,
+		},
+		{
+			desc:              "Old NEG has no endpoints but has attach transactions, should keep in status",
+			attachEndpoints:   false,
+			addTransactions:   true,
+			expectOldInStatus: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeCloud = negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+
+			fakeBindingClient := fakenegbinding.NewSimpleClientset()
+			bindingInformer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeBindingClient, "", 0, utils.NewNamespaceIndexer())
+
+			binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      bindingName,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Kind: "Service",
+						Name: "svc-name",
+						Port: 80,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Name:   negName,
+							Subnet: subnetName,
+							Zones:  []string{testZone1},
+						},
+					},
+				},
+				Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+					NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+						{
+							ResourceURL: cloud.NewNetworkEndpointGroupsResourceID("mock-project", testZone1, negName).SelfLink(meta.VersionAlpha),
+							SubnetURL:   testSubnetwork,
+						},
+						{
+							ResourceURL: cloud.NewNetworkEndpointGroupsResourceID("mock-project", testZone2, negName).SelfLink(meta.VersionAlpha),
+							SubnetURL:   testSubnetwork,
+						},
+					},
+				},
+			}
+
+			bindingInformer.GetIndexer().Add(binding)
+			_, err := fakeBindingClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), binding, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create NEGBinding: %v", err)
+			}
+
+			registry := &testNegBindingRegistry{
+				owners: map[string]string{
+					negName: fmt.Sprintf("%s/%s", namespace, bindingName),
+				},
+			}
+
+			negMetrics := metrics.NewNegMetrics()
+			statusHandler := negstatushandler.NewNEGBindingStatusHandler(
+				bindingName,
+				namespace,
+				fakeBindingClient,
+				bindingInformer.GetIndexer(),
+				negMetrics,
+				registry,
+				klog.TODO(),
+			)
+
+			err = fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
+				Name:       negName,
+				Network:    testNetwork,
+				Subnetwork: testSubnetwork,
+			}, testZone1, klog.TODO())
+			if err != nil {
+				t.Fatalf("Failed to create desired NEG: %v", err)
+			}
+			err = fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
+				Name:       negName,
+				Network:    testNetwork,
+				Subnetwork: testSubnetwork,
+			}, testZone2, klog.TODO())
+			if err != nil {
+				t.Fatalf("Failed to create old NEG: %v", err)
+			}
+
+			if tc.attachEndpoints {
+				err = fakeCloud.AttachNetworkEndpoints(negName, testZone2, []*composite.NetworkEndpoint{
+					{IpAddress: "10.0.0.1", Port: 80},
+				}, meta.VersionAlpha, klog.TODO())
+				if err != nil {
+					t.Fatalf("Failed to attach endpoints: %v", err)
+				}
+			}
+
+			negSyncerKey := negtypes.NegSyncerKey{
+				Namespace:      namespace,
+				Name:           "svc-name",
+				NegType:        negtypes.VmIpPortEndpointType,
+				NEGBindingName: bindingName,
+				NegName:        negName,
+				PortTuple: negtypes.SvcPortTuple{
+					Port:       80,
+					TargetPort: "8080",
+				},
+			}
+
+			negNamer := namer.NewNegBindingNamer(namespace, bindingName, bindingInformer.GetIndexer())
+
+			topoProvider := &fakeTopologyProvider{
+				subnets: []nodetopologyv1.SubnetConfig{
+					{Name: subnetName, SubnetPath: testSubnetwork},
+				},
+				zones: map[string]sets.Set[string]{
+					subnetName: sets.New(testZone1),
+				},
+			}
+
+			syncer := &transactionSyncer{
+				NegSyncerKey:         negSyncerKey,
+				statusHandler:        statusHandler,
+				topologyProvider:     topoProvider,
+				cloud:                fakeCloud,
+				transactions:         NewTransactionTable(),
+				logger:               klog.TODO().WithName("TestSyncer"),
+				namer:                negNamer,
+				customName:           false,
+				networkInfo:          network.NetworkInfo{IsDefault: true, NetworkURL: testNetwork, SubnetworkURL: testSubnetwork},
+				syncMetricsCollector: metricscollector.FakeSyncerMetrics(),
+			}
+
+			if tc.addTransactions {
+				syncer.transactions.Put(negtypes.NetworkEndpoint{IP: "10.0.0.2", Port: "80"}, transactionEntry{
+					Operation: attachOp,
+					Subnet:    subnetName,
+					Zone:      testZone2,
+				})
+			}
+
+			_, err = syncer.ensureNetworkEndpointGroups()
+			if err != nil {
+				t.Fatalf("ensureNetworkEndpointGroups failed: %v", err)
+			}
+
+			updatedBinding, err := fakeBindingClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), bindingName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get updated binding: %v", err)
+			}
+
+			expectedNegURLs := sets.New[string]()
+			expectedNegURLs.Insert(cloud.NewNetworkEndpointGroupsResourceID("mock-project", testZone1, negName).SelfLink(meta.VersionAlpha))
+			if tc.expectOldInStatus {
+				expectedNegURLs.Insert(cloud.NewNetworkEndpointGroupsResourceID("mock-project", testZone2, negName).SelfLink(meta.VersionAlpha))
+			}
+
+			actualNegURLs := sets.New[string]()
+			for _, ref := range updatedBinding.Status.NetworkEndpointGroups {
+				actualNegURLs.Insert(ref.ResourceURL)
+			}
+
+			if !actualNegURLs.Equal(expectedNegURLs) {
+				t.Errorf("Expected status NEGs to be %v, but got %v", expectedNegURLs.UnsortedList(), actualNegURLs.UnsortedList())
+			}
+		})
+	}
+}
+
+func TestTransactionSyncerCleanOldNEGs(t *testing.T) {
+	t.Parallel()
+
+	// Setup fake GCE and syncer
+	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
+	negtypes.MockNetworkEndpointAPIs(fakeGCE)
+	fakeCloud := negtypes.NewAdapter(fakeGCE, negtypes.NewTestContext().NegMetrics)
+
+	_, syncer, err := newTestTransactionSyncer(fakeCloud, negtypes.VmIpPortEndpointType, "")
+	if err != nil {
+		t.Fatalf("failed to initialize transaction syncer: %v", err)
+	}
+
+	// Define desired zones
+	desiredZones := shared.ZonesPerSubnetMap{
+		"subnet-desired": sets.New("zone-a", "zone-b"),
+		"subnet-mixed":   sets.New("zone-a"),
+	}
+
+	fakeTP := &fakeTopologyProvider{
+		zones: desiredZones,
+	}
+	syncer.topologyProvider = fakeTP
+
+	// Define targetMap (inputs)
+	locDesired1 := negtypes.NEGLocation{Subnet: "subnet-desired", Zone: "zone-a"}
+	epsDesired1 := negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.1.1.1"})
+
+	locDesired2 := negtypes.NEGLocation{Subnet: "subnet-desired", Zone: "zone-b"}
+	epsDesired2 := negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "1.1.1.2"})
+
+	locUndesiredSubnet := negtypes.NEGLocation{Subnet: "subnet-undesired", Zone: "zone-a"}
+	epsUndesiredSubnet := negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "2.1.1.1"})
+
+	locUndesiredZone := negtypes.NEGLocation{Subnet: "subnet-mixed", Zone: "zone-b"}
+	epsUndesiredZone := negtypes.NewNetworkEndpointSet(negtypes.NetworkEndpoint{IP: "3.1.1.1"})
+
+	targetMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{
+		locDesired1:        epsDesired1,
+		locDesired2:        epsDesired2,
+		locUndesiredSubnet: epsUndesiredSubnet,
+		locUndesiredZone:   epsUndesiredZone,
+	}
+
+	resultMap := syncer.cleanOldNEGs(targetMap)
+
+	if len(resultMap) != len(targetMap) {
+		t.Errorf("Expected result map to have same length as target map (%d), got %d", len(targetMap), len(resultMap))
+	}
+
+	if !resultMap[locDesired1].Equal(epsDesired1) {
+		t.Errorf("Expected %v to be kept as %v, got %v", locDesired1, epsDesired1, resultMap[locDesired1])
+	}
+	if !resultMap[locDesired2].Equal(epsDesired2) {
+		t.Errorf("Expected %v to be kept as %v, got %v", locDesired2, epsDesired2, resultMap[locDesired2])
+	}
+
+	eps, ok := resultMap[locUndesiredSubnet]
+	if !ok {
+		t.Errorf("Expected key %v to be present in result map", locUndesiredSubnet)
+	} else if eps.Len() != 0 {
+		t.Errorf("Expected %v to be cleared (0 endpoints), got %d", locUndesiredSubnet, eps.Len())
+	}
+
+	eps, ok = resultMap[locUndesiredZone]
+	if !ok {
+		t.Errorf("Expected key %v to be present in result map", locUndesiredZone)
+	} else if eps.Len() != 0 {
+		t.Errorf("Expected %v to be cleared (0 endpoints), got %d", locUndesiredZone, eps.Len())
+	}
+
+	if targetMap[locUndesiredSubnet].Len() == 0 {
+		t.Errorf("Original targetMap was modified in-place for %v", locUndesiredSubnet)
+	}
+	if targetMap[locUndesiredZone].Len() == 0 {
+		t.Errorf("Original targetMap was modified in-place for %v", locUndesiredZone)
 	}
 }

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -699,7 +699,7 @@ func podBelongsToService(pod *apiv1.Pod, service *apiv1.Service) error {
 }
 
 // retrieveExistingZoneNetworkEndpointMap lists existing network endpoints in the neg and return the zone and endpoints map.
-func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, topologyProvider negtypes.TopologyProvider, ensuredZonesPerSubnet map[string]sets.Set[string], cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, enableDualStackNEG bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
+func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string, topologyProvider negtypes.TopologyProvider, statusHandler negtypes.NEGStatusHandler, ensuredZonesPerSubnet map[string]sets.Set[string], cloud negtypes.NetworkEndpointGroupCloud, version meta.Version, enableDualStackNEG bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics, retrieveDrainStatus bool) (map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, labels.EndpointPodLabelMap, map[negtypes.NetworkEndpoint]string, error) {
 	zoneNetworkEndpointMap := map[negtypes.NEGLocation]negtypes.NetworkEndpointSet{}
 	endpointPodLabelMap := labels.EndpointPodLabelMap{}
 	drainingEndpoints := make(map[negtypes.NetworkEndpoint]string)
@@ -709,6 +709,17 @@ func retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping map[string]string
 	allZonesPerSubnet, err := topologyProvider.ListZonesPerSubnet(zonegetter.AllNodesFilter, networkInfo, logger)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+
+	statusZonesPerSubnet, err := statusHandler.SubnetToZonesMap()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get status zones: %w", err)
+	}
+	for subnet, zones := range statusZonesPerSubnet {
+		if _, ok := allZonesPerSubnet[subnet]; !ok {
+			allZonesPerSubnet[subnet] = sets.New[string]()
+		}
+		allZonesPerSubnet[subnet] = allZonesPerSubnet[subnet].Union(zones)
 	}
 
 	for subnet, negName := range subnetToNegMapping {

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	nodetopologyv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodetopology/v1"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -41,11 +42,33 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/metrics"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+	"k8s.io/ingress-gce/pkg/neg/types/shared"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/zonegetter"
 	"k8s.io/klog/v2"
 )
+
+type fakeNEGStatusHandler struct {
+	zones shared.ZonesPerSubnetMap
+	err   error
+}
+
+func (f *fakeNEGStatusHandler) ReportSyncStatus(syncErr error) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeNEGStatusHandler) ReportStatus(negs []*composite.NetworkEndpointGroup, errList []error) error {
+	return nil
+}
+
+func (f *fakeNEGStatusHandler) SubnetToZonesMap() (shared.ZonesPerSubnetMap, error) {
+	return f.zones, f.err
+}
+
+func (f *fakeNEGStatusHandler) LastSyncTime() (time.Time, error) {
+	return time.Time{}, nil
+}
 
 const (
 	defaultTestSubnetURL          = "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
@@ -1452,7 +1475,7 @@ func TestRetrieveExistingZoneNetworkEndpointMap(t *testing.T) {
 				t.Fatalf("failed to list zones for test case %q: %v", tc.desc, err)
 			}
 		}
-		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, ensuredSubnetZones, negCloud, meta.VersionGA, tc.enableDualStackNEG, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
+		endpointSets, annotationMap, _, err := retrieveExistingZoneNetworkEndpointMap(tc.subnetToNegMapping, zoneGetter, &fakeNEGStatusHandler{}, ensuredSubnetZones, negCloud, meta.VersionGA, tc.enableDualStackNEG, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 
 		if tc.expectErr {
 			if err == nil {
@@ -1630,7 +1653,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapHealth(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to list zones: %v", err)
 			}
-			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesPerSubnet, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus)
+			endpointSets, _, drainingEndpoints, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, &fakeNEGStatusHandler{}, ensuredZonesPerSubnet, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), tc.useHealthStatus)
 			if err != nil {
 				t.Fatalf("retrieveExistingZoneNetworkEndpointMap: %v", err)
 			}
@@ -1713,7 +1736,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to list zones: %v", err)
 	}
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesNoDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, &fakeNEGStatusHandler{}, ensuredZonesNoDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err != nil {
 		t.Errorf("expected no error with includeDrainNodesL4Local=false and missing zone4 NEG, got: %v", err)
 	}
@@ -1726,7 +1749,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to list zones: %v", err)
 	}
-	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
+	_, _, _, err = retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, &fakeNEGStatusHandler{}, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err == nil {
 		t.Errorf("expected error with includeDrainNodesL4Local=true and missing zone4 NEG, got nil")
 	}
@@ -1736,7 +1759,7 @@ func TestRetrieveExistingZoneNetworkEndpointMapWithDrainNodes(t *testing.T) {
 	drainEndpoint := &composite.NetworkEndpoint{IpAddress: "10.0.4.1", Instance: "upgrade-instance1"}
 	fakeCloud.AttachNetworkEndpoints(negName, negtypes.TestZone4, []*composite.NetworkEndpoint{drainEndpoint}, meta.VersionGA, klog.TODO())
 
-	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
+	endpointSets, _, _, err := retrieveExistingZoneNetworkEndpointMap(subnetToNegMapping, zoneGetter, &fakeNEGStatusHandler{}, ensuredZonesWithDrain, fakeCloud, meta.VersionGA, false, defaultNetInfo, klog.TODO(), metrics.NewNegMetrics(), false)
 	if err != nil {
 		t.Fatalf("retrieveExistingZoneNetworkEndpointMap(drain=true, NEG exists): %v", err)
 	}

--- a/pkg/utils/namer/negbinding_namer.go
+++ b/pkg/utils/namer/negbinding_namer.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"k8s.io/client-go/tools/cache"
 	negbindingv1beta1 "k8s.io/ingress-gce/pkg/apis/negbinding/v1beta1"
 )
@@ -80,6 +81,21 @@ func (n *NegBindingNamer) negNameForSubnet(subnet, namespace, svcName string, po
 		return "", fmt.Errorf("%w: backendRef %s, negBinding.Spec.BackendRef %s", ErrNBNamerInvalidBackendRef, gotRef, expectedRef)
 	}
 
+	// Find NEG name in Status first to handle conflicts/cleanup
+	for _, ref := range binding.Status.NetworkEndpointGroups {
+		subnetID, err := cloud.ParseResourceURL(ref.SubnetURL)
+		if err != nil {
+			continue
+		}
+		if subnetID.Key.Name == subnet {
+			negID, err := cloud.ParseResourceURL(ref.ResourceURL)
+			if err == nil {
+				return negID.Key.Name, nil
+			}
+		}
+	}
+
+	// Find NEG name in Spec
 	for _, ref := range binding.Spec.NetworkEndpointGroups {
 		if ref.Subnet == subnet {
 			return ref.Name, nil

--- a/pkg/utils/namer/negbinding_namer_test.go
+++ b/pkg/utils/namer/negbinding_namer_test.go
@@ -34,124 +34,261 @@ func TestNegBindingNamer(t *testing.T) {
 
 	subnetName := "subnet-name"
 	negName := "neg-name"
-	subnetName2 := "subnet-name-2"
-	negName2 := "neg-name-2"
 
-	negBindingLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	namer := NewNegBindingNamer(namespace, name, negBindingLister)
-
-	// NEGBinding not in store
-	_, err := namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
-	if err == nil {
-		t.Errorf("Expected error when NEGBinding is not in store, got nil")
-	} else if !errors.Is(err, ErrNegBindingNotFound) {
-		t.Errorf("Expected error to be ErrNegBindingNotFound, got %v", err)
-	}
-
-	// Add NEGBinding to store
-	binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+	testCases := []struct {
+		desc         string
+		binding      interface{}
+		ns           string
+		svc          string
+		subnet       string
+		port         int32
+		customNEG    bool
+		expectedNEG  string
+		expectedErr  error
+		expectAnyErr bool
+	}{
+		{
+			desc:        "NEGBinding not in store",
+			binding:     nil,
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      subnetName,
+			port:        svcPort,
+			expectedErr: ErrNegBindingNotFound,
 		},
-		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
-			BackendRef: &negbindingv1beta1.BackendRefConfig{
-				Name: svcName,
-				Port: svcPort,
-			},
-			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
-				{
-					Subnet: subnetName,
-					Name:   negName,
+		{
+			desc: "Subnet in the NEGBinding's spec",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
 				},
-				{
-					Subnet: subnetName2,
-					Name:   negName2,
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
 				},
 			},
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      subnetName,
+			port:        svcPort,
+			expectedNEG: negName,
+		},
+		{
+			desc: "NonDefaultSubnetCustomNEG with subnet in spec",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
+				},
+			},
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      subnetName,
+			port:        svcPort,
+			customNEG:   true,
+			expectedErr: ErrNBNamerNotImplemented,
+		},
+		{
+			desc: "Subnet not in the NEGBinding's spec",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{},
+				},
+			},
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      "unset-subnet",
+			port:        svcPort,
+			expectedErr: ErrNegNameNotFound,
+		},
+		{
+			desc: "NonDefaultSubnetCustomNEG with subnet unset",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{},
+				},
+			},
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      "unset-subnet",
+			port:        svcPort,
+			customNEG:   true,
+			expectedErr: ErrNBNamerNotImplemented,
+		},
+		{
+			desc: "BackendRef validation: wrong namespace",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
+				},
+			},
+			ns:          "wrong-ns",
+			svc:         svcName,
+			subnet:      subnetName,
+			port:        svcPort,
+			expectedErr: ErrNBNamerInvalidBackendRef,
+		},
+		{
+			desc: "BackendRef validation: wrong service name",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
+				},
+			},
+			ns:          namespace,
+			svc:         "wrong-svc",
+			subnet:      subnetName,
+			port:        svcPort,
+			expectedErr: ErrNBNamerInvalidBackendRef,
+		},
+		{
+			desc: "BackendRef validation: wrong port",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
+				},
+			},
+			ns:          namespace,
+			svc:         svcName,
+			subnet:      subnetName,
+			port:        999,
+			expectedErr: ErrNBNamerInvalidBackendRef,
+		},
+		{
+			desc: "Unexpected object type in cache",
+			binding: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			},
+			ns:           namespace,
+			svc:          svcName,
+			subnet:       subnetName,
+			port:         svcPort,
+			expectAnyErr: true,
 		},
 	}
-	err = negBindingLister.Add(binding)
-	if err != nil {
-		t.Fatalf("Failed to add NEGBinding to store: %v", err)
-	}
 
-	// Subnet in the NEGBinding's spec
-	gotNegName, err := namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
-	if err != nil {
-		t.Errorf("NonDefaultSubnetNEG: Unexpected error: %v", err)
-	}
-	if gotNegName != negName {
-		t.Errorf("NonDefaultSubnetNEG: Expected %s, got %s", negName, gotNegName)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			negBindingLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.binding != nil {
+				if err := negBindingLister.Add(tc.binding); err != nil {
+					t.Fatalf("Failed to add object to store: %v", err)
+				}
+			}
+			namer := NewNegBindingNamer(namespace, name, negBindingLister)
 
-	gotNegName, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName2, svcPort)
-	if err != nil {
-		t.Errorf("NonDefaultSubnetNEG: Unexpected error: %v", err)
-	}
-	if gotNegName != negName2 {
-		t.Errorf("NonDefaultSubnetNEG: Expected %s, got %s", negName2, gotNegName)
-	}
+			var gotNegName string
+			var err error
+			if tc.customNEG {
+				gotNegName, err = namer.NonDefaultSubnetCustomNEG("custom-neg", tc.subnet)
+			} else {
+				gotNegName, err = namer.NonDefaultSubnetNEG(tc.ns, tc.svc, tc.subnet, tc.port)
+			}
 
-	_, err = namer.NonDefaultSubnetCustomNEG("custom-neg", subnetName)
-	if err == nil {
-		t.Errorf("NonDefaultSubnetCustomNEG: Expected error, got nil")
-	} else if !errors.Is(err, ErrNBNamerNotImplemented) {
-		t.Errorf("Expected error to be ErrNBNamerNotImplemented, got %v", err)
-	}
+			if tc.expectedErr != nil {
+				if err == nil {
+					t.Fatalf("Expected error %v, got nil", tc.expectedErr)
+				}
+				if !errors.Is(err, tc.expectedErr) {
+					t.Errorf("Expected error %v, got %v", tc.expectedErr, err)
+				}
+				return
+			}
 
-	// Subnet not on in the NEGBinding's spec
-	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, "unset-subnet", svcPort)
-	if err == nil {
-		t.Errorf("NonDefaultSubnetNEG: Expected error for subnet which not set in NEGBinding spec, got nil")
-	} else if !errors.Is(err, ErrNegNameNotFound) {
-		t.Errorf("Expected error to be ErrNegNameNotFound, got %v", err)
-	}
+			if tc.expectAnyErr {
+				if err == nil {
+					t.Errorf("Expected error for unexpected object type in cache, got nil")
+				}
+				return
+			}
 
-	_, err = namer.NonDefaultSubnetCustomNEG("custom-neg", "unset-subnet")
-	if err == nil {
-		t.Errorf("NonDefaultSubnetCustomNEG: Expected error for subnet which not set in NEGBinding spec, got nil")
-	} else if !errors.Is(err, ErrNBNamerNotImplemented) {
-		t.Errorf("Expected error to be ErrNBNamerNotImplemented, got %v", err)
-	}
-
-	// BackendRef validation
-	_, err = namer.NonDefaultSubnetNEG("wrong-ns", svcName, subnetName, svcPort)
-	if err == nil {
-		t.Errorf("Expected error for wrong namespace, got nil")
-	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
-		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
-	}
-
-	_, err = namer.NonDefaultSubnetNEG(namespace, "wrong-svc", subnetName, svcPort)
-	if err == nil {
-		t.Errorf("Expected error for wrong service name, got nil")
-	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
-		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
-	}
-
-	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, 999)
-	if err == nil {
-		t.Errorf("Expected error for wrong port, got nil")
-	} else if !errors.Is(err, ErrNBNamerInvalidBackendRef) {
-		t.Errorf("Expected error to be ErrNBNamerInvalidBackendRef, got %v", err)
-	}
-
-	// Unexpected object type in cache
-	invalidObj := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-	err = negBindingLister.Update(invalidObj)
-	if err != nil {
-		t.Fatalf("Failed to update NEGBinding store with invalid object: %v", err)
-	}
-
-	_, err = namer.NonDefaultSubnetNEG(namespace, svcName, subnetName, svcPort)
-	if err == nil {
-		t.Errorf("Expected error for unexpected object type in cache, got nil")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if gotNegName != tc.expectedNEG {
+				t.Errorf("Expected NEG name %s, got %s", tc.expectedNEG, gotNegName)
+			}
+		})
 	}
 }
 

--- a/pkg/utils/namer/negbinding_namer_test.go
+++ b/pkg/utils/namer/negbinding_namer_test.go
@@ -154,3 +154,128 @@ func TestNegBindingNamer(t *testing.T) {
 		t.Errorf("Expected error for unexpected object type in cache, got nil")
 	}
 }
+
+func TestNegBindingNamerStatusLookup(t *testing.T) {
+	namespace := "test-ns"
+	name := "test-name"
+	svcName := "svc-name"
+	svcPort := int32(80)
+
+	subnetName := "subnet-name"
+	negName := "neg-name"
+
+	testCases := []struct {
+		desc        string
+		binding     *negbindingv1beta1.NetworkEndpointGroupBinding
+		subnet      string
+		expectedNEG string
+	}{
+		{
+			desc: "Matches both Spec and Status",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   negName,
+						},
+					},
+				},
+				Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+					NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+						{
+							ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/" + negName,
+							SubnetURL:   "https://www.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/subnetworks/" + subnetName,
+						},
+					},
+				},
+			},
+			subnet:      subnetName,
+			expectedNEG: negName,
+		},
+		{
+			desc: "Conflicts between Spec and Status (Status priority)",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+						{
+							Subnet: subnetName,
+							Name:   "new-neg-name",
+						},
+					},
+				},
+				Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+					NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+						{
+							ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/" + negName,
+							SubnetURL:   "https://www.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/subnetworks/" + subnetName,
+						},
+					},
+				},
+			},
+			subnet:      subnetName,
+			expectedNEG: negName,
+		},
+		{
+			desc: "Removed from Spec (only exists in Status)",
+			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+					BackendRef: &negbindingv1beta1.BackendRefConfig{
+						Name: svcName,
+						Port: svcPort,
+					},
+					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{},
+				},
+				Status: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
+					NetworkEndpointGroups: []negbindingv1beta1.StatusNegRef{
+						{
+							ResourceURL: "https://www.googleapis.com/compute/v1/projects/mock-project/zones/us-central1-a/networkEndpointGroups/" + negName,
+							SubnetURL:   "https://www.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/subnetworks/" + subnetName,
+						},
+					},
+				},
+			},
+			subnet:      subnetName,
+			expectedNEG: negName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			negBindingLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := negBindingLister.Add(tc.binding); err != nil {
+				t.Fatalf("Failed to add NEGBinding in store: %v", err)
+			}
+			namer := NewNegBindingNamer(namespace, name, negBindingLister)
+
+			gotNegName, err := namer.NonDefaultSubnetNEG(namespace, svcName, tc.subnet, svcPort)
+			if err != nil {
+				t.Fatalf("NonDefaultSubnetNEG(%s) returned unexpected error: %v", tc.subnet, err)
+			}
+			if gotNegName != tc.expectedNEG {
+				t.Errorf("NonDefaultSubnetNEG(%s) = %s, expected %s", tc.subnet, gotNegName, tc.expectedNEG)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cleanup (detach all endpoints, but don't remove) all NEGs which were managed by the NEG CR, if should not be managed anymore in case:
* Zone removed from Spec
* Subnet removed from Spec
* NEG name for subnet changed in Spec (which is treated in a same way as first remove and then add new one)
* NEGBinding is removed
* Service is removed
* Service no longer has port specified by NEGBinding.Spec.BackendRef

As references to such NEGs are stored in the Status of CR - these are left there until cleanup is completed + CR itself now has finalizer, which will prevent actual removal of it before its NEGs cleaned up.

As mentioned above - changing NEG name for the subnet is treated as removal and then addition of the new one, which in practice creates such flow:
1. Old NEG is removed from Spec - cleanup started, new NEG is ignored
2. Old NEG is cleaning up - new NEG is ignored
3. Old NEG is cleaned up and removed from Status - start syncing new NEG

Depends on https://github.com/kubernetes/ingress-gce/pull/3177 and should not be merged before it. Contains commits from it - please review only ones, which are not in the dependency.