### PR TITLE
NEGBinding - NEG description validation

### DIFF
--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -996,7 +996,7 @@ func CheckStandaloneNEGDeletion(ctx context.Context, c cloud.Cloud, negName, por
 		}
 
 		if neg.Description != "" {
-			desc, err := utils.StandardNEGDescriptionFromString(neg.Description)
+			desc, err := utils.NEGDescriptionFromString[utils.StandardNEGDescription](neg.Description)
 			if err == nil && desc.Port != port {
 				continue
 			}

--- a/pkg/fuzz/gcp.go
+++ b/pkg/fuzz/gcp.go
@@ -996,7 +996,7 @@ func CheckStandaloneNEGDeletion(ctx context.Context, c cloud.Cloud, negName, por
 		}
 
 		if neg.Description != "" {
-			desc, err := utils.NegDescriptionFromString(neg.Description)
+			desc, err := utils.StandardNEGDescriptionFromString(neg.Description)
 			if err == nil && desc.Port != port {
 				continue
 			}

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -786,7 +786,7 @@ func (manager *syncerManager) processNEGDeletionCandidate(candidate deletionCand
 // would return `false`. In addition, if the deletion failed, the error will be
 // reported as an event on the given CR and added to the passed `errList`.
 func (manager *syncerManager) deleteNegOrReportErr(name, zone string, svcNegCR *negv1beta1.ServiceNetworkEndpointGroup, errList *[]error) bool {
-	expectedDesc := &utils.NegDescription{
+	expectedDesc := &utils.StandardNEGDescription{
 		ClusterUID:  string(manager.kubeSystemUID),
 		Namespace:   svcNegCR.Namespace,
 		ServiceName: svcNegCR.GetLabels()[negtypes.NegCRServiceNameKey],
@@ -823,7 +823,7 @@ func ensureExistingNegRef(neg *negv1beta1.ServiceNetworkEndpointGroup, deletedNe
 }
 
 // ensureDeleteNetworkEndpointGroup ensures neg is delete from zone
-func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string, expectedDesc *utils.NegDescription) error {
+func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string, expectedDesc *utils.StandardNEGDescription) error {
 	neg, err := manager.cloud.GetNetworkEndpointGroup(name, zone, meta.VersionGA, manager.logger)
 	if err != nil {
 		if utils.IsNotFoundError(err) || utils.IsHTTPErrorCode(err, http.StatusBadRequest) {

--- a/pkg/neg/manager.go
+++ b/pkg/neg/manager.go
@@ -841,7 +841,7 @@ func (manager *syncerManager) ensureDeleteNetworkEndpointGroup(name, zone string
 			manager.logger.V(2).Info("Skipping deletion of Neg because name was not generated and empty description", "negName", name, "zone", zone)
 			return nil
 		}
-		if matches, err := utils.VerifyDescription(*expectedDesc, neg.Description, name, zone); !matches {
+		if matches, err := expectedDesc.MatchesString(neg.Description, name, zone); !matches {
 			manager.logger.V(2).Info("Skipping deletion of Neg because of conflicting description", "negName", name, "zone", zone, "err", err)
 			return nil
 		}

--- a/pkg/neg/manager_test.go
+++ b/pkg/neg/manager_test.go
@@ -1242,14 +1242,14 @@ func TestGarbageCollectionNegCrdEnabled(t *testing.T) {
 	port80 := int32(80)
 	zones := []string{negtypes.TestZone1, negtypes.TestZone2}
 
-	matchingDesc := utils.NegDescription{
+	matchingDesc := utils.StandardNEGDescription{
 		ClusterUID:  KubeSystemUID,
 		Namespace:   testServiceNamespace,
 		ServiceName: testServiceName,
 		Port:        fmt.Sprintf("%v", port80),
 	}
 
-	wrongDesc := utils.NegDescription{
+	wrongDesc := utils.StandardNEGDescription{
 		ClusterUID:  "another-cluster",
 		Namespace:   "another-namespace",
 		ServiceName: "another-svc",
@@ -1553,7 +1553,7 @@ func TestGarbageCollectTBDNegs(t *testing.T) {
 		},
 	}
 	port80 := int32(80)
-	matchingDesc := utils.NegDescription{
+	matchingDesc := utils.StandardNEGDescription{
 		ClusterUID:  KubeSystemUID,
 		Namespace:   testServiceNamespace,
 		ServiceName: testServiceName,

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -638,6 +638,13 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 		subnetConfigs = []nodetopologyv1.SubnetConfig{subnetConfig}
 	}
 
+	expectedNEGDesc := utils.StandardNEGDescription{
+		ClusterUID:  s.kubeSystemUID,
+		Namespace:   s.Namespace,
+		ServiceName: s.Name,
+		Port:        fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
+	}
+
 	for _, subnetConfig := range subnetConfigs {
 		zones, ok := zonesPerSubnet[subnetConfig.Name]
 		if !ok {
@@ -674,8 +681,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 				negName,
 				zone,
 				s.NegSyncerKey.String(),
-				s.kubeSystemUID,
-				fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
+				expectedNEGDesc,
 				s.NegSyncerKey.NegType,
 				s.cloud,
 				s.serviceLister,

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -638,11 +638,20 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 		subnetConfigs = []nodetopologyv1.SubnetConfig{subnetConfig}
 	}
 
-	expectedNEGDesc := utils.StandardNEGDescription{
-		ClusterUID:  s.kubeSystemUID,
-		Namespace:   s.Namespace,
-		ServiceName: s.Name,
-		Port:        fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
+	var expectedNEGDesc utils.NEGDescription
+	if s.NegSyncerKey.IsBindingKey() {
+		expectedNEGDesc = utils.BoundNEGDescription{
+			ClusterName: flags.F.GKEClusterName,
+			Namespace:   s.Namespace,
+			BackendRef:  s.NegSyncerKey.NEGBindingName,
+		}
+	} else {
+		expectedNEGDesc = utils.StandardNEGDescription{
+			ClusterUID:  s.kubeSystemUID,
+			Namespace:   s.Namespace,
+			ServiceName: s.Name,
+			Port:        fmt.Sprint(s.NegSyncerKey.PortTuple.Port),
+		}
 	}
 
 	for _, subnetConfig := range subnetConfigs {

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -4742,19 +4742,24 @@ func getNegObjectReferences(negs []*composite.NetworkEndpointGroup, negState neg
 // checks the NEG Description on the cloud NEG Object and verifies with expected
 // description from the syncer.
 func checkNegDescription(t *testing.T, syncer *transactionSyncer, desc string) {
-	expectedNegDesc := utils.StandardNEGDescription{
-		ClusterUID:  syncer.kubeSystemUID,
-		Namespace:   syncer.NegSyncerKey.Namespace,
-		ServiceName: syncer.NegSyncerKey.Name,
-		Port:        fmt.Sprint(syncer.NegSyncerKey.PortTuple.Port),
+	var expectedNEGDesc utils.NEGDescription
+	if syncer.NegSyncerKey.IsBindingKey() {
+		expectedNEGDesc = utils.BoundNEGDescription{
+			ClusterName: flags.F.GKEClusterName,
+			Namespace:   syncer.NegSyncerKey.Namespace,
+			BackendRef:  syncer.NegSyncerKey.NEGBindingName,
+		}
+	} else {
+		expectedNEGDesc = utils.StandardNEGDescription{
+			ClusterUID:  syncer.kubeSystemUID,
+			Namespace:   syncer.NegSyncerKey.Namespace,
+			ServiceName: syncer.NegSyncerKey.Name,
+			Port:        fmt.Sprint(syncer.NegSyncerKey.PortTuple.Port),
+		}
 	}
-	actualNegDesc, err := utils.NEGDescriptionFromString[utils.StandardNEGDescription](desc)
-	if err != nil {
-		t.Errorf("Invalid neg description: %s", err)
-	}
-
-	if !reflect.DeepEqual(*actualNegDesc, expectedNegDesc) {
-		t.Errorf("Unexpected neg description %s, expected %s", desc, expectedNegDesc.String())
+	matches, err := expectedNEGDesc.MatchesString(desc, syncer.NegSyncerKey.Name, "")
+	if err != nil || !matches {
+		t.Errorf("Unexpected neg description %s, expected %s, err: %v", desc, expectedNEGDesc.String(), err)
 	}
 }
 
@@ -5517,18 +5522,26 @@ func TestEnsureNetworkEndpointGroupsForNEGBinding(t *testing.T) {
 				klog.TODO(),
 			)
 
+			boundDesc := utils.BoundNEGDescription{
+				ClusterName: flags.F.GKEClusterName,
+				Namespace:   namespace,
+				BackendRef:  bindingName,
+			}.String()
+
 			err = fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
-				Name:       negName,
-				Network:    testNetwork,
-				Subnetwork: testSubnetwork,
+				Name:        negName,
+				Network:     testNetwork,
+				Subnetwork:  testSubnetwork,
+				Description: boundDesc,
 			}, testZone1, klog.TODO())
 			if err != nil {
 				t.Fatalf("Failed to create desired NEG: %v", err)
 			}
 			err = fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
-				Name:       negName,
-				Network:    testNetwork,
-				Subnetwork: testSubnetwork,
+				Name:        negName,
+				Network:     testNetwork,
+				Subnetwork:  testSubnetwork,
+				Description: boundDesc,
 			}, testZone2, klog.TODO())
 			if err != nil {
 				t.Fatalf("Failed to create old NEG: %v", err)

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -1791,7 +1791,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, cr has with populated status, with correct neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -1810,7 +1810,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, with correct neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -1822,7 +1822,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, with mismatched cluster id in neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  "cluster-2",
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -1834,7 +1834,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, with mismatched namespace in neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   "namespace-2",
 				ServiceName: testServiceName,
@@ -1846,7 +1846,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, with mismatched service in neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: "service-2",
@@ -1860,7 +1860,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 		{
 			desc:      "Neg exists, with mismatched port in neg description",
 			negExists: true,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -1875,7 +1875,7 @@ func TestTransactionSyncerWithNegCR(t *testing.T) {
 			desc:      "Neg exists, cr has populated status, but error during initialization",
 			negExists: true,
 			// Cause error by having a conflicting neg description
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -2065,7 +2065,7 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 	flags.F.NodeTopologyCRName = "default"
 	flags.F.EnableMultiSubnetClusterPhase1 = true
 
-	negDesc := utils.NegDescription{
+	negDesc := utils.StandardNEGDescription{
 		ClusterUID:  kubeSystemUID,
 		Namespace:   testServiceNamespace,
 		ServiceName: testServiceName,
@@ -2118,7 +2118,7 @@ func TestEnsureNetworkEndpointGroupsMSC(t *testing.T) {
 		{
 			desc:           "NodeTopology CR contains additional subnets, conflicting NEG description",
 			nodeTopologyCr: &nodeTopologyCrWithAdditionalSubnets,
-			negDesc: utils.NegDescription{
+			negDesc: utils.StandardNEGDescription{
 				ClusterUID:  kubeSystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
@@ -4742,13 +4742,13 @@ func getNegObjectReferences(negs []*composite.NetworkEndpointGroup, negState neg
 // checks the NEG Description on the cloud NEG Object and verifies with expected
 // description from the syncer.
 func checkNegDescription(t *testing.T, syncer *transactionSyncer, desc string) {
-	expectedNegDesc := utils.NegDescription{
+	expectedNegDesc := utils.StandardNEGDescription{
 		ClusterUID:  syncer.kubeSystemUID,
 		Namespace:   syncer.NegSyncerKey.Namespace,
 		ServiceName: syncer.NegSyncerKey.Name,
 		Port:        fmt.Sprint(syncer.NegSyncerKey.PortTuple.Port),
 	}
-	actualNegDesc, err := utils.NegDescriptionFromString(desc)
+	actualNegDesc, err := utils.StandardNEGDescriptionFromString(desc)
 	if err != nil {
 		t.Errorf("Invalid neg description: %s", err)
 	}

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -4748,7 +4748,7 @@ func checkNegDescription(t *testing.T, syncer *transactionSyncer, desc string) {
 		ServiceName: syncer.NegSyncerKey.Name,
 		Port:        fmt.Sprint(syncer.NegSyncerKey.PortTuple.Port),
 	}
-	actualNegDesc, err := utils.StandardNEGDescriptionFromString(desc)
+	actualNegDesc, err := utils.NEGDescriptionFromString[utils.StandardNEGDescription](desc)
 	if err != nil {
 		t.Errorf("Invalid neg description: %s", err)
 	}

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -140,7 +140,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 	if neg == nil {
 		needToCreate = true
 	} else {
-		expectedDesc := utils.NegDescription{
+		expectedDesc := utils.StandardNEGDescription{
 			ClusterUID:  kubeSystemUID,
 			Namespace:   svcNamespace,
 			ServiceName: svcName,
@@ -198,7 +198,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 		}
 		negLogger.Info("Creating NEG", "negServicePortName", negServicePortName, "network", networkInfo.NetworkURL, "subnetwork", subnetwork)
 		desc := ""
-		negDesc := utils.NegDescription{
+		negDesc := utils.StandardNEGDescription{
 			ClusterUID:  kubeSystemUID,
 			Namespace:   svcNamespace,
 			ServiceName: svcName,

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -124,7 +124,7 @@ func getService(serviceLister cache.Indexer, namespace, name string, logger klog
 }
 
 // ensureNetworkEndpointGroup ensures corresponding NEG is configured correctly in the specified zone.
-func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName, kubeSystemUID, port string, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version, customName, manageLifecycle bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics) (*composite.NetworkEndpointGroup, error) {
+func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negServicePortName string, expectedDesc utils.NEGDescription, networkEndpointType negtypes.NetworkEndpointType, cloud negtypes.NetworkEndpointGroupCloud, serviceLister cache.Indexer, recorder record.EventRecorder, version meta.Version, customName, manageLifecycle bool, networkInfo network.NetworkInfo, logger klog.Logger, negMetrics *metrics.NegMetrics) (*composite.NetworkEndpointGroup, error) {
 	negLogger := logger.WithValues("negName", negName, "zone", zone)
 	neg, err := cloud.GetNetworkEndpointGroup(negName, zone, version, logger)
 	if err != nil {
@@ -140,12 +140,6 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 	if neg == nil {
 		needToCreate = true
 	} else {
-		expectedDesc := utils.StandardNEGDescription{
-			ClusterUID:  kubeSystemUID,
-			Namespace:   svcNamespace,
-			ServiceName: svcName,
-			Port:        port,
-		}
 		if customName && neg.Description == "" {
 			negLogger.Error(nil, "Found Neg with custom name but empty description")
 			return nil, fmt.Errorf("found a custom named neg %s with an empty description", negName)
@@ -197,14 +191,7 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 			subnetwork = networkInfo.SubnetworkURL
 		}
 		negLogger.Info("Creating NEG", "negServicePortName", negServicePortName, "network", networkInfo.NetworkURL, "subnetwork", subnetwork)
-		desc := ""
-		negDesc := utils.StandardNEGDescription{
-			ClusterUID:  kubeSystemUID,
-			Namespace:   svcNamespace,
-			ServiceName: svcName,
-			Port:        port,
-		}
-		desc = negDesc.String()
+		desc := expectedDesc.String()
 
 		err = cloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{
 			Version:             version,

--- a/pkg/neg/syncers/utils.go
+++ b/pkg/neg/syncers/utils.go
@@ -150,9 +150,9 @@ func ensureNetworkEndpointGroup(svcNamespace, svcName, negName, zone, negService
 			negLogger.Error(nil, "Found Neg with custom name but empty description")
 			return nil, fmt.Errorf("found a custom named neg %s with an empty description", negName)
 		}
-		if matches, err := utils.VerifyDescription(expectedDesc, neg.Description, negName, zone); !matches {
+		if matches, err := expectedDesc.MatchesString(neg.Description, negName, zone); !matches {
 			negLogger.Error(err, "Neg Name is already in use")
-			// Wrap returned error from VerifyDescription() since we need to check if error is ErrNEGUsedByAnotherSyncer.
+			// Wrap returned error from MatchesString() since we need to check if error is ErrNEGUsedByAnotherSyncer.
 			return nil, fmt.Errorf("found conflicting description in neg %s: %w", negName, err)
 		}
 

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -501,7 +501,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				Port:        testPort,
 			}
 
-			actualNegDesc, err := utils.StandardNEGDescriptionFromString(neg.Description)
+			actualNegDesc, err := utils.NEGDescriptionFromString[utils.StandardNEGDescription](neg.Description)
 			if err != nil {
 				t.Errorf("Invalid neg description: %s", err)
 			}

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -451,14 +451,19 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				tc.networkInfo.NetworkURL = fakeCloud.NetworkURL()
 				tc.networkInfo.SubnetworkURL = fakeCloud.SubnetworkURL()
 			}
+			expectedNegDesc := utils.StandardNEGDescription{
+				ClusterUID:  testKubesystemUID,
+				Namespace:   testServiceNameSpace,
+				ServiceName: testServiceName,
+				Port:        testPort,
+			}
 			_, err := ensureNetworkEndpointGroup(
 				testServiceNameSpace,
 				testServiceName,
 				tc.negName,
 				testZone,
 				testNamedPort,
-				testKubesystemUID,
-				testPort,
+				expectedNegDesc,
 				tc.networkEndpointType,
 				fakeCloud,
 				nil,
@@ -494,13 +499,6 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				t.Errorf("Unexpected Network, expecting %q but got %q", tc.expectedNetwork, neg.Network)
 			}
 
-			expectedNegDesc := utils.StandardNEGDescription{
-				ClusterUID:  testKubesystemUID,
-				Namespace:   testServiceNamespace,
-				ServiceName: testServiceName,
-				Port:        testPort,
-			}
-
 			actualNegDesc, err := utils.NEGDescriptionFromString[utils.StandardNEGDescription](neg.Description)
 			if err != nil {
 				t.Errorf("Invalid neg description: %s", err)
@@ -517,8 +515,7 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				tc.negName,
 				testZone,
 				testNamedPort,
-				testKubesystemUID,
-				testPort,
+				expectedNegDesc,
 				tc.networkEndpointType,
 				fakeCloud,
 				nil,
@@ -1902,14 +1899,19 @@ func TestNameUniqueness(t *testing.T) {
 		}
 	)
 	fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+	expectedNegDesc := utils.StandardNEGDescription{
+		ClusterUID:  testKubesystemUID,
+		Namespace:   testServiceNameSpace,
+		ServiceName: testServiceName,
+		Port:        testPort,
+	}
 	_, err := ensureNetworkEndpointGroup(
 		testServiceNameSpace,
 		testServiceName,
 		negName,
 		testZone,
 		testNamedPort,
-		testKubesystemUID,
-		testPort,
+		expectedNegDesc,
 		networkEndpointType,
 		fakeCloud,
 		nil,
@@ -1934,6 +1936,12 @@ func TestNameUniqueness(t *testing.T) {
 		t.Errorf("Failed to find neg")
 	}
 
+	expectedNegDesc2 := utils.StandardNEGDescription{
+		ClusterUID:  testKubesystemUID,
+		Namespace:   testServiceNameSpace,
+		ServiceName: testServiceName2,
+		Port:        testPort,
+	}
 	// Call ensureNetworkEndpointGroup with the same NEG name and different service name
 	_, err = ensureNetworkEndpointGroup(
 		testServiceNameSpace,
@@ -1941,8 +1949,7 @@ func TestNameUniqueness(t *testing.T) {
 		negName,
 		testZone,
 		testNamedPort,
-		testKubesystemUID,
-		testPort,
+		expectedNegDesc2,
 		networkEndpointType,
 		fakeCloud,
 		nil,
@@ -1984,14 +1991,19 @@ func TestNegObjectCrd(t *testing.T) {
 		negtypes.NonGCPPrivateEndpointType,
 	} {
 		fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
+		expectedNegDesc := utils.StandardNEGDescription{
+			ClusterUID:  testKubesystemUID,
+			Namespace:   testServiceNameSpace,
+			ServiceName: testServiceName,
+			Port:        testPort,
+		}
 		negObj, err := ensureNetworkEndpointGroup(
 			testServiceNameSpace,
 			testServiceName,
 			negName,
 			testZone,
 			testNamedPort,
-			testKubesystemUID,
-			testPort,
+			expectedNegDesc,
 			networkEndpointType,
 			fakeCloud,
 			nil,
@@ -2026,8 +2038,7 @@ func TestNegObjectCrd(t *testing.T) {
 			negName,
 			testZone,
 			testNamedPort,
-			testKubesystemUID,
-			testPort,
+			expectedNegDesc,
 			networkEndpointType,
 			fakeCloud,
 			nil,
@@ -2192,6 +2203,12 @@ func TestNEGRecreate(t *testing.T) {
 			Description:         tc.negDescription,
 		}, testZone, klog.TODO())
 
+		expectedNegDesc := utils.StandardNEGDescription{
+			ClusterUID:  testKubesystemUID,
+			Namespace:   testServiceNameSpace,
+			ServiceName: testServiceName,
+			Port:        testPort,
+		}
 		// Ensure with the correct network and subnet
 		_, err := ensureNetworkEndpointGroup(
 			testServiceNameSpace,
@@ -2199,8 +2216,7 @@ func TestNEGRecreate(t *testing.T) {
 			negName,
 			testZone,
 			testNamedPort,
-			testKubesystemUID,
-			testPort,
+			expectedNegDesc,
 			tc.negType,
 			fakeCloud,
 			nil,
@@ -2266,6 +2282,12 @@ func TestEnsureNetworkEndpointGroupManageLifecycle(t *testing.T) {
 		t.Run(fmt.Sprintf("manageLifecycle=%v", tc.manageLifecycle), func(t *testing.T) {
 			fakeCloud := negtypes.NewFakeNetworkEndpointGroupCloud(testSubnetwork, testNetwork)
 
+			expectedNegDesc := utils.StandardNEGDescription{
+				ClusterUID:  testKubesystemUID,
+				Namespace:   testServiceNameSpace,
+				ServiceName: testServiceName,
+				Port:        testPort,
+			}
 			// If there is no NEG in location it is expected to be for manageLifecycle=true it should create it
 			// and complete without any errors. Otherwise should return not found error.
 			_, err := ensureNetworkEndpointGroup(
@@ -2274,8 +2296,7 @@ func TestEnsureNetworkEndpointGroupManageLifecycle(t *testing.T) {
 				negName,
 				testZone,
 				testNamedPort,
-				testKubesystemUID,
-				testPort,
+				expectedNegDesc,
 				negtypes.VmIpPortEndpointType,
 				fakeCloud,
 				nil,
@@ -2367,6 +2388,12 @@ func TestEnsureNetworkEndpointGroupManageLifecycleNetSubnetMismatch(t *testing.T
 				Description:         matchingNegDesc,
 			}, testZone, klog.TODO())
 
+			expectedNegDesc := utils.StandardNEGDescription{
+				ClusterUID:  testKubesystemUID,
+				Namespace:   testServiceNameSpace,
+				ServiceName: testServiceName,
+				Port:        testPort,
+			}
 			// Call ensureNetworkEndpointGroup with the correct networkInfo (testNetwork/testSubnetwork)
 			_, err := ensureNetworkEndpointGroup(
 				testServiceNameSpace,
@@ -2374,8 +2401,7 @@ func TestEnsureNetworkEndpointGroupManageLifecycleNetSubnetMismatch(t *testing.T
 				negName,
 				testZone,
 				testNamedPort,
-				testKubesystemUID,
-				testPort,
+				expectedNegDesc,
 				negtypes.VmIpPortEndpointType,
 				fakeCloud,
 				nil,

--- a/pkg/neg/syncers/utils_test.go
+++ b/pkg/neg/syncers/utils_test.go
@@ -494,14 +494,14 @@ func TestEnsureNetworkEndpointGroup(t *testing.T) {
 				t.Errorf("Unexpected Network, expecting %q but got %q", tc.expectedNetwork, neg.Network)
 			}
 
-			expectedNegDesc := utils.NegDescription{
+			expectedNegDesc := utils.StandardNEGDescription{
 				ClusterUID:  testKubesystemUID,
 				Namespace:   testServiceNamespace,
 				ServiceName: testServiceName,
 				Port:        testPort,
 			}
 
-			actualNegDesc, err := utils.NegDescriptionFromString(neg.Description)
+			actualNegDesc, err := utils.StandardNEGDescriptionFromString(neg.Description)
 			if err != nil {
 				t.Errorf("Invalid neg description: %s", err)
 			}
@@ -2071,14 +2071,14 @@ func TestNEGRecreate(t *testing.T) {
 		}
 	)
 
-	matchingNegDesc := utils.NegDescription{
+	matchingNegDesc := utils.StandardNEGDescription{
 		ClusterUID:  testKubesystemUID,
 		Namespace:   testServiceNamespace,
 		ServiceName: testServiceName,
 		Port:        testPort,
 	}.String()
 
-	anotherNegDesc := utils.NegDescription{
+	anotherNegDesc := utils.StandardNEGDescription{
 		ClusterUID:  "another-cluster",
 		Namespace:   testServiceNamespace,
 		ServiceName: testServiceName,
@@ -2324,7 +2324,7 @@ func TestEnsureNetworkEndpointGroupManageLifecycleNetSubnetMismatch(t *testing.T
 		}
 	)
 
-	matchingNegDesc := utils.NegDescription{
+	matchingNegDesc := utils.StandardNEGDescription{
 		ClusterUID:  testKubesystemUID,
 		Namespace:   testServiceNameSpace,
 		ServiceName: testServiceName,

--- a/pkg/utils/negdescription.go
+++ b/pkg/utils/negdescription.go
@@ -27,7 +27,7 @@ import (
 var ErrNEGUsedByAnotherSyncer = errors.New("NEG is used by another syncer in the same cluster and namespace")
 
 // Description stores the description for a BackendService.
-type NegDescription struct {
+type StandardNEGDescription struct {
 	ClusterUID  string `json:"cluster-uid,omitempty"`
 	Namespace   string `json:"namespace,omitempty"`
 	ServiceName string `json:"service-name,omitempty"`
@@ -35,7 +35,7 @@ type NegDescription struct {
 }
 
 // String returns the string representation of a Description.
-func (desc NegDescription) String() string {
+func (desc StandardNEGDescription) String() string {
 	descJson, err := json.Marshal(desc)
 	if err != nil {
 		klog.Errorf("Failed to generate neg description string: %v, falling back to empty string", err)
@@ -45,11 +45,11 @@ func (desc NegDescription) String() string {
 }
 
 // DescriptionFromString gets a Description from string,
-func NegDescriptionFromString(descString string) (*NegDescription, error) {
-	var desc NegDescription
+func StandardNEGDescriptionFromString(descString string) (*StandardNEGDescription, error) {
+	var desc StandardNEGDescription
 	if err := json.Unmarshal([]byte(descString), &desc); err != nil {
 		klog.Errorf("Failed to parse neg description: %s, falling back to empty list", descString)
-		return &NegDescription{}, err
+		return &StandardNEGDescription{}, err
 	}
 	return &desc, nil
 }
@@ -57,10 +57,10 @@ func NegDescriptionFromString(descString string) (*NegDescription, error) {
 // VerifyDescription returns whether the provided descString fields match Neg Description expectDesc.
 // If an empty string or malformed description is provided, VerifyDescription will return true.
 // When returning false, a detailed error will also be returned
-func VerifyDescription(expectDesc NegDescription, descString, negName, zone string) (bool, error) {
+func VerifyDescription(expectDesc StandardNEGDescription, descString, negName, zone string) (bool, error) {
 	// Return true if description string is empty
 	if descString != "" {
-		desc, err := NegDescriptionFromString(descString)
+		desc, err := StandardNEGDescriptionFromString(descString)
 		if err != nil {
 			klog.Warningf("Error unmarshalling Neg Description %s err:%s", negName, err)
 		} else {

--- a/pkg/utils/negdescription.go
+++ b/pkg/utils/negdescription.go
@@ -26,6 +26,12 @@ import (
 
 var ErrNEGUsedByAnotherSyncer = errors.New("NEG is used by another syncer in the same cluster and namespace")
 
+// NEGDescription provides an interface for serializing and verifying NEG descriptions.
+type NEGDescription interface {
+	String() string
+	MatchesString(descString, negName, zone string) (bool, error)
+}
+
 // Description stores the description for a BackendService.
 type StandardNEGDescription struct {
 	ClusterUID  string `json:"cluster-uid,omitempty"`
@@ -44,23 +50,13 @@ func (desc StandardNEGDescription) String() string {
 	return string(descJson)
 }
 
-// DescriptionFromString gets a Description from string,
-func StandardNEGDescriptionFromString(descString string) (*StandardNEGDescription, error) {
-	var desc StandardNEGDescription
-	if err := json.Unmarshal([]byte(descString), &desc); err != nil {
-		klog.Errorf("Failed to parse neg description: %s, falling back to empty list", descString)
-		return &StandardNEGDescription{}, err
-	}
-	return &desc, nil
-}
-
-// VerifyDescription returns whether the provided descString fields match Neg Description expectDesc.
-// If an empty string or malformed description is provided, VerifyDescription will return true.
+// MatchesString returns whether the provided descString fields match description's fields.
+// If an empty string or malformed description is provided, MatchesString will return true.
 // When returning false, a detailed error will also be returned
-func VerifyDescription(expectDesc StandardNEGDescription, descString, negName, zone string) (bool, error) {
+func (expectDesc StandardNEGDescription) MatchesString(descString, negName, zone string) (bool, error) {
 	// Return true if description string is empty
 	if descString != "" {
-		desc, err := StandardNEGDescriptionFromString(descString)
+		desc, err := NEGDescriptionFromString[StandardNEGDescription](descString)
 		if err != nil {
 			klog.Warningf("Error unmarshalling Neg Description %s err:%s", negName, err)
 		} else {
@@ -82,4 +78,14 @@ func VerifyDescription(expectDesc StandardNEGDescription, descString, negName, z
 		}
 	}
 	return true, nil
+}
+
+// NEGDescriptionFromString parses string into NEG description structs
+func NEGDescriptionFromString[T NEGDescription](descString string) (*T, error) {
+	var desc T
+	if err := json.Unmarshal([]byte(descString), &desc); err != nil {
+		klog.Errorf("Failed to parse neg description: %s, falling back to empty %T", descString, desc)
+		return &desc, err
+	}
+	return &desc, nil
 }

--- a/pkg/utils/negdescription.go
+++ b/pkg/utils/negdescription.go
@@ -80,6 +80,41 @@ func (expectDesc StandardNEGDescription) MatchesString(descString, negName, zone
 	return true, nil
 }
 
+// BoundNEGDescription stores the description for a NEG managed for NEGBinding CR.
+type BoundNEGDescription struct {
+	ClusterName string `json:"cluster-name,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	BackendRef  string `json:"backend-ref,omitempty"`
+}
+
+// String returns the string representation of a BoundNEGDescription.
+func (desc BoundNEGDescription) String() string {
+	descJson, err := json.Marshal(desc)
+	if err != nil {
+		klog.Errorf("Failed to generate neg description string: %v, falling back to empty string", err)
+		return ""
+	}
+	return string(descJson)
+}
+
+// MatchesString returns whether the provided descString fields match description's fields.
+// Unlike StandardNEGDescription if descString can't be unmarshalled into description it's considered as invalid description of NEG.
+func (expectDesc BoundNEGDescription) MatchesString(descString, negName, zone string) (bool, error) {
+	desc, err := NEGDescriptionFromString[BoundNEGDescription](descString)
+	if err != nil {
+		klog.Warningf("Error unmarshalling Neg Description %s err:%s", negName, err)
+		return false, fmt.Errorf("Error unmarshalling Neg Description %s err:%s", negName, err)
+	}
+
+	if desc.ClusterName != expectDesc.ClusterName ||
+		desc.Namespace != expectDesc.Namespace ||
+		desc.BackendRef != expectDesc.BackendRef {
+		return false, fmt.Errorf("expected description of NEG object %q/%q to be %+v, but got %+v", zone, negName, expectDesc, desc)
+	}
+
+	return true, nil
+}
+
 // NEGDescriptionFromString parses string into NEG description structs
 func NEGDescriptionFromString[T NEGDescription](descString string) (*T, error) {
 	var desc T

--- a/pkg/utils/negdescription_test.go
+++ b/pkg/utils/negdescription_test.go
@@ -24,7 +24,7 @@ import (
 func TestNegString(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		description    StandardNEGDescription
+		description    NEGDescription
 		expectedString string
 	}{
 		{
@@ -52,7 +52,7 @@ func TestNegString(t *testing.T) {
 	}
 }
 
-func TestStandardNEGDescriptionFromString(t *testing.T) {
+func TestNEGDescriptionFromString(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		negDesc      string
@@ -92,7 +92,7 @@ func TestStandardNEGDescriptionFromString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		description, err := StandardNEGDescriptionFromString(tc.negDesc)
+		description, err := NEGDescriptionFromString[StandardNEGDescription](tc.negDesc)
 		if err != nil && !tc.expectError {
 			t.Errorf("%s: NegDescriptionFromString(%s) resulted in error: %s", tc.desc, tc.negDesc, err)
 		}
@@ -113,7 +113,7 @@ func TestVerifyDescription(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		negDescString string
-		expectNegDesc StandardNEGDescription
+		expectNegDesc NEGDescription
 		shouldMatch   bool
 	}{
 		{
@@ -185,7 +185,7 @@ func TestVerifyDescription(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		matches, err := VerifyDescription(tc.expectNegDesc, tc.negDescString, "my-neg", "zone")
+		matches, err := tc.expectNegDesc.MatchesString(tc.negDescString, "my-neg", "zone")
 		if tc.shouldMatch && err != nil {
 			t.Errorf("%s: VerifyDescription(%+v, %s) had an unexpected error: %s", tc.desc, tc.expectNegDesc, tc.negDescString, err)
 		} else if !tc.shouldMatch && err == nil {

--- a/pkg/utils/negdescription_test.go
+++ b/pkg/utils/negdescription_test.go
@@ -24,12 +24,12 @@ import (
 func TestNegString(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		description    NegDescription
+		description    StandardNEGDescription
 		expectedString string
 	}{
 		{
 			desc: "all fields",
-			description: NegDescription{
+			description: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
@@ -39,7 +39,7 @@ func TestNegString(t *testing.T) {
 		},
 		{
 			desc:           "empty",
-			description:    NegDescription{},
+			description:    StandardNEGDescription{},
 			expectedString: "{}",
 		},
 	}
@@ -52,11 +52,11 @@ func TestNegString(t *testing.T) {
 	}
 }
 
-func TestNegDescriptionFromString(t *testing.T) {
+func TestStandardNEGDescriptionFromString(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		negDesc      string
-		expectedDesc NegDescription
+		expectedDesc StandardNEGDescription
 		expectError  bool
 	}{
 		{
@@ -71,7 +71,7 @@ func TestNegDescriptionFromString(t *testing.T) {
 		{
 			desc:    "no feature",
 			negDesc: `{"cluster-uid":"00000000001", "namespace":"my-namespace", "service-name":"my-service", "port":"80"}`,
-			expectedDesc: NegDescription{
+			expectedDesc: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
@@ -82,7 +82,7 @@ func TestNegDescriptionFromString(t *testing.T) {
 		{
 			desc:    "missing a field",
 			negDesc: `{"cluster-uid":"00000000001","service-name":"my-service", "port":"80"}`,
-			expectedDesc: NegDescription{
+			expectedDesc: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				ServiceName: "my-service",
 				Port:        "80",
@@ -92,7 +92,7 @@ func TestNegDescriptionFromString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		description, err := NegDescriptionFromString(tc.negDesc)
+		description, err := StandardNEGDescriptionFromString(tc.negDesc)
 		if err != nil && !tc.expectError {
 			t.Errorf("%s: NegDescriptionFromString(%s) resulted in error: %s", tc.desc, tc.negDesc, err)
 		}
@@ -103,7 +103,7 @@ func TestNegDescriptionFromString(t *testing.T) {
 }
 
 func TestVerifyDescription(t *testing.T) {
-	negDesc := NegDescription{
+	negDesc := StandardNEGDescription{
 		ClusterUID:  "00000000001",
 		Namespace:   "my-namespace",
 		ServiceName: "my-service",
@@ -113,13 +113,13 @@ func TestVerifyDescription(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		negDescString string
-		expectNegDesc NegDescription
+		expectNegDesc StandardNEGDescription
 		shouldMatch   bool
 	}{
 		{
 			desc:          "fields match",
 			negDescString: negDesc,
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
@@ -130,7 +130,7 @@ func TestVerifyDescription(t *testing.T) {
 		{
 			desc:          "empty description",
 			negDescString: "",
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
@@ -141,7 +141,7 @@ func TestVerifyDescription(t *testing.T) {
 		{
 			desc:          "cluster uid doesn't match",
 			negDescString: negDesc,
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000002",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
@@ -152,7 +152,7 @@ func TestVerifyDescription(t *testing.T) {
 		{
 			desc:          "namespace doesn't match",
 			negDescString: negDesc,
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000002",
 				Namespace:   "not-my-namespace",
 				ServiceName: "my-service",
@@ -163,7 +163,7 @@ func TestVerifyDescription(t *testing.T) {
 		{
 			desc:          "service name doesn't match",
 			negDescString: negDesc,
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000002",
 				Namespace:   "my-namespace",
 				ServiceName: "not-my-service",
@@ -174,7 +174,7 @@ func TestVerifyDescription(t *testing.T) {
 		{
 			desc:          "port doesn't match",
 			negDescString: negDesc,
-			expectNegDesc: NegDescription{
+			expectNegDesc: StandardNEGDescription{
 				ClusterUID:  "00000000002",
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",

--- a/pkg/utils/negdescription_test.go
+++ b/pkg/utils/negdescription_test.go
@@ -28,7 +28,7 @@ func TestNegString(t *testing.T) {
 		expectedString string
 	}{
 		{
-			desc: "all fields",
+			desc: "StandardNEGDescription all fields",
 			description: StandardNEGDescription{
 				ClusterUID:  "00000000001",
 				Namespace:   "my-namespace",
@@ -38,8 +38,22 @@ func TestNegString(t *testing.T) {
 			expectedString: `{"cluster-uid":"00000000001","namespace":"my-namespace","service-name":"my-service","port":"80"}`,
 		},
 		{
-			desc:           "empty",
+			desc:           "StandardNEGDescription empty",
 			description:    StandardNEGDescription{},
+			expectedString: "{}",
+		},
+		{
+			desc: "BoundNEGDescription all fields",
+			description: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			expectedString: `{"cluster-name":"cluster-1","namespace":"my-namespace","backend-ref":"my-backend"}`,
+		},
+		{
+			desc:           "BoundNEGDescription empty",
+			description:    BoundNEGDescription{},
 			expectedString: "{}",
 		},
 	}
@@ -52,7 +66,55 @@ func TestNegString(t *testing.T) {
 	}
 }
 
-func TestNEGDescriptionFromString(t *testing.T) {
+func TestBoundNEGDescriptionFromString(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		negDesc      string
+		expectedDesc BoundNEGDescription
+		expectError  bool
+	}{
+		{
+			desc:        "empty string",
+			expectError: true,
+		},
+		{
+			desc:        "invalid format",
+			negDesc:     "invalid",
+			expectError: true,
+		},
+		{
+			desc:    "all fields",
+			negDesc: `{"cluster-name":"cluster-1", "namespace":"my-namespace", "backend-ref":"my-backend"}`,
+			expectedDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			expectError: false,
+		},
+		{
+			desc:    "missing a field",
+			negDesc: `{"cluster-name":"cluster-1", "backend-ref":"my-backend"}`,
+			expectedDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				BackendRef:  "my-backend",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		description, err := NEGDescriptionFromString[BoundNEGDescription](tc.negDesc)
+		if err != nil && !tc.expectError {
+			t.Errorf("%s: BoundNEGDescriptionFromString(%s) resulted in error: %s", tc.desc, tc.negDesc, err)
+		}
+		if !reflect.DeepEqual(*description, tc.expectedDesc) {
+			t.Errorf("%s: BoundNEGDescriptionFromString(%s)=%s, want %s", tc.desc, tc.negDesc, description, tc.expectedDesc)
+		}
+	}
+}
+
+func TestStandardNEGDescriptionFromString(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		negDesc      string
@@ -179,6 +241,82 @@ func TestVerifyDescription(t *testing.T) {
 				Namespace:   "my-namespace",
 				ServiceName: "my-service",
 				Port:        "81",
+			},
+			shouldMatch: false,
+		},
+		{
+			desc: "BoundNEGDescription fields match",
+			negDescString: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			}.String(),
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			shouldMatch: true,
+		},
+		{
+			desc:          "BoundNEGDescription empty description string",
+			negDescString: "",
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			shouldMatch: false,
+		},
+		{
+			desc:          "BoundNEGDescription invalid format description string",
+			negDescString: "invalid-json",
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			shouldMatch: false,
+		},
+		{
+			desc: "BoundNEGDescription cluster name doesn't match",
+			negDescString: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			}.String(),
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "other-cluster",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			},
+			shouldMatch: false,
+		},
+		{
+			desc: "BoundNEGDescription namespace doesn't match",
+			negDescString: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			}.String(),
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "other-namespace",
+				BackendRef:  "my-backend",
+			},
+			shouldMatch: false,
+		},
+		{
+			desc: "BoundNEGDescription backend ref doesn't match",
+			negDescString: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "my-backend",
+			}.String(),
+			expectNegDesc: BoundNEGDescription{
+				ClusterName: "cluster-1",
+				Namespace:   "my-namespace",
+				BackendRef:  "other-backend",
 			},
 			shouldMatch: false,
 		},


### PR DESCRIPTION
Just like any other NEGs managed by NEG controller, NEGs, which can be attached using NEGBinding CR should also have description of the certain format to ensure that NEG won't be managed by multiple controllers simultaneously. 

Structure of the description is changed a bit however: instead of  `cluster-uid` field, just cluster name is used + port is excluded.

Depends on https://github.com/kubernetes/ingress-gce/pull/3180 and should not be merged before it. Contains commits from it - please review only ones, which are not in the dependency.