### PR TITLE
NEGBinding - NEG Metrics

### DIFF
--- a/pkg/neg/metrics/metricscollector/features.go
+++ b/pkg/neg/metrics/metricscollector/features.go
@@ -36,4 +36,6 @@ const (
 	negInSuccess = feature("NegInSuccess")
 	// negInError feature specifies that an error occurring in ensuring Neg Syncer
 	negInError = feature("NegInError")
+	// negBindingNeg feature specifies that NEGs are bound using NEGBinding CR
+	negBindingNeg = feature("NegBindingNEG")
 )

--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -448,6 +448,11 @@ func (sm *SyncerMetrics) SetNegService(svcKey string, negState NegServiceState) 
 	if sm.negMap == nil {
 		klog.Fatalf("Ingress Metrics failed to initialize correctly.")
 	}
+	if existing, ok := sm.negMap[svcKey]; ok {
+		negState.NegBindingNeg = existing.NegBindingNeg
+		negState.BindingSuccessfulNeg = existing.BindingSuccessfulNeg
+		negState.BindingErrorNeg = existing.BindingErrorNeg
+	}
 	sm.negMap[svcKey] = negState
 }
 
@@ -456,7 +461,70 @@ func (sm *SyncerMetrics) DeleteNegService(svcKey string) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	delete(sm.negMap, svcKey)
+	existing, ok := sm.negMap[svcKey]
+	if !ok {
+		return
+	}
+	if existing.NegBindingNeg == 0 {
+		delete(sm.negMap, svcKey)
+	} else {
+		sm.negMap[svcKey] = NegServiceState{
+			NegBindingNeg:        existing.NegBindingNeg,
+			BindingSuccessfulNeg: existing.BindingSuccessfulNeg,
+			BindingErrorNeg:      existing.BindingErrorNeg,
+		}
+	}
+}
+
+// GetNegService returns the NegServiceState for a given service key.
+func (sm *SyncerMetrics) GetNegService(svcKey string) (NegServiceState, bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	state, ok := sm.negMap[svcKey]
+	return state, ok
+}
+
+// SetNegBindingService sets or updates NegBindingNeg counts for a service key without overwriting other neg types.
+func (sm *SyncerMetrics) SetNegBindingService(svcKey string, negState NegServiceState) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.negMap == nil {
+		klog.Fatalf("Ingress Metrics failed to initialize correctly.")
+	}
+	existing, ok := sm.negMap[svcKey]
+	if !ok {
+		if negState.NegBindingNeg == 0 {
+			return
+		}
+		sm.negMap[svcKey] = negState
+		return
+	}
+	existing.NegBindingNeg = negState.NegBindingNeg
+	existing.BindingSuccessfulNeg = negState.BindingSuccessfulNeg
+	existing.BindingErrorNeg = negState.BindingErrorNeg
+	sm.negMap[svcKey] = existing
+}
+
+// DeleteNegBindingService resets NegBindingNeg for a service key and removes the service if no other NEGs exist.
+func (sm *SyncerMetrics) DeleteNegBindingService(svcKey string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	existing, ok := sm.negMap[svcKey]
+	if !ok {
+		return
+	}
+
+	if existing.SuccessfulNeg != 0 || existing.ErrorNeg != 0 || existing.StandaloneNeg != 0 || existing.IngressNeg != 0 || existing.VmIpNeg != nil {
+		existing.NegBindingNeg = 0
+		existing.BindingSuccessfulNeg = 0
+		existing.BindingErrorNeg = 0
+		sm.negMap[svcKey] = existing
+	} else {
+		delete(sm.negMap, svcKey)
+	}
 }
 
 // computeNegMetrics aggregates NEG metrics in the cache
@@ -474,20 +542,22 @@ func (sm *SyncerMetrics) computeNegMetrics() map[feature]int {
 		vmIpNegCluster:    0,
 		customNamedNeg:    0,
 		preprovisionedNeg: 0,
+		negBindingNeg:     0,
 		negInSuccess:      0,
 		negInError:        0,
 	}
 
 	for key, negState := range sm.negMap {
-		klog.V(6).Infof("For service %s, it has standaloneNegs:%d, ingressNegs:%d and vmPrimaryNeg:%v",
-			key, negState.StandaloneNeg, negState.IngressNeg, negState.VmIpNeg)
+		klog.V(6).Infof("For service %s, it has standaloneNegs:%d, ingressNegs:%d, negBindingNegs:%d and vmPrimaryNeg:%v",
+			key, negState.StandaloneNeg, negState.IngressNeg, negState.NegBindingNeg, negState.VmIpNeg)
 		counts[standaloneNeg] += negState.StandaloneNeg
 		counts[ingressNeg] += negState.IngressNeg
-		counts[neg] += negState.StandaloneNeg + negState.IngressNeg
+		counts[negBindingNeg] += negState.NegBindingNeg
+		counts[neg] += negState.StandaloneNeg + negState.IngressNeg + negState.NegBindingNeg
 		counts[customNamedNeg] += negState.CustomNamedNeg
 		counts[preprovisionedNeg] += negState.PreprovisionedNeg
-		counts[negInSuccess] += negState.SuccessfulNeg
-		counts[negInError] += negState.ErrorNeg
+		counts[negInSuccess] += negState.SuccessfulNeg + negState.BindingSuccessfulNeg
+		counts[negInError] += negState.ErrorNeg + negState.BindingErrorNeg
 		if negState.VmIpNeg != nil {
 			counts[neg] += 1
 			counts[vmIpNeg] += 1

--- a/pkg/neg/metrics/metricscollector/metrics_collector_test.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector_test.go
@@ -423,6 +423,7 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    0,
 				customNamedNeg:    0,
 				preprovisionedNeg: 0,
+				negBindingNeg:     0,
 				negInSuccess:      0,
 				negInError:        0,
 			},
@@ -441,6 +442,7 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    0,
 				customNamedNeg:    0,
 				preprovisionedNeg: 0,
+				negBindingNeg:     0,
 				negInSuccess:      1,
 				negInError:        0,
 			},
@@ -459,6 +461,7 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    1,
 				customNamedNeg:    0,
 				preprovisionedNeg: 0,
+				negBindingNeg:     0,
 				negInSuccess:      1,
 				negInError:        0,
 			},
@@ -477,6 +480,7 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    0,
 				customNamedNeg:    1,
 				preprovisionedNeg: 0,
+				negBindingNeg:     0,
 				negInSuccess:      1,
 				negInError:        0,
 			},
@@ -495,6 +499,7 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    0,
 				customNamedNeg:    0,
 				preprovisionedNeg: 1,
+				negBindingNeg:     0,
 				negInSuccess:      1,
 				negInError:        0,
 			},
@@ -516,8 +521,32 @@ func TestComputeNegMetrics(t *testing.T) {
 				vmIpNegCluster:    1,
 				customNamedNeg:    0,
 				preprovisionedNeg: 2,
+				negBindingNeg:     0,
 				negInSuccess:      6,
 				negInError:        6,
+			},
+		},
+		{
+			"negbinding neg",
+			[]NegServiceState{
+				{
+					NegBindingNeg:        2,
+					BindingSuccessfulNeg: 1,
+					BindingErrorNeg:      1,
+				},
+			},
+			map[feature]int{
+				standaloneNeg:     0,
+				ingressNeg:        0,
+				neg:               2,
+				vmIpNeg:           0,
+				vmIpNegLocal:      0,
+				vmIpNegCluster:    0,
+				customNamedNeg:    0,
+				preprovisionedNeg: 0,
+				negBindingNeg:     2,
+				negInSuccess:      1,
+				negInError:        1,
 			},
 		},
 	} {
@@ -532,6 +561,142 @@ func TestComputeNegMetrics(t *testing.T) {
 			gotNegCount := newMetrics.computeNegMetrics()
 			if diff := cmp.Diff(tc.expectNegCount, gotNegCount); diff != "" {
 				t.Errorf("Got diff for NEG counts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSetNegBindingService(t *testing.T) {
+	svcKey := "test-ns/test-svc"
+
+	testCases := []struct {
+		desc         string
+		initialState map[string]NegServiceState
+		inputKey     string
+		inputState   NegServiceState
+		expectExist  bool
+		expectState  NegServiceState
+	}{
+		{
+			desc:         "NegBindingNeg=0 on non-existing entry does not create entry",
+			initialState: nil,
+			inputKey:     "test-ns/non-existing",
+			inputState:   NegServiceState{NegBindingNeg: 0},
+			expectExist:  false,
+		},
+		{
+			desc:         "creates new entry when svcKey does not exist in negMap",
+			initialState: nil,
+			inputKey:     svcKey,
+			inputState:   NegServiceState{NegBindingNeg: 1, BindingSuccessfulNeg: 1, BindingErrorNeg: 0},
+			expectExist:  true,
+			expectState:  NegServiceState{NegBindingNeg: 1, BindingSuccessfulNeg: 1, BindingErrorNeg: 0},
+		},
+		{
+			desc: "updates existing entry while preserving standalone/ingress fields",
+			initialState: map[string]NegServiceState{
+				svcKey: {StandaloneNeg: 2, SuccessfulNeg: 1, ErrorNeg: 0},
+			},
+			inputKey:    svcKey,
+			inputState:  NegServiceState{NegBindingNeg: 3, BindingSuccessfulNeg: 2, BindingErrorNeg: 1},
+			expectExist: true,
+			expectState: NegServiceState{StandaloneNeg: 2, SuccessfulNeg: 1, ErrorNeg: 0, NegBindingNeg: 3, BindingSuccessfulNeg: 2, BindingErrorNeg: 1},
+		},
+		{
+			desc: "overwrites existing NegBindingNeg fields while preserving standalone fields",
+			initialState: map[string]NegServiceState{
+				svcKey: {StandaloneNeg: 2, SuccessfulNeg: 1, ErrorNeg: 0, NegBindingNeg: 1, BindingSuccessfulNeg: 1, BindingErrorNeg: 0},
+			},
+			inputKey:    svcKey,
+			inputState:  NegServiceState{NegBindingNeg: 3, BindingSuccessfulNeg: 1, BindingErrorNeg: 2},
+			expectExist: true,
+			expectState: NegServiceState{StandaloneNeg: 2, SuccessfulNeg: 1, ErrorNeg: 0, NegBindingNeg: 3, BindingSuccessfulNeg: 1, BindingErrorNeg: 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			sm := FakeSyncerMetrics()
+			for k, v := range tc.initialState {
+				sm.negMap[k] = v
+			}
+			sm.SetNegBindingService(tc.inputKey, tc.inputState)
+
+			state, ok := sm.GetNegService(tc.inputKey)
+			if ok != tc.expectExist {
+				t.Fatalf("GetNegService(%q) exist = %v, want %v", tc.inputKey, ok, tc.expectExist)
+			}
+			if tc.expectExist {
+				if diff := cmp.Diff(tc.expectState, state); diff != "" {
+					t.Errorf("GetNegService(%q) diff (-want +got):\n%s", tc.inputKey, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteNegBindingService(t *testing.T) {
+	svcKey := "test-ns/test-svc"
+
+	testCases := []struct {
+		desc         string
+		initialState map[string]NegServiceState
+		inputKey     string
+		expectExist  bool
+		expectState  NegServiceState
+	}{
+		{
+			desc:         "non-existing key returns safely",
+			initialState: nil,
+			inputKey:     "test-ns/non-existing",
+			expectExist:  false,
+		},
+		{
+			desc: "deletes entry when only NegBindingNeg fields were present",
+			initialState: map[string]NegServiceState{
+				svcKey: {NegBindingNeg: 2, BindingSuccessfulNeg: 2, BindingErrorNeg: 0},
+			},
+			inputKey:    svcKey,
+			expectExist: false,
+		},
+		{
+			desc: "resets NegBindingNeg fields to zero while preserving standalone and ingress NEGs",
+			initialState: map[string]NegServiceState{
+				svcKey: {StandaloneNeg: 2, IngressNeg: 1, NegBindingNeg: 3, BindingSuccessfulNeg: 3},
+			},
+			inputKey:    svcKey,
+			expectExist: true,
+			expectState: NegServiceState{StandaloneNeg: 2, IngressNeg: 1, NegBindingNeg: 0, BindingSuccessfulNeg: 0, BindingErrorNeg: 0},
+		},
+		{
+			desc: "resets NegBindingNeg fields to zero while preserving VmIpNeg",
+			initialState: map[string]NegServiceState{
+				svcKey: {VmIpNeg: &VmIpNegType{}, NegBindingNeg: 1, BindingSuccessfulNeg: 1},
+			},
+			inputKey:    svcKey,
+			expectExist: true,
+			expectState: NegServiceState{VmIpNeg: &VmIpNegType{}, NegBindingNeg: 0, BindingSuccessfulNeg: 0, BindingErrorNeg: 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			sm := FakeSyncerMetrics()
+			for k, v := range tc.initialState {
+				sm.negMap[k] = v
+			}
+			sm.DeleteNegBindingService(tc.inputKey)
+
+			state, ok := sm.GetNegService(tc.inputKey)
+			if ok != tc.expectExist {
+				t.Fatalf("GetNegService(%q) exist = %v, want %v", tc.inputKey, ok, tc.expectExist)
+			}
+			if tc.expectExist {
+				if diff := cmp.Diff(tc.expectState, state, cmpopts.IgnoreUnexported(VmIpNegType{})); diff != "" {
+					t.Errorf("GetNegService(%q) diff (-want +got):\n%s", tc.inputKey, diff)
+				}
 			}
 		})
 	}

--- a/pkg/neg/metrics/metricscollector/types.go
+++ b/pkg/neg/metrics/metricscollector/types.go
@@ -32,9 +32,15 @@ type NegServiceState struct {
 	CustomNamedNeg int
 	// PreprovisionedNeg is the count of standalone negs with pre-provisioning zones
 	PreprovisionedNeg int
+	// NegBindingNeg is the count of NEGs managed by NEGBinding CRs
+	NegBindingNeg int
+	// BindingSuccessfulNeg is the count of successful NEGBinding NEG syncers
+	BindingSuccessfulNeg int
+	// BindingErrorNeg is the count of error NEGBinding NEG syncers
+	BindingErrorNeg int
 	// SuccessfulNeg is the count of successful NEG syncer creations
 	SuccessfulNeg int
-	// SuccessfulNeg is the count of errors in NEG syncer creations
+	// ErrorNeg is the count of errors in NEG syncer creations
 	ErrorNeg int
 }
 

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -70,7 +70,7 @@ func ServiceKeyIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return []string{}, fmt.Errorf("unexpected object type %T", obj)
 	}
-	if binding.Spec.BackendRef != nil && binding.Spec.BackendRef.Kind == negbindingv1beta1.ServiceKind {
+	if binding.Spec.BackendRef.Kind == negbindingv1beta1.ServiceKind {
 		return []string{fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)}, nil
 	}
 	return []string{}, nil
@@ -158,7 +158,7 @@ func (r *negOwnershipRegistry) setOwnerLocked(negName, owner string) {
 	r.ownedNEGs[owner].Insert(negName)
 }
 
-// setOwnerLocked ensures that owners and ownedNEGs are consistent when releasing NEG ownership. Should have lock when called.
+// unsetOwnerLocked ensures that owners and ownedNEGs are consistent when releasing NEG ownership. Should have lock when called.
 func (r *negOwnershipRegistry) unsetOwnerLocked(negName string) {
 	owner, ok := r.owners[negName]
 	if !ok {
@@ -300,7 +300,62 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 	if syncer != nil {
 		syncer.Sync()
 	}
+	m.updateSyncerMetricsForService(svcKey)
 	return nil
+}
+
+func (m *negBindingManager) updateSyncerMetricsForService(svcKey string) {
+	objs, err := m.negBindingLister.ByIndex(ServiceKeyIndex, svcKey)
+	if err != nil {
+		m.logger.Error(err, "failed to list bindings for service to update metrics", "service", svcKey)
+		return
+	}
+	var totalNegBindingNeg, successfulNeg, errorNeg int
+	for _, obj := range objs {
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			continue
+		}
+		if len(binding.Spec.NetworkEndpointGroups) == 0 {
+			continue
+		}
+
+		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		m.mu.Lock()
+		syncer, syncerExists := m.syncerMap[bindingKey]
+		_, hasConfig := m.syncerConfigs[bindingKey]
+		m.mu.Unlock()
+
+		if !syncerExists || !hasConfig {
+			continue
+		}
+
+		var managedNEGs int
+		for _, negRef := range binding.Spec.NetworkEndpointGroups {
+			if m.ownershipRegistry.GetOwner(negRef.Name) == bindingKey {
+				managedNEGs++
+			}
+		}
+		if managedNEGs == 0 {
+			continue
+		}
+		totalNegBindingNeg += managedNEGs
+		if syncer == nil || syncer.IsStopped() {
+			errorNeg += managedNEGs
+		} else {
+			successfulNeg += managedNEGs
+		}
+	}
+
+	if totalNegBindingNeg == 0 {
+		m.syncerMetrics.DeleteNegBindingService(svcKey)
+		return
+	}
+	m.syncerMetrics.SetNegBindingService(svcKey, metricscollector.NegServiceState{
+		NegBindingNeg:        totalNegBindingNeg,
+		BindingSuccessfulNeg: successfulNeg,
+		BindingErrorNeg:      errorNeg,
+	})
 }
 
 func (m *negBindingManager) ensureCleanupSyncer(binding *negbindingv1beta1.NetworkEndpointGroupBinding) (negtypes.NegSyncer, error) {
@@ -580,14 +635,23 @@ func (m *negBindingManager) ProcessServiceDeletion(svcNamespace, svcName string)
 
 // StopSyncer stops the syncer associated with the binding and removes it from the map.
 func (m *negBindingManager) StopSyncer(namespace, name string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	bindingKey := fmt.Sprintf("%s/%s", namespace, name)
-	if syncer, ok := m.syncerMap[bindingKey]; ok {
+	m.mu.Lock()
+	syncer, ok := m.syncerMap[bindingKey]
+	if ok {
 		syncer.Stop()
 		m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
 		delete(m.syncerMap, bindingKey)
 		delete(m.syncerConfigs, bindingKey)
+	}
+	m.mu.Unlock()
+
+	obj, exists, err := m.negBindingLister.GetByKey(bindingKey)
+	if err == nil && exists {
+		if binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding); ok {
+			svcKey := fmt.Sprintf("%s/%s", namespace, binding.Spec.BackendRef.Name)
+			m.updateSyncerMetricsForService(svcKey)
+		}
 	}
 }
 
@@ -668,9 +732,6 @@ func (m *negBindingManager) getPortTuple(svc *apiv1.Service, port int32) (negtyp
 // InitializeOwnershipRegistry reads NEG names from existing NEGBinding CRs' statuses and acquires them.
 // In case same NEG name found in multiple CRs, only one selected.
 func (m *negBindingManager) InitializeOwnershipRegistry() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	bindings := m.negBindingLister.List()
 	for _, obj := range bindings {
 		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
@@ -679,6 +740,7 @@ func (m *negBindingManager) InitializeOwnershipRegistry() error {
 			continue
 		}
 		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
+		var needUpdateMetrics bool
 		for _, statusRef := range binding.Status.NetworkEndpointGroups {
 			negID, err := cloud.ParseResourceURL(statusRef.ResourceURL)
 			if err != nil {
@@ -688,10 +750,15 @@ func (m *negBindingManager) InitializeOwnershipRegistry() error {
 			negName := negID.Key.Name
 			acquired, currentOwner := m.ownershipRegistry.Acquire(negName, bindingKey)
 			if acquired {
+				needUpdateMetrics = true
 				m.logger.Info("Acquired NEG ownership from status during registry init", "negName", negName, "owner", bindingKey)
 			} else {
 				m.logger.Info("Conflict acquiring NEG ownership from status during registry init", "negName", negName, "attemptedOwner", bindingKey, "currentOwner", currentOwner)
 			}
+		}
+		if needUpdateMetrics {
+			svcKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)
+			m.updateSyncerMetricsForService(svcKey)
 		}
 	}
 	return nil
@@ -708,6 +775,8 @@ func (m *negBindingManager) ReconcileDeletion(binding *negbindingv1beta1.Network
 	if !ok {
 		if len(binding.Status.NetworkEndpointGroups) == 0 {
 			m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, nil)
+			svcKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)
+			m.updateSyncerMetricsForService(svcKey)
 			return m.removeFinalizer(binding)
 		}
 		if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
@@ -727,6 +796,9 @@ func (m *negBindingManager) ReconcileDeletion(binding *negbindingv1beta1.Network
 			delete(m.syncerMap, bindingKey)
 			delete(m.syncerConfigs, bindingKey)
 		}()
+
+		svcKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)
+		m.updateSyncerMetricsForService(svcKey)
 
 		return m.removeFinalizer(binding)
 	}
@@ -947,4 +1019,6 @@ func (m *negBindingManager) acquireNEGsForBinding(binding *negbindingv1beta1.Net
 	}
 
 	m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, acquiredNEGs)
+	svcKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)
+	m.updateSyncerMetricsForService(svcKey)
 }

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -318,20 +318,6 @@ func TestNEGBindingManagerErrorCases(t *testing.T) {
 		expectedReason string
 	}{
 		{
-			desc:       "BackendRef is nil",
-			addService: false,
-			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "binding-nil-ref"},
-				Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
-					BackendRef:            nil,
-					NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{{Name: "neg-1", Subnet: "default", Zones: []string{"us-central1-a"}}},
-				},
-			},
-			expectedErr:    ErrInvalidBackendRef.Error(),
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "InvalidBackendRef",
-		},
-		{
 			desc:       "BackendRef Kind is invalid",
 			addService: false,
 			binding: &negbindingv1beta1.NetworkEndpointGroupBinding{
@@ -1230,5 +1216,264 @@ func TestNEGBindingManagerDeletionNoAcquireReleased(t *testing.T) {
 	owner := m.ownershipRegistry.GetOwner("neg-released")
 	if owner != "" {
 		t.Errorf("Expected released NEG 'neg-released' not to be acquired by deleting binding, got owner %s", owner)
+	}
+}
+
+func TestNEGBindingManagerMetrics(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      svcName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       svcPort,
+					TargetPort: intstr.FromString(targetPort),
+				},
+			},
+		},
+	}
+	_, err := kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	bindingName := "test-binding"
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      bindingName,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: svcName,
+				Port: svcPort,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-1",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+				{
+					Name:   "neg-2",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+			},
+		},
+	}
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	_, err = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding: %v", err)
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	err = negBindingLister.Add(testBinding)
+	if err != nil {
+		t.Fatalf("failed to add binding to lister: %v", err)
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	err = serviceLister.Add(testSvc)
+	if err != nil {
+		t.Fatalf("failed to add service to lister: %v", err)
+	}
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	svcKey := fmt.Sprintf("%s/%s", namespace, svcName)
+
+	err = m.EnsureSyncerForNEGBinding(testBinding)
+	if err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+	}
+
+	var state metricscollector.NegServiceState
+	var ok bool
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		state, ok = syncerMetrics.GetNegService(svcKey)
+		return ok && state.NegBindingNeg == 2 && state.BindingSuccessfulNeg == 2 && state.BindingErrorNeg == 0, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for syncerMetrics to reflect binding, ok=%v state=%+v", ok, state)
+	}
+
+	m.StopSyncer(namespace, bindingName)
+	if _, ok := syncerMetrics.GetNegService(svcKey); ok {
+		t.Errorf("Expected metrics entry for service %s to be deleted after StopSyncer", svcKey)
+	}
+}
+
+func TestNEGBindingManagerMetricsConflict(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      svcName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       svcPort,
+					TargetPort: intstr.FromString(targetPort),
+				},
+			},
+		},
+	}
+	_, err := kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingInformer := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers)
+	negBindingLister := negBindingInformer.GetIndexer()
+
+	var testBindings []*negbindingv1beta1.NetworkEndpointGroupBinding
+	for i := 1; i <= 10; i++ {
+		binding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("binding-%d", i),
+			},
+			Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+				BackendRef: &negbindingv1beta1.BackendRefConfig{
+					Kind: negbindingv1beta1.ServiceKind,
+					Name: svcName,
+					Port: svcPort,
+				},
+				NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+					{
+						Name:   "neg-shared",
+						Subnet: "default",
+						Zones:  []string{"us-central1-a"},
+					},
+				},
+			},
+		}
+		testBindings = append(testBindings, binding)
+		_, err = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), binding, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create binding: %v", err)
+		}
+		if err := negBindingLister.Add(binding); err != nil {
+			t.Fatalf("failed to add binding to lister: %v", err)
+		}
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	err = serviceLister.Add(testSvc)
+	if err != nil {
+		t.Fatalf("failed to add service to lister: %v", err)
+	}
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	for _, binding := range testBindings {
+		if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
+			t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+		}
+	}
+
+	svcKey := fmt.Sprintf("%s/%s", namespace, svcName)
+	var state metricscollector.NegServiceState
+	var ok bool
+	err = wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		state, ok = syncerMetrics.GetNegService(svcKey)
+		return ok && state.NegBindingNeg == 1, nil
+	})
+	if err != nil {
+		t.Fatalf("Expected NegBindingNeg=1 for 10 bindings referencing same NEG name, got ok=%v state=%+v", ok, state)
 	}
 }


### PR DESCRIPTION
Report NEGs bound by NEGBinding CRs in NEG metrics.

NEGs normally (not binding-related) count as set across zones, which in fact means number of unique NEG names, not number of NEGs. According to this when reporting binding-related NEGs, also reporting number of unique NEG names + towards which service count NEG is decided based on the ownership of NEG names by bindings (https://github.com/kubernetes/ingress-gce/pull/3177).

Depends on https://github.com/kubernetes/ingress-gce/pull/3185 and should not be merged before it. Contains commits from it - please review only ones, which are not in the dependency.