### PR TITLE
Add BackendNotAttached condition reason to Standalone NEG LB controller

### DIFF
--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -62,6 +62,8 @@ const (
 	UnsupportedLBType = lbConditionReason("UnsupportedLBType")
 	// InvalidForwardingRule Reason
 	InvalidForwardingRule = lbConditionReason("InvalidForwardingRule")
+	// BackendNotAttached Reason
+	BackendNotAttached = lbConditionReason("BackendNotAttached")
 	// ProviderError Reason
 	ProviderError = lbConditionReason("ProviderError")
 	// Maximum number of forwarding rules
@@ -381,7 +383,7 @@ func (lc *StandaloneNEGLBController) validateBackendService(fr *composite.Forwar
 	}
 
 	if !backendServiceHasNEGAttached(bs, targetNEGs) {
-		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer (backend service: %s)", resourceID.Key.Name))
+		return l4utils.NewUserError(l4utils.NewBackendNotAttachedError(resourceID.Key.Name))
 	}
 
 	return nil
@@ -594,6 +596,9 @@ func classifyError(err error) lbConditionReason {
 	if err == nil {
 		return ProviderError
 	}
+	if l4utils.IsBackendNotAttachedError(err) {
+		return BackendNotAttached
+	}
 	if utils.IsNotFoundError(err) {
 		return InvalidForwardingRule
 	}
@@ -637,6 +642,8 @@ func messageForReason(reason lbConditionReason) string {
 		return "The referenced forwarding rule has an unsupported load balancing scheme"
 	case InvalidForwardingRule:
 		return "The custom forwarding rule reference is invalid"
+	case BackendNotAttached:
+		return "The service NEGs are not attached to the load balancer backend service"
 	case ProviderError:
 		return "GCE provider error encountered while retrieving forwarding rules"
 	default:

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -1199,8 +1199,8 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
 				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidForwardingRule",
-				Message: "The custom forwarding rule reference is invalid",
+				Reason:  "BackendNotAttached",
+				Message: "The service NEGs are not attached to the load balancer backend service",
 			},
 		},
 		{
@@ -1462,8 +1462,8 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
 				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidForwardingRule",
-				Message: "The custom forwarding rule reference is invalid",
+				Reason:  "BackendNotAttached",
+				Message: "The service NEGs are not attached to the load balancer backend service",
 			},
 		},
 	}
@@ -2295,6 +2295,21 @@ func TestClassifyError(t *testing.T) {
 			desc:     "unsupported protocol wrapped in UserError and fmt.Errorf",
 			err:      fmt.Errorf("wrapped: %w", l4utils.NewUserError(l4utils.NewUnsupportedProtocolError("fr-name", "UAUDP", []string{"TCP"}))),
 			expected: InvalidForwardingRule,
+		},
+		{
+			desc:     "backend not attached",
+			err:      l4utils.NewBackendNotAttachedError("bs1"),
+			expected: BackendNotAttached,
+		},
+		{
+			desc:     "backend not attached wrapped in UserError",
+			err:      l4utils.NewUserError(l4utils.NewBackendNotAttachedError("bs1")),
+			expected: BackendNotAttached,
+		},
+		{
+			desc:     "backend not attached wrapped in UserError and fmt.Errorf",
+			err:      fmt.Errorf("wrapped: %w", l4utils.NewUserError(l4utils.NewBackendNotAttachedError("bs1"))),
+			expected: BackendNotAttached,
 		},
 		{
 			desc:     "generic error",

--- a/pkg/l4/utils/errors.go
+++ b/pkg/l4/utils/errors.go
@@ -230,3 +230,23 @@ func IsUnsupportedProtocolError(err error) bool {
 	var unsupportedProtocolErr *UnsupportedProtocolError
 	return errors.As(err, &unsupportedProtocolErr)
 }
+
+// BackendNotAttachedError is an error returned when service NEGs are not attached to the load balancer backend service.
+type BackendNotAttachedError struct {
+	bsName string
+}
+
+func (e *BackendNotAttachedError) Error() string {
+	return fmt.Sprintf("the service NEGs are not attached to the load balancer (backend service: %s)", e.bsName)
+}
+
+// NewBackendNotAttachedError creates a new BackendNotAttachedError.
+func NewBackendNotAttachedError(bsName string) *BackendNotAttachedError {
+	return &BackendNotAttachedError{bsName: bsName}
+}
+
+// IsBackendNotAttachedError checks if wrapped error is a BackendNotAttachedError.
+func IsBackendNotAttachedError(err error) bool {
+	var backendNotAttachedErr *BackendNotAttachedError
+	return errors.As(err, &backendNotAttachedErr)
+}

--- a/pkg/l4/utils/errors_test.go
+++ b/pkg/l4/utils/errors_test.go
@@ -300,3 +300,62 @@ func TestUnsupportedProtocolError(t *testing.T) {
 		})
 	}
 }
+
+func TestBackendNotAttachedError(t *testing.T) {
+	customErr := NewBackendNotAttachedError("test-backend-service")
+
+	testCases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			desc: "direct error",
+			err:  customErr,
+			want: true,
+		},
+		{
+			desc: "wrapped in fmt.Errorf",
+			err:  fmt.Errorf("wrapped: %w", customErr),
+			want: true,
+		},
+		{
+			desc: "wrapped in UserError",
+			err:  NewUserError(customErr),
+			want: true,
+		},
+		{
+			desc: "wrapped in UserError and then fmt.Errorf",
+			err:  fmt.Errorf("wrapped: %w", NewUserError(customErr)),
+			want: true,
+		},
+		{
+			desc: "joined with other errors",
+			err:  errors.Join(errors.New("generic error"), customErr),
+			want: true,
+		},
+		{
+			desc: "joined and wrapped in UserError",
+			err:  NewUserError(errors.Join(errors.New("generic error"), customErr)),
+			want: true,
+		},
+		{
+			desc: "other error",
+			err:  errors.New("other error"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := IsBackendNotAttachedError(tc.err); got != tc.want {
+				t.Errorf("IsBackendNotAttachedError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Differentiate unattached backend NEGs from generic invalid forwarding rules. Introduce BackendNotAttached condition reason and typed error for clearer user feedback in Service conditions.