### PR TITLE
TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking flaky test fix by explicilly waiting for NEGs in SVCNEG

### DIFF
--- a/hack/run-e2e-gce.sh
+++ b/hack/run-e2e-gce.sh
@@ -53,7 +53,7 @@ if [[ -z "${IMAGE_TAG:-}" ]]; then
   IMAGE_TAG=$(git rev-parse --short HEAD)-$(date +%Y%m%dT%H%M%S)
 fi
 
-KO_GLBC_IMAGE=$(go run github.com/google/ko@v0.12.0 build --tags ${IMAGE_TAG} --base-import-paths --push=true ./cmd/glbc/)
+KO_GLBC_IMAGE=$(go run github.com/google/ko@v0.17.1 build --tags ${IMAGE_TAG} --base-import-paths --push=true ./cmd/glbc/)
 # remove the sha from the image name, it does not work with gce registry per example
 export GCE_GLBC_IMAGE=$(echo $KO_GLBC_IMAGE | cut -d\@ -f1)
 echo "GCE_GLBC_IMAGE=${GCE_GLBC_IMAGE}"

--- a/pkg/multiproject/start/start_test.go
+++ b/pkg/multiproject/start/start_test.go
@@ -702,7 +702,11 @@ func checkSvcNEG(
 			}
 			return false, fmt.Errorf("failed to get Svc NEG %s/%s: %v", svc.Namespace, negName, err)
 		}
-		t.Logf("Svc NEG found: %s/%s with %d endpoints", negCheck.Namespace, negCheck.Name, len(negCheck.Status.NetworkEndpointGroups))
+		if len(negCheck.Status.NetworkEndpointGroups) == 0 {
+			t.Logf("Svc NEG found: %s/%s with 0 NEGs, waiting...", negCheck.Namespace, negCheck.Name)
+			return false, nil
+		}
+		t.Logf("Svc NEG found: %s/%s with %d NEGs", negCheck.Namespace, negCheck.Name, len(negCheck.Status.NetworkEndpointGroups))
 		return true, nil
 	})
 }


### PR DESCRIPTION
```
--- FAIL: TestSharedInformers_PC1Stops_PC2AndPC3KeepWorking (17.52s)

        start_test.go:552: NEG status annotation not yet present on service pc-2/svc2-a
    start_test.go:552: NEG status annotation not yet present on service pc-2/svc2-a
    start_test.go:609: Svc NEG found: pc-2/gk3-mt1-abcdef12-pc-2-svc2-a-80-160cee63 with 0 endpoints
    start_test.go:364: NEG "gk3-mt1-abcdef12-pc-2-svc2-a-80-160cee63" on Service "svc2-a" is not in the expected state: failed to get NEG "gk3-mt1-abcdef12-pc-2-svc2-a-80-160cee63" from cloud in region us-central1: googleapi: Error 404: MockBetaNetworkEndpointGroups Key{"gk3-mt1-abcdef12-pc-2-svc2-a-80-160cee63", zone: "us-central1"} not found


FAIL	k8s.io/ingress-gce/pkg/multiproject/start	37.904s
```

**Root Cause Analysis**
The flakiness was caused by an asynchronous event ingestion race condition interacting poorly with the test's assertions in pkg/multiproject/start/start_test.go.

**The Race Condition**: The test populates the fake cluster via seedAll(), creating Nodes, EndpointSlices, and a Service. These resources generate asynchronous watch events.

**The Controller's Reaction**: When the newly-started NEG controller processes the Service, it immediately creates a NEG syncer. In its first synchronization pass, the syncer attempts to calculate the required NEG zones by examining the current cached nodes (zoneGetter).

**The Flake: If the Node watch events haven't been fully processed by the informer yet (because of the asynchronous ingestion), the syncer sees zero candidate zones. Consequently, it creates zero NEGs in the mock GCE and updates the SvcNeg Custom Resource with an empty Status.NetworkEndpointGroups list.**

**The Assertion Gap**: The checkSvcNEG helper strictly waited until the SvcNeg CR existed. When it encountered the freshly created (but empty) CR, it returned successfully, advancing the test to verifyCloudNEG.

The Timeout: verifyCloudNEG loops with a hardcoded defaultTimeout of 10s. Meanwhile, the delayed Node watch events arrive, triggering SyncNodes(), which detects a zone change (from 0 to 1 zones) and signals the syncer to run again. The syncer then creates the NEGs in GCE. However, if this second sync finishes slightly past the 10-second mark, verifyCloudNEG times out, resulting in the googleapi: Error 404 failure seen in the logs.

**The Fix
The fix resides entirely in the test's polling logic. By making checkSvcNEG robust enough to wait until the controller has fully discovered the endpoints and provisioned the cloud NEGs, we ensure that verifyCloudNEG doesn't begin checking GCE prematurely.**

I modified checkSvcNEG() to wait until len(negCheck.Status.NetworkEndpointGroups) > 0 before returning true:

```go
// pkg/multiproject/start/start_test.go
if len(negCheck.Status.NetworkEndpointGroups) == 0 {
	t.Logf("Svc NEG found: %s/%s with 0 NEGs, waiting...", negCheck.Namespace, negCheck.Name)
	return false, nil
}
```
This forces the test to naturally wait out the informer's ingestion delay (up to 30 seconds, defaultTimeout*3), ensuring verifyCloudNEG will successfully find the resources in GCE.