### PR TITLE
NEGBinding - Fix naming for NEGBinding CR's conditions

### DIFF
--- a/pkg/neg/negbinding_manager.go
+++ b/pkg/neg/negbinding_manager.go
@@ -56,6 +56,8 @@ const (
 
 	// NEGBindingFinalizer is the finalizer key used to block NEGBinding deletion until NEGs are drained.
 	NEGBindingFinalizer = "networking.gke.io/negbinding-cleanup"
+
+	BackendRefAttachedCondition = "BackendRefAttached"
 )
 
 var (
@@ -263,7 +265,7 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 	m.acquireNEGsForBinding(binding)
 	err := m.validateBackendRef(binding)
 	if err != nil {
-		_ = m.updateBackendRefCondition(binding, err)
+		_ = m.updateBackendRefAttachedCondition(binding, err)
 		return err
 	}
 
@@ -271,7 +273,7 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 	svcKey := fmt.Sprintf("%s/%s", binding.Namespace, svcName)
 	svc, err := m.getServiceFromCache(svcKey)
 	if err != nil {
-		_ = m.updateBackendRefCondition(binding, err)
+		_ = m.updateBackendRefAttachedCondition(binding, err)
 		if errors.Is(err, ErrServiceNotFound) {
 			bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
 			m.logger.Info("Service not found for NEGBinding, ensuring cleanup syncer", "binding", bindingKey, "serviceKey", svcKey)
@@ -289,7 +291,7 @@ func (m *negBindingManager) EnsureSyncerForNEGBinding(binding *negbindingv1beta1
 
 	networkInfo, err := m.getAndVerifyNetworkInfo(svc)
 	if err != nil {
-		_ = m.updateBackendRefCondition(binding, err)
+		_ = m.updateBackendRefAttachedCondition(binding, err)
 		return err
 	}
 
@@ -452,13 +454,13 @@ func (m *negBindingManager) EnsureSyncersForService(svcNamespace, svcName string
 
 		err := m.validateBackendRef(binding)
 		if err != nil {
-			_ = m.updateBackendRefCondition(binding, err)
+			_ = m.updateBackendRefAttachedCondition(binding, err)
 			errs = append(errs, err)
 			continue
 		}
 
 		if networkInfoErr != nil {
-			_ = m.updateBackendRefCondition(binding, networkInfoErr)
+			_ = m.updateBackendRefAttachedCondition(binding, networkInfoErr)
 			continue
 		}
 
@@ -493,11 +495,11 @@ func (m *negBindingManager) ensureSyncerForNEGBinding(
 
 	portTuple, err := m.getPortTuple(svc, svcPort)
 	if err != nil {
-		_ = m.updateBackendRefCondition(binding, err)
+		_ = m.updateBackendRefAttachedCondition(binding, err)
 		return nil, err
 	}
 
-	if err := m.updateBackendRefCondition(binding, nil); err != nil {
+	if err := m.updateBackendRefAttachedCondition(binding, nil); err != nil {
 		return nil, err
 	}
 
@@ -625,7 +627,7 @@ func (m *negBindingManager) ProcessServiceDeletion(svcNamespace, svcName string)
 		}
 		bindingKey := fmt.Sprintf("%s/%s", binding.Namespace, binding.Name)
 		m.logger.Info("Service deleted, ensuring cleanup syncer for binding", "binding", bindingKey, "service", svcKey)
-		_ = m.updateBackendRefCondition(binding, fmt.Errorf("%w: %s/%s", ErrServiceNotFound, svcNamespace, svcName))
+		_ = m.updateBackendRefAttachedCondition(binding, fmt.Errorf("%w: %s/%s", ErrServiceNotFound, svcNamespace, svcName))
 
 		// Will ensure cleanup syncer, as there is no service, which needed for normal syncer
 		if err := m.EnsureSyncerForNEGBinding(binding); err != nil {
@@ -856,9 +858,9 @@ func (m *negBindingManager) validateBackendRef(binding *negbindingv1beta1.Networ
 	return nil
 }
 
-func (m *negBindingManager) updateBackendRefCondition(binding *negbindingv1beta1.NetworkEndpointGroupBinding, validationErr error) error {
+func (m *negBindingManager) updateBackendRefAttachedCondition(binding *negbindingv1beta1.NetworkEndpointGroupBinding, validationErr error) error {
 	cond := negbindingv1beta1.Condition{
-		Type:               "BackendRef",
+		Type:               BackendRefAttachedCondition,
 		LastTransitionTime: metav1.Now(),
 	}
 	if validationErr == nil {

--- a/pkg/neg/negbinding_manager_test.go
+++ b/pkg/neg/negbinding_manager_test.go
@@ -168,9 +168,9 @@ func TestNEGBindingManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get updated binding: %v", err)
 	}
-	cond, found := findCondition(updatedBinding.Status.Conditions, "BackendRef")
+	cond, found := findCondition(updatedBinding.Status.Conditions, BackendRefAttachedCondition)
 	if !found {
-		t.Fatalf("Condition BackendRef not found")
+		t.Fatalf("Condition %s not found", BackendRefAttachedCondition)
 	}
 	if cond.Status != metav1.ConditionTrue {
 		t.Errorf("Expected BackendRef condition status True, got %s", cond.Status)
@@ -475,16 +475,16 @@ func TestNEGBindingManagerErrorCases(t *testing.T) {
 				t.Fatalf("Failed to get updated binding: %v", err)
 			}
 
-			cond, found := findCondition(updatedBinding.Status.Conditions, "BackendRef")
+			cond, found := findCondition(updatedBinding.Status.Conditions, BackendRefAttachedCondition)
 			if !found {
-				t.Fatalf("Condition %s not found in updated status", "BackendRef")
+				t.Fatalf("Condition %s not found in updated status", BackendRefAttachedCondition)
 			}
 
 			if cond.Status != tc.expectedStatus {
-				t.Errorf("Condition %s status got %s, expected %s", "BackendRef", cond.Status, tc.expectedStatus)
+				t.Errorf("Condition %s status got %s, expected %s", BackendRefAttachedCondition, cond.Status, tc.expectedStatus)
 			}
 			if cond.Reason != tc.expectedReason {
-				t.Errorf("Condition %s reason got %s, expected %s", "BackendRef", cond.Reason, tc.expectedReason)
+				t.Errorf("Condition %s reason got %s, expected %s", BackendRefAttachedCondition, cond.Reason, tc.expectedReason)
 			}
 		})
 	}

--- a/pkg/neg/syncers/negstatushandler/negbinding.go
+++ b/pkg/neg/syncers/negstatushandler/negbinding.go
@@ -42,8 +42,8 @@ type negOwnershipRegistry interface {
 }
 
 const (
-	ManagedCondition = "Managed"
-	NEGsAttached     = "NEGsAttached"
+	ManagedCondition      = "Managed"
+	NegsAttachedCondition = "NegsAttached"
 
 	NEGOwnershipNoConflicts  = "NEGOwnershipNoConflicts"
 	NEGOwnershipConflict     = "NEGOwnershipConflict"
@@ -180,7 +180,7 @@ func (h *NEGBindingStatusHandler) ReportSyncStatus(syncErr error) (bool, error) 
 
 	ts := metav1.Now()
 	needInit := false
-	if _, _, exists := h.findCondition(binding.Status.Conditions, NEGsAttached); !exists {
+	if _, _, exists := h.findCondition(binding.Status.Conditions, NegsAttachedCondition); !exists {
 		needInit = true
 	}
 	h.negMetrics.PublishNegSyncerStalenessMetrics(ts.Sub(binding.Status.LastSyncTime.Time))
@@ -229,7 +229,7 @@ func (h *NEGBindingStatusHandler) ensureCondition(binding *negbindingv1beta1.Net
 func (h *NEGBindingStatusHandler) getAttachedCondition(err error) negbindingv1beta1.Condition {
 	if err != nil {
 		return negbindingv1beta1.Condition{
-			Type:               NEGsAttached,
+			Type:               NegsAttachedCondition,
 			Status:             metav1.ConditionFalse,
 			Reason:             NEGsAttachmentFailed,
 			LastTransitionTime: metav1.Now(),
@@ -238,7 +238,7 @@ func (h *NEGBindingStatusHandler) getAttachedCondition(err error) negbindingv1be
 	}
 
 	return negbindingv1beta1.Condition{
-		Type:               NEGsAttached,
+		Type:               NegsAttachedCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             NEGsAttachmentSuccessful,
 		LastTransitionTime: metav1.Now(),

--- a/pkg/neg/syncers/negstatushandler/negbinding_test.go
+++ b/pkg/neg/syncers/negstatushandler/negbinding_test.go
@@ -106,7 +106,7 @@ func TestReportStatus(t *testing.T) {
 			errList: nil,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  "NEGsAttachmentSuccessful",
 					Message: "NEGs have been successfully attached and synced",
@@ -138,7 +138,7 @@ func TestReportStatus(t *testing.T) {
 			errList: nil,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  "NEGsAttachmentSuccessful",
 					Message: "NEGs have been successfully attached and synced",
@@ -161,7 +161,7 @@ func TestReportStatus(t *testing.T) {
 			errList: []error{fmt.Errorf("GCE API timeout error"), fmt.Errorf("Quota exceeded")},
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionFalse,
 					Reason:  "NEGsAttachmentFailed",
 					Message: utilerrors.NewAggregate([]error{fmt.Errorf("GCE API timeout error"), fmt.Errorf("Quota exceeded")}).Error(),
@@ -182,7 +182,7 @@ func TestReportStatus(t *testing.T) {
 			errList: []error{fmt.Errorf("Quota exceeded for zone us-central1-b")},
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionFalse,
 					Reason:  "NEGsAttachmentFailed",
 					Message: utilerrors.NewAggregate([]error{fmt.Errorf("Quota exceeded for zone us-central1-b")}).Error(),
@@ -286,7 +286,7 @@ func TestReportSyncStatus(t *testing.T) {
 			expectedNeedInit: true,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  NEGsAttachmentSuccessful,
 					Message: "NEGs have been successfully attached and synced",
@@ -307,7 +307,7 @@ func TestReportSyncStatus(t *testing.T) {
 			expectedNeedInit: true,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  NEGsAttachmentSuccessful,
 					Message: "NEGs have been successfully attached and synced",
@@ -319,7 +319,7 @@ func TestReportSyncStatus(t *testing.T) {
 			initialStatus: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
 				Conditions: []negbindingv1beta1.Condition{
 					{
-						Type:   NEGsAttached,
+						Type:   NegsAttachedCondition,
 						Status: metav1.ConditionTrue,
 						Reason: NEGsAttachmentSuccessful,
 					},
@@ -329,7 +329,7 @@ func TestReportSyncStatus(t *testing.T) {
 			expectedNeedInit: true,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  NEGsAttachmentSuccessful,
 					Message: "NEGs have been successfully attached and synced",
@@ -341,7 +341,7 @@ func TestReportSyncStatus(t *testing.T) {
 			initialStatus: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
 				Conditions: []negbindingv1beta1.Condition{
 					{
-						Type:   NEGsAttached,
+						Type:   NegsAttachedCondition,
 						Status: metav1.ConditionTrue,
 						Reason: NEGsAttachmentSuccessful,
 					},
@@ -357,7 +357,7 @@ func TestReportSyncStatus(t *testing.T) {
 			expectedNeedInit: false,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionTrue,
 					Reason:  NEGsAttachmentSuccessful,
 					Message: "NEGs have been successfully attached and synced",
@@ -369,7 +369,7 @@ func TestReportSyncStatus(t *testing.T) {
 			initialStatus: negbindingv1beta1.NetworkEndpointGroupBindingStatus{
 				Conditions: []negbindingv1beta1.Condition{
 					{
-						Type:   NEGsAttached,
+						Type:   NegsAttachedCondition,
 						Status: metav1.ConditionTrue,
 						Reason: NEGsAttachmentSuccessful,
 					},
@@ -385,7 +385,7 @@ func TestReportSyncStatus(t *testing.T) {
 			expectedNeedInit: false,
 			expectedConditions: []negbindingv1beta1.Condition{
 				{
-					Type:    NEGsAttached,
+					Type:    NegsAttachedCondition,
 					Status:  metav1.ConditionFalse,
 					Reason:  NEGsAttachmentFailed,
 					Message: "syncer failed to reconcile endpoints",
@@ -651,7 +651,7 @@ func TestPatchStatusNoChanges(t *testing.T) {
 	}
 
 	expectedCond := negbindingv1beta1.Condition{
-		Type:    NEGsAttached,
+		Type:    NegsAttachedCondition,
 		Status:  metav1.ConditionTrue,
 		Reason:  "NEGsAttachmentSuccessful",
 		Message: "NEGs have been successfully attached and synced",
@@ -730,7 +730,7 @@ func TestNEGBindingStatusHandlerOwnership(t *testing.T) {
 	}
 
 	updatedBinding, _ := fakeClient.NetworkingV1beta1().NetworkEndpointGroupBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	cond, _, found := h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	cond, _, found := h.findCondition(updatedBinding.Status.Conditions, NegsAttachedCondition)
 	if !found || cond.Status != metav1.ConditionTrue {
 		t.Errorf("Expected NEGsAttached=True, got: %+v", cond)
 	}
@@ -764,7 +764,7 @@ func TestNEGBindingStatusHandlerOwnership(t *testing.T) {
 	if cond.Message != expectedMessage {
 		t.Errorf("Expected Message %q, got %q", expectedMessage, cond.Message)
 	}
-	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NegsAttachedCondition)
 	if !found || cond.Status != metav1.ConditionTrue {
 		t.Errorf("Expected NEGsAttached=True on conflict (no sync error), got: %+v", cond)
 	}
@@ -779,7 +779,7 @@ func TestNEGBindingStatusHandlerOwnership(t *testing.T) {
 	if !found || cond.Status != metav1.ConditionFalse || cond.Reason != NEGOwnershipConflict {
 		t.Errorf("Expected Managed=False due to conflict in ReportSyncStatus, got: %+v", cond)
 	}
-	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NegsAttachedCondition)
 	if !found || cond.Status != metav1.ConditionTrue {
 		t.Errorf("Expected NEGsAttached=True due to conflict in ReportSyncStatus (no sync error), got: %+v", cond)
 	}
@@ -802,7 +802,7 @@ func TestNEGBindingStatusHandlerOwnership(t *testing.T) {
 	if cond.Reason != NEGOwnershipNoConflicts {
 		t.Errorf("Expected Reason=%s after conflict resolved, got %q", NEGOwnershipNoConflicts, cond.Reason)
 	}
-	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NEGsAttached)
+	cond, _, found = h.findCondition(updatedBinding.Status.Conditions, NegsAttachedCondition)
 	if !found || cond.Status != metav1.ConditionTrue {
 		t.Errorf("Expected NEGsAttached=True after conflict resolved, got: %+v", cond)
 	}


### PR DESCRIPTION
Conditions' types misaligned a bit with expected ones - fixing this.

* `BackendRef` -> `BackendRefAttached`
* `NEGsAttached` -> `NegsAttached`