### PR TITLE
NEG tests - fix flaky "missing cancel error"

### DIFF
--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -540,7 +540,7 @@ func TestEnqueueNodeWithILBSubsetting(t *testing.T) {
 	// start the informer directly, without starting the entire controller.
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 		controller.stop()
 	}()
 	ctx := context.Background()
@@ -581,7 +581,7 @@ func TestEnqueueNodeWhenProviderIDPopulated(t *testing.T) {
 	// start the informer directly, without starting the entire controller.
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 		controller.stop()
 	}()
 	ctx := context.Background()
@@ -1602,7 +1602,7 @@ func TestEnqueueEndpoints(t *testing.T) {
 			// start the informer directly, without starting the entire controller.
 			go testContext.EndpointSliceInformer.Run(stopChan)
 			defer func() {
-				stopChan <- struct{}{}
+				close(stopChan)
 				controller.stop()
 			}()
 			ctx := context.Background()
@@ -2585,7 +2585,7 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 	stopChan := make(chan struct{}, 1)
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 	}()
 	if !cache.WaitForCacheSync(stopChan, testContext.NodeInformer.HasSynced) {
 		t.Fatal("timed out waiting for node informer to sync")

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -164,6 +164,7 @@ func TestRetryOnSyncError(t *testing.T) {
 	if err := syncerTester.syncer.Start(); err != nil {
 		t.Fatalf("Failed to start syncer: %v", err)
 	}
+	defer syncerTester.syncer.Stop()
 
 	if err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
 		// In 5 seconds, syncer should be able to retry 3 times.


### PR DESCRIPTION
```
panic: context: internal error: missing cancel error
goroutine 110 [running]:
context.(*cancelCtx).cancel(0x4602eb8?, 0x50?, {0x0?, 0x0?}, {0x0?, 0x0?})
	/usr/local/go/src/context/context.go:551 +0x308
context.(*cancelCtx).propagateCancel.func2()
	/usr/local/go/src/context/context.go:525 +0xf3
created by context.(*cancelCtx).propagateCancel in goroutine 108
	/usr/local/go/src/context/context.go:522 +0x409
FAIL	k8s.io/ingress-gce/pkg/neg	12.076s
```

This fixes a flaky race condition in `pkg/neg` tests that resulted in the
Go runtime panic: `context: internal error: missing cancel error`.

**Root Cause**:
The `k8s.io/apimachinery/pkg/util/wait` package provides `ContextForChannel`, 
which wraps a `stopCh` to act as a `context.Context`. Its `Err()` method 
relies on the channel being explicitly closed to return `context.Canceled`. 
In several NEG tests, `stopChan <- struct{}{}` was used during test teardown 
instead of `close(stopChan)`. When a value is sent:
1. The background context watcher (`propagateCancel` goroutine) consumes the 
   value, causing `<-parent.Done()` to unblock.
2. The watcher then calls `parent.Err()` to determine the cancellation cause.
3. Because the single value was consumed, the channel appears empty but not 
   closed, causing `Err()` to erroneously return `nil`.
4. The Go 1.20+ context package strictly panics if a context cancellation 
   propagates a `nil` error.
This race condition only triggered if the background watcher goroutine was 
scheduled precisely between the value being sent and the test process tearing 
down.
 
**Fixes:**
1. Replaced all occurrences of `stopChan <- struct{}{}` with `close(stopChan)` 
   in `pkg/neg/controller_test.go` to ensure deterministic context cancellation.
2. Added a missing `defer syncerTester.syncer.Stop()` to `TestRetryOnSyncError` 
   in `pkg/neg/syncers/syncer_test.go` to prevent background syncer goroutines 
   from leaking between test boundaries, which further exacerbated the race condition.