### PR TITLE
Implement allowMissing in FilteredInformer and enable it for Node informer

### DIFF
--- a/pkg/multiproject/common/filteredinformer/filteredcache.go
+++ b/pkg/multiproject/common/filteredinformer/filteredcache.go
@@ -8,6 +8,7 @@ import (
 type providerConfigFilteredCache struct {
 	cache.Indexer
 	providerConfigName string
+	allowMissing       bool
 }
 
 func (pc *providerConfigFilteredCache) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
@@ -15,7 +16,7 @@ func (pc *providerConfigFilteredCache) ByIndex(indexName, indexedValue string) (
 	if err != nil {
 		return nil, err
 	}
-	return providerConfigFilteredList(items, pc.providerConfigName), nil
+	return providerConfigFilteredList(items, pc.providerConfigName, pc.allowMissing), nil
 }
 
 func (pc *providerConfigFilteredCache) Index(indexName string, obj interface{}) ([]interface{}, error) {
@@ -23,11 +24,11 @@ func (pc *providerConfigFilteredCache) Index(indexName string, obj interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	return providerConfigFilteredList(items, pc.providerConfigName), nil
+	return providerConfigFilteredList(items, pc.providerConfigName, pc.allowMissing), nil
 }
 
 func (pc *providerConfigFilteredCache) List() []interface{} {
-	return providerConfigFilteredList(pc.Indexer.List(), pc.providerConfigName)
+	return providerConfigFilteredList(pc.Indexer.List(), pc.providerConfigName, pc.allowMissing)
 }
 
 func (pc *providerConfigFilteredCache) ListKeys() []string {
@@ -54,7 +55,7 @@ func (pc *providerConfigFilteredCache) GetByKey(key string) (item interface{}, e
 	if !exists || err != nil {
 		return nil, exists, err
 	}
-	if isObjectInProviderConfig(item, pc.providerConfigName) {
+	if isObjectInProviderConfig(item, pc.providerConfigName, pc.allowMissing) {
 		return item, true, nil
 	}
 	return nil, false, nil

--- a/pkg/multiproject/common/filteredinformer/filteredcache_test.go
+++ b/pkg/multiproject/common/filteredinformer/filteredcache_test.go
@@ -15,6 +15,7 @@ func TestProviderConfigFilteredCache_ByIndex(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		cacheProviderConfig string
+		allowMissing        bool
 		objectsInCache      []interface{}
 		queryName           string
 		expectedItemNames   []string
@@ -22,6 +23,7 @@ func TestProviderConfigFilteredCache_ByIndex(t *testing.T) {
 		{
 			desc:                "Retrieve items by index in provider config",
 			cacheProviderConfig: "cs123456-abc",
+			allowMissing:        false,
 			objectsInCache: []interface{}{
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "cs123456-abc"}, Namespace: "cs123456-abc-namespace", Name: "obj1"},
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "cs123456-abc"}, Namespace: "cs123456-abc-namespace", Name: "obj2"},
@@ -31,8 +33,21 @@ func TestProviderConfigFilteredCache_ByIndex(t *testing.T) {
 			expectedItemNames: []string{"obj1"},
 		},
 		{
+			desc:                "Retrieve items by index, allowing missing",
+			cacheProviderConfig: "cs123456-abc",
+			allowMissing:        true,
+			objectsInCache: []interface{}{
+				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "cs123456-abc"}, Namespace: "ns1", Name: "obj1"},
+				&v1.ObjectMeta{Name: "obj1"}, // missing label
+				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "cs654321-edf"}, Namespace: "ns2", Name: "obj1"}, // wrong label
+			},
+			queryName:         "obj1",
+			expectedItemNames: []string{"obj1", "obj1"},
+		},
+		{
 			desc:                "No items when index key does not match",
 			cacheProviderConfig: "cs123456-abc",
+			allowMissing:        false,
 			objectsInCache: []interface{}{
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "cs123456-abc"}, Name: "obj1"},
 			},
@@ -56,6 +71,7 @@ func TestProviderConfigFilteredCache_ByIndex(t *testing.T) {
 			nsCache := &providerConfigFilteredCache{
 				Indexer:            indexer,
 				providerConfigName: tc.cacheProviderConfig,
+				allowMissing:       tc.allowMissing,
 			}
 
 			for _, obj := range tc.objectsInCache {
@@ -86,12 +102,14 @@ func TestProviderConfigFilteredCache_List(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		cacheProviderConfig string
+		allowMissing        bool
 		objectsInCache      []interface{}
 		expectedItemNames   []string
 	}{
 		{
 			desc:                "List items in the provider config",
 			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
 			objectsInCache: []interface{}{
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}, Name: "obj1"},
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-edf"}, Name: "obj2"},
@@ -101,10 +119,22 @@ func TestProviderConfigFilteredCache_List(t *testing.T) {
 		{
 			desc:                "List no items when provider config has no objects",
 			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
 			objectsInCache: []interface{}{
 				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-edf"}, Name: "obj1"},
 			},
 			expectedItemNames: []string{},
+		},
+		{
+			desc:                "List items, allowing missing",
+			cacheProviderConfig: "p123456-abc",
+			allowMissing:        true,
+			objectsInCache: []interface{}{
+				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}, Name: "obj1"},
+				&v1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-edf"}, Name: "obj2"},
+				&v1.ObjectMeta{Name: "obj3"},
+			},
+			expectedItemNames: []string{"obj1", "obj3"},
 		},
 	}
 
@@ -115,6 +145,7 @@ func TestProviderConfigFilteredCache_List(t *testing.T) {
 			nsCache := &providerConfigFilteredCache{
 				Indexer:            indexer,
 				providerConfigName: tc.cacheProviderConfig,
+				allowMissing:       tc.allowMissing,
 			}
 
 			for _, obj := range tc.objectsInCache {
@@ -142,6 +173,7 @@ func TestProviderConfigFilteredCache_GetByKey(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		cacheProviderConfig string
+		allowMissing        bool
 		queryKey            string
 		objectsInCache      []interface{}
 		expectedExist       bool
@@ -150,6 +182,7 @@ func TestProviderConfigFilteredCache_GetByKey(t *testing.T) {
 		{
 			desc:                "Get existing item by key in provider config",
 			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
 			queryKey:            "p123456-abc-namespace/obj1",
 			objectsInCache: []interface{}{&v1.ObjectMeta{
 				Labels:    map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"},
@@ -160,8 +193,32 @@ func TestProviderConfigFilteredCache_GetByKey(t *testing.T) {
 			expectedName:  "obj1",
 		},
 		{
+			desc:                "Get missing item by key when allowMissing is true",
+			cacheProviderConfig: "p123456-abc",
+			allowMissing:        true,
+			queryKey:            "default/obj1",
+			objectsInCache: []interface{}{&v1.ObjectMeta{
+				Namespace: "default",
+				Name:      "obj1",
+			}},
+			expectedExist: true,
+			expectedName:  "obj1",
+		},
+		{
+			desc:                "Get missing item by key when allowMissing is false",
+			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
+			queryKey:            "default/obj1",
+			objectsInCache: []interface{}{&v1.ObjectMeta{
+				Namespace: "default",
+				Name:      "obj1",
+			}},
+			expectedExist: false,
+		},
+		{
 			desc:                "Item exists but in different provider config",
 			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
 			queryKey:            "p654321-edf-namespace/obj1",
 			objectsInCache: []interface{}{&v1.ObjectMeta{
 				Labels:    map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-edf"},
@@ -173,6 +230,7 @@ func TestProviderConfigFilteredCache_GetByKey(t *testing.T) {
 		{
 			desc:                "Item does not exist",
 			cacheProviderConfig: "p123456-abc",
+			allowMissing:        false,
 			objectsInCache: []interface{}{&v1.ObjectMeta{
 				Labels:    map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"},
 				Namespace: "p123456-abc-namespace",
@@ -190,6 +248,7 @@ func TestProviderConfigFilteredCache_GetByKey(t *testing.T) {
 			nsCache := &providerConfigFilteredCache{
 				Indexer:            indexer,
 				providerConfigName: tc.cacheProviderConfig,
+				allowMissing:       tc.allowMissing,
 			}
 
 			for _, obj := range tc.objectsInCache {

--- a/pkg/multiproject/common/filteredinformer/filteredinformer.go
+++ b/pkg/multiproject/common/filteredinformer/filteredinformer.go
@@ -10,13 +10,15 @@ import (
 type ProviderConfigFilteredInformer struct {
 	cache.SharedIndexInformer
 	providerConfigName string
+	allowMissing       bool
 }
 
 // NewProviderConfigFilteredInformer creates a new ProviderConfigFilteredInformer.
-func NewProviderConfigFilteredInformer(informer cache.SharedIndexInformer, providerConfigName string) cache.SharedIndexInformer {
+func NewProviderConfigFilteredInformer(informer cache.SharedIndexInformer, providerConfigName string, allowMissing bool) cache.SharedIndexInformer {
 	return &ProviderConfigFilteredInformer{
 		SharedIndexInformer: informer,
 		providerConfigName:  providerConfigName,
+		allowMissing:        allowMissing,
 	}
 }
 
@@ -43,13 +45,14 @@ func (i *ProviderConfigFilteredInformer) AddEventHandlerWithResyncPeriod(handler
 
 // providerConfigFilter filters objects based on the provider config.
 func (i *ProviderConfigFilteredInformer) providerConfigFilter(obj interface{}) bool {
-	return isObjectInProviderConfig(obj, i.providerConfigName)
+	return isObjectInProviderConfig(obj, i.providerConfigName, i.allowMissing)
 }
 
 func (i *ProviderConfigFilteredInformer) GetStore() cache.Store {
 	return &providerConfigFilteredCache{
 		Indexer:            i.SharedIndexInformer.GetIndexer(),
 		providerConfigName: i.providerConfigName,
+		allowMissing:       i.allowMissing,
 	}
 }
 
@@ -57,5 +60,6 @@ func (i *ProviderConfigFilteredInformer) GetIndexer() cache.Indexer {
 	return &providerConfigFilteredCache{
 		Indexer:            i.SharedIndexInformer.GetIndexer(),
 		providerConfigName: i.providerConfigName,
+		allowMissing:       i.allowMissing,
 	}
 }

--- a/pkg/multiproject/common/filteredinformer/filteredinformer_test.go
+++ b/pkg/multiproject/common/filteredinformer/filteredinformer_test.go
@@ -15,7 +15,7 @@ func TestFilteredInformer_AddEventHandler(t *testing.T) {
 	flags.F.ProviderConfigNameLabelKey = "provider-config-name-label"
 
 	sharedInformer := cache.NewSharedIndexInformer(nil, &corev1.Pod{}, 0, nil)
-	filteredinformer := NewProviderConfigFilteredInformer(sharedInformer, "test-provider-config")
+	filteredinformer := NewProviderConfigFilteredInformer(sharedInformer, "test-provider-config", false)
 
 	handler := cache.ResourceEventHandlerFuncs{}
 
@@ -54,7 +54,7 @@ func TestFilteredInformer_AddEventHandlerWithResyncPeriod(t *testing.T) {
 			t.Parallel()
 
 			sharedInformer := cache.NewSharedIndexInformer(nil, &corev1.Pod{}, 0, nil)
-			filteredinformer := NewProviderConfigFilteredInformer(sharedInformer, tc.providerConfigName)
+			filteredinformer := NewProviderConfigFilteredInformer(sharedInformer, tc.providerConfigName, false)
 
 			handler := cache.ResourceEventHandlerFuncs{}
 			_, err := filteredinformer.AddEventHandlerWithResyncPeriod(handler, tc.resyncPeriod)

--- a/pkg/multiproject/common/filteredinformer/helpers.go
+++ b/pkg/multiproject/common/filteredinformer/helpers.go
@@ -7,7 +7,7 @@ import (
 )
 
 // isObjectInProviderConfig checks if an object belongs to a specific provider config.
-func isObjectInProviderConfig(obj interface{}, providerConfigName string) bool {
+func isObjectInProviderConfig(obj interface{}, providerConfigName string, allowMissing bool) bool {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -15,14 +15,19 @@ func isObjectInProviderConfig(obj interface{}, providerConfigName string) bool {
 	if err != nil {
 		return false
 	}
-	return metaObj.GetLabels()[flags.F.ProviderConfigNameLabelKey] == providerConfigName
+	labels := metaObj.GetLabels()
+	val, ok := labels[flags.F.ProviderConfigNameLabelKey]
+	if !ok {
+		return allowMissing
+	}
+	return val == providerConfigName
 }
 
 // providerConfigFilteredList filters a list of objects by provider config name.
-func providerConfigFilteredList(items []interface{}, providerConfigName string) []interface{} {
+func providerConfigFilteredList(items []interface{}, providerConfigName string, allowMissing bool) []interface{} {
 	var filtered []interface{}
 	for _, item := range items {
-		if isObjectInProviderConfig(item, providerConfigName) {
+		if isObjectInProviderConfig(item, providerConfigName, allowMissing) {
 			filtered = append(filtered, item)
 		}
 	}

--- a/pkg/multiproject/common/filteredinformer/helpers_test.go
+++ b/pkg/multiproject/common/filteredinformer/helpers_test.go
@@ -12,42 +12,67 @@ import (
 )
 
 func TestIsObjectInProviderConfig(t *testing.T) {
+	flags.F.ProviderConfigNameLabelKey = "provider-config-name-label"
+
 	testCases := []struct {
 		desc               string
 		providerConfigName string
+		allowMissing       bool
 		object             interface{}
 		expectedToMatch    bool
 	}{
 		{
 			desc:               "Object in provider config should return true",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			object:             &metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
 			expectedToMatch:    true,
 		},
 		{
 			desc:               "Object in different provider config should return false",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			object:             &metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-def"}},
 			expectedToMatch:    false,
 		},
 		{
-			desc:               "Object with no provider config should return false",
+			desc:               "Object with no provider config should return false when allowMissing is false",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			object:             &metav1.ObjectMeta{Name: "obj3"},
 			expectedToMatch:    false,
 		},
 		{
+			desc:               "Object with no provider config should return true when allowMissing is true",
+			providerConfigName: "p123456-abc",
+			allowMissing:       true,
+			object:             &metav1.ObjectMeta{Name: "obj3"},
+			expectedToMatch:    true,
+		},
+		{
 			desc:               "Invalid object should return false",
 			providerConfigName: "p123456-abc",
+			allowMissing:       true, // shouldn't matter
 			object:             "invalid-object",
 			expectedToMatch:    false,
 		},
 		{
 			desc:               "Tombstone object in provider config should return true",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			object: cache.DeletedFinalStateUnknown{
 				Key: "some-key",
 				Obj: &metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
+			},
+			expectedToMatch: true,
+		},
+		{
+			desc:               "Tombstone object missing provider config should return true when allowMissing is true",
+			providerConfigName: "p123456-abc",
+			allowMissing:       true,
+			object: cache.DeletedFinalStateUnknown{
+				Key: "some-key",
+				Obj: &metav1.ObjectMeta{Name: "obj3"},
 			},
 			expectedToMatch: true,
 		},
@@ -58,7 +83,7 @@ func TestIsObjectInProviderConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			result := isObjectInProviderConfig(tc.object, tc.providerConfigName)
+			result := isObjectInProviderConfig(tc.object, tc.providerConfigName, tc.allowMissing)
 			if result != tc.expectedToMatch {
 				t.Errorf("Expected isObjectInProviderConfig to return %v, got %v", tc.expectedToMatch, result)
 			}
@@ -67,15 +92,19 @@ func TestIsObjectInProviderConfig(t *testing.T) {
 }
 
 func TestProviderConfigFilteredList(t *testing.T) {
+	flags.F.ProviderConfigNameLabelKey = "provider-config-name-label"
+
 	testCases := []struct {
 		desc               string
 		providerConfigName string
+		allowMissing       bool
 		objects            []interface{}
 		expectedObjects    []interface{}
 	}{
 		{
 			desc:               "All objects in the provider config",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			objects: []interface{}{
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
@@ -88,6 +117,7 @@ func TestProviderConfigFilteredList(t *testing.T) {
 		{
 			desc:               "Some objects in the provider config",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			objects: []interface{}{
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-def"}},
@@ -101,6 +131,7 @@ func TestProviderConfigFilteredList(t *testing.T) {
 		{
 			desc:               "No objects in the provider config",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			objects: []interface{}{
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-def"}},
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-def"}},
@@ -108,8 +139,23 @@ func TestProviderConfigFilteredList(t *testing.T) {
 			expectedObjects: []interface{}{},
 		},
 		{
+			desc:               "Allow missing objects",
+			providerConfigName: "p123456-abc",
+			allowMissing:       true,
+			objects: []interface{}{
+				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}, Name: "obj1"},
+				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p654321-def"}, Name: "obj2"},
+				&metav1.ObjectMeta{Name: "obj3"}, // missing label
+			},
+			expectedObjects: []interface{}{
+				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}, Name: "obj1"},
+				&metav1.ObjectMeta{Name: "obj3"},
+			},
+		},
+		{
 			desc:               "Invalid objects in the list",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			objects: []interface{}{
 				"invalid-object",
 				&metav1.ObjectMeta{Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "p123456-abc"}},
@@ -122,6 +168,7 @@ func TestProviderConfigFilteredList(t *testing.T) {
 		{
 			desc:               "Empty object list",
 			providerConfigName: "p123456-abc",
+			allowMissing:       false,
 			objects:            []interface{}{},
 			expectedObjects:    []interface{}{},
 		},
@@ -132,7 +179,7 @@ func TestProviderConfigFilteredList(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			result := providerConfigFilteredList(tc.objects, tc.providerConfigName)
+			result := providerConfigFilteredList(tc.objects, tc.providerConfigName, tc.allowMissing)
 
 			if len(result) != len(tc.expectedObjects) {
 				t.Errorf("Expected %d objects, got %d", len(tc.expectedObjects), len(result))

--- a/pkg/multiproject/neg/informerset/informerset.go
+++ b/pkg/multiproject/neg/informerset/informerset.go
@@ -176,36 +176,36 @@ func (i *InformerSet) FilterByProviderConfig(providerConfigName string) *Informe
 
 	// Wrap core informers
 	if i.Ingress != nil {
-		filteredInformers.Ingress = newProviderConfigFilteredInformer(i.Ingress, providerConfigName)
+		filteredInformers.Ingress = newProviderConfigFilteredInformer(i.Ingress, providerConfigName, false)
 	}
 	if i.Service != nil {
-		filteredInformers.Service = newProviderConfigFilteredInformer(i.Service, providerConfigName)
+		filteredInformers.Service = newProviderConfigFilteredInformer(i.Service, providerConfigName, false)
 	}
 	if i.Pod != nil {
-		filteredInformers.Pod = newProviderConfigFilteredInformer(i.Pod, providerConfigName)
+		filteredInformers.Pod = newProviderConfigFilteredInformer(i.Pod, providerConfigName, false)
 	}
 	if i.Node != nil {
-		filteredInformers.Node = newProviderConfigFilteredInformer(i.Node, providerConfigName)
+		filteredInformers.Node = newProviderConfigFilteredInformer(i.Node, providerConfigName, true)
 	}
 	if i.EndpointSlice != nil {
-		filteredInformers.EndpointSlice = newProviderConfigFilteredInformer(i.EndpointSlice, providerConfigName)
+		filteredInformers.EndpointSlice = newProviderConfigFilteredInformer(i.EndpointSlice, providerConfigName, false)
 	}
 
 	// Wrap optional informers
 	if i.SvcNeg != nil {
-		filteredInformers.SvcNeg = newProviderConfigFilteredInformer(i.SvcNeg, providerConfigName)
+		filteredInformers.SvcNeg = newProviderConfigFilteredInformer(i.SvcNeg, providerConfigName, false)
 	}
 	if i.Network != nil {
-		filteredInformers.Network = newProviderConfigFilteredInformer(i.Network, providerConfigName)
+		filteredInformers.Network = newProviderConfigFilteredInformer(i.Network, providerConfigName, false)
 	}
 	if i.GkeNetworkParams != nil {
-		filteredInformers.GkeNetworkParams = newProviderConfigFilteredInformer(i.GkeNetworkParams, providerConfigName)
+		filteredInformers.GkeNetworkParams = newProviderConfigFilteredInformer(i.GkeNetworkParams, providerConfigName, false)
 	}
 	if i.NodeTopology != nil {
-		filteredInformers.NodeTopology = newProviderConfigFilteredInformer(i.NodeTopology, providerConfigName)
+		filteredInformers.NodeTopology = newProviderConfigFilteredInformer(i.NodeTopology, providerConfigName, false)
 	}
 	if i.NEGBinding != nil {
-		filteredInformers.NEGBinding = newProviderConfigFilteredInformer(i.NEGBinding, providerConfigName)
+		filteredInformers.NEGBinding = newProviderConfigFilteredInformer(i.NEGBinding, providerConfigName, false)
 	}
 
 	return filteredInformers
@@ -213,8 +213,8 @@ func (i *InformerSet) FilterByProviderConfig(providerConfigName string) *Informe
 
 // newProviderConfigFilteredInformer wraps an informer with a provider config filter.
 // The filtered informer shares the same underlying cache and indexers.
-func newProviderConfigFilteredInformer(informer cache.SharedIndexInformer, providerConfigName string) cache.SharedIndexInformer {
-	return filteredinformer.NewProviderConfigFilteredInformer(informer, providerConfigName)
+func newProviderConfigFilteredInformer(informer cache.SharedIndexInformer, providerConfigName string, allowMissing bool) cache.SharedIndexInformer {
+	return filteredinformer.NewProviderConfigFilteredInformer(informer, providerConfigName, allowMissing)
 }
 
 // CombinedHasSynced returns a function that checks if all informers have synced.

--- a/pkg/multiproject/neg/informerset/informerset_test.go
+++ b/pkg/multiproject/neg/informerset/informerset_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-gce/pkg/flags"
 	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
 	negbindingfake "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned/fake"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
@@ -353,5 +354,92 @@ func TestFilterByProviderConfig_PreservesIndexers(t *testing.T) {
 
 	if len(filtered) != len(original) {
 		t.Errorf("filtered indexers count mismatch: got=%d want=%d", len(filtered), len(original))
+	}
+}
+
+func TestFilterByProviderConfig_AllowMissingOnNodes(t *testing.T) {
+	t.Parallel()
+	flags.F.ProviderConfigNameLabelKey = "provider-config-name-label"
+
+	kubeClient := k8sfake.NewSimpleClientset()
+	inf := NewInformerSet(kubeClient, nil, nil, nil, nil, metav1.Duration{Duration: 0})
+
+	// Add nodes to the underlying indexer.
+	nodeIndexer := inf.Node.GetIndexer()
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-with-matching-pc",
+			Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "pc-1"},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-without-pc",
+		},
+	}
+	node3 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-with-different-pc",
+			Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "pc-2"},
+		},
+	}
+	nodeIndexer.Add(node1)
+	nodeIndexer.Add(node2)
+	nodeIndexer.Add(node3)
+
+	// Add pods to the underlying indexer.
+	podIndexer := inf.Pod.GetIndexer()
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pod-with-matching-pc",
+			Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "pc-1"},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-without-pc",
+		},
+	}
+	pod3 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pod-with-different-pc",
+			Labels: map[string]string{flags.F.ProviderConfigNameLabelKey: "pc-2"},
+		},
+	}
+	podIndexer.Add(pod1)
+	podIndexer.Add(pod2)
+	podIndexer.Add(pod3)
+
+	filtered := inf.FilterByProviderConfig("pc-1")
+
+	// Verify Node informer (allowMissing=true)
+	filteredNodes := filtered.Node.GetStore().List()
+	expectedNodeNames := map[string]bool{
+		"node-with-matching-pc": true,
+		"node-without-pc":       true,
+	}
+	if len(filteredNodes) != 2 {
+		t.Errorf("Expected 2 filtered nodes, got %d", len(filteredNodes))
+	}
+	for _, n := range filteredNodes {
+		node := n.(*corev1.Node)
+		if !expectedNodeNames[node.Name] {
+			t.Errorf("Unexpected node in filtered list: %s", node.Name)
+		}
+	}
+
+	// Verify Pod informer (allowMissing=false)
+	filteredPods := filtered.Pod.GetStore().List()
+	expectedPodNames := map[string]bool{
+		"pod-with-matching-pc": true,
+	}
+	if len(filteredPods) != 1 {
+		t.Errorf("Expected 1 filtered pod, got %d", len(filteredPods))
+	}
+	for _, p := range filteredPods {
+		pod := p.(*corev1.Pod)
+		if !expectedPodNames[pod.Name] {
+			t.Errorf("Unexpected pod in filtered list: %s", pod.Name)
+		}
 	}
 }


### PR DESCRIPTION
Fixing gap between gke-enterprise-mt implementation for filtered informers for Node for supervisor not having labels. 