### PR TITLE
Standalone L4 NEG - validate NEG attachment 

### DIFF
--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -31,8 +31,10 @@ import (
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
 	ccontext "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
@@ -40,6 +42,7 @@ import (
 	"k8s.io/ingress-gce/pkg/l4/resources"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
 )
 
@@ -103,6 +106,7 @@ type StandaloneNEGLBController struct {
 	ctx       *ccontext.ControllerContext
 	svcQueue  utils.TaskQueue
 	logger    klog.Logger
+	namer     namer.L4ResourcesNamer
 	stopCh    <-chan struct{}
 	hasSynced func() bool
 }
@@ -113,6 +117,7 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 	lc := &StandaloneNEGLBController{
 		ctx:       ctx,
 		stopCh:    stopCh,
+		namer:     ctx.L4Namer,
 		hasSynced: ctx.HasSynced,
 		logger:    logger,
 	}
@@ -286,6 +291,120 @@ func validateForwardingRule(fr *composite.ForwardingRule, frName string) error {
 	return errors.Join(errs...)
 }
 
+func (lc *StandaloneNEGLBController) validateLoadBalancer(parsedFR parsedForwardingRule, targetNEGs sets.Set[cloud.ResourceMapKey], bsValidationCache map[string]error, svcLogger klog.Logger) (addresses []string, scheme string, err error) {
+	fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsedFR.key, meta.VersionBeta, svcLogger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			svcLogger.Error(err, "failed to get forwarding rule", "frName", parsedFR.rawName)
+			err = l4utils.NewUserError(err)
+		}
+		return nil, "", err
+	}
+
+	if err := validateForwardingRule(fr, parsedFR.rawName); err != nil {
+		svcLogger.Error(err, "invalid forwarding rule", "frName", parsedFR.rawName)
+		return nil, fr.LoadBalancingScheme, l4utils.NewUserError(err)
+	}
+
+	bsURL := fr.BackendService
+	var bsErr error
+	if cachedErr, ok := bsValidationCache[bsURL]; ok {
+		bsErr = cachedErr
+	} else {
+		bsErr = lc.validateBackendService(fr, targetNEGs, svcLogger)
+		bsValidationCache[bsURL] = bsErr
+	}
+	if bsErr != nil {
+		errWithContext := fmt.Errorf("forwarding rule %s: %w", parsedFR.rawName, bsErr)
+		svcLogger.Error(errWithContext, "invalid backend service for forwarding rule", "frName", parsedFR.rawName, "bsURL", bsURL)
+		return nil, fr.LoadBalancingScheme, errWithContext
+	}
+	return frAddresses(fr), fr.LoadBalancingScheme, nil
+}
+
+func (lc *StandaloneNEGLBController) getServiceNEGLinks(svc *v1.Service) (sets.Set[cloud.ResourceMapKey], error) {
+	neglinks := sets.New[cloud.ResourceMapKey]()
+	if svc == nil {
+		return neglinks, nil
+	}
+
+	negName := lc.namer.L4Backend(svc.Namespace, svc.Name)
+	svcNegKey := fmt.Sprintf("%s/%s", svc.Namespace, negName)
+
+	if lc.ctx != nil && lc.ctx.SvcNegInformer != nil {
+		obj, exists, err := lc.ctx.SvcNegInformer.GetIndexer().GetByKey(svcNegKey)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+		svcNeg, ok := obj.(*negv1beta1.ServiceNetworkEndpointGroup)
+		if !ok || svcNeg == nil {
+			return nil, fmt.Errorf("failed to retrieve ServiceNetworkEndpointGroup")
+		}
+
+		for _, negRef := range svcNeg.Status.NetworkEndpointGroups {
+			if negRef.SelfLink != "" {
+				resourceKey, err := cloud.ParseResourceURL(negRef.SelfLink)
+				if err != nil {
+					continue
+				}
+				neglinks.Insert(resourceKey.MapKey())
+			}
+		}
+	}
+	return neglinks, nil
+}
+
+func (lc *StandaloneNEGLBController) validateBackendService(fr *composite.ForwardingRule, targetNEGs sets.Set[cloud.ResourceMapKey], svcLogger klog.Logger) error {
+	bsURL := fr.BackendService
+	if bsURL == "" {
+		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer, forwarding rule is missing the backend service reference"))
+	}
+
+	resourceID, err := cloud.ParseResourceURL(bsURL)
+	if err != nil {
+		return l4utils.NewUserError(fmt.Errorf("failed to parse backend service URL %s: %w", bsURL, err))
+	}
+	if resourceID == nil || resourceID.Key == nil || resourceID.Key.Name == "" {
+		return l4utils.NewUserError(fmt.Errorf("invalid backend service URL %s: missing resource key", bsURL))
+	}
+
+	bs, err := composite.GetBackendService(lc.ctx.Cloud, resourceID.Key, meta.VersionBeta, svcLogger)
+	if err != nil {
+		wrappedError := fmt.Errorf("failed to get backend service %s: %w", bsURL, err)
+		if utils.IsNotFoundError(err) {
+			return l4utils.NewUserError(wrappedError)
+		}
+		return wrappedError
+	}
+
+	if !backendServiceHasNEGAttached(bs, targetNEGs) {
+		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer (backend service: %s)", resourceID.Key.Name))
+	}
+
+	return nil
+}
+
+// backendServiceHasNEGAttached checks if the backend service has any of
+// the targetNEGs attached.
+func backendServiceHasNEGAttached(bs *composite.BackendService, targetNEGs sets.Set[cloud.ResourceMapKey]) bool {
+	hasMatchingNEG := false
+	for _, be := range bs.Backends {
+		if be == nil || be.Group == "" {
+			continue
+		}
+		groupKey, err := cloud.ParseResourceURL(be.Group)
+
+		if err == nil && groupKey != nil && targetNEGs.Has(groupKey.MapKey()) {
+			hasMatchingNEG = true
+			break
+		}
+	}
+	return hasMatchingNEG
+}
+
 // IPAddress field is used for creating Regional NetLB forwarding rules, IPAddresses[] field is used for creating Global NetLB forwarding rules.
 func frAddresses(fr *composite.ForwardingRule) []string {
 	ipAddrs := fr.IPAddresses
@@ -309,7 +428,7 @@ func sortParsedFRs(frs []parsedForwardingRule) {
 	})
 }
 
-func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) (lbSchemes []string, err error) {
+func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) (lbSchemes sets.Set[string], err error) {
 	frNamesStr, ok := svc.Annotations[annotations.CustomForwardingRuleKey]
 	if !ok || frNamesStr == "" {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
@@ -340,10 +459,10 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		if len(errs) > 0 {
 			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule: %v", errors.Join(errs...))
 			allErrs := append([]error{clearErr}, errs...)
-			return nil, errors.Join(allErrs...)
+			return nil, joinMaybeUserErrors(allErrs...)
 		}
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
-		return nil, errors.Join(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
+		return nil, joinMaybeUserErrors(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
 	}
 
 	if len(parsedRules) > ForwardingRulesLimit {
@@ -356,28 +475,23 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 
 	var lbIngresses []v1.LoadBalancerIngress
 	vipMode := v1.LoadBalancerIPModeVIP
-	var schemes []string
+	schemes := sets.New[string]()
+
+	targetNEGs, err := lc.getServiceNEGLinks(svc)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	bsValidationCache := make(map[string]error)
 
 	for _, parsed := range parsedRules {
-		fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsed.key, meta.VersionBeta, svcLogger)
+		addresses, lbScheme, err := lc.validateLoadBalancer(parsed, targetNEGs, bsValidationCache, svcLogger)
 		if err != nil {
-			if utils.IsNotFoundError(err) {
-				svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
-				err = l4utils.NewUserError(err)
-			}
 			errs = append(errs, err)
 			continue
 		}
-		schemes = append(schemes, fr.LoadBalancingScheme)
-
-		if err := validateForwardingRule(fr, parsed.rawName); err != nil {
-			svcLogger.Error(err, "invalid forwarding rule", "frName", parsed.rawName)
-			errs = append(errs, l4utils.NewUserError(err))
-			continue
-		}
-
-		addrs := frAddresses(fr)
-		for _, a := range addrs {
+		schemes.Insert(lbScheme)
+		for _, a := range addresses {
 			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
 			trimmedIP := strings.Split(a, "/")[0]
 			// And make it canonical to avoid warnings from k8s apiserver
@@ -394,10 +508,14 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	// if at least one FR was ok then we use it
 	if len(lbIngresses) == 0 {
 		// if none of the FRs is usable remove any that is possibly there
-		cond := NewConditionExternalIPProgrammedFalse(classifyError(errs[0]))
+		var firstErr error
+		if len(errs) > 0 {
+			firstErr = errs[0]
+		}
+		cond := NewConditionExternalIPProgrammedFalse(classifyError(firstErr))
 		clearErr := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
 		allErrs := append([]error{clearErr}, errs...)
-		return schemes, errors.Join(allErrs...)
+		return schemes, joinMaybeUserErrors(allErrs...)
 	}
 
 	newStatus := &v1.LoadBalancerStatus{
@@ -419,10 +537,26 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	}
 
 	if len(errs) > 0 {
-		return schemes, errors.Join(errs...)
+		return schemes, joinMaybeUserErrors(errs...)
 	}
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "SyncLoadBalancerSuccessful", "Successfully ensured Standalone NEG LoadBalancer resources")
 	return schemes, nil
+}
+
+// join errors but if all are UserErrors make the wrapping error a UserError as
+// well. This is required to properly attribute sync status in metrics.
+func joinMaybeUserErrors(errs ...error) error {
+	allUserErrors := true
+	for _, err := range errs {
+		if !resources.IsUserError(err) {
+			allUserErrors = false
+			break
+		}
+	}
+	if allUserErrors {
+		return l4utils.NewUserError(errors.Join(errs...))
+	}
+	return errors.Join(errs...)
 }
 
 func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {
@@ -434,7 +568,7 @@ func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLo
 	return updateServiceStatus(lc.ctx, svc, newStatus, nil, conditionsToRemove, svcLogger)
 }
 
-func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string, syncErr error, start time.Time) {
+func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes sets.Set[string], syncErr error, start time.Time) {
 	state := l4metrics.L4StandaloneNEGServiceState{
 		Status: l4metrics.StatusSuccess,
 	}
@@ -448,9 +582,9 @@ func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string
 		}
 	}
 
-	state.LBSchemeExternal = slices.Contains(schemes, "EXTERNAL")
-	state.LBSchemeExternalPassthrough = slices.Contains(schemes, "EXTERNAL_PASSTHROUGH")
-	state.LBSchemeInternal = slices.Contains(schemes, "INTERNAL")
+	state.LBSchemeExternal = schemes.Has("EXTERNAL")
+	state.LBSchemeExternalPassthrough = schemes.Has("EXTERNAL_PASSTHROUGH")
+	state.LBSchemeInternal = schemes.Has("INTERNAL")
 
 	lc.ctx.L4Metrics.SetL4StandaloneNEGService(key, state)
 	l4metrics.PublishL4StandaloneNEGSyncLatency(syncErr == nil, start)

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -28,24 +28,29 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/googleapi"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
 	l4metrics "k8s.io/ingress-gce/pkg/l4/metrics"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
+	svcnegclientfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
 )
 
 func TestStandaloneNEGLBSync(t *testing.T) {
+	l4Namer := namer.NewL4Namer("k8s2-cluster-uid", namer.NewNamer("cluster-id", "firewall-id", klog.TODO()))
 	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
 	frName := "custom-fr"
 	frIP := "10.0.0.100"
@@ -59,6 +64,9 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 		desc               string
 		svc                *v1.Service
 		frs                map[string]*composite.ForwardingRule
+		bss                map[string]*composite.BackendService
+		svcNegs            []*negv1beta1.ServiceNetworkEndpointGroup
+		getBSErr           error
 		expectIPs          []string
 		expectEventReasons []string
 		expectError        bool
@@ -237,7 +245,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					LoadBalancingScheme: "EXTERNAL",
 					IPProtocol:          "TCP",
 					Scope:               meta.Regional,
-					Version:             meta.VersionGA,
+					Version:             meta.VersionBeta,
 				},
 			},
 			expectIPs:   []string{""},
@@ -1016,13 +1024,454 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				Message: "IPs programmed: 10.0.0.100, 10.0.0.109, 10.0.0.110, 10.0.0.111, 10.0.0.101, 10.0.0.102, 10.0.0.103, 10.0.0.104, 10.0.0.105, 10.0.0.106",
 			},
 		},
+		{
+			desc: "Forwarding Rule with missing BackendService URL -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-missing-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-missing-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-missing-bs": {
+					Name:                "fr-missing-bs",
+					IPAddress:           frIP,
+					BackendService:      "",
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with non-existent Backend Service (404) -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-404-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-404-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-404-bs": {
+					Name:                "fr-404-bs",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/non-existent-bs", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss:                map[string]*composite.BackendService{},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service returning non-404 system error (500) -> expect ProviderError condition reason",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-500-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-500-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-500-bs": {
+					Name:                "fr-500-bs",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-500", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-500": {
+					Name:    "bs-500",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+				},
+			},
+			getBSErr:           &googleapi.Error{Code: http.StatusInternalServerError, Message: "Internal Server Error"},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "ProviderError",
+				Message: "GCE provider error encountered while retrieving forwarding rules",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service whose backends belong to a different Service -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-diff-neg",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-diff-neg",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-diff-neg": {
+					Name:                "fr-diff-neg",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-other", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-other": {
+					Name:    "bs-other",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/other-svc-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-diff-neg"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-diff-neg"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/my-svc-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service matching target Service NEG via SvcNeg CRD informer -> expect VIP programmed successfully",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-match-crd",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-match-crd",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-match-crd": {
+					Name:                "fr-match-crd",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-crd", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-crd": {
+					Name:    "bs-crd",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/crd-neg-1", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-match-crd"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-match-crd"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/crd-neg-1", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{frIP},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.100",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service matching target Service NEG via SvcNeg CRD -> expect VIP programmed successfully",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-match-ann",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-match-ann",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-match-ann": {
+					Name:                "fr-match-ann",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-ann", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-ann": {
+					Name:    "bs-ann",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/ann-neg-1", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-match-ann"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-match-ann"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/ann-neg-1", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{frIP},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.100",
+			},
+		},
+		{
+			desc: "Multiple Forwarding Rules pointing to the same Backend Service -> verify deduplication",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-dedup",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-dedup-1,fr-dedup-2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-dedup-1": {
+					Name:                "fr-dedup-1",
+					IPAddress:           "10.0.0.1",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+				"fr-dedup-2": {
+					Name:                "fr-dedup-2",
+					IPAddress:           "10.0.0.2",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-dedup": {
+					Name:    "bs-dedup",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/dedup-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-dedup"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-dedup"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/dedup-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{"10.0.0.1", "10.0.0.2"},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.1, 10.0.0.2",
+			},
+		},
+		{
+			desc: "Multiple Forwarding Rules pointing to the same failing Backend Service -> verify deduplication",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-dedup-failing",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-dedup-fail-1,fr-dedup-fail-2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-dedup-fail-1": {
+					Name:                "fr-dedup-fail-1",
+					IPAddress:           "10.0.0.1",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup-failing", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+				"fr-dedup-fail-2": {
+					Name:                "fr-dedup-fail-2",
+					IPAddress:           "10.0.0.2",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup-failing", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-dedup-failing": {
+					Name:    "bs-dedup-failing",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/other-svc-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-dedup-failing"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-dedup-failing"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/my-svc-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset()
 			fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
-			namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
 
 			// Populate fakeGCE client with forwarding rules defined in each test case
 			for name, fr := range tc.frs {
@@ -1036,13 +1485,78 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				}
 			}
 
+			// If tc.bss is nil and tc.frs has rules with BackendService, populate default matching BS and SvcNeg for existing test cases
+			if tc.bss == nil && len(tc.frs) > 0 {
+				defaultBSMap := make(map[string]*composite.BackendService)
+				for _, fr := range tc.frs {
+					if fr.BackendService != "" {
+						if resID, err := cloud.ParseResourceURL(fr.BackendService); err == nil && resID.Key != nil {
+							defaultBSMap[resID.Key.Name] = &composite.BackendService{
+								Name:    resID.Key.Name,
+								Scope:   resID.Key.Type(),
+								Version: meta.VersionBeta,
+								Backends: []*composite.Backend{
+									{
+										Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/default-neg", project),
+									},
+								},
+							}
+						}
+					}
+				}
+				if len(defaultBSMap) > 0 {
+					tc.bss = defaultBSMap
+					if tc.svcNegs == nil && tc.svc != nil {
+						svcNegName := l4Namer.L4Backend(tc.svc.Namespace, tc.svc.Name)
+						tc.svcNegs = []*negv1beta1.ServiceNetworkEndpointGroup{
+							test.NewSvcNeg(types.NamespacedName{Namespace: tc.svc.Namespace, Name: svcNegName}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+								NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+									{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/default-neg", project)},
+								},
+							}),
+						}
+					}
+				}
+			}
+
+			// Populate fakeGCE client with backend services defined in each test case
+			for name, bs := range tc.bss {
+				key, err := composite.CreateKey(fakeGCE, name, bs.Scope)
+				if err != nil {
+					t.Fatalf("Failed to create key for backend service %s: %v", name, err)
+				}
+				err = composite.CreateBackendService(fakeGCE, key, bs, klog.TODO())
+				if err != nil {
+					t.Fatalf("Failed to create backend service %s: %v", name, err)
+				}
+			}
+
+			bsGetCount := 0
+			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+			mockGCE.MockBetaRegionBackendServices.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockBetaRegionBackendServices, options ...cloud.Option) (bool, *computebeta.BackendService, error) {
+				if tc.getBSErr != nil {
+					return true, nil, tc.getBSErr
+				}
+				if strings.HasPrefix(key.Name, "bs-dedup") {
+					bsGetCount++
+				}
+				return false, nil, nil
+			}
+
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
 			ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+			svcNegClient := svcnegclientfake.NewSimpleClientset()
+			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, nil, kubeClient, fakeGCE, l4Namer.Namer, "k8s2-cluster-uid", ctxConfig, klog.TODO())
 			if err != nil {
 				t.Fatalf("Failed to create controller context: %v", err)
+			}
+			c.L4Namer = l4Namer
+
+			for _, svcneg := range tc.svcNegs {
+				c.SvcNegInformer.GetIndexer().Add(svcneg)
+				c.SvcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcneg.Namespace).Create(context.TODO(), svcneg, metav1.CreateOptions{})
 			}
 
 			lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
@@ -1056,6 +1570,12 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			err = lc.syncWrapper(key)
 			if (err != nil) != tc.expectError {
 				t.Errorf("sync() error = %v, expectError %v", err, tc.expectError)
+			}
+
+			if strings.Contains(tc.desc, "verify deduplication") {
+				if bsGetCount != 1 {
+					t.Errorf("Expected BackendService bs-dedup to be fetched 1 time, got %d", bsGetCount)
+				}
 			}
 
 			updatedSvc, _ := kubeClient.CoreV1().Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
@@ -1249,15 +1769,17 @@ func TestValidateForwardingRule(t *testing.T) {
 func setupControllerContext(t *testing.T) (*fake.Clientset, *gce.Cloud, *StandaloneNEGLBController, chan struct{}) {
 	kubeClient := fake.NewSimpleClientset()
 	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
-	namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
+	l4Namer := namer.NewL4Namer("k8s2-cluster-uid", namer.NewNamer("cluster-id", "firewall-id", klog.TODO()))
 
 	stopCh := make(chan struct{})
 
 	ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+	svcNegClient := svcnegclientfake.NewSimpleClientset()
+	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, nil, kubeClient, fakeGCE, l4Namer.Namer, "k8s2-cluster-uid", ctxConfig, klog.TODO())
 	if err != nil {
 		t.Fatalf("Failed to create controller context: %v", err)
 	}
+	c.L4Namer = l4Namer
 
 	lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
 	return kubeClient, fakeGCE, lc, stopCh
@@ -1306,6 +1828,24 @@ func TestStandaloneNEGLBControllerMetrics_Success(t *testing.T) {
 			LoadBalancerClass: &lbClass,
 		},
 	}
+
+	// Create Backend Service and SvcNeg for BS validation
+	bsKey, _ := composite.CreateKey(fakeGCE, "bs1", meta.Regional)
+	bs := &composite.BackendService{
+		Name:    "bs1",
+		Scope:   meta.Regional,
+		Version: meta.VersionBeta,
+		Backends: []*composite.Backend{
+			{Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	}
+	composite.CreateBackendService(fakeGCE, bsKey, bs, klog.TODO())
+	svcNeg := test.NewSvcNeg(types.NamespacedName{Namespace: "default", Name: lc.namer.L4Backend(svc.Namespace, svc.Name)}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+		NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+			{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	})
+	lc.ctx.SvcNegInformer.GetIndexer().Add(svcNeg)
 
 	// Add service to informer and fake kube client
 	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
@@ -1493,6 +2033,24 @@ func TestStandaloneNEGLBControllerMetrics_Deletion(t *testing.T) {
 			LoadBalancerClass: &lbClass,
 		},
 	}
+
+	// Create Backend Service and SvcNeg for BS validation
+	bsKey, _ := composite.CreateKey(fakeGCE, "bs1", meta.Regional)
+	bs := &composite.BackendService{
+		Name:    "bs1",
+		Scope:   meta.Regional,
+		Version: meta.VersionBeta,
+		Backends: []*composite.Backend{
+			{Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	}
+	composite.CreateBackendService(fakeGCE, bsKey, bs, klog.TODO())
+	svcNeg := test.NewSvcNeg(types.NamespacedName{Namespace: "default", Name: lc.namer.L4Backend(svc.Namespace, svc.Name)}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+		NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+			{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	})
+	lc.ctx.SvcNegInformer.GetIndexer().Add(svcNeg)
 
 	// Add service to informer and fake kube client
 	lc.ctx.ServiceInformer.GetIndexer().Add(svc)


### PR DESCRIPTION
before writing LB VIP into service status, check if the service NEGs are attached to the LB.
LB VIPs for LBs that do not use the controller created NEGs will not be programmed in the cluster.