### PR TITLE
Refactor Ingress-GCE metrics to support scoped Multi-Tenant metrics

### DIFF
--- a/cmd/glbc/app/handlers.go
+++ b/cmd/glbc/app/handlers.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"syscall"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 
@@ -40,6 +42,7 @@ func RunHTTPServer(healthChecker func() systemhealth.HealthCheckResults, logger 
 	http.HandleFunc("/healthz", healthCheckHandler(healthChecker, logger))
 	http.HandleFunc("/flag", flagHandler)
 	http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics/multitenancy", promhttp.HandlerFor(metrics.DefaultMultiGatherer.(prometheus.Gatherer), promhttp.HandlerOpts{}))
 
 	logger.V(0).Info("Running http server", "port", flags.F.HealthzPort)
 	klog.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", flags.F.HealthzPort), nil))

--- a/cmd/glbc/main.go
+++ b/cmd/glbc/main.go
@@ -25,10 +25,12 @@ import (
 	"sync"
 	"time"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	firewallcrclient "github.com/GoogleCloudPlatform/gke-networking-api/client/gcpfirewall/clientset/versioned"
 	networkclient "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned"
 	nodetopologyclient "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	k8scp "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/prometheus/client_golang/prometheus"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -67,7 +69,7 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	_ "k8s.io/ingress-gce/pkg/klog"
 	"k8s.io/ingress-gce/pkg/neg"
-	"k8s.io/ingress-gce/pkg/neg/metrics"
+	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
@@ -164,7 +166,7 @@ func main() {
 	}
 
 	// register NEG prometheus metrics
-	metrics.RegisterMetrics()
+	negmetrics.RegisterMetrics()
 	syncMetrics.RegisterMetrics()
 
 	if flags.F.EnableNEGController {
@@ -271,6 +273,18 @@ func main() {
 		klog.Fatalf("unable to get hostname: %v", err)
 	}
 
+	stdFactory := metrics.NewStdMetricFactory(prometheus.DefaultRegisterer)
+	syncerMetrics, err := syncMetrics.NewNegMetricsCollector(flags.F.NegMetricsExportInterval, stdFactory, rootLogger)
+	if err != nil {
+		klog.Fatalf("Failed to initialize syncer metrics: %v", err)
+	}
+	go syncerMetrics.Run(stopCh)
+
+	negMetrics, err := negmetrics.NewNegMetricsWithFactory(stdFactory)
+	if err != nil {
+		klog.Fatalf("Failed to initialize NEG metrics: %v", err)
+	}
+
 	if flags.F.EnableMultiProjectMode {
 		rootLogger.Info("Multi-project mode is enabled, starting project-syncer")
 
@@ -284,8 +298,6 @@ func main() {
 				klog.Fatalf("Failed to create ProviderConfig client: %v", err)
 			}
 			ctx := context.Background()
-			syncerMetrics := syncMetrics.NewNegMetricsCollector(flags.F.NegMetricsExportInterval, rootLogger)
-			go syncerMetrics.Run(stopCh)
 
 			if flags.F.LeaderElection.LeaderElect {
 				err := multiprojectstart.StartWithLeaderElection(
@@ -397,7 +409,7 @@ func main() {
 		logger.Info("Start running the enabled controllers",
 			"NEG controller", flags.F.EnableNEGController,
 		)
-		err := runNEGController(ctx, systemHealth, rOption, logger)
+		err := runNEGController(ctx, systemHealth, rOption, logger, negMetrics, syncerMetrics)
 		if err != nil {
 			klog.Fatalf("failed to run NEG controller: %s", err)
 		}
@@ -428,7 +440,7 @@ func main() {
 			logger.Info("Start running NEG leader election",
 				"NEG controller", flags.F.EnableNEGController,
 			)
-			negRunner, err := makeNEGRunnerWithLeaderElection(ctx, systemHealth, rOption, leOption, logger)
+			negRunner, err := makeNEGRunnerWithLeaderElection(ctx, systemHealth, rOption, leOption, logger, negMetrics, syncerMetrics)
 			if err != nil {
 				klog.Fatalf("makeNEGLeaderElectionConfig()=%v, want nil", err)
 			}
@@ -523,12 +535,14 @@ func makeNEGRunnerWithLeaderElection(
 	runOption runOption,
 	leOption leaderElectionOption,
 	logger klog.Logger,
+	negMetrics *negmetrics.NegMetrics,
+	syncerMetrics *syncMetrics.SyncerMetrics,
 ) (*leaderelection.LeaderElectionConfig, error) {
 	return makeRunnerWithLeaderElection(
 		leOption,
 		negLockName,
 		func(context.Context) {
-			err := runNEGController(ctx, systemHealth, runOption, logger)
+			err := runNEGController(ctx, systemHealth, runOption, logger, negMetrics, syncerMetrics)
 			if err != nil {
 				klog.Fatalf("failed to run NEG controller: %s", err)
 			}
@@ -694,13 +708,13 @@ func runL4Controllers(ctx *ingctx.ControllerContext, systemHealth *systemhealth.
 	ctx.Start(option.stopCh)
 }
 
-func runNEGController(ctx *ingctx.ControllerContext, systemHealth *systemhealth.SystemHealth, option runOption, logger klog.Logger) error {
+func runNEGController(ctx *ingctx.ControllerContext, systemHealth *systemhealth.SystemHealth, option runOption, logger klog.Logger, negMetrics *negmetrics.NegMetrics, syncerMetrics *syncMetrics.SyncerMetrics) error {
 	lockLogger := logger.WithValues("lockName", negLockName)
 	lockLogger.Info("Attempting to grab lock", "lockName", negLockName)
 	go collectLockAvailabilityMetrics(negLockName, flags.F.GKEClusterType, option.stopCh, logger)
 
 	if flags.F.EnableNEGController {
-		negController, err := createNEGController(ctx, systemHealth, option.stopCh, logger)
+		negController, err := createNEGController(ctx, systemHealth, option.stopCh, logger, negMetrics, syncerMetrics)
 		if err != nil {
 			return fmt.Errorf("failed to create NEG controller: %w", err)
 		}
@@ -717,7 +731,14 @@ func runNEGController(ctx *ingctx.ControllerContext, systemHealth *systemhealth.
 	return nil
 }
 
-func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemhealth.SystemHealth, stopCh <-chan struct{}, logger klog.Logger) (*neg.Controller, error) {
+func createNEGController(
+	ctx *ingctx.ControllerContext,
+	systemHealth *systemhealth.SystemHealth,
+	stopCh <-chan struct{},
+	logger klog.Logger,
+	negMetrics *negmetrics.NegMetrics,
+	syncerMetrics *syncMetrics.SyncerMetrics,
+) (*neg.Controller, error) {
 	zoneGetter := ctx.ZoneGetter
 
 	// In NonGCP mode, use the zone specified in gce.conf directly.
@@ -743,10 +764,6 @@ func createNEGController(ctx *ingctx.ControllerContext, systemHealth *systemheal
 		// if it was not possible to retrieve network information use standard context as cloud network provider
 		adapter = ctx.Cloud
 	}
-
-	negMetrics := metrics.NewNegMetrics()
-	syncerMetrics := syncMetrics.NewNegMetricsCollector(flags.F.NegMetricsExportInterval, logger)
-	go syncerMetrics.Run(stopCh)
 
 	// TODO: Refactor NEG to use cloud mocks so ctx.Cloud can be referenced within NewController.
 	negController, err := neg.NewController(

--- a/cmd/glbc/main_test.go
+++ b/cmd/glbc/main_test.go
@@ -47,7 +47,7 @@ func TestOnStoppedLeadingClosesRootStop(t *testing.T) {
 			buildRunner: func(ro runOption) (*leaderelection.LeaderElectionConfig, error) {
 				var ctx *ingctx.ControllerContext
 				var sh *systemhealth.SystemHealth
-				return makeNEGRunnerWithLeaderElection(ctx, sh, ro, le, klog.TODO())
+				return makeNEGRunnerWithLeaderElection(ctx, sh, ro, le, klog.TODO(), nil, nil)
 			},
 		},
 		{

--- a/pkg/multiproject/framework/manager.go
+++ b/pkg/multiproject/framework/manager.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	providerconfig "k8s.io/ingress-gce/pkg/apis/providerconfig/v1"
@@ -209,7 +209,7 @@ func (m *manager) ForceCleanupTenant(pcKey string) {
 	m.deletingMu.Unlock()
 
 	if tenantUID != "" {
-		mtmetrics.DefaultMultiGatherer.Unregister(tenantUID)
-		mtmetrics.DefaultGlobalTracker.ResetTenant(tenantUID)
+		metrics.DefaultMultiGatherer.Unregister(tenantUID)
+		metrics.DefaultGlobalTracker.ResetTenant(tenantUID)
 	}
 }

--- a/pkg/multiproject/neg/neg.go
+++ b/pkg/multiproject/neg/neg.go
@@ -3,8 +3,10 @@ package neg
 import (
 	"fmt"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	networkclient "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned"
 	nodetopologyclient "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -13,7 +15,7 @@ import (
 	"k8s.io/ingress-gce/pkg/flags"
 	multiprojectinformers "k8s.io/ingress-gce/pkg/multiproject/neg/informerset"
 	"k8s.io/ingress-gce/pkg/neg"
-	"k8s.io/ingress-gce/pkg/neg/metrics"
+	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	syncMetrics "k8s.io/ingress-gce/pkg/neg/metrics/metricscollector"
 	"k8s.io/ingress-gce/pkg/neg/syncers/labels"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
@@ -65,6 +67,15 @@ func StartNEGController(
 	providerConfigName := providerConfig.Name
 	logger.V(2).Info("Initializing NEG controller", "providerConfig", providerConfigName)
 
+	tenantUID := providerConfig.Name
+	if providerConfig.Spec.PrincipalInfo != nil && providerConfig.Spec.PrincipalInfo.ID != "" {
+		tenantUID = providerConfig.Spec.PrincipalInfo.ID
+	}
+	mtFactory := metrics.NewMTMetricFactory(tenantUID, prometheus.DefaultRegisterer, metrics.DefaultGlobalTracker)
+	if err := metrics.DefaultMultiGatherer.Register(tenantUID, mtFactory.Registry()); err != nil {
+		logger.Error(err, "Failed to register multi-tenant gatherer for tenant", "tenantUID", tenantUID)
+	}
+
 	// The ProviderConfig-specific stop channel. We close this in StopControllersForProviderConfig.
 	providerConfigStopCh := make(chan struct{})
 
@@ -74,6 +85,8 @@ func StartNEGController(
 		defer func() {
 			close(joinedStopCh)
 			logger.V(2).Info("NEG controller stop channel closed")
+			metrics.DefaultMultiGatherer.Unregister(tenantUID)
+			mtFactory.Cleanup()
 		}()
 		select {
 		case <-globalStopCh:
@@ -117,6 +130,7 @@ func StartNEGController(
 		lpConfig,
 		joinedStopCh,
 		logger,
+		mtFactory,
 		syncerMetrics,
 	)
 
@@ -153,6 +167,7 @@ func createNEGController(
 	lpConfig labels.PodLabelPropagationConfig,
 	stopCh <-chan struct{},
 	logger klog.Logger,
+	factory metrics.MetricFactory,
 	syncerMetrics *syncMetrics.SyncerMetrics,
 ) (*neg.Controller, error) {
 
@@ -164,7 +179,10 @@ func createNEGController(
 	}
 
 	noDefaultBackendServicePort := utils.ServicePort{}
-	negMetrics := metrics.NewNegMetrics()
+	negMetrics, err := negmetrics.NewNegMetricsWithFactory(factory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NEG metrics: %w", err)
+	}
 
 	negController, err := newNEGController(
 		kubeClient,

--- a/pkg/neg/controller.go
+++ b/pkg/neg/controller.go
@@ -592,7 +592,7 @@ func (c *Controller) processNextNodeWorkItem() bool {
 func (c *Controller) processNode() {
 	defer func() {
 		now := c.nodeSyncTracker.Track()
-		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.negMetrics.PublishLastSyncTimestamp(now)
 	}()
 
 	if c.readOnlyMode {
@@ -607,7 +607,7 @@ func (c *Controller) processNode() {
 func (c *Controller) processEndpoint(key string) {
 	defer func() {
 		now := c.syncTracker.Track()
-		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.negMetrics.PublishLastSyncTimestamp(now)
 	}()
 
 	if c.readOnlyMode {
@@ -649,7 +649,7 @@ func (c *Controller) processService(key string) error {
 	c.logger.V(3).Info("Processing service", "service", key)
 	defer func() {
 		now := c.syncTracker.Track()
-		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.negMetrics.PublishLastSyncTimestamp(now)
 		c.logger.V(3).Info("Finished processing service", "service", key)
 	}()
 
@@ -762,7 +762,7 @@ func (c *Controller) processNextNodeTopologyWorkItem() bool {
 func (c *Controller) processNodeTopology() {
 	defer func() {
 		now := c.syncTracker.Track()
-		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.negMetrics.PublishLastSyncTimestamp(now)
 	}()
 	if c.readOnlyMode {
 		c.logger.V(3).Info("Skipping syncing node topology since NEG controller is in read-only mode")
@@ -1239,7 +1239,7 @@ func (c *Controller) processNEGBinding(key string) error {
 	c.logger.V(3).Info("Processing NEGBinding", "binding", key)
 	defer func() {
 		now := c.syncTracker.Track()
-		metrics.LastSyncTimestamp.Set(float64(now.UTC().UnixNano()))
+		c.negMetrics.PublishLastSyncTimestamp(now)
 		c.logger.V(3).Info("Finished processing NEGBinding", "binding", key)
 	}()
 

--- a/pkg/neg/metrics/metrics.go
+++ b/pkg/neg/metrics/metrics.go
@@ -17,11 +17,14 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -56,275 +59,280 @@ const (
 	ListNEHealthRequest   = "ListNEHealth"
 )
 
-var (
-	NegOperationLatency = prometheus.NewHistogramVec(
+var register sync.Once
+
+// RegisterMetrics is now a no-op as metrics are registered via the MetricFactory. (cache invalidation)
+func RegisterMetrics() {
+	// No-op
+}
+
+type NegMetrics struct {
+	negOperationLatency     metrics.ObserverVec
+	negOperationEndpoints   metrics.ObserverVec
+	syncerSyncLatency       metrics.ObserverVec
+	managerProcessLatency   metrics.ObserverVec
+	initializationLatency   prometheus.Histogram
+	lastSyncTimestamp       prometheus.Gauge
+	syncerStaleness         prometheus.Histogram
+	epsStaleness            prometheus.Histogram
+	degradeModeCorrectness  metrics.ObserverVec
+	negControllerErrorCount metrics.CounterVec
+	labelNumber             prometheus.Histogram
+	annotationSize          prometheus.Histogram
+	labelPropagationError   metrics.CounterVec
+	gceRequestCount         metrics.CounterVec
+	gceRequestLatency       metrics.ObserverVec
+	k8sRequestCount         metrics.CounterVec
+	k8sRequestLatency       metrics.ObserverVec
+}
+
+// NewNegMetrics returns a NegMetrics initialized with the default global registry.
+func NewNegMetrics() *NegMetrics {
+	m, err := NewNegMetricsWithFactory(metrics.NewStdMetricFactory(prometheus.DefaultRegisterer))
+	if err != nil {
+		klog.Errorf("Failed to initialize NegMetrics: %v", err)
+	}
+	return m
+}
+
+func NewNegMetricsWithFactory(factory metrics.MetricFactory) (*NegMetrics, error) {
+	var err error
+	m := &NegMetrics{}
+
+	if m.negOperationLatency, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "neg_operation_duration_seconds",
 			Help:      "Latency of a NEG Operation",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-		[]string{
-			"operation",   // endpoint operation
-			"neg_type",    // type of neg
-			"api_version", // GCE API version
-			"result",      // result of the sync
-		},
-	)
+		[]string{"operation", "neg_type", "api_version", "result"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to create negOperationLatency: %w", err)
+	}
 
-	NegOperationEndpoints = prometheus.NewHistogramVec(
+	if m.negOperationEndpoints, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "neg_operation_endpoints",
 			Help:      "Number of Endpoints during an NEG Operation",
-			// custom buckets - [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-		[]string{
-			"operation", // endpoint operation
-			"neg_type",  // type of neg
-			"result",    // result of the sync
-		},
-	)
+		[]string{"operation", "neg_type", "result"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to create negOperationEndpoints: %w", err)
+	}
 
-	SyncerSyncLatency = prometheus.NewHistogramVec(
+	if m.syncerSyncLatency, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "syncer_sync_duration_seconds",
 			Help:      "Sync latency for NEG Syncer",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-		[]string{
-			"neg_type",                 //type of neg
-			"endpoint_calculator_mode", // type of endpoint calculator used
-			"result",                   // result of the sync
-		},
-	)
+		[]string{"neg_type", "endpoint_calculator_mode", "result"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to create syncerSyncLatency: %w", err)
+	}
 
-	ManagerProcessLatency = prometheus.NewHistogramVec(
+	if m.managerProcessLatency, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "manager_process_duration_seconds",
 			Help:      "Process latency for NEG Manager",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-		[]string{
-			"process", // type of manager process loop
-			"result",  // result of the process
-		},
-	)
+		[]string{"process", "result"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to create managerProcessLatency: %w", err)
+	}
 
-	InitializationLatency = prometheus.NewHistogram(
+	if m.initializationLatency, err = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "neg_initialization_duration_seconds",
 			Help:      "Initialization latency of a NEG",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create initializationLatency: %w", err)
+	}
 
-	LastSyncTimestamp = prometheus.NewGauge(
+	if m.lastSyncTimestamp, err = factory.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "sync_timestamp",
 			Help:      "The timestamp of the last execution of NEG controller sync loop.",
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create lastSyncTimestamp: %w", err)
+	}
 
-	// SyncerStaleness tracks for every syncer, how long since the syncer last syncs
-	SyncerStaleness = prometheus.NewHistogram(
+	if m.syncerStaleness, err = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "syncer_staleness",
 			Help:      "The duration of a syncer since it last syncs",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), 8192(~136min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 14),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 14),
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create syncerStaleness: %w", err)
+	}
 
-	// EPSStaleness tracks for every endpoint slice, how long since it was last processed
-	EPSStaleness = prometheus.NewHistogram(
+	if m.epsStaleness, err = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "endpointslice_staleness",
 			Help:      "The duration for an endpoint slice since it was last processed by syncer",
-			// custom buckets - [1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s(~4min), 512s(~8min), 1024s(~17min), 2048 (~34min), 4096(~68min), 8192(~136min), +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 14),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 14),
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create epsStaleness: %w", err)
+	}
 
-	DegradeModeCorrectness = prometheus.NewHistogramVec(
+	if m.degradeModeCorrectness, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "degraded_mode_correctness",
 			Help:      "Number of endpoints differed between current endpoint calculation and degraded mode calculation",
-			// custom buckets - [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, +Inf]
-			Buckets: append([]float64{0}, prometheus.ExponentialBuckets(1, 2, 20)...),
+			Buckets:   append([]float64{0}, prometheus.ExponentialBuckets(1, 2, 20)...),
 		},
-		[]string{
-			"neg_type",      // type of neg
-			"endpoint_type", // type of endpoint
-		},
-	)
+		[]string{"neg_type", "endpoint_type"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to create degradeModeCorrectness: %w", err)
+	}
 
-	// NegControllerErrorCount tracks the count of server errors(GCE/K8s) and
-	// all errors from NEG controller.
-	NegControllerErrorCount = prometheus.NewCounterVec(
+	if m.negControllerErrorCount, err = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "error_count",
 			Help:      "Counts of server errors and NEG controller errors.",
 		},
 		[]string{"error_type"},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create negControllerErrorCount: %w", err)
+	}
 
-	LabelNumber = prometheus.NewHistogram(
+	if m.labelNumber, err = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "label_number_per_endpoint",
 			Help:      "The number of labels per endpoint",
-			// custom buckets - [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create labelNumber: %w", err)
+	}
 
-	AnnotationSize = prometheus.NewHistogram(
+	if m.annotationSize, err = factory.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "annotation_size_per_endpoint",
 			Help:      "The size in byte of endpoint annotations per endpoint",
-			// custom buckets - [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 13),
 		},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create annotationSize: %w", err)
+	}
 
-	LabelPropagationError = prometheus.NewCounterVec(
+	if m.labelPropagationError, err = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "label_propagation_error_count",
 			Help:      "the number of errors occurred for label propagation",
 		},
 		[]string{"error_type"},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create labelPropagationError: %w", err)
+	}
 
-	// GCERequestCount tracks the number of GCE requests the neg controller sends to the NEG API
-	GCERequestCount = prometheus.NewCounterVec(
+	if m.gceRequestCount, err = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "gce_request_count",
 			Help:      "Number of requests sent by NEG Controller to Arcus.",
 		},
 		[]string{"request", "result"},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create gceRequestCount: %w", err)
+	}
 
-	// GCERequestLatency tracks the latency of GCE requests the neg controller sends to the NEG API
-	GCERequestLatency = prometheus.NewHistogramVec(
+	if m.gceRequestLatency, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "gce_request_latency",
 			Help:      "Observed request latency for requests sent by NEG Controller to Arcus.",
-			// custom buckets - [0.001, 0.01, 0.1, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, +Inf]
-			Buckets: append([]float64{0.001, 0.01, 0.1}, prometheus.ExponentialBuckets(1, 2, 20)...),
+			Buckets:   append([]float64{0.001, 0.01, 0.1}, prometheus.ExponentialBuckets(1, 2, 20)...),
 		},
 		[]string{"request", "result"},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create gceRequestLatency: %w", err)
+	}
 
-	// K8sRequestCount tracks the number of K8s requests the neg controller sends to the K8s API
-	K8sRequestCount = prometheus.NewCounterVec(
+	if m.k8sRequestCount, err = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "k8s_request_count",
 			Help:      "Number of requests sent by NEG Controller to Kubernetes API Server.",
 		},
 		[]string{"request", "result"},
-	)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create k8sRequestCount: %w", err)
+	}
 
-	// K8sRequestLatency tracks the latency of K8s requests the neg controller sends to the K8s API
-	K8sRequestLatency = prometheus.NewHistogramVec(
+	if m.k8sRequestLatency, err = factory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: negControllerSubsystem,
 			Name:      "k8s_request_latency",
 			Help:      "Observed request latency for requests sent by NEG Controller to Kubernetes API Server.",
-			// custom buckets - [0.001, 0.01, 0.1, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, +Inf]
-			Buckets: append([]float64{0.001, 0.01, 0.1}, prometheus.ExponentialBuckets(1, 2, 20)...),
+			Buckets:   append([]float64{0.001, 0.01, 0.1}, prometheus.ExponentialBuckets(1, 2, 20)...),
 		},
 		[]string{"request", "result"},
-	)
-)
+	); err != nil {
+		return nil, fmt.Errorf("failed to create k8sRequestLatency: %w", err)
+	}
 
-var register sync.Once
-
-func RegisterMetrics() {
-	register.Do(func() {
-		prometheus.MustRegister(NegOperationLatency)
-		prometheus.MustRegister(NegOperationEndpoints)
-		prometheus.MustRegister(ManagerProcessLatency)
-		prometheus.MustRegister(SyncerSyncLatency)
-		prometheus.MustRegister(LastSyncTimestamp)
-		prometheus.MustRegister(InitializationLatency)
-		prometheus.MustRegister(SyncerStaleness)
-		prometheus.MustRegister(EPSStaleness)
-		prometheus.MustRegister(LabelPropagationError)
-		prometheus.MustRegister(LabelNumber)
-		prometheus.MustRegister(AnnotationSize)
-		prometheus.MustRegister(DegradeModeCorrectness)
-		prometheus.MustRegister(NegControllerErrorCount)
-		prometheus.MustRegister(GCERequestCount)
-		prometheus.MustRegister(GCERequestLatency)
-		prometheus.MustRegister(K8sRequestCount)
-		prometheus.MustRegister(K8sRequestLatency)
-	})
-}
-
-type NegMetrics struct {
-}
-
-func NewNegMetrics() *NegMetrics {
-	return &NegMetrics{}
+	return m, nil
 }
 
 // PublishNegOperationMetrics publishes collected metrics for neg operations
 func (m *NegMetrics) PublishNegOperationMetrics(operation, negType, apiVersion string, err error, numEndpoints int, start time.Time) {
 	result := getResult(err)
 
-	NegOperationLatency.WithLabelValues(operation, negType, apiVersion, result).Observe(time.Since(start).Seconds())
-	NegOperationEndpoints.WithLabelValues(operation, negType, result).Observe(float64(numEndpoints))
+	m.negOperationLatency.WithLabelValues(operation, negType, apiVersion, result).Observe(time.Since(start).Seconds())
+	m.negOperationEndpoints.WithLabelValues(operation, negType, result).Observe(float64(numEndpoints))
 }
 
 // PublishNegSyncMetrics publishes collected metrics for the sync of NEG
 func (m *NegMetrics) PublishNegSyncMetrics(negType, endpointCalculator string, err error, start time.Time) {
 	result := getResult(err)
 
-	SyncerSyncLatency.WithLabelValues(negType, endpointCalculator, result).Observe(time.Since(start).Seconds())
+	m.syncerSyncLatency.WithLabelValues(negType, endpointCalculator, result).Observe(time.Since(start).Seconds())
 }
 
 // PublishNegManagerProcessMetrics publishes collected metrics for the neg manager loops
 func (m *NegMetrics) PublishNegManagerProcessMetrics(process string, err error, start time.Time) {
 	result := getResult(err)
-	ManagerProcessLatency.WithLabelValues(process, result).Observe(time.Since(start).Seconds())
+	m.managerProcessLatency.WithLabelValues(process, result).Observe(time.Since(start).Seconds())
 }
 
 // PublishNegInitializationMetrics publishes collected metrics for time from request to initialization of NEG
 func (m *NegMetrics) PublishNegInitializationMetrics(latency time.Duration) {
-	InitializationLatency.Observe(latency.Seconds())
+	m.initializationLatency.Observe(latency.Seconds())
 }
 
 func (m *NegMetrics) PublishNegSyncerStalenessMetrics(syncerStaleness time.Duration) {
-	SyncerStaleness.Observe(syncerStaleness.Seconds())
+	m.syncerStaleness.Observe(syncerStaleness.Seconds())
 }
 
 func (m *NegMetrics) PublishNegEPSStalenessMetrics(epsStaleness time.Duration) {
-	EPSStaleness.Observe(epsStaleness.Seconds())
+	m.epsStaleness.Observe(epsStaleness.Seconds())
 }
 
 // PublishDegradedModeCorrectnessMetrics publishes collected metrics
 // of the correctness of degraded mode calculations compared with the current one
 func (m *NegMetrics) PublishDegradedModeCorrectnessMetrics(count int, endpointType string, negType string) {
-	DegradeModeCorrectness.WithLabelValues(negType, endpointType).Observe(float64(count))
+	m.degradeModeCorrectness.WithLabelValues(negType, endpointType).Observe(float64(count))
 }
 
 // PublishNegControllerErrorCountMetrics publishes collected metrics
@@ -333,19 +341,19 @@ func (m *NegMetrics) PublishNegControllerErrorCountMetrics(err error, isIgnored 
 	if err == nil {
 		return
 	}
-	NegControllerErrorCount.WithLabelValues(totalNegError).Inc()
-	NegControllerErrorCount.WithLabelValues(getErrorLabel(err, isIgnored)).Inc()
+	m.negControllerErrorCount.WithLabelValues(totalNegError).Inc()
+	m.negControllerErrorCount.WithLabelValues(getErrorLabel(err, isIgnored)).Inc()
 }
 
-// PublishLabelPropagationError publishes error occured during label propagation.
-func PublishLabelPropagationError(errType string) {
-	LabelPropagationError.WithLabelValues(errType).Inc()
+// PublishLabelPropagationError publishes error occurred during label propagation.
+func (m *NegMetrics) PublishLabelPropagationError(errType string) {
+	m.labelPropagationError.WithLabelValues(errType).Inc()
 }
 
 // PublishAnnotationMetrics publishes collected metrics for endpoint annotations.
-func PublishAnnotationMetrics(annotationSize int, labelNumber int) {
-	AnnotationSize.Observe(float64(annotationSize))
-	LabelNumber.Observe(float64(labelNumber))
+func (m *NegMetrics) PublishAnnotationMetrics(annotationSize int, labelNumber int) {
+	m.annotationSize.Observe(float64(annotationSize))
+	m.labelNumber.Observe(float64(labelNumber))
 }
 
 // PublishGCERequestCountMetrics publishes collected metrics for GCE Request Counts
@@ -360,8 +368,8 @@ func (m *NegMetrics) PublishGCERequestCountMetrics(start time.Time, requestType 
 			result = otherError
 		}
 	}
-	GCERequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
-	GCERequestCount.WithLabelValues(requestType, result).Inc()
+	m.gceRequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
+	m.gceRequestCount.WithLabelValues(requestType, result).Inc()
 }
 
 // PublishK8sRequestCountMetrics publishes collected metrics for K8s Request Counts
@@ -376,8 +384,12 @@ func (m *NegMetrics) PublishK8sRequestCountMetrics(start time.Time, requestType 
 			result = otherError
 		}
 	}
-	K8sRequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
-	K8sRequestCount.WithLabelValues(requestType, result).Inc()
+	m.k8sRequestLatency.WithLabelValues(requestType, result).Observe(time.Since(start).Seconds())
+	m.k8sRequestCount.WithLabelValues(requestType, result).Inc()
+}
+
+func (m *NegMetrics) PublishLastSyncTimestamp(t time.Time) {
+	m.lastSyncTimestamp.Set(float64(t.UTC().UnixNano()))
 }
 
 func getResult(err error) string {

--- a/pkg/neg/metrics/metricscollector/metrics.go
+++ b/pkg/neg/metrics/metricscollector/metrics.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package metricscollector
 
-import "github.com/prometheus/client_golang/prometheus"
-
 const (
 	negControllerSubsystem = "neg_controller"
 
@@ -49,108 +47,4 @@ const (
 	ipv6EndpointType      = "IPv6"
 	dualStackEndpointType = "DualStack"
 	migrationEndpointType = "Migration"
-)
-
-var (
-	// SyncerCountBySyncResult tracks the count of syncer in different states
-	SyncerCountBySyncResult = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "syncer_count",
-			Help:      "Current count of syncers in each state",
-		},
-		[]string{"last_sync_result", "in_error_state"},
-	)
-
-	// syncerEndpointState tracks the count of endpoints in different states
-	syncerEndpointState = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "syncer_endpoint_state",
-			Help:      "Current count of endpoints in each state",
-		},
-		[]string{"state"},
-	)
-
-	// syncerEndpointSliceState tracks the count of endpoint slices in different states
-	syncerEndpointSliceState = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "syncer_endpoint_slice_state",
-			Help:      "Current count of endpoint slices in each state",
-		},
-		[]string{"state"},
-	)
-
-	NumberOfEndpoints = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "number_of_endpoints",
-			Help:      "The total number of endpoints",
-		},
-		[]string{"feature"},
-	)
-
-	DualStackMigrationFinishedDurations = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "dual_stack_migration_finished_durations_seconds",
-			Help:      "Time taken to migrate all endpoints within all NEGs for a service port",
-			// Buckets ~= [1s, 1.85s, 3.42s, 6s, 11s, 21s, 40s, 1m14s, 2m17s, 4m13s, 7m49s, 14m28s, 26m47s, 49m33s, 1h31m40s, 2h49m35s, 5h13m45s, 9h40m27s, +Inf]
-			Buckets: prometheus.ExponentialBuckets(1, 1.85, 18),
-		},
-	)
-
-	// A zero value for this metric means that there are no ongoing migrations.
-	DualStackMigrationLongestUnfinishedDuration = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "dual_stack_migration_longest_unfinished_duration_seconds",
-			Help:      "Longest time elapsed since a migration was started which hasn't yet completed",
-		},
-	)
-
-	SyncerCountByEndpointType = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "syncer_count_by_endpoint_type",
-			Help:      "Number of Syncers managing NEGs containing endpoint of a particular kind",
-		},
-		[]string{"endpoint_type"},
-	)
-
-	DualStackMigrationServiceCount = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "dual_stack_migration_service_count",
-			Help:      "Number of Services which have migration endpoints",
-		},
-	)
-
-	// syncerSyncResult tracks the count for each sync result
-	syncerSyncResult = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "sync_result",
-			Help:      "Current count for each sync result",
-		},
-		[]string{"result"},
-	)
-
-	negsManagedCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: negControllerSubsystem,
-			Name:      "managed_neg_count",
-			Help:      "Number of NEGs the Neg Controller Manages",
-		},
-		[]string{"location", "endpoint_type"},
-	)
-
-	networkEndpointGroupCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "number_of_negs",
-			Help: "Number of NEGs",
-		},
-		[]string{"feature"},
-	)
 )

--- a/pkg/neg/metrics/metricscollector/metrics_collector.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,21 +33,8 @@ import (
 
 var register sync.Once
 
-// RegisterSyncerMetrics registers syncer related metrics
+// RegisterMetrics is a no-op because metrics are registered via the factory.
 func RegisterMetrics() {
-	register.Do(func() {
-		prometheus.MustRegister(SyncerCountBySyncResult)
-		prometheus.MustRegister(syncerEndpointState)
-		prometheus.MustRegister(syncerEndpointSliceState)
-		prometheus.MustRegister(NumberOfEndpoints)
-		prometheus.MustRegister(DualStackMigrationFinishedDurations)
-		prometheus.MustRegister(DualStackMigrationLongestUnfinishedDuration)
-		prometheus.MustRegister(DualStackMigrationServiceCount)
-		prometheus.MustRegister(SyncerCountByEndpointType)
-		prometheus.MustRegister(syncerSyncResult)
-		prometheus.MustRegister(negsManagedCount)
-		prometheus.MustRegister(networkEndpointGroupCount)
-	})
 }
 
 type SyncerMetricsCollector interface {
@@ -91,10 +79,123 @@ type SyncerMetrics struct {
 
 	// logger logs message related to NegMetricsCollector
 	logger klog.Logger
+
+	// Syncer metrics scoped to struct fields
+	syncerCountBySyncResult                     metrics.GaugeVec
+	syncerEndpointState                         metrics.GaugeVec
+	syncerEndpointSliceState                    metrics.GaugeVec
+	numberOfEndpoints                           metrics.GaugeVec
+	dualStackMigrationFinishedDurations         prometheus.Histogram
+	dualStackMigrationLongestUnfinishedDuration prometheus.Gauge
+	syncerCountByEndpointType                   metrics.GaugeVec
+	dualStackMigrationServiceCount              prometheus.Gauge
+	syncerSyncResult                            metrics.CounterVec
+	negsManagedCount                            metrics.GaugeVec
+	networkEndpointGroupCount                   metrics.GaugeVec
 }
 
-// NewNEGMetricsCollector initializes SyncerMetrics and starts a go routine to compute and export metrics periodically.
-func NewNegMetricsCollector(exportInterval time.Duration, logger klog.Logger) *SyncerMetrics {
+// NewNegMetricsCollector initializes SyncerMetrics and starts a go routine to compute and export metrics periodically.
+func NewNegMetricsCollector(exportInterval time.Duration, factory metrics.MetricFactory, logger klog.Logger) (*SyncerMetrics, error) {
+	syncerCountBySyncResult, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "syncer_count",
+		Help:      "Current count of syncers in each state",
+	}, []string{"last_sync_result", "in_error_state"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create syncer_count: %w", err)
+	}
+
+	syncerEndpointState, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "syncer_endpoint_state",
+		Help:      "Current count of endpoints in each state",
+	}, []string{"state"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create syncer_endpoint_state: %w", err)
+	}
+
+	syncerEndpointSliceState, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "syncer_endpoint_slice_state",
+		Help:      "Current count of endpoint slices in each state",
+	}, []string{"state"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create syncer_endpoint_slice_state: %w", err)
+	}
+
+	numberOfEndpoints, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "number_of_endpoints",
+		Help:      "The total number of endpoints",
+	}, []string{"feature"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create number_of_endpoints: %w", err)
+	}
+
+	dualStackMigrationFinishedDurations, err := factory.NewHistogram(prometheus.HistogramOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "dual_stack_migration_finished_durations_seconds",
+		Help:      "Time taken to migrate all endpoints within all NEGs for a service port",
+		// Buckets ~= [1s, 1.85s, 3.42s, 6s, 11s, 21s, 40s, 1m14s, 2m17s, 4m13s, 7m49s, 14m28s, 26m47s, 49m33s, 1h31m40s, 2h49m35s, 5h13m45s, 9h40m27s, +Inf]
+		Buckets: prometheus.ExponentialBuckets(1, 1.85, 18),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dual_stack_migration_finished_durations_seconds: %w", err)
+	}
+
+	dualStackMigrationLongestUnfinishedDuration, err := factory.NewGauge(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "dual_stack_migration_longest_unfinished_duration_seconds",
+		Help:      "Longest time elapsed since a migration was started which hasn't yet completed",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dual_stack_migration_longest_unfinished_duration_seconds: %w", err)
+	}
+
+	syncerCountByEndpointType, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "syncer_count_by_endpoint_type",
+		Help:      "Number of Syncers managing NEGs containing endpoint of a particular kind",
+	}, []string{"endpoint_type"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create syncer_count_by_endpoint_type: %w", err)
+	}
+
+	dualStackMigrationServiceCount, err := factory.NewGauge(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "dual_stack_migration_service_count",
+		Help:      "Number of Services which have migration endpoints",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dual_stack_migration_service_count: %w", err)
+	}
+
+	syncerSyncResult, err := factory.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "sync_result",
+		Help:      "Current count for each sync result",
+	}, []string{"result"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sync_result: %w", err)
+	}
+
+	negsManagedCount, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: negControllerSubsystem,
+		Name:      "managed_neg_count",
+		Help:      "Number of NEGs the Neg Controller Manages",
+	}, []string{"location", "endpoint_type"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create managed_neg_count: %w", err)
+	}
+
+	networkEndpointGroupCount, err := factory.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "number_of_negs",
+		Help: "Number of NEGs",
+	}, []string{"feature"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create number_of_negs: %w", err)
+	}
+
 	return &SyncerMetrics{
 		syncerStateMap:              make(map[negtypes.NegSyncerKey]syncerState),
 		syncerEndpointStateMap:      make(map[negtypes.NegSyncerKey]negtypes.StateCountMap),
@@ -108,12 +209,28 @@ func NewNegMetricsCollector(exportInterval time.Duration, logger klog.Logger) *S
 		clock:                       clock.RealClock{},
 		metricsInterval:             exportInterval,
 		logger:                      logger.WithName("NegMetricsCollector"),
-	}
+
+		syncerCountBySyncResult:                     syncerCountBySyncResult,
+		syncerEndpointState:                         syncerEndpointState,
+		syncerEndpointSliceState:                    syncerEndpointSliceState,
+		numberOfEndpoints:                           numberOfEndpoints,
+		dualStackMigrationFinishedDurations:         dualStackMigrationFinishedDurations,
+		dualStackMigrationLongestUnfinishedDuration: dualStackMigrationLongestUnfinishedDuration,
+		syncerCountByEndpointType:                   syncerCountByEndpointType,
+		dualStackMigrationServiceCount:              dualStackMigrationServiceCount,
+		syncerSyncResult:                            syncerSyncResult,
+		negsManagedCount:                            negsManagedCount,
+		networkEndpointGroupCount:                   networkEndpointGroupCount,
+	}, nil
 }
 
 // FakeSyncerMetrics creates new NegMetricsCollector with fixed 5 second metricsInterval, to be used in tests
 func FakeSyncerMetrics() *SyncerMetrics {
-	return NewNegMetricsCollector(5*time.Second, klog.TODO())
+	sm, err := NewNegMetricsCollector(5*time.Second, metrics.NewStdMetricFactory(prometheus.NewRegistry()), klog.TODO())
+	if err != nil {
+		klog.Errorf("Failed to create FakeSyncerMetrics: %v", err)
+	}
+	return sm
 }
 
 func (sm *SyncerMetrics) Run(stopCh <-chan struct{}) {
@@ -129,29 +246,29 @@ func (sm *SyncerMetrics) Run(stopCh <-chan struct{}) {
 // export exports syncer metrics.
 func (sm *SyncerMetrics) export() {
 	lpMetrics := sm.computeLabelMetrics()
-	NumberOfEndpoints.WithLabelValues(totalEndpoints).Set(float64(lpMetrics.NumberOfEndpoints))
-	NumberOfEndpoints.WithLabelValues(epWithAnnotation).Set(float64(lpMetrics.EndpointsWithAnnotation))
+	sm.numberOfEndpoints.WithLabelValues(totalEndpoints).Set(float64(lpMetrics.NumberOfEndpoints))
+	sm.numberOfEndpoints.WithLabelValues(epWithAnnotation).Set(float64(lpMetrics.EndpointsWithAnnotation))
 
 	stateCount, syncerCount := sm.computeSyncerStateMetrics()
 	//Reset metric so non-existent keys are now 0
-	SyncerCountBySyncResult.Reset()
+	sm.syncerCountBySyncResult.Reset()
 	for syncerState, count := range stateCount {
-		SyncerCountBySyncResult.WithLabelValues(string(syncerState.lastSyncResult), strconv.FormatBool(syncerState.inErrorState)).Set(float64(count))
+		sm.syncerCountBySyncResult.WithLabelValues(string(syncerState.lastSyncResult), strconv.FormatBool(syncerState.inErrorState)).Set(float64(count))
 	}
 
 	epStateCount, epsStateCount, epCount, epsCount := sm.computeEndpointStateMetrics()
 	for state, count := range epStateCount {
-		syncerEndpointState.WithLabelValues(string(state)).Set(float64(count))
+		sm.syncerEndpointState.WithLabelValues(string(state)).Set(float64(count))
 	}
 	for state, count := range epsStateCount {
-		syncerEndpointSliceState.WithLabelValues(string(state)).Set(float64(count))
+		sm.syncerEndpointSliceState.WithLabelValues(string(state)).Set(float64(count))
 	}
 
 	negCounts := sm.computeNegCounts()
 	//Clear existing metrics (ensures that keys that don't exist anymore are reset)
-	negsManagedCount.Reset()
+	sm.negsManagedCount.Reset()
 	for key, count := range negCounts {
-		negsManagedCount.WithLabelValues(key.location, key.endpointType).Set(float64(count))
+		sm.negsManagedCount.WithLabelValues(key.location, key.endpointType).Set(float64(count))
 	}
 
 	sm.logger.V(3).Info("Exporting syncer related metrics", "Syncer count", syncerCount,
@@ -163,22 +280,22 @@ func (sm *SyncerMetrics) export() {
 
 	finishedDurations, longestUnfinishedDurations := sm.computeDualStackMigrationDurations()
 	for _, duration := range finishedDurations {
-		DualStackMigrationFinishedDurations.Observe(float64(duration))
+		sm.dualStackMigrationFinishedDurations.Observe(float64(duration))
 	}
-	DualStackMigrationLongestUnfinishedDuration.Set(float64(longestUnfinishedDurations))
+	sm.dualStackMigrationLongestUnfinishedDuration.Set(float64(longestUnfinishedDurations))
 
 	syncerCountByEndpointType, migrationEndpointCount, migrationServicesCount := sm.computeDualStackMigrationCounts()
 	for endpointType, count := range syncerCountByEndpointType {
-		SyncerCountByEndpointType.WithLabelValues(endpointType).Set(float64(count))
+		sm.syncerCountByEndpointType.WithLabelValues(endpointType).Set(float64(count))
 	}
-	syncerEndpointState.WithLabelValues(string(negtypes.DualStackMigration)).Set(float64(migrationEndpointCount))
-	DualStackMigrationServiceCount.Set(float64(migrationServicesCount))
+	sm.syncerEndpointState.WithLabelValues(string(negtypes.DualStackMigration)).Set(float64(migrationEndpointCount))
+	sm.dualStackMigrationServiceCount.Set(float64(migrationServicesCount))
 
 	sm.logger.V(3).Info("Exported DualStack Migration metrics")
 
 	negCount := sm.computeNegMetrics()
 	for feature, count := range negCount {
-		networkEndpointGroupCount.WithLabelValues(feature.String()).Set(float64(count))
+		sm.networkEndpointGroupCount.WithLabelValues(feature.String()).Set(float64(count))
 	}
 	sm.logger.V(3).Info("Exported NEG usage metrics", "NEG count", fmt.Sprintf("%#v", negCount))
 }
@@ -190,7 +307,7 @@ func (sm *SyncerMetrics) UpdateSyncerStatusInMetrics(key negtypes.NegSyncerKey, 
 		syncErr := negtypes.ClassifyError(err)
 		reason = syncErr.Reason
 	}
-	syncerSyncResult.WithLabelValues(string(reason)).Inc()
+	sm.syncerSyncResult.WithLabelValues(string(reason)).Inc()
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if sm.syncerStateMap == nil {

--- a/pkg/neg/metrics/metricscollector/metrics_collector_test.go
+++ b/pkg/neg/metrics/metricscollector/metrics_collector_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 	"time"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/ingress-gce/pkg/neg/types"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 	"k8s.io/klog/v2"
@@ -238,7 +240,10 @@ func TestComputeDualStackMigrationCounts(t *testing.T) {
 }
 
 func TestComputeLabelMetrics(t *testing.T) {
-	collector := NewNegMetricsCollector(10*time.Second, klog.TODO())
+	collector, err := NewNegMetricsCollector(10*time.Second, metrics.NewStdMetricFactory(prometheus.NewRegistry()), klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to create NegMetricsCollector: %v", err)
+	}
 	syncer1 := negtypes.NegSyncerKey{
 		Namespace:        "ns1",
 		Name:             "svc-1",
@@ -308,7 +313,10 @@ func TestComputeLabelMetrics(t *testing.T) {
 }
 
 func TestComputeNegCounts(t *testing.T) {
-	collector := NewNegMetricsCollector(10*time.Second, klog.TODO())
+	collector, err := NewNegMetricsCollector(10*time.Second, metrics.NewStdMetricFactory(prometheus.NewRegistry()), klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to create NegMetricsCollector: %v", err)
+	}
 	l7Syncer1 := negtypes.NegSyncerKey{
 		Namespace:        "ns1",
 		Name:             "svc-1",

--- a/pkg/neg/syncers/labels/label_test.go
+++ b/pkg/neg/syncers/labels/label_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-gce/pkg/neg/metrics"
 	negtypes "k8s.io/ingress-gce/pkg/neg/types"
 )
 
@@ -114,7 +115,7 @@ func TestGetPodLabelMap(t *testing.T) {
 			expectErr: true,
 		},
 	} {
-		ret, err := GetPodLabelMap(pod, tc.lpConfig)
+		ret, err := GetPodLabelMap(pod, tc.lpConfig, metrics.NewNegMetrics())
 		if !reflect.DeepEqual(ret, tc.expect) {
 			t.Errorf("For test case %q, got label map %+v, want %+v", tc.desc, ret, tc.expect)
 		}

--- a/pkg/neg/syncers/labels/labels.go
+++ b/pkg/neg/syncers/labels/labels.go
@@ -62,7 +62,7 @@ const minLabelLength = 5
 // GetPodLabelMap will return the label map extracted from a pod according to PodLabelPropagationConfig.
 // The returned map has the pod label key as key and label value as value.
 // This function will raise an error if pod label truncation happens or truncation fails.
-func GetPodLabelMap(pod *v1.Pod, lpConfig PodLabelPropagationConfig) (PodLabelMap, error) {
+func GetPodLabelMap(pod *v1.Pod, lpConfig PodLabelPropagationConfig, m *metrics.NegMetrics) (PodLabelMap, error) {
 	labelMap := PodLabelMap{}
 	var errs []error
 	for _, label := range lpConfig.Labels {
@@ -75,7 +75,7 @@ func GetPodLabelMap(pod *v1.Pod, lpConfig PodLabelPropagationConfig) (PodLabelMa
 			labelVal, err := truncatePodLabel(lpKey, val, label.MaxLabelSizeBytes)
 			if err != nil {
 				errs = append(errs, err)
-				publishLabelPropagationTruncationMetrics(err)
+				publishLabelPropagationTruncationMetrics(err, m)
 			}
 
 			// Add the label to the map only if the truncation result is valid
@@ -92,11 +92,11 @@ func GetPodLabelMap(pod *v1.Pod, lpConfig PodLabelPropagationConfig) (PodLabelMa
 
 // publishLabelPropagationTruncationMetrics publishes errors occured during
 // label truncation.
-func publishLabelPropagationTruncationMetrics(err error) {
+func publishLabelPropagationTruncationMetrics(err error, m *metrics.NegMetrics) {
 	if errors.Is(err, ErrLabelTruncated) {
-		metrics.PublishLabelPropagationError(Truncated)
+		m.PublishLabelPropagationError(Truncated)
 	} else if errors.Is(err, ErrLabelTruncationFailed) {
-		metrics.PublishLabelPropagationError(TruncationFailure)
+		m.PublishLabelPropagationError(TruncationFailure)
 	}
 }
 

--- a/pkg/neg/syncers/transaction.go
+++ b/pkg/neg/syncers/transaction.go
@@ -443,7 +443,7 @@ func (s *transactionSyncer) syncInternalImpl() error {
 	// Only fetch label from pod for L7 endpoints
 	if flags.F.EnableNEGLabelPropagation && s.NegType == negtypes.VmIpPortEndpointType {
 		endpointPodLabelMap = getEndpointPodLabelMap(addEndpoints, endpointPodMap, s.podLister, s.podLabelPropagationConfig, s.recorder, s.logger, s.negMetrics)
-		publishAnnotationSizeMetrics(addEndpoints, endpointPodLabelMap)
+		publishAnnotationSizeMetrics(addEndpoints, endpointPodLabelMap, s.negMetrics)
 	}
 
 	s.syncMetricsCollector.SetLabelPropagationStats(s.NegSyncerKey, collectLabelStats(currentPodLabelMap, endpointPodLabelMap, targetMap))
@@ -1190,18 +1190,18 @@ func getEndpointPodLabelMap(endpoints map[negtypes.NEGLocation]negtypes.NetworkE
 			key := fmt.Sprintf("%s/%s", endpointPodMap[endpoint].Namespace, endpointPodMap[endpoint].Name)
 			obj, ok, err := podLister.GetByKey(key)
 			if err != nil || !ok {
-				metrics.PublishLabelPropagationError(labels.OtherError)
+				m.PublishLabelPropagationError(labels.OtherError)
 				logger.Error(err, "getEndpointPodLabelMap: error getting pod", "pod", key, "exist", ok)
 				m.PublishNegControllerErrorCountMetrics(err, true)
 				continue
 			}
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
-				metrics.PublishLabelPropagationError(labels.OtherError)
+				m.PublishLabelPropagationError(labels.OtherError)
 				logger.Error(nil, "expected type *v1.Pod", "pod", key, "type", fmt.Sprintf("%T", obj))
 				continue
 			}
-			labelMap, err := labels.GetPodLabelMap(pod, lpConfig)
+			labelMap, err := labels.GetPodLabelMap(pod, lpConfig, m)
 			if err != nil {
 				recorder.Eventf(pod, v1.EventTypeWarning, "LabelsExceededLimit", "Label Propagation Error: %v", err)
 				m.PublishNegControllerErrorCountMetrics(err, true)
@@ -1214,11 +1214,11 @@ func getEndpointPodLabelMap(endpoints map[negtypes.NEGLocation]negtypes.NetworkE
 
 // publishAnnotationSizeMetrics goes through all the endpoints to be attached
 // and publish annotation size metrics.
-func publishAnnotationSizeMetrics(endpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap) {
+func publishAnnotationSizeMetrics(endpoints map[negtypes.NEGLocation]negtypes.NetworkEndpointSet, endpointPodLabelMap labels.EndpointPodLabelMap, m *metrics.NegMetrics) {
 	for _, endpointSet := range endpoints {
 		for endpoint := range endpointSet {
 			labelMap := endpointPodLabelMap[endpoint]
-			metrics.PublishAnnotationMetrics(labels.GetPodLabelMapSize(labelMap), len(labelMap))
+			m.PublishAnnotationMetrics(labels.GetPodLabelMapSize(labelMap), len(labelMap))
 		}
 	}
 }

--- a/pkg/neg/types/testing.go
+++ b/pkg/neg/types/testing.go
@@ -21,11 +21,13 @@ import (
 
 	"k8s.io/klog/v2"
 
+	metrics "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/mtmetrics"
 	netfake "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned/fake"
 	informergkenetworkparamset "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
 	informernetwork "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
 	nodetopologyfake "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned/fake"
 	informernodetopology "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/informers/externalversions/nodetopology/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	informerv1 "k8s.io/client-go/informers/core/v1"
@@ -35,7 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/cloud-provider-gcp/providers/gce"
-	"k8s.io/ingress-gce/pkg/neg/metrics"
+	negmetrics "k8s.io/ingress-gce/pkg/neg/metrics"
 	svcnegclient "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned"
 	negfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	informersvcneg "k8s.io/ingress-gce/pkg/svcneg/client/informers/externalversions/svcneg/v1beta1"
@@ -77,7 +79,7 @@ type TestContext struct {
 	EnableDualStackNEG       bool
 	IncludeDrainNodesL4Local bool
 
-	NegMetrics *metrics.NegMetrics
+	NegMetrics *negmetrics.NegMetrics
 }
 
 func NewTestContext() *TestContext {
@@ -94,7 +96,10 @@ func NewTestContextWithKubeClient(kubeClient kubernetes.Interface) *TestContext 
 
 	clusterNamer := namer.NewNamer(clusterID, "", klog.TODO())
 	l4namer := namer.NewL4Namer(kubeSystemUID, clusterNamer)
-	negMetrics := metrics.NewNegMetrics()
+	negMetrics, err := negmetrics.NewNegMetricsWithFactory(metrics.NewStdMetricFactory(prometheus.NewRegistry()))
+	if err != nil {
+		klog.Fatalf("failed to create negMetrics: %v", err)
+	}
 
 	return &TestContext{
 		KubeClient:                 kubeClient,


### PR DESCRIPTION
- Change default metrics to register to StandardFactory
- Add functionality to support /multitenancy endpoint for emitting tenant metrics 
- For MT clusters, pass tenantUID & create MT metric factory