### PR TITLE
Fix L4 Address Manager IP validation and regex matching bugs

### DIFF
--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"regexp"
 	"strings"
 
 	compute "google.golang.org/api/compute/v1"
@@ -185,37 +184,10 @@ func (m *Manager) removeAddress(name, reason string) error {
 	return nil
 }
 
-// DecompressAddr re-adds ommited hextets in IPv6 address.
-// For example, running the function with argument "2001:db8::ff00:42:8329"
-// returns "2001:db8:0:0:0:ff00:42:8329".
-func DecompressAddr(addr string) string {
-	const hextetsInIPv6 = 8
-	if !strings.Contains(addr, "::") {
-		// no compression
-		return addr
-	}
-	hextets := strings.Split(addr, ":")
-	numOfHextets := len(hextets)
-	if numOfHextets < 3 || numOfHextets > 9 {
-		// Address not in a valid compressed form (shortest: "::" (3), longest: one hextet skipped
-		// at beginning or end (9)), returning without any changes.
-		return addr
-	}
-	// To calculate number of missing hextets, we subtract the number of hextets from number of
-	// hextets in IPv6 (8) + 1, since compressed hextets will be represented by one empty item.
-	// Note that it will be decompressed using strings.Replace, so we don't have to worry about
-	// addresses without compression.
-	toAdd := hextetsInIPv6 + 1 - numOfHextets
-	expanded := strings.Repeat(":0", toAdd) + ":"
-	if strings.HasPrefix(addr, "::") {
-		expanded = "0" + expanded
-	}
-	if strings.HasSuffix(addr, "::") {
-		expanded += "0"
-	}
-	return strings.Replace(addr, "::", expanded, 1)
-}
-
+// IsAddressInForwardingRules evaluates whether the requested Address is already effectively
+// bound to an existing Forwarding Rule for this service. It ensures the IPs precisely match,
+// and that the pre-existing Forwarding Rule satisfies the intended Network Tier and LoadBalancing
+// scheme (Internal vs External).
 func (m *Manager) IsAddressInForwardingRules() bool {
 	// Check if the address is in forwarding rules. If it is, we don't need to reserve it.
 	if gceCloud, ok := m.svc.(*gce.Cloud); ok {
@@ -225,16 +197,48 @@ func (m *Manager) IsAddressInForwardingRules() bool {
 			m.frLogger.V(4).Info("failed to lookup forwarding rules, err: %v", err)
 			return false
 		}
-		// We might need to match de-compressed address with mask.
-		pattern := DecompressAddr(m.targetIP) + "(/\\d+)?"
-		ok, err := regexp.MatchString(pattern, fr.IPAddress)
-		if err != nil {
-			m.frLogger.V(4).Info("failed to regexp match %v in %v", pattern, fr.IPAddress)
+
+		targetIP := net.ParseIP(m.targetIP)
+		if targetIP == nil {
+			m.frLogger.V(4).Info("failed to parse requested IP", "ip", m.targetIP)
 			return false
 		}
-		if !ok {
-			m.frLogger.V(4).Info("forwarding rule IP %q doesn't match requested IP %q", fr.IPAddress, m.targetIP)
+
+		var frIP net.IP
+		if strings.Contains(fr.IPAddress, "/") {
+			ip, _, err := net.ParseCIDR(fr.IPAddress)
+			if err != nil {
+				m.frLogger.V(4).Info("failed to parse forwarding rule IP CIDR", "ip", fr.IPAddress)
+				return false
+			}
+			frIP = ip
+		} else {
+			frIP = net.ParseIP(fr.IPAddress)
+			if frIP == nil {
+				m.frLogger.V(4).Info("failed to parse forwarding rule IP", "ip", fr.IPAddress)
+				return false
+			}
+		}
+
+		if !targetIP.Equal(frIP) {
+			m.frLogger.V(4).Info("forwarding rule IP doesn't match requested IP", "forwardingRuleIP", fr.IPAddress, "requestedIP", m.targetIP)
 			return false
+		}
+
+		// Ensure the forwarding rule has the same Network Tier as the service demands.
+		if fr.NetworkTier != "" && fr.NetworkTier != m.networkTier.ToGCEValue() {
+			m.frLogger.V(4).Info("forwarding rule network tier doesn't match", "forwardingRuleNetworkTier", fr.NetworkTier, "requestedNetworkTier", m.networkTier.ToGCEValue())
+			return false
+		}
+
+		// Ensure the forwarding rule's load balancing scheme implies the correct address type.
+		if fr.LoadBalancingScheme != "" {
+			isFrExternal := strings.HasPrefix(fr.LoadBalancingScheme, "EXTERNAL")
+			isExpectedExternal := m.addressType == cloud.SchemeExternal
+			if isFrExternal != isExpectedExternal {
+				m.frLogger.V(4).Info("forwarding rule address type (implied by LoadBalancingScheme) doesn't match", "forwardingRuleScheme", fr.LoadBalancingScheme, "requestedAddressType", m.addressType)
+				return false
+			}
 		}
 
 		// If the forwarding rule service name matches.

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -323,6 +323,8 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 		ipVersion      address.IPVersion
 		forwardingRule *composite.ForwardingRule
 		serviceName    string
+		managerTier    cloud.NetworkTier
+		managerScheme  cloud.LbScheme
 		wantResult     bool
 	}{
 		{
@@ -335,7 +337,7 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			desc:      "match IPv6",
+			desc:      "match IPv6 (standard compression)",
 			address:   "1111:2222:3333:4444:5555::",
 			ipVersion: address.IPv6Version,
 			forwardingRule: &composite.ForwardingRule{
@@ -344,7 +346,43 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			desc:      "IP addres not matching",
+			desc:      "match IPv6 (no compression)",
+			address:   "2001:db8:1:2:3:ff00:42:8329",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "2001:db8:1:2:3:ff00:42:8329/96", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
+		},
+		{
+			desc:      "match IPv6 (compression in middle)",
+			address:   "2001:db8::ff00:42:8329",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "2001:db8:0:0:0:ff00:42:8329/96", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
+		},
+		{
+			desc:      "match IPv6 (loopback / match-all)",
+			address:   "::1",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "0:0:0:0:0:0:0:1/96", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
+		},
+		{
+			desc:      "match IPv6 (compression at beginning)",
+			address:   "::ff00:42:8329",
+			ipVersion: address.IPv6Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "0:0:0:0:0:ff00:42:8329/96", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: true,
+		},
+		{
+			desc:      "IP address not matching",
 			address:   "35.190.1.3",
 			ipVersion: address.IPv4Version,
 			forwardingRule: &composite.ForwardingRule{
@@ -352,7 +390,8 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 			},
 			wantResult: false,
 		},
-		{desc: "IP addres not matching IPv6",
+		{
+			desc:      "IP address not matching IPv6",
 			address:   "2222:2222:3333:4444:5555::",
 			ipVersion: address.IPv6Version,
 			forwardingRule: &composite.ForwardingRule{
@@ -386,6 +425,55 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 			},
 			wantResult: false,
 		},
+		{
+			desc:      "prefix bug (unanchored regex prevention)",
+			address:   "10.0.0.1",
+			ipVersion: address.IPv4Version,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "10.0.0.123", Name: testLBName, ServiceName: testSvcName,
+			},
+			wantResult: false,
+		},
+		{
+			desc:        "network tier mismatch",
+			address:     "35.190.1.1",
+			ipVersion:   address.IPv4Version,
+			managerTier: cloud.NetworkTierPremium,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", Name: testLBName, ServiceName: testSvcName, NetworkTier: "STANDARD",
+			},
+			wantResult: false,
+		},
+		{
+			desc:          "scheme mismatch (external vs internal)",
+			address:       "35.190.1.1",
+			ipVersion:     address.IPv4Version,
+			managerScheme: cloud.SchemeInternal,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", Name: testLBName, ServiceName: testSvcName, LoadBalancingScheme: "EXTERNAL",
+			},
+			wantResult: false,
+		},
+		{
+			desc:          "scheme match internal",
+			address:       "10.0.0.1",
+			ipVersion:     address.IPv4Version,
+			managerScheme: cloud.SchemeInternal,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "10.0.0.1", Name: testLBName, ServiceName: testSvcName, LoadBalancingScheme: "INTERNAL_MANAGED",
+			},
+			wantResult: true,
+		},
+		{
+			desc:          "scheme match external",
+			address:       "35.190.1.1",
+			ipVersion:     address.IPv4Version,
+			managerScheme: cloud.SchemeExternal,
+			forwardingRule: &composite.ForwardingRule{
+				IPAddress: "35.190.1.1", Name: testLBName, ServiceName: testSvcName, LoadBalancingScheme: "EXTERNAL",
+			},
+			wantResult: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -409,10 +497,19 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 				mustCreateForwardingRules(t, svc, []*composite.ForwardingRule{tc.forwardingRule})
 			}
 
-			m := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", tc.address, cloud.SchemeInternal, cloud.NetworkTierPremium, tc.ipVersion, klog.TODO())
+			scheme := tc.managerScheme
+			if scheme == "" {
+				scheme = cloud.SchemeInternal
+			}
+			tier := tc.managerTier
+			if tier == "" {
+				tier = cloud.NetworkTierPremium
+			}
+
+			m := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", tc.address, scheme, tier, tc.ipVersion, klog.TODO())
 			got := m.IsAddressInForwardingRules()
 			if got != tc.wantResult {
-				t.Errorf("IsAddressInForwardingRules() unexpectet result, want = %v, got=%v, svc=%+v", tc.wantResult, tc.address, svc)
+				t.Errorf("IsAddressInForwardingRules() unexpected result, want = %v, got=%v, svc=%+v", tc.wantResult, got, svc)
 			}
 		})
 	}
@@ -453,74 +550,6 @@ func fakeGCECloud(vals gce.TestClusterValues) (*gce.Cloud, error) {
 	mockGCE.MockAlphaAddresses.X = mock.AddressAttributes{}
 	mockGCE.MockAddresses.X = mock.AddressAttributes{}
 	return gce, nil
-}
-
-func TestDecompressIPv6(t *testing.T) {
-	testCases := []struct {
-		name     string
-		addr     string
-		expected string
-	}{
-		{
-			name:     "No compression",
-			addr:     "2001:db8:1:2:3:ff00:42:8329",
-			expected: "2001:db8:1:2:3:ff00:42:8329",
-		},
-		{
-			name:     "Compression in middle",
-			addr:     "2001:db8::ff00:42:8329",
-			expected: "2001:db8:0:0:0:ff00:42:8329",
-		},
-		{
-			name:     "Compression in middle (Short)",
-			addr:     "1:2::3",
-			expected: "1:2:0:0:0:0:0:3",
-		},
-		{
-			name:     "Compression in middle (single hextet)",
-			addr:     "1:2:3:4::6:7:8",
-			expected: "1:2:3:4:0:6:7:8",
-		},
-		{
-			name:     "Match-all",
-			addr:     "::",
-			expected: "0:0:0:0:0:0:0:0",
-		},
-		{
-			name:     "Loopback",
-			addr:     "::1",
-			expected: "0:0:0:0:0:0:0:1",
-		},
-		{
-			name:     "Compression at beginning",
-			addr:     "::ff00:42:8329",
-			expected: "0:0:0:0:0:ff00:42:8329",
-		},
-		{
-			name:     "Compression at end",
-			addr:     "2001:db8::",
-			expected: "2001:db8:0:0:0:0:0:0",
-		},
-		{
-			name:     "Compression at beginning (single hextet)",
-			addr:     "::db8:1:2:3:ff00:42:8329",
-			expected: "0:db8:1:2:3:ff00:42:8329",
-		},
-		{
-			name:     "Compression at end (single hextet)",
-			addr:     "2001:db8:1:2:3:ff00:42::",
-			expected: "2001:db8:1:2:3:ff00:42:0",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := address.DecompressAddr(tc.addr)
-			if actual != tc.expected {
-				t.Errorf("DecompressIPv6(%q) = %q; want %q", tc.addr, actual, tc.expected)
-			}
-		})
-	}
 }
 
 func mustCreateForwardingRules(t *testing.T, cloud *gce.Cloud, frs []*composite.ForwardingRule) {


### PR DESCRIPTION
* Change unanchored 'regexp.MatchString' to 'net.ParseIP().Equal()', preventing false positive substring matches (e.g., 10.0.0.1 matching 10.0.0.123).
* Enforce explicit Network Tier and LoadBalancingScheme validation inside 'IsAddressInForwardingRules' to prevent incorrectly paired internal/external configurations.
* Remove brittle manual IPv6 string manipulation ('DecompressAddr') by leveraging native 'net.ParseIP' functionality.
* Expand 'TestIsAddressInForwardingRules' to cover new negative validation paths and re-incorporate legacy IPv6 compression matrix test cases.