### PR TITLE
Allow static BYOIPv6 addresses without ip-collection-v6 annotation

### DIFF
--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -399,8 +399,16 @@ func (m *Manager) validateAddress(addr *compute.Address) error {
 	if addr.NetworkTier != m.networkTier.ToGCEValue() {
 		return l4utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
 	}
-	if flags.F.EnableBYOIPv6 && m.ipCollection != addr.IpCollection {
-		return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
+	if flags.F.EnableBYOIPv6 {
+		// 1. If the Service specifies an explicit IP collection, any address MUST match it.
+		if m.ipCollection != "" && m.ipCollection != addr.IpCollection {
+			return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
+		}
+		// 2. If the Service omits IP collection AND omits static address (ephemeral),
+		// do not reuse a leftover PDP ephemeral address so we revert to a Google IP.
+		if m.ipCollection == "" && m.targetIP == "" && addr.IpCollection != "" {
+			return fmt.Errorf("ipCollection mismatch for ephemeral address, expected empty collection (Google IP), actual: %q", addr.IpCollection)
+		}
 	}
 	return nil
 }

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -550,6 +551,71 @@ func testReleaseAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddress
 	require.NoError(t, err)
 	_, err = svc.GetRegionAddress(name, region)
 	assert.True(t, utils.IsNotFoundError(err))
+}
+
+func TestBYOIPv6AddressValidation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	existingAddr := &compute.Address{
+		Name:             "existing-ipv6-addr",
+		Address:          "2001:db8::1",
+		IpVersion:        string(address.IPv6Version),
+		PrefixLength:     96,
+		AddressType:      string(cloud.SchemeExternal),
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "my-pdp",
+	}
+	require.NoError(t, svc.ReserveRegionAddress(existingAddr, vals.Region))
+
+	testCases := []struct {
+		desc         string
+		ipCollection string
+		targetIP     string
+		expectErr    bool
+	}{
+		{
+			desc:         "Case 1: Reserved PDP static address without ip-collection-v6 annotation is accepted",
+			ipCollection: "",
+			targetIP:     "2001:db8::1",
+			expectErr:    false,
+		},
+		{
+			desc:         "Case 2: Static address matching ip-collection-v6 is accepted",
+			ipCollection: "my-pdp",
+			targetIP:     "2001:db8::1",
+			expectErr:    false,
+		},
+		{
+			desc:         "Case 3: Static address mismatching ip-collection-v6 is rejected",
+			ipCollection: "other-pdp",
+			targetIP:     "2001:db8::1",
+			expectErr:    true,
+		},
+		{
+			desc:         "Case 4: Removing ip-collection-v6 from ephemeral service rejects leftover PDP address",
+			ipCollection: "",
+			targetIP:     "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, "test-lb-name", "existing-ipv6-addr", tc.targetIP, cloud.SchemeExternal, cloud.NetworkTierDefault, address.IPv6Version, klog.TODO())
+			mgr.SetIPCollection(tc.ipCollection)
+
+			_, _, err := mgr.HoldAddress()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func fakeGCECloud(vals gce.TestClusterValues) (*gce.Cloud, error) {

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -284,25 +284,6 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service, 
 		return result
 	}
 
-	// Check conflicts between spec.loadBalancerIP and ip-collection
-	if ipCollectionV6 != "" && svc.Spec.LoadBalancerIP != "" {
-		err := fmt.Errorf("cannot specify both spec.LoadBalancerIP (%q) and %s (%q) for LoadBalancer", svc.Spec.LoadBalancerIP, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
-		result.Error = l4utils.NewUserError(err)
-		result.MetricsState.Status = metrics.StatusUserError
-		result.MetricsLegacyState.IsUserError = true
-		return result
-	}
-
-	// Check conflicts between load-balancer-ip-addresses and ip-collection
-	staticL4Addresses := svc.Annotations[annotations.StaticL4AddressesAnnotationKey]
-	if ipCollectionV6 != "" && staticL4Addresses != "" {
-		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.StaticL4AddressesAnnotationKey, staticL4Addresses, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
-		result.Error = l4utils.NewUserError(err)
-		result.MetricsState.Status = metrics.StatusUserError
-		result.MetricsLegacyState.IsUserError = true
-		return result
-	}
-
 	// Check if ip-collection-v6 is specified for an IPv4 service
 	if ipCollectionV6 != "" && l4utils.NeedsIPv4(svc) {
 		err := fmt.Errorf("%s is currently only supported for IPv6-only Services", annotations.IPCollectionV6AnnotationKey)

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -2480,3 +2480,98 @@ func TestEnsureFrontendDualStackIPCollectionError(t *testing.T) {
 		t.Errorf("Expected UserError for ip-collection on dualstack service, but got %v", result.Error)
 	}
 }
+
+func TestIPv6NetLBIPCollectionWithStaticAddressValidation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	ipv6AddressMatching := &ga.Address{
+		Name:             "ipv6-address-matching",
+		Address:          "2::2",
+		IpVersion:        "IPV6",
+		PrefixLength:     96,
+		AddressType:      "EXTERNAL",
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "my-collection",
+	}
+	ipv6AddressMismatching := &ga.Address{
+		Name:             "ipv6-address-mismatching",
+		Address:          "2::3",
+		IpVersion:        "IPV6",
+		PrefixLength:     96,
+		AddressType:      "EXTERNAL",
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "other-collection",
+	}
+
+	testCases := []struct {
+		desc                string
+		ipCollectionVal     string
+		staticAnnotationVal string
+		addressToReserve    *ga.Address
+		expectError         bool
+	}{
+		{
+			desc:                "Case 1: Reserved PDP static address without ip-collection-v6 annotation is accepted",
+			ipCollectionVal:     "",
+			staticAnnotationVal: "ipv6-address-matching",
+			addressToReserve:    ipv6AddressMatching,
+			expectError:         false,
+		},
+		{
+			desc:                "Case 2: Static address matching ip-collection-v6 is accepted",
+			ipCollectionVal:     "my-collection",
+			staticAnnotationVal: "ipv6-address-matching",
+			addressToReserve:    ipv6AddressMatching,
+			expectError:         false,
+		},
+		{
+			desc:                "Case 3: Static address mismatching ip-collection-v6 is rejected",
+			ipCollectionVal:     "my-collection",
+			staticAnnotationVal: "ipv6-address-mismatching",
+			addressToReserve:    ipv6AddressMismatching,
+			expectError:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := test.NewL4NetLBRBSService(8080)
+			l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+			if err := l4NetLB.cloud.ReserveRegionAddress(tc.addressToReserve, l4NetLB.cloud.Region()); err != nil {
+				t.Fatalf("Failed to reserve region address: %v", err)
+			}
+
+			if tc.ipCollectionVal != "" {
+				svc.Annotations[annotations.IPCollectionV6AnnotationKey] = tc.ipCollectionVal
+			}
+			svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = tc.staticAnnotationVal
+			svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+			result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+			if tc.expectError {
+				if result.Error == nil {
+					t.Errorf("Expected error for static address with mismatching IpCollection, but got nil")
+				}
+			} else {
+				if result.Error != nil {
+					t.Errorf("Expected success, but got err %v", result.Error)
+				}
+				frName := l4NetLB.ipv6FRName()
+				fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+				if err != nil {
+					t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+				}
+				if tc.ipCollectionVal != "" && fwdRule.IpCollection != tc.ipCollectionVal {
+					t.Errorf("fwdRule.IpCollection = %v, want %v", fwdRule.IpCollection, tc.ipCollectionVal)
+				}
+				if strings.Split(fwdRule.IPAddress, "/")[0] != tc.addressToReserve.Address {
+					t.Errorf("fwdRule.IPAddress = %v, want %v", fwdRule.IPAddress, tc.addressToReserve.Address)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Allow static PDP addresses in validateAddress without requiring the ip-collection-v6 annotation.
- Allow specifying both ip-collection-v6 and load-balancer-ip-addresses annotations in EnsureFrontend.
- Ensure removing ip-collection-v6 from an ephemeral BYOIPv6 Service releases the PDP address and reverts to a standard Google IP.