### PR TITLE
Warn when ip-collection-v6 annotation is used on ILB

### DIFF
--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -424,9 +424,9 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 	l4.network = *svcNetwork
 
-	// Check if ip-collection is specified for IPv4 service
-	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" && l4utils.NeedsIPv4(svc) {
-		err := fmt.Errorf("%s is currently only supported for IPv6-only external LBs", annotations.IPCollectionV6AnnotationKey)
+	// Check if ip-collection-v6 is specified for internal load balancer
+	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" {
+		err := fmt.Errorf("%s is not supported for Internal LoadBalancers. To use BYOIPv6 with ILB, specify a BYOIP subnet using the \"%s\" annotation", annotations.IPCollectionV6AnnotationKey, annotations.CustomSubnetAnnotationKey)
 		l4.recorder.Event(l4.Service, corev1.EventTypeWarning, "IPCollectionV6Error", err.Error())
 	}
 

--- a/pkg/l4/resources/l4_test.go
+++ b/pkg/l4/resources/l4_test.go
@@ -3443,46 +3443,85 @@ func TestEnsureInternalLoadBalancer_L4LBConfigLogging(t *testing.T) {
 func TestEnsureInternalLoadBalancerIPCollectionError(t *testing.T) {
 	flags.F.EnableBYOIPv6 = true
 	defer func() { flags.F.EnableBYOIPv6 = false }()
-	nodeNames := []string{"test-node-1"}
-	vals := gce.DefaultTestClusterValues()
-	fakeGCE := getFakeGCECloud(vals)
 
-	svc := test.NewL4ILBService(false, 8080)
-	if svc.Annotations == nil {
-		svc.Annotations = make(map[string]string)
-	}
-	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
-
-	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
-
-	l4Params := &L4ILBParams{
-		Service:         svc,
-		Cloud:           fakeGCE,
-		Namer:           namer,
-		Recorder:        record.NewFakeRecorder(100),
-		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
-	}
-	l4 := NewL4Handler(l4Params, klog.TODO())
-
-	if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
-		t.Errorf("Unexpected error when adding nodes %v", err)
+	testCases := []struct {
+		desc       string
+		ipFamilies []v1.IPFamily
+	}{
+		{
+			desc:       "IPv4 ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol},
+		},
+		{
+			desc:       "IPv6-only ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv6Protocol},
+		},
+		{
+			desc:       "Dual-stack ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+		},
 	}
 
-	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
-	if result.Error != nil {
-		t.Errorf("Expected no error for conflicting annotations, but got %v", result.Error)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nodeNames := []string{"test-node-1"}
+			vals := gce.DefaultTestClusterValues()
+			fakeGCE := getFakeGCECloud(vals)
 
-	fakeRecorder := l4.recorder.(*record.FakeRecorder)
-	warningFound := false
-	for len(fakeRecorder.Events) > 0 {
-		event := <-fakeRecorder.Events
-		if strings.Contains(event, "Warning IPCollectionV6Error") {
-			warningFound = true
-			break
-		}
-	}
-	if !warningFound {
-		t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+			key := meta.RegionalKey("", fakeGCE.Region())
+			subnetToCreate := &compute.Subnetwork{
+				Ipv6AccessType: subnetInternalIPv6AccessType,
+				StackType:      "IPV4_IPV6",
+			}
+			if err := fakeGCE.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), key, subnetToCreate); err != nil {
+				t.Fatalf("Failed to create mock cluster subnet: %v", err)
+			}
+
+			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, v1.ServiceExternalTrafficPolicyTypeCluster)
+			if svc.Annotations == nil {
+				svc.Annotations = make(map[string]string)
+			}
+			svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+
+			namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+			l4Params := &L4ILBParams{
+				Service:          svc,
+				Cloud:            fakeGCE,
+				Namer:            namer,
+				Recorder:         record.NewFakeRecorder(100),
+				NetworkResolver:  network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+				DualStackEnabled: true,
+			}
+			l4 := NewL4Handler(l4Params, klog.TODO())
+
+			if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
+				t.Errorf("Unexpected error when adding nodes %v", err)
+			}
+
+			result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
+			if result.Error != nil {
+				t.Errorf("Expected no fatal error for unsupported annotation, but got %v", result.Error)
+			}
+
+			fakeRecorder := l4.recorder.(*record.FakeRecorder)
+			warningFound := false
+			for len(fakeRecorder.Events) > 0 {
+				event := <-fakeRecorder.Events
+				if strings.Contains(event, "Warning IPCollectionV6Error") {
+					warningFound = true
+					if !strings.Contains(event, "not supported for Internal LoadBalancers") {
+						t.Errorf("Expected warning to mention not supported for Internal LoadBalancers, got: %s", event)
+					}
+					if !strings.Contains(event, annotations.CustomSubnetAnnotationKey) {
+						t.Errorf("Expected warning to suggest %s annotation, got: %s", annotations.CustomSubnetAnnotationKey, event)
+					}
+					break
+				}
+			}
+			if !warningFound {
+				t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Internal LoadBalancer services don't support the ip collection annotation because GCE rejects ip_collection on internal forwarding rules. For ILB customers must specify their BYOIP subnet via networking.gke.io/load-balancer-subnet