### PR TITLE
Prevent RESOURCE_IN_USE reconciliation loop on ip-collection-v6 updates

### DIFF
--- a/pkg/l4/address/to_use.go
+++ b/pkg/l4/address/to_use.go
@@ -6,6 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
 	"k8s.io/klog/v2"
 
@@ -70,6 +71,10 @@ func IPv6ToUse(cloud *gce.Cloud, svc *v1.Service, ipv6FwdRule *composite.Forward
 	}
 	if requestedSubnet != ipv6FwdRule.Subnetwork {
 		logger.V(2).Info("ipv6AddressToUse: reset IPv6 Address due to changed subnet")
+		return "", "", nil
+	}
+	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != ipv6FwdRule.IpCollection {
+		logger.V(2).Info("ipv6AddressToUse: reset IPv6 Address due to changed IP collection")
 		return "", "", nil
 	}
 

--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -208,11 +208,6 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 		return nil, l4utils.ResourceResync, err
 	}
 
-	// If the IP collection changed, we cannot reuse the old forwarding rule's IP.
-	if fwdRuleToDetermineIP != nil && fwdRuleToDetermineIP.IpCollection != ipCollection {
-		ipv6AddrToUse = ""
-	}
-
 	frLogger.V(2).Info("ipv6AddressToUse for service", "ipv6AddressToUse", ipv6AddrToUse)
 
 	netTier, isFromAnnotation := annotations.NetworkTier(l4netlb.Service)
@@ -237,6 +232,16 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 			if err := l4netlb.tearDownResourcesWithWrongNetworkTier(fwdRuleToDetermineIP, netTier, addrMgr, frLogger); err != nil {
 				return nil, l4utils.ResourceResync, err
 			}
+		}
+
+		if flags.F.EnableBYOIPv6 && existingIPv6FwdRule != nil && existingIPv6FwdRule.IpCollection != ipCollection {
+			frLogger.V(2).Info("deleting forwarding rule for service due to ip collection mismatch", "existingIpCollection", existingIPv6FwdRule.IpCollection, "expectedIpCollection", ipCollection)
+			if err := l4netlb.forwardingRules.Delete(existingIPv6FwdRule.Name); err != nil {
+				frLogger.Error(err, "l4netlb.forwardingRules.Delete returned error, want nil")
+				return nil, l4utils.ResourceResync, err
+			}
+			l4netlb.recorder.Eventf(l4netlb.Service, corev1.EventTypeNormal, events.SyncIngress, "External ForwardingRule %q deleted due to ip-collection-v6 change", existingIPv6FwdRule.Name)
+			existingIPv6FwdRule = nil
 		}
 
 		ipv6AddrToUse, _, err = addrMgr.HoldAddress()

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -18,6 +18,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
@@ -37,6 +38,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/compute/v1"
 	ga "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -2478,5 +2480,176 @@ func TestEnsureFrontendDualStackIPCollectionError(t *testing.T) {
 		t.Errorf("Expected error for ip-collection on dualstack service, but got nil")
 	} else if !IsUserError(result.Error) {
 		t.Errorf("Expected UserError for ip-collection on dualstack service, but got %v", result.Error)
+	}
+}
+
+func TestIPv6NetLBIPCollectionAnnotationUpdate(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection-a"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	frName := l4NetLB.ipv6FRName()
+	fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection-a" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection-a", fwdRule.IpCollection)
+	}
+
+	// Update the annotation to a new collection
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection-b"
+	result = l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer after annotation update, err %v", result.Error)
+	}
+
+	fwdRule, err = composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s after update - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection-b" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection-b", fwdRule.IpCollection)
+	}
+}
+
+func TestIPv6NetLBIPCollectionUpdateResourceInUseLoop(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection-a"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	// Hook MockAddresses.DeleteHook to reproduce the RESOURCE_IN_USE error when trying to delete an address still in use by a forwarding rule.
+	l4NetLB.cloud.Compute().(*cloud.MockGCE).MockAddresses.DeleteHook = func(ctx context.Context, key *meta.Key, m *cloud.MockAddresses, options ...cloud.Option) (bool, error) {
+		if key.Name != l4NetLB.ipv6FRName() {
+			return false, nil
+		}
+		// In GCE, an address cannot be deleted if a forwarding rule is currently referencing it.
+		// If the forwarding rule has already been deleted, GCE allows deleting the address.
+		frKey := meta.RegionalKey(l4NetLB.ipv6FRName(), l4NetLB.cloud.Region())
+		if _, err := composite.GetForwardingRule(l4NetLB.cloud, frKey, meta.VersionGA, klog.TODO()); err == nil {
+			return true, &googleapi.Error{Code: http.StatusBadRequest, Message: "The resource is already being used by another resource"}
+		}
+		return false, nil
+	}
+	defer func() {
+		l4NetLB.cloud.Compute().(*cloud.MockGCE).MockAddresses.DeleteHook = nil
+	}()
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection-b"
+	result = l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	// In the empirical baseline before modifying production code, we assert that the update succeeds without falling into a RESOURCE_IN_USE error loop.
+	if result.Error != nil {
+		t.Fatalf("Expected successful update without RESOURCE_IN_USE error loop, got err %v", result.Error)
+	}
+}
+
+func TestIPv6NetLBIPCollectionAnnotationRemoval(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	frName := l4NetLB.ipv6FRName()
+	fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection", fwdRule.IpCollection)
+	}
+	if fwdRule.Subnetwork != "" {
+		t.Errorf("fwdRule.Subnetwork = %v, want empty string", fwdRule.Subnetwork)
+	}
+
+	// Remove the IP collection annotation
+	delete(svc.Annotations, annotations.IPCollectionV6AnnotationKey)
+	result = l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer after annotation removal, err %v", result.Error)
+	}
+
+	fwdRule, err = composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s after removal - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "" {
+		t.Errorf("fwdRule.IpCollection = %v, want empty string after removal", fwdRule.IpCollection)
+	}
+	if fwdRule.Subnetwork == "" {
+		t.Errorf("fwdRule.Subnetwork should not be empty after removing IP collection annotation")
+	}
+}
+
+func TestIPv6NetLBIPCollectionSubnetworkIndependence(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+
+	frName := l4NetLB.ipv6FRName()
+	fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection", fwdRule.IpCollection)
+	}
+	if fwdRule.Subnetwork != "" {
+		t.Errorf("fwdRule.Subnetwork = %v, want empty string when IP collection is specified", fwdRule.Subnetwork)
+	}
+
+	// Verify idempotency and subnetwork independence on resync
+	result = l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer on resync, err %v", result.Error)
+	}
+	fwdRule, err = composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s on resync - err %v", frName, err)
+	}
+	if fwdRule.Subnetwork != "" {
+		t.Errorf("fwdRule.Subnetwork = %v, want empty string on resync", fwdRule.Subnetwork)
 	}
 }


### PR DESCRIPTION
When updating networking.gke.io/ip-collection-v6 on an existing Service, GCE rejects deleting the Address if an existing ForwardingRule still references it, causing an infinite RESOURCE_IN_USE loop. This change:
- Deletes the existing IPv6 ForwardingRule before calling HoldAddress() when ip-collection-v6 changes.
- Resets the address in IPv6ToUse when the IP collection changes on an ephemeral BYOIPv6 Service.
- Adds positive and negative unit tests verifying collection updates, removals, subnetwork independence, and loop prevention.