### PR TITLE
TestRetryOnSyncError Fix

### DIFF
--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -160,10 +160,10 @@ func TestRetryOnSyncError(t *testing.T) {
 	syncerTester.mu.Lock()
 	syncerTester.syncError = true
 	syncerTester.mu.Unlock()
+	syncerTester.syncer.(*syncer).backoff = backoff.NewExponentialBackoffHandler(maxRetry, 0, 0)
 	if err := syncerTester.syncer.Start(); err != nil {
 		t.Fatalf("Failed to start syncer: %v", err)
 	}
-	syncerTester.syncer.(*syncer).backoff = backoff.NewExponentialBackoffHandler(maxRetry, 0, 0)
 
 	if err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
 		// In 5 seconds, syncer should be able to retry 3 times.


### PR DESCRIPTION
```
E0827 07:30:37.368267   22890 syncer.go:109] "Sync failed" err="sync error" syncerKey="test-ns/test-name-test-neg-name-/80-80--" retry="(will retry)"
E0827 07:30:42.368357   22890 syncer.go:109] "Sync failed" err="sync error" syncerKey="test-ns/test-name-test-neg-name-/80-80--" retry="(will retry)"
E0827 07:30:42.368385   22890 syncer.go:109] "Sync failed" err="sync error" syncerKey="test-ns/test-name-test-neg-name-/80-80--" retry="(will retry)"
E0827 07:30:42.368392   22890 syncer.go:109] "Sync failed" err="sync error" syncerKey="test-ns/test-name-test-neg-name-/80-80--" retry="(will retry)"
E0827 07:30:42.368398   22890 syncer.go:109] "Sync failed" err="sync error" syncerKey="test-ns/test-name-test-neg-name-/80-80--" retry="(will not retry)"
--- FAIL: TestRetryOnSyncError (5.00s)
    syncer_test.go:175: Syncer failed to retry and record error: timed out waiting for the condition
    syncer_test.go:182: Expect sync count to be 4, but got 5
```

The `TestRetryOnSyncError` test was occasionally failing with a timeout 
and an unexpected sync count due to an initialization order bug. 
`syncer.Start()` was being called before overriding the default backoff 
handler with the test-specific one, leading to the following sequence 
of events:
1. `syncer.Start()` runs in a goroutine and attempts the first sync.
2. The initial sync fails. Because the custom backoff isn't applied 
   yet, it uses the default handler which enforces a 5-second minimum 
   delay.
3. The main thread overwrites the backoff handler with the test config 
   (maxRetry=3, delay=0) and enters a 5-second `wait.PollImmediate`.
4. The test times out waiting for `syncCount == 4` because the syncer 
   goroutine is asleep for the entire 5-second duration.
5. Right as the test times out, the 5-second timer finishes and the 
   syncer wakes up to resume its loop.
6. The syncer queries the *new* backoff handler. Because it is the 
   first time this new handler is invoked, its internal retry count 
   starts from 0, allowing an additional 3 retries (4 syncs total) with
   0-second delays.
7. The test records a total of 5 syncs (1 initial + 4 from the new 
   handler), leading to the `Expect sync count to be 4, but got 5` 
   failure.
This commit resolves the race condition by ensuring the custom test 
backoff handler is fully assigned before starting the syncer.