### PR TITLE
Remove flakiness in provider config tests

### DIFF
--- a/pkg/multiproject/common/filteredinformer/filteredcache_test.go
+++ b/pkg/multiproject/common/filteredinformer/filteredcache_test.go
@@ -1,6 +1,7 @@
 package filteredinformer
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -82,15 +83,17 @@ func TestProviderConfigFilteredCache_ByIndex(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
-			if len(items) != len(tc.expectedItemNames) {
-				t.Errorf("Expected %d items, got %d", len(tc.expectedItemNames), len(items))
+			expectedCounts := make(map[string]int)
+			for _, name := range tc.expectedItemNames {
+				expectedCounts[name]++
 			}
-
-			for i, item := range items {
+			actualCounts := make(map[string]int)
+			for _, item := range items {
 				metaObj, _ := meta.Accessor(item)
-				if metaObj.GetName() != tc.expectedItemNames[i] {
-					t.Errorf("Expected item name %s, got %s", tc.expectedItemNames[i], metaObj.GetName())
-				}
+				actualCounts[metaObj.GetName()]++
+			}
+			if !reflect.DeepEqual(expectedCounts, actualCounts) {
+				t.Errorf("Expected item counts %v, got %v", expectedCounts, actualCounts)
 			}
 		})
 	}
@@ -153,15 +156,17 @@ func TestProviderConfigFilteredCache_List(t *testing.T) {
 			}
 
 			items := nsCache.List()
-			if len(items) != len(tc.expectedItemNames) {
-				t.Errorf("Expected %d items, got %d", len(tc.expectedItemNames), len(items))
+			expectedCounts := make(map[string]int)
+			for _, name := range tc.expectedItemNames {
+				expectedCounts[name]++
 			}
-
-			for i, item := range items {
+			actualCounts := make(map[string]int)
+			for _, item := range items {
 				metaObj, _ := meta.Accessor(item)
-				if metaObj.GetName() != tc.expectedItemNames[i] {
-					t.Errorf("Expected item name %s, got %s", tc.expectedItemNames[i], metaObj.GetName())
-				}
+				actualCounts[metaObj.GetName()]++
+			}
+			if !reflect.DeepEqual(expectedCounts, actualCounts) {
+				t.Errorf("Expected item counts %v, got %v", expectedCounts, actualCounts)
 			}
 		})
 	}


### PR DESCRIPTION
During testing of the https://github.com/kubernetes/ingress-gce/pull/3185 discovered flakiness in `TestProviderConfigFilteredCache_ByIndex` and `TestProviderConfigFilteredCache_List` tests: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/ingress-gce/3185/pull-ingress-gce-test/2084572763120472064.

The reason - comparison of lists item-by-item, while indexes do not enforce any ordering. Fixing by using map (multi-set) comparison instead.