### PR TITLE
NEGBinding - Readiness Gate

### DIFF
--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -272,6 +272,7 @@ func NewController(
 		includeDrainNodesL4Local,
 	)
 
+	negLookup := readiness.NewCompositeNegLookup(manager)
 	var reflector readiness.Reflector
 	if enableReadinessReflector {
 		reflector = readiness.NewReadinessReflector(
@@ -279,7 +280,7 @@ func NewController(
 			eventRecorderClient,
 			podInformer.GetIndexer(),
 			cloud,
-			manager,
+			negLookup,
 			zoneGetter,
 			enableDualStackNEG,
 			flags.F.EnableMultiSubnetCluster && !flags.F.EnableMultiSubnetClusterPhase1,
@@ -322,6 +323,7 @@ func NewController(
 			kubeSystemUID,
 			logger,
 		)
+		negLookup.AddLookup(negBindingMgr)
 	}
 
 	negController := &Controller{

--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -37,7 +38,7 @@ import (
 	"k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/readiness"
 	negsyncer "k8s.io/ingress-gce/pkg/neg/syncers"
-	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
+	podlabels "k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	"k8s.io/ingress-gce/pkg/neg/syncers/negstatushandler"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	negbindingclient "k8s.io/ingress-gce/pkg/negbinding/client/clientset/versioned"
@@ -592,7 +593,7 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 		false,
 		false,
 		m.logger,
-		labels.PodLabelPropagationConfig{},
+		podlabels.PodLabelPropagationConfig{},
 		false,
 		*networkInfo,
 		nbNamer,
@@ -1021,4 +1022,69 @@ func (m *negBindingManager) acquireNEGsForBinding(binding *negbindingv1beta1.Net
 	m.ownershipRegistry.ReleaseAllOwnedExcept(bindingKey, acquiredNEGs)
 	svcKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Spec.BackendRef.Name)
 	m.updateSyncerMetricsForService(svcKey)
+}
+
+// ReadinessGateEnabledNegs returns a list of NEGs which have readiness gate enabled for the input pod's namespace and labels.
+func (m *negBindingManager) ReadinessGateEnabledNegs(namespace string, podLabels map[string]string) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ret := sets.New[string]()
+	objs, err := m.negBindingLister.ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		m.logger.Error(err, "Failed to list NEGBindings from indexer by namespace", "namespace", namespace)
+		m.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
+		return sets.List(ret)
+	}
+
+	for _, obj := range objs {
+		binding, ok := obj.(*negbindingv1beta1.NetworkEndpointGroupBinding)
+		if !ok {
+			continue
+		}
+
+		svcKey := fmt.Sprintf("%s/%s", namespace, binding.Spec.BackendRef.Name)
+		svcObj, exists, err := m.serviceLister.GetByKey(svcKey)
+		if err != nil {
+			m.logger.Error(err, "Failed to retrieve service from store", "service", svcKey)
+			m.negMetrics.PublishNegControllerErrorCountMetrics(err, true)
+			continue
+		}
+		if !exists {
+			continue
+		}
+
+		service, ok := svcObj.(*apiv1.Service)
+		if !ok || service.Spec.Selector == nil {
+			continue
+		}
+
+		selector := labels.Set(service.Spec.Selector).AsSelectorPreValidated()
+		if !selector.Matches(labels.Set(podLabels)) {
+			continue
+		}
+
+		bindingKey := fmt.Sprintf("%s/%s", namespace, binding.Name)
+		for _, negRef := range binding.Spec.NetworkEndpointGroups {
+			owner := m.ownershipRegistry.GetOwner(negRef.Name)
+			if owner == bindingKey || owner == "" {
+				ret.Insert(negRef.Name)
+			}
+		}
+	}
+	return sets.List(ret)
+}
+
+// ReadinessGateEnabled returns true if the NEG requires readiness feedback.
+func (m *negBindingManager) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool {
+	if syncerKey.NEGBindingName == "" {
+		return false
+	}
+	bindingKey := fmt.Sprintf("%s/%s", syncerKey.Namespace, syncerKey.NEGBindingName)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	syncer, ok := m.syncerMap[bindingKey]
+	return ok && syncer != nil && !syncer.IsStopped()
 }

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1475,5 +1476,140 @@ func TestNEGBindingManagerMetricsConflict(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Expected NegBindingNeg=1 for 10 bindings referencing same NEG name, got ok=%v state=%+v", ok, state)
+	}
+}
+
+func TestNEGBindingManagerReadinessGate(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	namespace := "test-ns"
+	svcName := "test-svc"
+	svcPort := int32(80)
+	targetPort := "8080"
+	testSvc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      svcName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{"app": "test-app"},
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       svcPort,
+					TargetPort: intstr.FromString(targetPort),
+				},
+			},
+		},
+	}
+	_, err := kubeClient.CoreV1().Services(namespace).Create(context.TODO(), testSvc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	bindingName := "test-binding"
+	testBinding := &negbindingv1beta1.NetworkEndpointGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      bindingName,
+		},
+		Spec: negbindingv1beta1.NetworkEndpointGroupBindingSpec{
+			BackendRef: &negbindingv1beta1.BackendRefConfig{
+				Kind: negbindingv1beta1.ServiceKind,
+				Name: svcName,
+				Port: svcPort,
+			},
+			NetworkEndpointGroups: []negbindingv1beta1.SpecNegRef{
+				{
+					Name:   "neg-1",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+				{
+					Name:   "neg-2",
+					Subnet: "default",
+					Zones:  []string{"us-central1-a"},
+				},
+			},
+		},
+	}
+	fakeNBClient := fakenegbinding.NewSimpleClientset()
+	_, err = fakeNBClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Create(context.TODO(), testBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create binding: %v", err)
+	}
+
+	indexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		ServiceKeyIndex:      ServiceKeyIndexFunc,
+	}
+	negBindingLister := informernegbinding.NewNetworkEndpointGroupBindingInformer(fakeNBClient, "", 0, indexers).GetIndexer()
+	err = negBindingLister.Add(testBinding)
+	if err != nil {
+		t.Fatalf("failed to add binding to lister: %v", err)
+	}
+
+	podLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	serviceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	err = serviceLister.Add(testSvc)
+	if err != nil {
+		t.Fatalf("failed to add service to lister: %v", err)
+	}
+	endpointSliceLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	nodeLister := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	nodeInformer := zonegetter.FakeNodeInformer()
+	zonegetter.PopulateFakeNodeInformer(nodeInformer, false)
+	zoneGetter, err := zonegetter.NewFakeZoneGetter(nodeInformer, zonegetter.FakeNodeTopologyInformer(), "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default", false)
+	if err != nil {
+		t.Fatalf("failed to create zone getter: %v", err)
+	}
+
+	clusterNamer := namer.NewNamer("cluster-id", "", klog.TODO())
+	negMetrics := metrics.NewNegMetrics()
+	syncerMetrics := metricscollector.FakeSyncerMetrics()
+	defaultTestSubnetURL := "https://www.googleapis.com/compute/v1/projects/mock-project/regions/test-region/subnetworks/default"
+	cloudAdapter := negtypes.NewAdapterWithNetwork(fakeGCE, "default-network", defaultTestSubnetURL, negMetrics)
+	fakeNetworkResolver := network.NewFakeResolver(&network.NetworkInfo{IsDefault: true, NetworkURL: "default-network", SubnetworkURL: defaultTestSubnetURL})
+
+	m := newNEGBindingManager(
+		fakeNBClient,
+		negBindingLister,
+		podLister,
+		serviceLister,
+		endpointSliceLister,
+		nodeLister,
+		zoneGetter,
+		fakeNetworkResolver,
+		cloudAdapter,
+		record.NewFakeRecorder(100),
+		clusterNamer,
+		negMetrics,
+		syncerMetrics,
+		&readiness.NoopReflector{},
+		"kube-system-uid",
+		klog.TODO(),
+	)
+
+	if err := m.EnsureSyncerForNEGBinding(testBinding); err != nil {
+		t.Fatalf("EnsureSyncerForNEGBinding failed: %v", err)
+	}
+
+	enabledNegs := m.ReadinessGateEnabledNegs(namespace, map[string]string{"app": "test-app"})
+	expectedNegs := []string{"neg-1", "neg-2"}
+	if !cmp.Equal(enabledNegs, expectedNegs) {
+		t.Errorf("Expected ReadinessGateEnabledNegs=%v, got %v", expectedNegs, enabledNegs)
+	}
+
+	enabledNegsOther := m.ReadinessGateEnabledNegs(namespace, map[string]string{"app": "other"})
+	if len(enabledNegsOther) != 0 {
+		t.Errorf("Expected 0 ReadinessGateEnabledNegs for non-matching selector, got %v", enabledNegsOther)
+	}
+
+	if !m.ReadinessGateEnabled(negtypes.NegSyncerKey{Namespace: namespace, Name: svcName, NEGBindingName: bindingName}) {
+		t.Errorf("Expected ReadinessGateEnabled=true for bound syncer key")
+	}
+
+	if m.ReadinessGateEnabled(negtypes.NegSyncerKey{Namespace: namespace, Name: svcName, NEGBindingName: "non-existing"}) {
+		t.Errorf("Expected ReadinessGateEnabled=false for non-existing binding name")
 	}
 }

--- a/pkg/neg/readiness/lookup.go
+++ b/pkg/neg/readiness/lookup.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	negtypes "k8s.io/ingress-gce/pkg/neg/types"
+)
+
+// CompositeNegLookup aggregates multiple NegLookup implementations to evaluate NEG pod membership and readiness gate enablement across all registered NEG lookup sources.
+type CompositeNegLookup struct {
+	lookups []NegLookup
+}
+
+// NewCompositeNegLookup returns a new CompositeNegLookup initialized with the provided lookups.
+func NewCompositeNegLookup(lookups ...NegLookup) *CompositeNegLookup {
+	return &CompositeNegLookup{
+		lookups: lookups,
+	}
+}
+
+// AddLookup appends a NegLookup delegate to the composite lookup.
+func (h *CompositeNegLookup) AddLookup(lookup NegLookup) {
+	h.lookups = append(h.lookups, lookup)
+}
+
+// ReadinessGateEnabledNegs returns the union of NEGs from all underlying lookups.
+func (h *CompositeNegLookup) ReadinessGateEnabledNegs(namespace string, labels map[string]string) []string {
+	ret := sets.New[string]()
+	for _, lookup := range h.lookups {
+		ret.Insert(lookup.ReadinessGateEnabledNegs(namespace, labels)...)
+	}
+	return sets.List(ret)
+}
+
+// ReadinessGateEnabled returns true if any underlying lookup enables readiness gate.
+func (h *CompositeNegLookup) ReadinessGateEnabled(syncerKey negtypes.NegSyncerKey) bool {
+	for _, lookup := range h.lookups {
+		if lookup.ReadinessGateEnabled(syncerKey) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/neg/readiness/reflector_test.go
+++ b/pkg/neg/readiness/reflector_test.go
@@ -648,3 +648,31 @@ func TestSyncPodMultipleSubnets(t *testing.T) {
 		})
 	}
 }
+
+func TestCompositeNegLookup(t *testing.T) {
+	lookup1 := &fakeLookUp{
+		readinessGateEnabled:     true,
+		readinessGateEnabledNegs: []string{"neg1", "neg2"},
+	}
+	lookup2 := &fakeLookUp{
+		readinessGateEnabled:     false,
+		readinessGateEnabledNegs: []string{"neg2", "neg3"},
+	}
+	holder := NewCompositeNegLookup(lookup1)
+	holder.AddLookup(lookup2)
+
+	negs := holder.ReadinessGateEnabledNegs("ns", map[string]string{"k": "v"})
+	expectedNegs := []string{"neg1", "neg2", "neg3"}
+	if !cmp.Equal(negs, expectedNegs) {
+		t.Errorf("Expected ReadinessGateEnabledNegs=%v, got %v", expectedNegs, negs)
+	}
+
+	if !holder.ReadinessGateEnabled(negtypes.NegSyncerKey{}) {
+		t.Errorf("Expected ReadinessGateEnabled=true when any lookup returns true")
+	}
+
+	holderNone := NewCompositeNegLookup(&fakeLookUp{readinessGateEnabled: false})
+	if holderNone.ReadinessGateEnabled(negtypes.NegSyncerKey{}) {
+		t.Errorf("Expected ReadinessGateEnabled=false when all lookups return false")
+	}
+}


### PR DESCRIPTION
Manage Pods' `cloud.google.com/load-balancer-neg-ready` readiness gate in NEGBinding syncers in a same way it's done for other NEG controller's features.