### PR TITLE
Fix user error classification and IP sanitization in Standalone NEG LB controller

### DIFF
--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -407,11 +407,13 @@ func backendServiceHasNEGAttached(bs *composite.BackendService, targetNEGs sets.
 
 // IPAddress field is used for creating Regional NetLB forwarding rules, IPAddresses[] field is used for creating Global NetLB forwarding rules.
 func frAddresses(fr *composite.ForwardingRule) []string {
-	ipAddrs := fr.IPAddresses
-	if len(ipAddrs) == 0 {
-		ipAddrs = []string{fr.IPAddress}
+	if len(fr.IPAddresses) > 0 {
+		return fr.IPAddresses
 	}
-	return ipAddrs
+	if fr.IPAddress != "" {
+		return []string{fr.IPAddress}
+	}
+	return nil
 }
 
 func parsedFRNames(frs []parsedForwardingRule) []string {
@@ -490,15 +492,24 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 			errs = append(errs, err)
 			continue
 		}
+		if len(addresses) == 0 {
+			errs = append(errs, l4utils.NewUserError(fmt.Errorf("forwarding rule %s has no IP address", parsed.rawName)))
+			continue
+		}
 		schemes.Insert(lbScheme)
 		for _, a := range addresses {
+			if a == "" {
+				continue
+			}
 			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
 			trimmedIP := strings.Split(a, "/")[0]
 			// And make it canonical to avoid warnings from k8s apiserver
 			if ipAddr, err := netip.ParseAddr(trimmedIP); err == nil {
 				trimmedIP = ipAddr.String()
 			}
-			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
+			if trimmedIP != "" {
+				lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
+			}
 		}
 	}
 
@@ -546,17 +557,28 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 // join errors but if all are UserErrors make the wrapping error a UserError as
 // well. This is required to properly attribute sync status in metrics.
 func joinMaybeUserErrors(errs ...error) error {
-	allUserErrors := true
+	var nonNilErrs []error
 	for _, err := range errs {
+		if err != nil {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+	if len(nonNilErrs) == 0 {
+		return nil
+	}
+
+	allUserErrors := true
+	for _, err := range nonNilErrs {
 		if !resources.IsUserError(err) {
 			allUserErrors = false
 			break
 		}
 	}
+	joinedErr := errors.Join(nonNilErrs...)
 	if allUserErrors {
-		return l4utils.NewUserError(errors.Join(errs...))
+		return l4utils.NewUserError(joinedErr)
 	}
-	return errors.Join(errs...)
+	return joinedErr
 }
 
 func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -248,13 +248,14 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					Version:             meta.VersionBeta,
 				},
 			},
-			expectIPs:   []string{""},
-			expectError: false,
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
-				Status:  metav1.ConditionTrue,
-				Reason:  "IPProgrammed",
-				Message: "IPs programmed: ",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
 			},
 		},
 		{
@@ -2319,4 +2320,63 @@ func generateForwardingRuleKey(fr string, num int) string {
 		buffer.WriteString(fmt.Sprintf("%s%d,", fr, i))
 	}
 	return strings.TrimSuffix(buffer.String(), ",")
+}
+
+func TestJoinMaybeUserErrors(t *testing.T) {
+	userErr1 := l4utils.NewUserError(errors.New("user err 1"))
+	userErr2 := l4utils.NewUserError(errors.New("user err 2"))
+	sysErr := errors.New("system err")
+
+	testCases := []struct {
+		desc       string
+		errs       []error
+		expectNil  bool
+		expectUser bool
+	}{
+		{
+			desc:      "all nil errors",
+			errs:      []error{nil, nil},
+			expectNil: true,
+		},
+		{
+			desc:       "nil mixed with user errors",
+			errs:       []error{nil, userErr1, nil, userErr2},
+			expectUser: true,
+		},
+		{
+			desc:       "only user errors",
+			errs:       []error{userErr1, userErr2},
+			expectUser: true,
+		},
+		{
+			desc:       "nil mixed with system error",
+			errs:       []error{nil, sysErr},
+			expectUser: false,
+		},
+		{
+			desc:       "user error mixed with system error and nil",
+			errs:       []error{nil, userErr1, sysErr},
+			expectUser: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := joinMaybeUserErrors(tc.errs...)
+			if tc.expectNil {
+				if got != nil {
+					t.Fatalf("expected nil error, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil error, got nil")
+			}
+			var userErr *l4utils.UserError
+			isUser := errors.As(got, &userErr) && got == userErr
+			if isUser != tc.expectUser {
+				t.Errorf("isUserErrorWrapper(%v) = %v, expected %v", got, isUser, tc.expectUser)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Filter nil errors in joinMaybeUserErrors to ensure user-caused errors are properly attributed in metrics. Sanitize forwarding rule IP addresses to prevent empty string entries from being written to service status ingress.