### PR TITLE
NEGBinding - Fix validation of backend-ref in NEGs description

### DIFF
--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -643,7 +643,7 @@ func (s *transactionSyncer) ensureNetworkEndpointGroups() (shared.ZonesPerSubnet
 		expectedNEGDesc = utils.BoundNEGDescription{
 			ClusterName: flags.F.GKEClusterName,
 			Namespace:   s.Namespace,
-			BackendRef:  s.NegSyncerKey.NEGBindingName,
+			BackendRef:  s.NegSyncerKey.Name,
 		}
 	} else {
 		expectedNEGDesc = utils.StandardNEGDescription{

--- a/pkg/neg/syncers/transaction_test.go
+++ b/pkg/neg/syncers/transaction_test.go
@@ -5525,7 +5525,7 @@ func TestEnsureNetworkEndpointGroupsForNEGBinding(t *testing.T) {
 			boundDesc := utils.BoundNEGDescription{
 				ClusterName: flags.F.GKEClusterName,
 				Namespace:   namespace,
-				BackendRef:  bindingName,
+				BackendRef:  "svc-name",
 			}.String()
 
 			err = fakeCloud.CreateNetworkEndpointGroup(&composite.NetworkEndpointGroup{


### PR DESCRIPTION
Fixing expected `BoundNEGDescription` - `BackendRef` field is expected to be name of service, which is attached to NEGBinding CR, not CR itself.