### PR TITLE
[release-1.41] Backport Standalone L4 NEG improvements and BYOIPv6 support

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -160,6 +160,7 @@ var F = struct {
 	// EnableL4DenyFirewallExplicitlySet will be set to true if the argument was explicitly set by the user.
 	EnableL4DenyFirewallExplicitlySet bool
 	EnableL4NetLBRBSByDefault         bool
+	EnableBYOIPv6                     bool
 	// ===============================
 	// DEPRECATED FLAGS
 	// ===============================
@@ -381,6 +382,7 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableL4NEGLocalIncludeDrainNodes, "enable-l4-neg-local-include-drain-nodes", false, "For L4 LB NEGs with externalTrafficPolicy=Local, keep nodes carrying the GKE drain label in the NEG as long as they still host a backing pod. Unready-node behavior is unchanged.")
 	flag.BoolVar(&F.EnableL4NetLBRBSByDefault, "enable-l4-netlb-rbs-by-default", false, "Enable L4 NetLB Regional Backend Services by default for new L4 NetLB services.")
 	flag.BoolVar(&F.EnableNEGPreprovisioning, "enable-neg-preprovisioning", false, "Enable support for NEG pre-provisioning.")
+	flag.BoolVar(&F.EnableBYOIPv6, "enable-byo-ipv6", false, "Enable Bring Your Own IPv6 (BYOIPv6) feature for ip-collection annotations.")
 }
 
 func Validate() {

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/klog/v2"
@@ -59,19 +60,25 @@ const (
 
 // Original file in https://github.com/kubernetes/legacy-cloud-providers/blob/6aa80146c33550e908aed072618bd7f9998837f6/gce/gce_address_manager.go
 type Manager struct {
-	svc         gce.CloudAddressService
-	name        string
-	serviceName string
-	addressName string
-	targetIP    string
-	addressType cloud.LbScheme
-	region      string
-	subnetURL   string
-	tryRelease  bool
-	networkTier cloud.NetworkTier
-	ipVersion   IPVersion
+	svc          gce.CloudAddressService
+	name         string
+	serviceName  string
+	addressName  string
+	targetIP     string
+	addressType  cloud.LbScheme
+	region       string
+	subnetURL    string
+	tryRelease   bool
+	networkTier  cloud.NetworkTier
+	ipVersion    IPVersion
+	ipCollection string
 
 	frLogger klog.Logger
+}
+
+// SetIPCollection sets the ipCollection for the manager.
+func (m *Manager) SetIPCollection(ipCollection string) {
+	m.ipCollection = ipCollection
 }
 
 func NewManager(svc gce.CloudAddressService, serviceName, region, subnetURL, name, addressName, targetIP string, addressType cloud.LbScheme, networkTier cloud.NetworkTier, ipVersion IPVersion, frLogger klog.Logger) *Manager {
@@ -265,11 +272,12 @@ func (m *Manager) ensureAddressReservation() (string, IPAddressType, error) {
 	// Try reserving the IP with controller-owned address name
 	// If am.targetIP is an empty string, a new IP will be created.
 	newAddr := &compute.Address{
-		Name:        m.name,
-		Description: fmt.Sprintf(`{"kubernetes.io/service-name":"%s"}`, m.serviceName),
-		Address:     m.targetIP,
-		AddressType: string(m.addressType),
-		Subnetwork:  m.subnetURL,
+		Name:         m.name,
+		Description:  fmt.Sprintf(`{"kubernetes.io/service-name":"%s"}`, m.serviceName),
+		Address:      m.targetIP,
+		AddressType:  string(m.addressType),
+		Subnetwork:   m.subnetURL,
+		IpCollection: m.ipCollection,
 	}
 	// NetworkTier is supported only for External IP Address
 	if m.addressType == cloud.SchemeExternal {
@@ -390,6 +398,9 @@ func (m *Manager) validateAddress(addr *compute.Address) error {
 	}
 	if addr.NetworkTier != m.networkTier.ToGCEValue() {
 		return l4utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
+	}
+	if flags.F.EnableBYOIPv6 && m.ipCollection != addr.IpCollection {
+		return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
 	}
 	return nil
 }

--- a/pkg/l4/address/manager.go
+++ b/pkg/l4/address/manager.go
@@ -399,8 +399,16 @@ func (m *Manager) validateAddress(addr *compute.Address) error {
 	if addr.NetworkTier != m.networkTier.ToGCEValue() {
 		return l4utils.NewNetworkTierErr(fmt.Sprintf("Static IP (%v)", m.name), m.networkTier.ToGCEValue(), addr.NetworkTier)
 	}
-	if flags.F.EnableBYOIPv6 && m.ipCollection != addr.IpCollection {
-		return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
+	if flags.F.EnableBYOIPv6 {
+		// 1. If the Service specifies an explicit IP collection, any address MUST match it.
+		if m.ipCollection != "" && m.ipCollection != addr.IpCollection {
+			return fmt.Errorf("ipCollection mismatch, expected %q, actual: %q", m.ipCollection, addr.IpCollection)
+		}
+		// 2. If the Service omits IP collection AND omits static address (ephemeral),
+		// do not reuse a leftover PDP ephemeral address so we revert to a Google IP.
+		if m.ipCollection == "" && m.targetIP == "" && addr.IpCollection != "" {
+			return fmt.Errorf("ipCollection mismatch for ephemeral address, expected empty collection (Google IP), actual: %q", addr.IpCollection)
+		}
 	}
 	return nil
 }

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -53,7 +53,7 @@ func TestAddressManagerNoRequestedIP(t *testing.T) {
 	targetIP := ""
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -64,7 +64,20 @@ func TestAddressManagerBasic(t *testing.T) {
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
+	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
+}
+
+// TestAddressManagerWithIPCollection tests reserving an address with an IP collection
+func TestAddressManagerWithIPCollection(t *testing.T) {
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	targetIP := "1.1.1.1"
+	ipCollection := "my-ip-collection"
+
+	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeExternal, cloud.NetworkTierPremium, address.IPv4Version, klog.TODO())
+	mgr.SetIPCollection(ipCollection)
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierPremium.ToGCEValue(), ipCollection)
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -80,7 +93,7 @@ func TestAddressManagerOrphaned(t *testing.T) {
 	require.NoError(t, err)
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -92,7 +105,7 @@ func TestAddressManagerStandardNetworkTier(t *testing.T) {
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeExternal, cloud.NetworkTierStandard, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierStandard.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeExternal), cloud.NetworkTierStandard.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -103,7 +116,7 @@ func TestAddressManagerStandardNetworkTierNotAvailableForInternalAddress(t *test
 	targetIP := "1.1.1.1"
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierStandard, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierPremium.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierPremium.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -120,7 +133,7 @@ func TestAddressManagerOutdatedOrphan(t *testing.T) {
 	require.NoError(t, err)
 
 	mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv4Version, klog.TODO())
-	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+	testHoldAddress(t, mgr, svc, testLBName, vals.Region, targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 	testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 }
 
@@ -310,7 +323,7 @@ func TestAddressManagerIPv6(t *testing.T) {
 			}
 
 			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, testLBName, "", tc.targetIP, cloud.SchemeInternal, cloud.NetworkTierDefault, address.IPv6Version, klog.TODO())
-			testHoldAddress(t, mgr, svc, testLBName, vals.Region, tc.targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue())
+			testHoldAddress(t, mgr, svc, testLBName, vals.Region, tc.targetIP, string(cloud.SchemeInternal), cloud.NetworkTierDefault.ToGCEValue(), "")
 			testReleaseAddress(t, mgr, svc, testLBName, vals.Region)
 		})
 	}
@@ -515,7 +528,7 @@ func TestIsAddressInForwardingRules(t *testing.T) {
 	}
 }
 
-func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier string) {
+func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region, targetIP, scheme, netTier, ipCollection string) {
 	ipToUse, ipType, err := mgr.HoldAddress()
 	require.NoError(t, err)
 	assert.NotEmpty(t, ipToUse)
@@ -529,6 +542,7 @@ func testHoldAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressSer
 	}
 	assert.EqualValues(t, scheme, addr.AddressType)
 	assert.EqualValues(t, addr.NetworkTier, netTier)
+	assert.EqualValues(t, ipCollection, addr.IpCollection)
 }
 
 func testReleaseAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddressService, name, region string) {

--- a/pkg/l4/address/manager_test.go
+++ b/pkg/l4/address/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/flags"
 	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -550,6 +551,71 @@ func testReleaseAddress(t *testing.T, mgr *address.Manager, svc gce.CloudAddress
 	require.NoError(t, err)
 	_, err = svc.GetRegionAddress(name, region)
 	assert.True(t, utils.IsNotFoundError(err))
+}
+
+func TestBYOIPv6AddressValidation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+
+	svc, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	existingAddr := &compute.Address{
+		Name:             "existing-ipv6-addr",
+		Address:          "2001:db8::1",
+		IpVersion:        string(address.IPv6Version),
+		PrefixLength:     96,
+		AddressType:      string(cloud.SchemeExternal),
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "my-pdp",
+	}
+	require.NoError(t, svc.ReserveRegionAddress(existingAddr, vals.Region))
+
+	testCases := []struct {
+		desc         string
+		ipCollection string
+		targetIP     string
+		expectErr    bool
+	}{
+		{
+			desc:         "Case 1: Reserved PDP static address without ip-collection-v6 annotation is accepted",
+			ipCollection: "",
+			targetIP:     "2001:db8::1",
+			expectErr:    false,
+		},
+		{
+			desc:         "Case 2: Static address matching ip-collection-v6 is accepted",
+			ipCollection: "my-pdp",
+			targetIP:     "2001:db8::1",
+			expectErr:    false,
+		},
+		{
+			desc:         "Case 3: Static address mismatching ip-collection-v6 is rejected",
+			ipCollection: "other-pdp",
+			targetIP:     "2001:db8::1",
+			expectErr:    true,
+		},
+		{
+			desc:         "Case 4: Removing ip-collection-v6 from ephemeral service rejects leftover PDP address",
+			ipCollection: "",
+			targetIP:     "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mgr := address.NewManager(svc, testSvcName, vals.Region, testSubnet, "test-lb-name", "existing-ipv6-addr", tc.targetIP, cloud.SchemeExternal, cloud.NetworkTierDefault, address.IPv6Version, klog.TODO())
+			mgr.SetIPCollection(tc.ipCollection)
+
+			_, _, err := mgr.HoldAddress()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func fakeGCECloud(vals gce.TestClusterValues) (*gce.Cloud, error) {

--- a/pkg/l4/annotations/service.go
+++ b/pkg/l4/annotations/service.go
@@ -110,6 +110,10 @@ const (
 
 	// CustomForwardingRuleKey is the annotation key for custom forwarding rule name.
 	CustomForwardingRuleKey = "networking.gke.io/custom-forwarding-rule"
+
+	// IPCollectionV6AnnotationKey is the annotation key for BYOIP IPv6 IP collection.
+	// The value of this annotation must be a full resource URL.
+	IPCollectionV6AnnotationKey = "networking.gke.io/ip-collection-v6"
 )
 
 // Service represents Service annotations.
@@ -123,6 +127,14 @@ func FromService(obj *v1.Service) *Service {
 		return &Service{}
 	}
 	return &Service{obj.Annotations}
+}
+
+// GetIPCollectionV6 returns the configured IP collection for BYOIP.
+func (svc *Service) GetIPCollectionV6() string {
+	if val, exists := svc.v[IPCollectionV6AnnotationKey]; exists {
+		return val
+	}
+	return ""
 }
 
 // WantsL4ILB checks if the given service requires L4 ILB.

--- a/pkg/l4/annotations/service_test.go
+++ b/pkg/l4/annotations/service_test.go
@@ -380,3 +380,35 @@ func TestWantsL4NetLB(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIPCollection(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		svc  *v1.Service
+		want string
+	}{
+		{
+			desc: "ip-collection annotation not specified",
+			svc:  &v1.Service{},
+			want: "",
+		},
+		{
+			desc: "ip-collection annotation specified",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						IPCollectionV6AnnotationKey: "my-ip-collection",
+					},
+				},
+			},
+			want: "my-ip-collection",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := FromService(tc.svc).GetIPCollectionV6()
+			if got != tc.want {
+				t.Errorf("FromService().GetIPCollection() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -143,12 +143,12 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					logger.Error(nil, "unexpected object type in DeleteFunc", "type", fmt.Sprintf("%T", obj))
+					logger.Error(nil, "Unexpected object type in DeleteFunc", "type", fmt.Sprintf("%T", obj))
 					return
 				}
 				svc, ok = tombstone.Obj.(*v1.Service)
 				if !ok {
-					logger.Error(nil, "unexpected object type in tombstone in DeleteFunc", "type", fmt.Sprintf("%T", tombstone.Obj))
+					logger.Error(nil, "Unexpected object type in tombstone in DeleteFunc", "type", fmt.Sprintf("%T", tombstone.Obj))
 					return
 				}
 			}
@@ -259,7 +259,7 @@ func (lc *StandaloneNEGLBController) parseForwardingRuleKeys(frNamesStr string, 
 		if strings.Contains(frName, "/") {
 			resourceID, err := cloud.ParseResourceURL(frName)
 			if err != nil {
-				svcLogger.Error(err, "failed to parse forwarding rule reference URL", "frRef", frName)
+				svcLogger.Error(err, "Failed to parse forwarding rule reference URL", "frRef", frName)
 				errs = append(errs, fmt.Errorf("failed to parse forwarding rule reference URL %s: %w", frName, err))
 				continue
 			}
@@ -313,7 +313,7 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	frNamesStr, ok := svc.Annotations[annotations.CustomForwardingRuleKey]
 	if !ok || frNamesStr == "" {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
-		svcLogger.V(4).Info("Service has no forwarding rule reference, skipping")
+		svcLogger.V(4).Info("Service has no forwarding rule reference; skipping")
 		cond := NewConditionExternalIPProgrammedFalse(NoForwardingRuleRef)
 		err := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
 		if err != nil {
@@ -330,23 +330,20 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 
 	if len(parsedRules) == 0 {
 		var reason lbConditionReason
-		var err error
 		if len(parseErrs) > 0 {
 			reason = InvalidForwardingRule
 		} else {
 			reason = NoForwardingRuleRef
 		}
 		cond := NewConditionExternalIPProgrammedFalse(reason)
-		err = updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		clearErr := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
 		if len(errs) > 0 {
-			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule %s", errors.Join(errs...).Error())
-			return nil, errors.Join(errs...)
+			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule: %v", errors.Join(errs...))
+			allErrs := append([]error{clearErr}, errs...)
+			return nil, errors.Join(allErrs...)
 		}
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
-		return nil, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation"))
+		return nil, errors.Join(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
 	}
 
 	if len(parsedRules) > ForwardingRulesLimit {
@@ -364,14 +361,13 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	for _, parsed := range parsedRules {
 		fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsed.key, meta.VersionBeta, svcLogger)
 		if err != nil {
-			svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
 			if utils.IsNotFoundError(err) {
+				svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
 				err = l4utils.NewUserError(err)
 			}
 			errs = append(errs, err)
 			continue
 		}
-
 		schemes = append(schemes, fr.LoadBalancingScheme)
 
 		if err := validateForwardingRule(fr, parsed.rawName); err != nil {
@@ -393,17 +389,15 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	}
 
 	if len(errs) > 0 {
-		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use all Forwarding Rules %s", errors.Join(errs...).Error())
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use all Forwarding Rules: %v", errors.Join(errs...))
 	}
 	// if at least one FR was ok then we use it
 	if len(lbIngresses) == 0 {
 		// if none of the FRs is usable remove any that is possibly there
 		cond := NewConditionExternalIPProgrammedFalse(classifyError(errs[0]))
-		err := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		return schemes, errors.Join(errs...)
+		clearErr := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
+		allErrs := append([]error{clearErr}, errs...)
+		return schemes, errors.Join(allErrs...)
 	}
 
 	newStatus := &v1.LoadBalancerStatus{
@@ -427,6 +421,7 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	if len(errs) > 0 {
 		return schemes, errors.Join(errs...)
 	}
+	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "SyncLoadBalancerSuccessful", "Successfully ensured Standalone NEG LoadBalancer resources")
 	return schemes, nil
 }
 
@@ -436,10 +431,7 @@ func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLo
 	}
 
 	conditionsToRemove := []string{ExternalIPProgrammed}
-	if err := updateServiceStatus(lc.ctx, svc, newStatus, nil, conditionsToRemove, svcLogger); err != nil {
-		return err
-	}
-	return nil
+	return updateServiceStatus(lc.ctx, svc, newStatus, nil, conditionsToRemove, svcLogger)
 }
 
 func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string, syncErr error, start time.Time) {

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
-	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -44,6 +43,7 @@ import (
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
+	"slices"
 )
 
 const (
@@ -201,8 +201,8 @@ func (lc *StandaloneNEGLBController) Run() {
 }
 
 func (lc *StandaloneNEGLBController) syncWrapper(key string) (err error) {
-	syncTrackingId := rand.Int31()
-	svcLogger := lc.logger.WithValues("serviceKey", key, "syncId", syncTrackingId)
+	syncTrackingID := rand.Int31()
+	svcLogger := lc.logger.WithValues("serviceKey", key, "syncId", syncTrackingID)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -325,9 +325,9 @@ func (lc *StandaloneNEGLBController) validateLoadBalancer(parsedFR parsedForward
 }
 
 func (lc *StandaloneNEGLBController) getServiceNEGLinks(svc *v1.Service) (sets.Set[cloud.ResourceMapKey], error) {
-	neglinks := sets.New[cloud.ResourceMapKey]()
+	negLinks := sets.New[cloud.ResourceMapKey]()
 	if svc == nil {
-		return neglinks, nil
+		return negLinks, nil
 	}
 
 	negName := lc.namer.L4Backend(svc.Namespace, svc.Name)
@@ -352,11 +352,11 @@ func (lc *StandaloneNEGLBController) getServiceNEGLinks(svc *v1.Service) (sets.S
 				if err != nil {
 					continue
 				}
-				neglinks.Insert(resourceKey.MapKey())
+				negLinks.Insert(resourceKey.MapKey())
 			}
 		}
 	}
-	return neglinks, nil
+	return negLinks, nil
 }
 
 func (lc *StandaloneNEGLBController) validateBackendService(fr *composite.ForwardingRule, targetNEGs sets.Set[cloud.ResourceMapKey], svcLogger klog.Logger) error {
@@ -469,11 +469,11 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		return nil, joinMaybeUserErrors(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
 	}
 
+	// Sort alphabetically forwarding rules so rules and status ingress IPs are deterministic between resyncs.
+	sortParsedFRs(parsedRules)
 	if len(parsedRules) > ForwardingRulesLimit {
-		// Sort alphabetically forwarding rules so potentially skipped rules are consistent between resyncs.
-		sortParsedFRs(parsedRules)
 		skippedFrs := strings.Join(parsedFRNames(parsedRules[ForwardingRulesLimit:]), ", ")
-		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Up to %d forwarding rules are supported. Skipping remaining forwarding rules (%s)", ForwardingRulesLimit, skippedFrs)
+		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRulesLimitExceeded", "Up to %d forwarding rules are supported. Skipping remaining forwarding rules (%s)", ForwardingRulesLimit, skippedFrs)
 		parsedRules = parsedRules[:ForwardingRulesLimit]
 	}
 
@@ -516,7 +516,11 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	}
 
 	if len(errs) > 0 {
-		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use all Forwarding Rules: %v", errors.Join(errs...))
+		if len(lbIngresses) == 0 {
+			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "None of the Forwarding Rules could be used: %v", errors.Join(errs...))
+		} else {
+			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Some Forwarding Rules could not be used: %v", errors.Join(errs...))
+		}
 	}
 	// if at least one FR was ok then we use it
 	if len(lbIngresses) == 0 {
@@ -552,7 +556,7 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	if len(errs) > 0 {
 		return schemes, joinMaybeUserErrors(errs...)
 	}
-	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "SyncLoadBalancerSuccessful", "Successfully ensured Standalone NEG LoadBalancer resources")
+	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "SyncLoadBalancerSuccessful", "Successfully programmed Standalone NEG LoadBalancer IP(s)")
 	return schemes, nil
 }
 

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -62,6 +62,8 @@ const (
 	UnsupportedLBType = lbConditionReason("UnsupportedLBType")
 	// InvalidForwardingRule Reason
 	InvalidForwardingRule = lbConditionReason("InvalidForwardingRule")
+	// BackendNotAttached Reason
+	BackendNotAttached = lbConditionReason("BackendNotAttached")
 	// ProviderError Reason
 	ProviderError = lbConditionReason("ProviderError")
 	// Maximum number of forwarding rules
@@ -381,7 +383,7 @@ func (lc *StandaloneNEGLBController) validateBackendService(fr *composite.Forwar
 	}
 
 	if !backendServiceHasNEGAttached(bs, targetNEGs) {
-		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer (backend service: %s)", resourceID.Key.Name))
+		return l4utils.NewUserError(l4utils.NewBackendNotAttachedError(resourceID.Key.Name))
 	}
 
 	return nil
@@ -594,6 +596,9 @@ func classifyError(err error) lbConditionReason {
 	if err == nil {
 		return ProviderError
 	}
+	if l4utils.IsBackendNotAttachedError(err) {
+		return BackendNotAttached
+	}
 	if utils.IsNotFoundError(err) {
 		return InvalidForwardingRule
 	}
@@ -637,6 +642,8 @@ func messageForReason(reason lbConditionReason) string {
 		return "The referenced forwarding rule has an unsupported load balancing scheme"
 	case InvalidForwardingRule:
 		return "The custom forwarding rule reference is invalid"
+	case BackendNotAttached:
+		return "The service NEGs are not attached to the load balancer backend service"
 	case ProviderError:
 		return "GCE provider error encountered while retrieving forwarding rules"
 	default:

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -31,8 +31,10 @@ import (
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
 	ccontext "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
@@ -40,6 +42,7 @@ import (
 	"k8s.io/ingress-gce/pkg/l4/resources"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
+	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
 )
 
@@ -103,6 +106,7 @@ type StandaloneNEGLBController struct {
 	ctx       *ccontext.ControllerContext
 	svcQueue  utils.TaskQueue
 	logger    klog.Logger
+	namer     namer.L4ResourcesNamer
 	stopCh    <-chan struct{}
 	hasSynced func() bool
 }
@@ -113,6 +117,7 @@ func NewStandaloneNEGLBController(ctx *ccontext.ControllerContext, stopCh <-chan
 	lc := &StandaloneNEGLBController{
 		ctx:       ctx,
 		stopCh:    stopCh,
+		namer:     ctx.L4Namer,
 		hasSynced: ctx.HasSynced,
 		logger:    logger,
 	}
@@ -286,6 +291,120 @@ func validateForwardingRule(fr *composite.ForwardingRule, frName string) error {
 	return errors.Join(errs...)
 }
 
+func (lc *StandaloneNEGLBController) validateLoadBalancer(parsedFR parsedForwardingRule, targetNEGs sets.Set[cloud.ResourceMapKey], bsValidationCache map[string]error, svcLogger klog.Logger) (addresses []string, scheme string, err error) {
+	fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsedFR.key, meta.VersionBeta, svcLogger)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			svcLogger.Error(err, "failed to get forwarding rule", "frName", parsedFR.rawName)
+			err = l4utils.NewUserError(err)
+		}
+		return nil, "", err
+	}
+
+	if err := validateForwardingRule(fr, parsedFR.rawName); err != nil {
+		svcLogger.Error(err, "invalid forwarding rule", "frName", parsedFR.rawName)
+		return nil, fr.LoadBalancingScheme, l4utils.NewUserError(err)
+	}
+
+	bsURL := fr.BackendService
+	var bsErr error
+	if cachedErr, ok := bsValidationCache[bsURL]; ok {
+		bsErr = cachedErr
+	} else {
+		bsErr = lc.validateBackendService(fr, targetNEGs, svcLogger)
+		bsValidationCache[bsURL] = bsErr
+	}
+	if bsErr != nil {
+		errWithContext := fmt.Errorf("forwarding rule %s: %w", parsedFR.rawName, bsErr)
+		svcLogger.Error(errWithContext, "invalid backend service for forwarding rule", "frName", parsedFR.rawName, "bsURL", bsURL)
+		return nil, fr.LoadBalancingScheme, errWithContext
+	}
+	return frAddresses(fr), fr.LoadBalancingScheme, nil
+}
+
+func (lc *StandaloneNEGLBController) getServiceNEGLinks(svc *v1.Service) (sets.Set[cloud.ResourceMapKey], error) {
+	neglinks := sets.New[cloud.ResourceMapKey]()
+	if svc == nil {
+		return neglinks, nil
+	}
+
+	negName := lc.namer.L4Backend(svc.Namespace, svc.Name)
+	svcNegKey := fmt.Sprintf("%s/%s", svc.Namespace, negName)
+
+	if lc.ctx != nil && lc.ctx.SvcNegInformer != nil {
+		obj, exists, err := lc.ctx.SvcNegInformer.GetIndexer().GetByKey(svcNegKey)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+		svcNeg, ok := obj.(*negv1beta1.ServiceNetworkEndpointGroup)
+		if !ok || svcNeg == nil {
+			return nil, fmt.Errorf("failed to retrieve ServiceNetworkEndpointGroup")
+		}
+
+		for _, negRef := range svcNeg.Status.NetworkEndpointGroups {
+			if negRef.SelfLink != "" {
+				resourceKey, err := cloud.ParseResourceURL(negRef.SelfLink)
+				if err != nil {
+					continue
+				}
+				neglinks.Insert(resourceKey.MapKey())
+			}
+		}
+	}
+	return neglinks, nil
+}
+
+func (lc *StandaloneNEGLBController) validateBackendService(fr *composite.ForwardingRule, targetNEGs sets.Set[cloud.ResourceMapKey], svcLogger klog.Logger) error {
+	bsURL := fr.BackendService
+	if bsURL == "" {
+		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer, forwarding rule is missing the backend service reference"))
+	}
+
+	resourceID, err := cloud.ParseResourceURL(bsURL)
+	if err != nil {
+		return l4utils.NewUserError(fmt.Errorf("failed to parse backend service URL %s: %w", bsURL, err))
+	}
+	if resourceID == nil || resourceID.Key == nil || resourceID.Key.Name == "" {
+		return l4utils.NewUserError(fmt.Errorf("invalid backend service URL %s: missing resource key", bsURL))
+	}
+
+	bs, err := composite.GetBackendService(lc.ctx.Cloud, resourceID.Key, meta.VersionBeta, svcLogger)
+	if err != nil {
+		wrappedError := fmt.Errorf("failed to get backend service %s: %w", bsURL, err)
+		if utils.IsNotFoundError(err) {
+			return l4utils.NewUserError(wrappedError)
+		}
+		return wrappedError
+	}
+
+	if !backendServiceHasNEGAttached(bs, targetNEGs) {
+		return l4utils.NewUserError(fmt.Errorf("the service NEGs are not attached to the load balancer (backend service: %s)", resourceID.Key.Name))
+	}
+
+	return nil
+}
+
+// backendServiceHasNEGAttached checks if the backend service has any of
+// the targetNEGs attached.
+func backendServiceHasNEGAttached(bs *composite.BackendService, targetNEGs sets.Set[cloud.ResourceMapKey]) bool {
+	hasMatchingNEG := false
+	for _, be := range bs.Backends {
+		if be == nil || be.Group == "" {
+			continue
+		}
+		groupKey, err := cloud.ParseResourceURL(be.Group)
+
+		if err == nil && groupKey != nil && targetNEGs.Has(groupKey.MapKey()) {
+			hasMatchingNEG = true
+			break
+		}
+	}
+	return hasMatchingNEG
+}
+
 // IPAddress field is used for creating Regional NetLB forwarding rules, IPAddresses[] field is used for creating Global NetLB forwarding rules.
 func frAddresses(fr *composite.ForwardingRule) []string {
 	ipAddrs := fr.IPAddresses
@@ -309,7 +428,7 @@ func sortParsedFRs(frs []parsedForwardingRule) {
 	})
 }
 
-func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) (lbSchemes []string, err error) {
+func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLogger klog.Logger) (lbSchemes sets.Set[string], err error) {
 	frNamesStr, ok := svc.Annotations[annotations.CustomForwardingRuleKey]
 	if !ok || frNamesStr == "" {
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
@@ -340,10 +459,10 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 		if len(errs) > 0 {
 			lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "ForwardingRuleUnusable", "Could not use any Forwarding Rule: %v", errors.Join(errs...))
 			allErrs := append([]error{clearErr}, errs...)
-			return nil, errors.Join(allErrs...)
+			return nil, joinMaybeUserErrors(allErrs...)
 		}
 		lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeWarning, "NoForwardingRuleRef", "Service has no forwarding rule reference")
-		return nil, errors.Join(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
+		return nil, joinMaybeUserErrors(clearErr, l4utils.NewUserError(fmt.Errorf("service has no valid forwarding rule reference in annotation")))
 	}
 
 	if len(parsedRules) > ForwardingRulesLimit {
@@ -356,28 +475,23 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 
 	var lbIngresses []v1.LoadBalancerIngress
 	vipMode := v1.LoadBalancerIPModeVIP
-	var schemes []string
+	schemes := sets.New[string]()
+
+	targetNEGs, err := lc.getServiceNEGLinks(svc)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	bsValidationCache := make(map[string]error)
 
 	for _, parsed := range parsedRules {
-		fr, err := composite.GetForwardingRule(lc.ctx.Cloud, parsed.key, meta.VersionBeta, svcLogger)
+		addresses, lbScheme, err := lc.validateLoadBalancer(parsed, targetNEGs, bsValidationCache, svcLogger)
 		if err != nil {
-			if utils.IsNotFoundError(err) {
-				svcLogger.Error(err, "failed to get forwarding rule", "frName", parsed.rawName)
-				err = l4utils.NewUserError(err)
-			}
 			errs = append(errs, err)
 			continue
 		}
-		schemes = append(schemes, fr.LoadBalancingScheme)
-
-		if err := validateForwardingRule(fr, parsed.rawName); err != nil {
-			svcLogger.Error(err, "invalid forwarding rule", "frName", parsed.rawName)
-			errs = append(errs, l4utils.NewUserError(err))
-			continue
-		}
-
-		addrs := frAddresses(fr)
-		for _, a := range addrs {
+		schemes.Insert(lbScheme)
+		for _, a := range addresses {
 			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
 			trimmedIP := strings.Split(a, "/")[0]
 			// And make it canonical to avoid warnings from k8s apiserver
@@ -394,10 +508,14 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	// if at least one FR was ok then we use it
 	if len(lbIngresses) == 0 {
 		// if none of the FRs is usable remove any that is possibly there
-		cond := NewConditionExternalIPProgrammedFalse(classifyError(errs[0]))
+		var firstErr error
+		if len(errs) > 0 {
+			firstErr = errs[0]
+		}
+		cond := NewConditionExternalIPProgrammedFalse(classifyError(firstErr))
 		clearErr := updateServiceStatus(lc.ctx, svc, &v1.LoadBalancerStatus{Ingress: nil}, []metav1.Condition{cond}, nil, svcLogger)
 		allErrs := append([]error{clearErr}, errs...)
-		return schemes, errors.Join(allErrs...)
+		return schemes, joinMaybeUserErrors(allErrs...)
 	}
 
 	newStatus := &v1.LoadBalancerStatus{
@@ -419,10 +537,26 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 	}
 
 	if len(errs) > 0 {
-		return schemes, errors.Join(errs...)
+		return schemes, joinMaybeUserErrors(errs...)
 	}
 	lc.ctx.Recorder(svc.Namespace).Eventf(svc, v1.EventTypeNormal, "SyncLoadBalancerSuccessful", "Successfully ensured Standalone NEG LoadBalancer resources")
 	return schemes, nil
+}
+
+// join errors but if all are UserErrors make the wrapping error a UserError as
+// well. This is required to properly attribute sync status in metrics.
+func joinMaybeUserErrors(errs ...error) error {
+	allUserErrors := true
+	for _, err := range errs {
+		if !resources.IsUserError(err) {
+			allUserErrors = false
+			break
+		}
+	}
+	if allUserErrors {
+		return l4utils.NewUserError(errors.Join(errs...))
+	}
+	return errors.Join(errs...)
 }
 
 func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {
@@ -434,7 +568,7 @@ func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLo
 	return updateServiceStatus(lc.ctx, svc, newStatus, nil, conditionsToRemove, svcLogger)
 }
 
-func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string, syncErr error, start time.Time) {
+func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes sets.Set[string], syncErr error, start time.Time) {
 	state := l4metrics.L4StandaloneNEGServiceState{
 		Status: l4metrics.StatusSuccess,
 	}
@@ -448,9 +582,9 @@ func (lc *StandaloneNEGLBController) publishMetrics(key string, schemes []string
 		}
 	}
 
-	state.LBSchemeExternal = slices.Contains(schemes, "EXTERNAL")
-	state.LBSchemeExternalPassthrough = slices.Contains(schemes, "EXTERNAL_PASSTHROUGH")
-	state.LBSchemeInternal = slices.Contains(schemes, "INTERNAL")
+	state.LBSchemeExternal = schemes.Has("EXTERNAL")
+	state.LBSchemeExternalPassthrough = schemes.Has("EXTERNAL_PASSTHROUGH")
+	state.LBSchemeInternal = schemes.Has("INTERNAL")
 
 	lc.ctx.L4Metrics.SetL4StandaloneNEGService(key, state)
 	l4metrics.PublishL4StandaloneNEGSyncLatency(syncErr == nil, start)

--- a/pkg/l4/controllers/standalonenegcontroller.go
+++ b/pkg/l4/controllers/standalonenegcontroller.go
@@ -409,11 +409,13 @@ func backendServiceHasNEGAttached(bs *composite.BackendService, targetNEGs sets.
 
 // IPAddress field is used for creating Regional NetLB forwarding rules, IPAddresses[] field is used for creating Global NetLB forwarding rules.
 func frAddresses(fr *composite.ForwardingRule) []string {
-	ipAddrs := fr.IPAddresses
-	if len(ipAddrs) == 0 {
-		ipAddrs = []string{fr.IPAddress}
+	if len(fr.IPAddresses) > 0 {
+		return fr.IPAddresses
 	}
-	return ipAddrs
+	if fr.IPAddress != "" {
+		return []string{fr.IPAddress}
+	}
+	return nil
 }
 
 func parsedFRNames(frs []parsedForwardingRule) []string {
@@ -492,15 +494,24 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 			errs = append(errs, err)
 			continue
 		}
+		if len(addresses) == 0 {
+			errs = append(errs, l4utils.NewUserError(fmt.Errorf("forwarding rule %s has no IP address", parsed.rawName)))
+			continue
+		}
 		schemes.Insert(lbScheme)
 		for _, a := range addresses {
+			if a == "" {
+				continue
+			}
 			// GCP IPv6 forwarding rules provide the IP in CIDR form (e.g. /96 range). We must extract the base IP.
 			trimmedIP := strings.Split(a, "/")[0]
 			// And make it canonical to avoid warnings from k8s apiserver
 			if ipAddr, err := netip.ParseAddr(trimmedIP); err == nil {
 				trimmedIP = ipAddr.String()
 			}
-			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
+			if trimmedIP != "" {
+				lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: trimmedIP, IPMode: &vipMode})
+			}
 		}
 	}
 
@@ -548,17 +559,28 @@ func (lc *StandaloneNEGLBController) syncStandaloneNEGLB(svc *v1.Service, svcLog
 // join errors but if all are UserErrors make the wrapping error a UserError as
 // well. This is required to properly attribute sync status in metrics.
 func joinMaybeUserErrors(errs ...error) error {
-	allUserErrors := true
+	var nonNilErrs []error
 	for _, err := range errs {
+		if err != nil {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+	if len(nonNilErrs) == 0 {
+		return nil
+	}
+
+	allUserErrors := true
+	for _, err := range nonNilErrs {
 		if !resources.IsUserError(err) {
 			allUserErrors = false
 			break
 		}
 	}
+	joinedErr := errors.Join(nonNilErrs...)
 	if allUserErrors {
-		return l4utils.NewUserError(errors.Join(errs...))
+		return l4utils.NewUserError(joinedErr)
 	}
-	return errors.Join(errs...)
+	return joinedErr
 }
 
 func (lc *StandaloneNEGLBController) clearStatusIngressIP(svc *v1.Service, svcLogger klog.Logger) error {

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -248,13 +248,14 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					Version:             meta.VersionBeta,
 				},
 			},
-			expectIPs:   []string{""},
-			expectError: false,
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
-				Status:  metav1.ConditionTrue,
-				Reason:  "IPProgrammed",
-				Message: "IPs programmed: ",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
 			},
 		},
 		{
@@ -2334,4 +2335,63 @@ func generateForwardingRuleKey(fr string, num int) string {
 		buffer.WriteString(fmt.Sprintf("%s%d,", fr, i))
 	}
 	return strings.TrimSuffix(buffer.String(), ",")
+}
+
+func TestJoinMaybeUserErrors(t *testing.T) {
+	userErr1 := l4utils.NewUserError(errors.New("user err 1"))
+	userErr2 := l4utils.NewUserError(errors.New("user err 2"))
+	sysErr := errors.New("system err")
+
+	testCases := []struct {
+		desc       string
+		errs       []error
+		expectNil  bool
+		expectUser bool
+	}{
+		{
+			desc:      "all nil errors",
+			errs:      []error{nil, nil},
+			expectNil: true,
+		},
+		{
+			desc:       "nil mixed with user errors",
+			errs:       []error{nil, userErr1, nil, userErr2},
+			expectUser: true,
+		},
+		{
+			desc:       "only user errors",
+			errs:       []error{userErr1, userErr2},
+			expectUser: true,
+		},
+		{
+			desc:       "nil mixed with system error",
+			errs:       []error{nil, sysErr},
+			expectUser: false,
+		},
+		{
+			desc:       "user error mixed with system error and nil",
+			errs:       []error{nil, userErr1, sysErr},
+			expectUser: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := joinMaybeUserErrors(tc.errs...)
+			if tc.expectNil {
+				if got != nil {
+					t.Fatalf("expected nil error, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil error, got nil")
+			}
+			var userErr *l4utils.UserError
+			isUser := errors.As(got, &userErr) && got == userErr
+			if isUser != tc.expectUser {
+				t.Errorf("isUserErrorWrapper(%v) = %v, expected %v", got, isUser, tc.expectUser)
+			}
+		})
+	}
 }

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -1199,8 +1199,8 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
 				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidForwardingRule",
-				Message: "The custom forwarding rule reference is invalid",
+				Reason:  "BackendNotAttached",
+				Message: "The service NEGs are not attached to the load balancer backend service",
 			},
 		},
 		{
@@ -1462,8 +1462,8 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			expectCondition: &metav1.Condition{
 				Type:    "ExternalIPProgrammed",
 				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidForwardingRule",
-				Message: "The custom forwarding rule reference is invalid",
+				Reason:  "BackendNotAttached",
+				Message: "The service NEGs are not attached to the load balancer backend service",
 			},
 		},
 	}
@@ -2295,6 +2295,21 @@ func TestClassifyError(t *testing.T) {
 			desc:     "unsupported protocol wrapped in UserError and fmt.Errorf",
 			err:      fmt.Errorf("wrapped: %w", l4utils.NewUserError(l4utils.NewUnsupportedProtocolError("fr-name", "UAUDP", []string{"TCP"}))),
 			expected: InvalidForwardingRule,
+		},
+		{
+			desc:     "backend not attached",
+			err:      l4utils.NewBackendNotAttachedError("bs1"),
+			expected: BackendNotAttached,
+		},
+		{
+			desc:     "backend not attached wrapped in UserError",
+			err:      l4utils.NewUserError(l4utils.NewBackendNotAttachedError("bs1")),
+			expected: BackendNotAttached,
+		},
+		{
+			desc:     "backend not attached wrapped in UserError and fmt.Errorf",
+			err:      fmt.Errorf("wrapped: %w", l4utils.NewUserError(l4utils.NewBackendNotAttachedError("bs1"))),
+			expected: BackendNotAttached,
 		},
 		{
 			desc:     "generic error",

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -1015,7 +1015,8 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					Version:             meta.VersionBeta,
 				},
 			},
-			expectError: false,
+			expectError:        false,
+			expectEventReasons: []string{"ForwardingRulesLimitExceeded", "SyncLoadBalancerSuccessful"},
 			// Note the alphabetical order.
 			expectIPs: []string{"10.0.0.100", "10.0.0.109", "10.0.0.110", "10.0.0.111", "10.0.0.101", "10.0.0.102", "10.0.0.103", "10.0.0.104", "10.0.0.105", "10.0.0.106"},
 			expectCondition: &metav1.Condition{
@@ -2102,6 +2103,7 @@ func TestStandaloneNEGLBControllerEventHandlers_Add(t *testing.T) {
 	go lc.svcQueue.Run()
 	defer lc.svcQueue.Shutdown()
 
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc1",
@@ -2109,7 +2111,7 @@ func TestStandaloneNEGLBControllerEventHandlers_Add(t *testing.T) {
 		},
 		Spec: v1.ServiceSpec{
 			Type:              v1.ServiceTypeLoadBalancer,
-			LoadBalancerClass: new(annotations.StandalonePassthroughNegLoadBalancerClass),
+			LoadBalancerClass: &lbClass,
 		},
 	}
 	svcKey := svc.Namespace + "/" + svc.Name
@@ -2134,6 +2136,7 @@ func TestStandaloneNEGLBControllerEventHandlers_Update(t *testing.T) {
 	kubeClient, _, lc, stopCh := setupControllerContext(t)
 	defer close(stopCh)
 
+	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "svc1",
@@ -2141,7 +2144,7 @@ func TestStandaloneNEGLBControllerEventHandlers_Update(t *testing.T) {
 		},
 		Spec: v1.ServiceSpec{
 			Type:              v1.ServiceTypeLoadBalancer,
-			LoadBalancerClass: new(annotations.StandalonePassthroughNegLoadBalancerClass),
+			LoadBalancerClass: &lbClass,
 		},
 	}
 	svcKey := svc.Namespace + "/" + svc.Name

--- a/pkg/l4/controllers/standalonenegcontroller_test.go
+++ b/pkg/l4/controllers/standalonenegcontroller_test.go
@@ -28,24 +28,29 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/googleapi"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/cloud-provider-gcp/providers/gce"
+	negv1beta1 "k8s.io/ingress-gce/pkg/apis/svcneg/v1beta1"
 	"k8s.io/ingress-gce/pkg/composite"
 	ingctx "k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
 	l4metrics "k8s.io/ingress-gce/pkg/l4/metrics"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
+	svcnegclientfake "k8s.io/ingress-gce/pkg/svcneg/client/clientset/versioned/fake"
 	"k8s.io/ingress-gce/pkg/test"
 	"k8s.io/ingress-gce/pkg/utils/namer"
 	"k8s.io/klog/v2"
 )
 
 func TestStandaloneNEGLBSync(t *testing.T) {
+	l4Namer := namer.NewL4Namer("k8s2-cluster-uid", namer.NewNamer("cluster-id", "firewall-id", klog.TODO()))
 	lbClass := annotations.StandalonePassthroughNegLoadBalancerClass
 	frName := "custom-fr"
 	frIP := "10.0.0.100"
@@ -59,6 +64,9 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 		desc               string
 		svc                *v1.Service
 		frs                map[string]*composite.ForwardingRule
+		bss                map[string]*composite.BackendService
+		svcNegs            []*negv1beta1.ServiceNetworkEndpointGroup
+		getBSErr           error
 		expectIPs          []string
 		expectEventReasons []string
 		expectError        bool
@@ -237,7 +245,7 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 					LoadBalancingScheme: "EXTERNAL",
 					IPProtocol:          "TCP",
 					Scope:               meta.Regional,
-					Version:             meta.VersionGA,
+					Version:             meta.VersionBeta,
 				},
 			},
 			expectIPs:   []string{""},
@@ -1016,13 +1024,454 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				Message: "IPs programmed: 10.0.0.100, 10.0.0.109, 10.0.0.110, 10.0.0.111, 10.0.0.101, 10.0.0.102, 10.0.0.103, 10.0.0.104, 10.0.0.105, 10.0.0.106",
 			},
 		},
+		{
+			desc: "Forwarding Rule with missing BackendService URL -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-missing-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-missing-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-missing-bs": {
+					Name:                "fr-missing-bs",
+					IPAddress:           frIP,
+					BackendService:      "",
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with non-existent Backend Service (404) -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-404-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-404-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-404-bs": {
+					Name:                "fr-404-bs",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/non-existent-bs", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss:                map[string]*composite.BackendService{},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service returning non-404 system error (500) -> expect ProviderError condition reason",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-500-bs",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-500-bs",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-500-bs": {
+					Name:                "fr-500-bs",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-500", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-500": {
+					Name:    "bs-500",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+				},
+			},
+			getBSErr:           &googleapi.Error{Code: http.StatusInternalServerError, Message: "Internal Server Error"},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "ProviderError",
+				Message: "GCE provider error encountered while retrieving forwarding rules",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service whose backends belong to a different Service -> expect validation error",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-diff-neg",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-diff-neg",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-diff-neg": {
+					Name:                "fr-diff-neg",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-other", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-other": {
+					Name:    "bs-other",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/other-svc-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-diff-neg"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-diff-neg"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/my-svc-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service matching target Service NEG via SvcNeg CRD informer -> expect VIP programmed successfully",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-match-crd",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-match-crd",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-match-crd": {
+					Name:                "fr-match-crd",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-crd", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-crd": {
+					Name:    "bs-crd",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/crd-neg-1", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-match-crd"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-match-crd"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/crd-neg-1", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{frIP},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.100",
+			},
+		},
+		{
+			desc: "Forwarding Rule with Backend Service matching target Service NEG via SvcNeg CRD -> expect VIP programmed successfully",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-match-ann",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-match-ann",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-match-ann": {
+					Name:                "fr-match-ann",
+					IPAddress:           frIP,
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-ann", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-ann": {
+					Name:    "bs-ann",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/ann-neg-1", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-match-ann"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-match-ann"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/ann-neg-1", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{frIP},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.100",
+			},
+		},
+		{
+			desc: "Multiple Forwarding Rules pointing to the same Backend Service -> verify deduplication",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-dedup",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-dedup-1,fr-dedup-2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-dedup-1": {
+					Name:                "fr-dedup-1",
+					IPAddress:           "10.0.0.1",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+				"fr-dedup-2": {
+					Name:                "fr-dedup-2",
+					IPAddress:           "10.0.0.2",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-dedup": {
+					Name:    "bs-dedup",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/dedup-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-dedup"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-dedup"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/dedup-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:   []string{"10.0.0.1", "10.0.0.2"},
+			expectError: false,
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionTrue,
+				Reason:  "IPProgrammed",
+				Message: "IPs programmed: 10.0.0.1, 10.0.0.2",
+			},
+		},
+		{
+			desc: "Multiple Forwarding Rules pointing to the same failing Backend Service -> verify deduplication",
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-dedup-failing",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.CustomForwardingRuleKey: "fr-dedup-fail-1,fr-dedup-fail-2",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Type:              v1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: &lbClass,
+				},
+			},
+			frs: map[string]*composite.ForwardingRule{
+				"fr-dedup-fail-1": {
+					Name:                "fr-dedup-fail-1",
+					IPAddress:           "10.0.0.1",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup-failing", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+				"fr-dedup-fail-2": {
+					Name:                "fr-dedup-fail-2",
+					IPAddress:           "10.0.0.2",
+					BackendService:      fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/backendServices/bs-dedup-failing", project, region),
+					LoadBalancingScheme: "EXTERNAL",
+					IPProtocol:          "TCP",
+					Scope:               meta.Regional,
+					Version:             meta.VersionBeta,
+				},
+			},
+			bss: map[string]*composite.BackendService{
+				"bs-dedup-failing": {
+					Name:    "bs-dedup-failing",
+					Scope:   meta.Regional,
+					Version: meta.VersionBeta,
+					Backends: []*composite.Backend{
+						{
+							Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/other-svc-neg", project),
+						},
+					},
+				},
+			},
+			svcNegs: []*negv1beta1.ServiceNetworkEndpointGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            l4Namer.L4Backend("default", "svc-dedup-failing"),
+						Namespace:       "default",
+						OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: "svc-dedup-failing"}},
+					},
+					Status: negv1beta1.ServiceNetworkEndpointGroupStatus{
+						NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+							{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/my-svc-neg", project)},
+						},
+					},
+				},
+			},
+			expectIPs:          nil,
+			expectError:        true,
+			expectEventReasons: []string{"ForwardingRuleUnusable"},
+			expectCondition: &metav1.Condition{
+				Type:    "ExternalIPProgrammed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidForwardingRule",
+				Message: "The custom forwarding rule reference is invalid",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset()
 			fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
-			namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
 
 			// Populate fakeGCE client with forwarding rules defined in each test case
 			for name, fr := range tc.frs {
@@ -1036,13 +1485,78 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 				}
 			}
 
+			// If tc.bss is nil and tc.frs has rules with BackendService, populate default matching BS and SvcNeg for existing test cases
+			if tc.bss == nil && len(tc.frs) > 0 {
+				defaultBSMap := make(map[string]*composite.BackendService)
+				for _, fr := range tc.frs {
+					if fr.BackendService != "" {
+						if resID, err := cloud.ParseResourceURL(fr.BackendService); err == nil && resID.Key != nil {
+							defaultBSMap[resID.Key.Name] = &composite.BackendService{
+								Name:    resID.Key.Name,
+								Scope:   resID.Key.Type(),
+								Version: meta.VersionBeta,
+								Backends: []*composite.Backend{
+									{
+										Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/default-neg", project),
+									},
+								},
+							}
+						}
+					}
+				}
+				if len(defaultBSMap) > 0 {
+					tc.bss = defaultBSMap
+					if tc.svcNegs == nil && tc.svc != nil {
+						svcNegName := l4Namer.L4Backend(tc.svc.Namespace, tc.svc.Name)
+						tc.svcNegs = []*negv1beta1.ServiceNetworkEndpointGroup{
+							test.NewSvcNeg(types.NamespacedName{Namespace: tc.svc.Namespace, Name: svcNegName}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+								NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+									{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/default-neg", project)},
+								},
+							}),
+						}
+					}
+				}
+			}
+
+			// Populate fakeGCE client with backend services defined in each test case
+			for name, bs := range tc.bss {
+				key, err := composite.CreateKey(fakeGCE, name, bs.Scope)
+				if err != nil {
+					t.Fatalf("Failed to create key for backend service %s: %v", name, err)
+				}
+				err = composite.CreateBackendService(fakeGCE, key, bs, klog.TODO())
+				if err != nil {
+					t.Fatalf("Failed to create backend service %s: %v", name, err)
+				}
+			}
+
+			bsGetCount := 0
+			mockGCE := fakeGCE.Compute().(*cloud.MockGCE)
+			mockGCE.MockBetaRegionBackendServices.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockBetaRegionBackendServices, options ...cloud.Option) (bool, *computebeta.BackendService, error) {
+				if tc.getBSErr != nil {
+					return true, nil, tc.getBSErr
+				}
+				if strings.HasPrefix(key.Name, "bs-dedup") {
+					bsGetCount++
+				}
+				return false, nil, nil
+			}
+
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
 			ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+			svcNegClient := svcnegclientfake.NewSimpleClientset()
+			c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, kubeClient, fakeGCE, l4Namer.Namer, "k8s2-cluster-uid", ctxConfig, klog.TODO())
 			if err != nil {
 				t.Fatalf("Failed to create controller context: %v", err)
+			}
+			c.L4Namer = l4Namer
+
+			for _, svcneg := range tc.svcNegs {
+				c.SvcNegInformer.GetIndexer().Add(svcneg)
+				c.SvcNegClient.NetworkingV1beta1().ServiceNetworkEndpointGroups(svcneg.Namespace).Create(context.TODO(), svcneg, metav1.CreateOptions{})
 			}
 
 			lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
@@ -1056,6 +1570,12 @@ func TestStandaloneNEGLBSync(t *testing.T) {
 			err = lc.syncWrapper(key)
 			if (err != nil) != tc.expectError {
 				t.Errorf("sync() error = %v, expectError %v", err, tc.expectError)
+			}
+
+			if strings.Contains(tc.desc, "verify deduplication") {
+				if bsGetCount != 1 {
+					t.Errorf("Expected BackendService bs-dedup to be fetched 1 time, got %d", bsGetCount)
+				}
 			}
 
 			updatedSvc, _ := kubeClient.CoreV1().Services(tc.svc.Namespace).Get(context.TODO(), tc.svc.Name, metav1.GetOptions{})
@@ -1249,15 +1769,17 @@ func TestValidateForwardingRule(t *testing.T) {
 func setupControllerContext(t *testing.T) (*fake.Clientset, *gce.Cloud, *StandaloneNEGLBController, chan struct{}) {
 	kubeClient := fake.NewSimpleClientset()
 	fakeGCE := gce.NewFakeGCECloud(test.DefaultTestClusterValues())
-	namer := namer.NewNamer("cluster-uid", "firewall-name", klog.TODO())
+	l4Namer := namer.NewL4Namer("k8s2-cluster-uid", namer.NewNamer("cluster-id", "firewall-id", klog.TODO()))
 
 	stopCh := make(chan struct{})
 
 	ctxConfig := ingctx.ControllerContextConfig{Namespace: v1.NamespaceAll}
-	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, nil, nil, nil, nil, nil, kubeClient, fakeGCE, namer, "", ctxConfig, klog.TODO())
+	svcNegClient := svcnegclientfake.NewSimpleClientset()
+	c, err := ingctx.NewControllerContext(kubeClient, nil, nil, nil, svcNegClient, nil, nil, nil, nil, kubeClient, fakeGCE, l4Namer.Namer, "k8s2-cluster-uid", ctxConfig, klog.TODO())
 	if err != nil {
 		t.Fatalf("Failed to create controller context: %v", err)
 	}
+	c.L4Namer = l4Namer
 
 	lc := NewStandaloneNEGLBController(c, stopCh, klog.TODO())
 	return kubeClient, fakeGCE, lc, stopCh
@@ -1306,6 +1828,24 @@ func TestStandaloneNEGLBControllerMetrics_Success(t *testing.T) {
 			LoadBalancerClass: &lbClass,
 		},
 	}
+
+	// Create Backend Service and SvcNeg for BS validation
+	bsKey, _ := composite.CreateKey(fakeGCE, "bs1", meta.Regional)
+	bs := &composite.BackendService{
+		Name:    "bs1",
+		Scope:   meta.Regional,
+		Version: meta.VersionBeta,
+		Backends: []*composite.Backend{
+			{Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	}
+	composite.CreateBackendService(fakeGCE, bsKey, bs, klog.TODO())
+	svcNeg := test.NewSvcNeg(types.NamespacedName{Namespace: "default", Name: lc.namer.L4Backend(svc.Namespace, svc.Name)}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+		NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+			{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	})
+	lc.ctx.SvcNegInformer.GetIndexer().Add(svcNeg)
 
 	// Add service to informer and fake kube client
 	lc.ctx.ServiceInformer.GetIndexer().Add(svc)
@@ -1493,6 +2033,24 @@ func TestStandaloneNEGLBControllerMetrics_Deletion(t *testing.T) {
 			LoadBalancerClass: &lbClass,
 		},
 	}
+
+	// Create Backend Service and SvcNeg for BS validation
+	bsKey, _ := composite.CreateKey(fakeGCE, "bs1", meta.Regional)
+	bs := &composite.BackendService{
+		Name:    "bs1",
+		Scope:   meta.Regional,
+		Version: meta.VersionBeta,
+		Backends: []*composite.Backend{
+			{Group: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	}
+	composite.CreateBackendService(fakeGCE, bsKey, bs, klog.TODO())
+	svcNeg := test.NewSvcNeg(types.NamespacedName{Namespace: "default", Name: lc.namer.L4Backend(svc.Namespace, svc.Name)}, negv1beta1.ServiceNetworkEndpointGroupStatus{
+		NetworkEndpointGroups: []negv1beta1.NegObjectReference{
+			{SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/us-central1-a/networkEndpointGroups/neg-1", project)},
+		},
+	})
+	lc.ctx.SvcNegInformer.GetIndexer().Add(svcNeg)
 
 	// Add service to informer and fake kube client
 	lc.ctx.ServiceInformer.GetIndexer().Add(svc)

--- a/pkg/l4/forwardingrules/equal.go
+++ b/pkg/l4/forwardingrules/equal.go
@@ -52,7 +52,8 @@ func EqualIPv6(fr1, fr2 *composite.ForwardingRule) (bool, error) {
 		fr1.AllowGlobalAccess == fr2.AllowGlobalAccess &&
 		fr1.AllPorts == fr2.AllPorts &&
 		fr1.Subnetwork == fr2.Subnetwork &&
-		fr1.NetworkTier == fr2.NetworkTier, nil
+		fr1.NetworkTier == fr2.NetworkTier &&
+		equalResourcePaths(fr1.IpCollection, fr2.IpCollection), nil
 }
 
 // equalPorts compares two port ranges or slices of ports. Before comparison,

--- a/pkg/l4/forwardingrules/equal_test.go
+++ b/pkg/l4/forwardingrules/equal_test.go
@@ -448,6 +448,24 @@ func TestEqualIPv6(t *testing.T) {
 		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
 		NetworkTier:         cloud.NetworkTierPremium.ToGCEValue(),
 	}
+	ipCollectionFwdRule1 := &composite.ForwardingRule{
+		Name:                "ip-collection-fwd-rule-1",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		IpCollection:        "my-collection",
+	}
+	ipCollectionFwdRule2 := &composite.ForwardingRule{
+		Name:                "ip-collection-fwd-rule-2",
+		IPAddress:           "0::1/32",
+		Ports:               []string{"123"},
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: string(cloud.SchemeInternal),
+		BackendService:      "http://www.googleapis.com/projects/test/regions/us-central1/backendServices/bs1",
+		IpCollection:        "other-collection",
+	}
 
 	testCases := []struct {
 		desc        string
@@ -502,6 +520,24 @@ func TestEqualIPv6(t *testing.T) {
 			oldFwdRule:  bsLink2PremiumNetworkTierFwdRule,
 			newFwdRule:  bsLink2StandardNetworkTierFwdRule,
 			expectEqual: false,
+		},
+		{
+			desc:        "different ip collection",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  ipCollectionFwdRule2,
+			expectEqual: false,
+		},
+		{
+			desc:        "one has ip collection, one does not",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  tcpFwdRule,
+			expectEqual: false,
+		},
+		{
+			desc:        "same ip collection",
+			oldFwdRule:  ipCollectionFwdRule1,
+			newFwdRule:  ipCollectionFwdRule1,
+			expectEqual: true,
 		},
 	}
 

--- a/pkg/l4/resources/forwarding_rules_ipv6.go
+++ b/pkg/l4/resources/forwarding_rules_ipv6.go
@@ -190,6 +190,14 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	if err != nil {
 		return nil, l4utils.ResourceResync, fmt.Errorf("error getting ipv6 forwarding rule subnet: %w", err)
 	}
+
+	var ipCollection string
+	if flags.F.EnableBYOIPv6 {
+		ipCollection = annotations.FromService(l4netlb.Service).GetIPCollectionV6()
+	}
+	if ipCollection != "" {
+		subnetworkURL = ""
+	}
 	frLogger.V(2).Info("subnetworkURL for service", "subnetworkURL", subnetworkURL)
 
 	// Determine IP which will be used for this LB. If no forwarding rule has been established
@@ -199,6 +207,12 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 		frLogger.Error(err, "address.IPv6ToUse for service returned error")
 		return nil, l4utils.ResourceResync, err
 	}
+
+	// If the IP collection changed, we cannot reuse the old forwarding rule's IP.
+	if fwdRuleToDetermineIP != nil && fwdRuleToDetermineIP.IpCollection != ipCollection {
+		ipv6AddrToUse = ""
+	}
+
 	frLogger.V(2).Info("ipv6AddressToUse for service", "ipv6AddressToUse", ipv6AddrToUse)
 
 	netTier, isFromAnnotation := annotations.NetworkTier(l4netlb.Service)
@@ -214,6 +228,7 @@ func (l4netlb *L4NetLB) ensureIPv6ForwardingRule(bsLink string) (*composite.Forw
 	if !l4netlb.cloud.IsLegacyNetwork() && netTier == cloud.NetworkTierPremium {
 		nm := types.NamespacedName{Namespace: l4netlb.Service.Namespace, Name: l4netlb.Service.Name}.String()
 		addrMgr := address.NewManager(l4netlb.cloud, nm, l4netlb.cloud.Region(), subnetworkURL, expectedIPv6FrName, ipv6AddressName, ipv6AddrToUse, cloud.SchemeExternal, netTier, address.IPv6Version, frLogger)
+		addrMgr.SetIPCollection(ipCollection)
 
 		// If network tier annotation in Service Spec is present
 		// check if it matches network tiers from forwarding rule and external ip Address.
@@ -333,6 +348,11 @@ func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse
 		}
 	}
 
+	var ipCollection string
+	if flags.F.EnableBYOIPv6 {
+		ipCollection = annotations.FromService(l4netlb.Service).GetIPCollectionV6()
+	}
+
 	fr := &composite.ForwardingRule{
 		Name:                frName,
 		Description:         frDesc,
@@ -346,6 +366,7 @@ func (l4netlb *L4NetLB) buildExpectedIPv6ForwardingRule(bsLink, ipv6AddressToUse
 		Subnetwork:          subnetworkURL,
 		AllPorts:            allPorts,
 		Ports:               ports,
+		IpCollection:        ipCollection,
 	}
 
 	return fr, nil

--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -424,6 +424,12 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 	l4.network = *svcNetwork
 
+	// Check if ip-collection is specified for IPv4 service
+	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" && l4utils.NeedsIPv4(svc) {
+		err := fmt.Errorf("%s is currently only supported for IPv6-only external LBs", annotations.IPCollectionV6AnnotationKey)
+		l4.recorder.Event(l4.Service, corev1.EventTypeWarning, "IPCollectionV6Error", err.Error())
+	}
+
 	// If service requires IPv6 LoadBalancer -- verify that Subnet with Internal IPv6 ranges is used.
 	if l4.enableDualStack && l4utils.NeedsIPv6(l4.Service) {
 		err := l4.serviceSubnetHasInternalIPv6Range()
@@ -494,6 +500,7 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	var ipv6AddressName string
 	if l4.enableDualStack && l4utils.NeedsIPv6(l4.Service) {
 		existingIPv6FR, err = l4.getOldIPv6ForwardingRule(existingBS)
+
 		ipv6AddrToUse, ipv6AddressName, err = address.IPv6ToUse(l4.cloud, l4.Service, existingIPv6FR, subnetworkURL, l4.svcLogger)
 		if err != nil {
 			result.Error = fmt.Errorf("EnsureInternalLoadBalancer error: address.IPv6ToUse returned error: %w", err)

--- a/pkg/l4/resources/l4.go
+++ b/pkg/l4/resources/l4.go
@@ -424,9 +424,9 @@ func (l4 *L4) EnsureInternalLoadBalancer(nodeNames []string, svc *corev1.Service
 	}
 	l4.network = *svcNetwork
 
-	// Check if ip-collection is specified for IPv4 service
-	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" && l4utils.NeedsIPv4(svc) {
-		err := fmt.Errorf("%s is currently only supported for IPv6-only external LBs", annotations.IPCollectionV6AnnotationKey)
+	// Check if ip-collection-v6 is specified for internal load balancer
+	if flags.F.EnableBYOIPv6 && annotations.FromService(svc).GetIPCollectionV6() != "" {
+		err := fmt.Errorf("%s is not supported for Internal LoadBalancers. To use BYOIPv6 with ILB, specify a BYOIP subnet using the \"%s\" annotation", annotations.IPCollectionV6AnnotationKey, annotations.CustomSubnetAnnotationKey)
 		l4.recorder.Event(l4.Service, corev1.EventTypeWarning, "IPCollectionV6Error", err.Error())
 	}
 

--- a/pkg/l4/resources/l4_test.go
+++ b/pkg/l4/resources/l4_test.go
@@ -3439,3 +3439,50 @@ func TestEnsureInternalLoadBalancer_L4LBConfigLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureInternalLoadBalancerIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4ILBService(false, 8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4Params := &L4ILBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4 := NewL4Handler(l4Params, klog.TODO())
+
+	if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
+	if result.Error != nil {
+		t.Errorf("Expected no error for conflicting annotations, but got %v", result.Error)
+	}
+
+	fakeRecorder := l4.recorder.(*record.FakeRecorder)
+	warningFound := false
+	for len(fakeRecorder.Events) > 0 {
+		event := <-fakeRecorder.Events
+		if strings.Contains(event, "Warning IPCollectionV6Error") {
+			warningFound = true
+			break
+		}
+	}
+	if !warningFound {
+		t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+	}
+}

--- a/pkg/l4/resources/l4_test.go
+++ b/pkg/l4/resources/l4_test.go
@@ -3443,46 +3443,85 @@ func TestEnsureInternalLoadBalancer_L4LBConfigLogging(t *testing.T) {
 func TestEnsureInternalLoadBalancerIPCollectionError(t *testing.T) {
 	flags.F.EnableBYOIPv6 = true
 	defer func() { flags.F.EnableBYOIPv6 = false }()
-	nodeNames := []string{"test-node-1"}
-	vals := gce.DefaultTestClusterValues()
-	fakeGCE := getFakeGCECloud(vals)
 
-	svc := test.NewL4ILBService(false, 8080)
-	if svc.Annotations == nil {
-		svc.Annotations = make(map[string]string)
-	}
-	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
-
-	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
-
-	l4Params := &L4ILBParams{
-		Service:         svc,
-		Cloud:           fakeGCE,
-		Namer:           namer,
-		Recorder:        record.NewFakeRecorder(100),
-		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
-	}
-	l4 := NewL4Handler(l4Params, klog.TODO())
-
-	if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
-		t.Errorf("Unexpected error when adding nodes %v", err)
+	testCases := []struct {
+		desc       string
+		ipFamilies []v1.IPFamily
+	}{
+		{
+			desc:       "IPv4 ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol},
+		},
+		{
+			desc:       "IPv6-only ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv6Protocol},
+		},
+		{
+			desc:       "Dual-stack ILB service with ip-collection-v6",
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+		},
 	}
 
-	result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
-	if result.Error != nil {
-		t.Errorf("Expected no error for conflicting annotations, but got %v", result.Error)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nodeNames := []string{"test-node-1"}
+			vals := gce.DefaultTestClusterValues()
+			fakeGCE := getFakeGCECloud(vals)
 
-	fakeRecorder := l4.recorder.(*record.FakeRecorder)
-	warningFound := false
-	for len(fakeRecorder.Events) > 0 {
-		event := <-fakeRecorder.Events
-		if strings.Contains(event, "Warning IPCollectionV6Error") {
-			warningFound = true
-			break
-		}
-	}
-	if !warningFound {
-		t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+			key := meta.RegionalKey("", fakeGCE.Region())
+			subnetToCreate := &compute.Subnetwork{
+				Ipv6AccessType: subnetInternalIPv6AccessType,
+				StackType:      "IPV4_IPV6",
+			}
+			if err := fakeGCE.Compute().(*cloud.MockGCE).Subnetworks().Insert(context.TODO(), key, subnetToCreate); err != nil {
+				t.Fatalf("Failed to create mock cluster subnet: %v", err)
+			}
+
+			svc := test.NewL4ILBDualStackService(8080, v1.ProtocolTCP, tc.ipFamilies, v1.ServiceExternalTrafficPolicyTypeCluster)
+			if svc.Annotations == nil {
+				svc.Annotations = make(map[string]string)
+			}
+			svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+
+			namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+			l4Params := &L4ILBParams{
+				Service:          svc,
+				Cloud:            fakeGCE,
+				Namer:            namer,
+				Recorder:         record.NewFakeRecorder(100),
+				NetworkResolver:  network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+				DualStackEnabled: true,
+			}
+			l4 := NewL4Handler(l4Params, klog.TODO())
+
+			if _, err := test.CreateAndInsertNodes(l4.cloud, nodeNames, vals.ZoneName); err != nil {
+				t.Errorf("Unexpected error when adding nodes %v", err)
+			}
+
+			result := l4.EnsureInternalLoadBalancer(nodeNames, svc)
+			if result.Error != nil {
+				t.Errorf("Expected no fatal error for unsupported annotation, but got %v", result.Error)
+			}
+
+			fakeRecorder := l4.recorder.(*record.FakeRecorder)
+			warningFound := false
+			for len(fakeRecorder.Events) > 0 {
+				event := <-fakeRecorder.Events
+				if strings.Contains(event, "Warning IPCollectionV6Error") {
+					warningFound = true
+					if !strings.Contains(event, "not supported for Internal LoadBalancers") {
+						t.Errorf("Expected warning to mention not supported for Internal LoadBalancers, got: %s", event)
+					}
+					if !strings.Contains(event, annotations.CustomSubnetAnnotationKey) {
+						t.Errorf("Expected warning to suggest %s annotation, got: %s", annotations.CustomSubnetAnnotationKey, event)
+					}
+					break
+				}
+			}
+			if !warningFound {
+				t.Errorf("Expected IPCollectionV6Error warning event, but got none")
+			}
+		})
 	}
 }

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -271,6 +271,47 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service, 
 
 	l4netlb.networkInfo = *networkInfo
 
+	var ipCollectionV6 string
+	if flags.F.EnableBYOIPv6 {
+		ipCollectionV6 = annotations.FromService(svc).GetIPCollectionV6()
+	}
+	subnet := annotations.FromService(svc).GetExternalLoadBalancerAnnotationSubnet()
+	if ipCollectionV6 != "" && subnet != "" {
+		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.CustomSubnetAnnotationKey, subnet, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check conflicts between spec.loadBalancerIP and ip-collection
+	if ipCollectionV6 != "" && svc.Spec.LoadBalancerIP != "" {
+		err := fmt.Errorf("cannot specify both spec.LoadBalancerIP (%q) and %s (%q) for LoadBalancer", svc.Spec.LoadBalancerIP, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check conflicts between load-balancer-ip-addresses and ip-collection
+	staticL4Addresses := svc.Annotations[annotations.StaticL4AddressesAnnotationKey]
+	if ipCollectionV6 != "" && staticL4Addresses != "" {
+		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.StaticL4AddressesAnnotationKey, staticL4Addresses, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
+	// Check if ip-collection-v6 is specified for an IPv4 service
+	if ipCollectionV6 != "" && l4utils.NeedsIPv4(svc) {
+		err := fmt.Errorf("%s is currently only supported for IPv6-only Services", annotations.IPCollectionV6AnnotationKey)
+		result.Error = l4utils.NewUserError(err)
+		result.MetricsState.Status = metrics.StatusUserError
+		result.MetricsLegacyState.IsUserError = true
+		return result
+	}
+
 	// if service requires strong session affinity, check requirements
 	if err := l4netlb.checkStrongSessionAffinityRequirements(); err != nil {
 		result.Error = err

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -284,25 +284,6 @@ func (l4netlb *L4NetLB) EnsureFrontend(nodeNames []string, svc *corev1.Service, 
 		return result
 	}
 
-	// Check conflicts between spec.loadBalancerIP and ip-collection
-	if ipCollectionV6 != "" && svc.Spec.LoadBalancerIP != "" {
-		err := fmt.Errorf("cannot specify both spec.LoadBalancerIP (%q) and %s (%q) for LoadBalancer", svc.Spec.LoadBalancerIP, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
-		result.Error = l4utils.NewUserError(err)
-		result.MetricsState.Status = metrics.StatusUserError
-		result.MetricsLegacyState.IsUserError = true
-		return result
-	}
-
-	// Check conflicts between load-balancer-ip-addresses and ip-collection
-	staticL4Addresses := svc.Annotations[annotations.StaticL4AddressesAnnotationKey]
-	if ipCollectionV6 != "" && staticL4Addresses != "" {
-		err := fmt.Errorf("cannot specify both %s (%q) and %s (%q) for LoadBalancer", annotations.StaticL4AddressesAnnotationKey, staticL4Addresses, annotations.IPCollectionV6AnnotationKey, ipCollectionV6)
-		result.Error = l4utils.NewUserError(err)
-		result.MetricsState.Status = metrics.StatusUserError
-		result.MetricsLegacyState.IsUserError = true
-		return result
-	}
-
 	// Check if ip-collection-v6 is specified for an IPv4 service
 	if ipCollectionV6 != "" && l4utils.NeedsIPv4(svc) {
 		err := fmt.Errorf("%s is currently only supported for IPv6-only Services", annotations.IPCollectionV6AnnotationKey)

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -1665,6 +1665,10 @@ func assertDualStackNetLBResources(t *testing.T, l4NetLB *L4NetLB, nodeNames []s
 func assertDualStackNetLBResourcesWithCustomIPv6Subnet(t *testing.T, l4NetLB *L4NetLB, nodeNames []string, expectedIPv6Subnet string) {
 	t.Helper()
 
+	if annotations.FromService(l4NetLB.Service).GetIPCollectionV6() != "" {
+		expectedIPv6Subnet = ""
+	}
+
 	// Check that HealthCheck is created
 	healthCheck, err := getAndVerifyNetLBHealthCheck(l4NetLB)
 	if err != nil {
@@ -1754,7 +1758,11 @@ func assertNetLBResourcesIPv6Only(t *testing.T, l4NetLB *L4NetLB, nodeNames []st
 		t.Errorf("getAndVerifyNetLBBackendService(_, %v) = %v, want nil", healthcheck, err)
 	}
 
-	if err := verifyNetLBIPv6ForwardingRule(l4NetLB, backendService.SelfLink, l4NetLB.cloud.SubnetworkURL()); err != nil {
+	expectedIPv6Subnet := l4NetLB.cloud.SubnetworkURL()
+	if annotations.FromService(l4NetLB.Service).GetIPCollectionV6() != "" {
+		expectedIPv6Subnet = ""
+	}
+	if err := verifyNetLBIPv6ForwardingRule(l4NetLB, backendService.SelfLink, expectedIPv6Subnet); err != nil {
 		t.Errorf("verifyNetLBIPv6ForwardingRule() = %v, want nil", err)
 	}
 
@@ -2016,6 +2024,12 @@ func buildExpectedNetLBAnnotations(l4netlb *L4NetLB) map[string]string {
 	if val, ok := l4netlb.Service.Annotations[annotations.NetworkTierAnnotationKey]; ok {
 		expectedAnnotations[annotations.NetworkTierAnnotationKey] = val
 	}
+	if val, ok := l4netlb.Service.Annotations[annotations.RBSAnnotationKey]; ok {
+		expectedAnnotations[annotations.RBSAnnotationKey] = val
+	}
+	if val, ok := l4netlb.Service.Annotations[annotations.IPCollectionV6AnnotationKey]; ok {
+		expectedAnnotations[annotations.IPCollectionV6AnnotationKey] = val
+	}
 	return expectedAnnotations
 }
 
@@ -2239,5 +2253,230 @@ func TestEnsureL4NetLB_L4LBConfigLogging(t *testing.T) {
 				t.Errorf("LogConfig mismatch following reconciliation (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestIPv6OnlyNetLBIPCollectionAnnotation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	svc := test.NewL4NetLBRBSService(8080)
+	l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+	result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error != nil {
+		t.Fatalf("Failed to ensure loadBalancer, err %v", result.Error)
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	for k, v := range result.Annotations {
+		svc.Annotations[k] = v
+	}
+	assertNetLBResourcesIPv6Only(t, l4NetLB, nodeNames)
+
+	// Check IpCollection and Subnetwork on IPv6 Forwarding Rule
+	frName := l4NetLB.ipv6FRName()
+	fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+	if err != nil {
+		t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+	}
+	if fwdRule.IpCollection != "my-collection" {
+		t.Errorf("fwdRule.IpCollection = %v, want my-collection", fwdRule.IpCollection)
+	}
+	if fwdRule.Subnetwork != "" {
+		t.Errorf("fwdRule.Subnetwork = %v, want empty string", fwdRule.Subnetwork)
+	}
+}
+
+func TestEnsureFrontendConflictingAnnotations(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Annotations[annotations.CustomSubnetAnnotationKey] = "my-subnet"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendConflictingIPAnnotations(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.LoadBalancerIP = "1.2.3.4"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendConflictingIPAddressesAnnotation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = "1.2.3.4"
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for conflicting annotations, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for conflicting annotations, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendIPv4OnlyIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol}
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for ip-collection on IPv4 service, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for ip-collection on IPv4 service, but got %v", result.Error)
+	}
+}
+
+func TestEnsureFrontendDualStackIPCollectionError(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+	vals := gce.DefaultTestClusterValues()
+	fakeGCE := getFakeGCECloud(vals)
+	svc := test.NewL4NetLBRBSService(8080)
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[annotations.IPCollectionV6AnnotationKey] = "my-collection"
+	svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
+
+	namer := namer_util.NewL4Namer(kubeSystemUID, namer_util.NewNamer(vals.ClusterName, "cluster-fw", klog.TODO()))
+
+	l4NetLBParams := &L4NetLBParams{
+		Service:         svc,
+		Cloud:           fakeGCE,
+		Namer:           namer,
+		Recorder:        record.NewFakeRecorder(100),
+		NetworkResolver: network.NewFakeResolver(network.DefaultNetwork(fakeGCE)),
+	}
+	l4netlb := NewL4NetLB(l4NetLBParams, klog.TODO())
+	l4netlb.healthChecks = healthchecks.Fake(fakeGCE, l4netlb.recorder)
+
+	if _, err := test.CreateAndInsertNodes(l4netlb.cloud, nodeNames, vals.ZoneName); err != nil {
+		t.Errorf("Unexpected error when adding nodes %v", err)
+	}
+
+	result := l4netlb.EnsureFrontend(nodeNames, svc, time.Now())
+	if result.Error == nil {
+		t.Errorf("Expected error for ip-collection on dualstack service, but got nil")
+	} else if !IsUserError(result.Error) {
+		t.Errorf("Expected UserError for ip-collection on dualstack service, but got %v", result.Error)
 	}
 }

--- a/pkg/l4/resources/l4netlb_test.go
+++ b/pkg/l4/resources/l4netlb_test.go
@@ -2480,3 +2480,98 @@ func TestEnsureFrontendDualStackIPCollectionError(t *testing.T) {
 		t.Errorf("Expected UserError for ip-collection on dualstack service, but got %v", result.Error)
 	}
 }
+
+func TestIPv6NetLBIPCollectionWithStaticAddressValidation(t *testing.T) {
+	flags.F.EnableBYOIPv6 = true
+	defer func() { flags.F.EnableBYOIPv6 = false }()
+	nodeNames := []string{"test-node-1"}
+
+	ipv6AddressMatching := &ga.Address{
+		Name:             "ipv6-address-matching",
+		Address:          "2::2",
+		IpVersion:        "IPV6",
+		PrefixLength:     96,
+		AddressType:      "EXTERNAL",
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "my-collection",
+	}
+	ipv6AddressMismatching := &ga.Address{
+		Name:             "ipv6-address-mismatching",
+		Address:          "2::3",
+		IpVersion:        "IPV6",
+		PrefixLength:     96,
+		AddressType:      "EXTERNAL",
+		Ipv6EndpointType: "NETLB",
+		IpCollection:     "other-collection",
+	}
+
+	testCases := []struct {
+		desc                string
+		ipCollectionVal     string
+		staticAnnotationVal string
+		addressToReserve    *ga.Address
+		expectError         bool
+	}{
+		{
+			desc:                "Case 1: Reserved PDP static address without ip-collection-v6 annotation is accepted",
+			ipCollectionVal:     "",
+			staticAnnotationVal: "ipv6-address-matching",
+			addressToReserve:    ipv6AddressMatching,
+			expectError:         false,
+		},
+		{
+			desc:                "Case 2: Static address matching ip-collection-v6 is accepted",
+			ipCollectionVal:     "my-collection",
+			staticAnnotationVal: "ipv6-address-matching",
+			addressToReserve:    ipv6AddressMatching,
+			expectError:         false,
+		},
+		{
+			desc:                "Case 3: Static address mismatching ip-collection-v6 is rejected",
+			ipCollectionVal:     "my-collection",
+			staticAnnotationVal: "ipv6-address-mismatching",
+			addressToReserve:    ipv6AddressMismatching,
+			expectError:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := test.NewL4NetLBRBSService(8080)
+			l4NetLB := mustSetupNetLBTestHandler(t, svc, nodeNames)
+
+			if err := l4NetLB.cloud.ReserveRegionAddress(tc.addressToReserve, l4NetLB.cloud.Region()); err != nil {
+				t.Fatalf("Failed to reserve region address: %v", err)
+			}
+
+			if tc.ipCollectionVal != "" {
+				svc.Annotations[annotations.IPCollectionV6AnnotationKey] = tc.ipCollectionVal
+			}
+			svc.Annotations[annotations.StaticL4AddressesAnnotationKey] = tc.staticAnnotationVal
+			svc.Spec.IPFamilies = []v1.IPFamily{v1.IPv6Protocol}
+
+			result := l4NetLB.EnsureFrontend(nodeNames, svc, time.Now())
+			if tc.expectError {
+				if result.Error == nil {
+					t.Errorf("Expected error for static address with mismatching IpCollection, but got nil")
+				}
+			} else {
+				if result.Error != nil {
+					t.Errorf("Expected success, but got err %v", result.Error)
+				}
+				frName := l4NetLB.ipv6FRName()
+				fwdRule, err := composite.GetForwardingRule(l4NetLB.cloud, meta.RegionalKey(frName, l4NetLB.cloud.Region()), meta.VersionGA, klog.TODO())
+				if err != nil {
+					t.Fatalf("failed to fetch forwarding rule %s - err %v", frName, err)
+				}
+				if tc.ipCollectionVal != "" && fwdRule.IpCollection != tc.ipCollectionVal {
+					t.Errorf("fwdRule.IpCollection = %v, want %v", fwdRule.IpCollection, tc.ipCollectionVal)
+				}
+				if strings.Split(fwdRule.IPAddress, "/")[0] != tc.addressToReserve.Address {
+					t.Errorf("fwdRule.IPAddress = %v, want %v", fwdRule.IPAddress, tc.addressToReserve.Address)
+				}
+			}
+		})
+	}
+}

--- a/pkg/l4/utils/errors.go
+++ b/pkg/l4/utils/errors.go
@@ -230,3 +230,23 @@ func IsUnsupportedProtocolError(err error) bool {
 	var unsupportedProtocolErr *UnsupportedProtocolError
 	return errors.As(err, &unsupportedProtocolErr)
 }
+
+// BackendNotAttachedError is an error returned when service NEGs are not attached to the load balancer backend service.
+type BackendNotAttachedError struct {
+	bsName string
+}
+
+func (e *BackendNotAttachedError) Error() string {
+	return fmt.Sprintf("the service NEGs are not attached to the load balancer (backend service: %s)", e.bsName)
+}
+
+// NewBackendNotAttachedError creates a new BackendNotAttachedError.
+func NewBackendNotAttachedError(bsName string) *BackendNotAttachedError {
+	return &BackendNotAttachedError{bsName: bsName}
+}
+
+// IsBackendNotAttachedError checks if wrapped error is a BackendNotAttachedError.
+func IsBackendNotAttachedError(err error) bool {
+	var backendNotAttachedErr *BackendNotAttachedError
+	return errors.As(err, &backendNotAttachedErr)
+}

--- a/pkg/l4/utils/errors_test.go
+++ b/pkg/l4/utils/errors_test.go
@@ -300,3 +300,62 @@ func TestUnsupportedProtocolError(t *testing.T) {
 		})
 	}
 }
+
+func TestBackendNotAttachedError(t *testing.T) {
+	customErr := NewBackendNotAttachedError("test-backend-service")
+
+	testCases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{
+			desc: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			desc: "direct error",
+			err:  customErr,
+			want: true,
+		},
+		{
+			desc: "wrapped in fmt.Errorf",
+			err:  fmt.Errorf("wrapped: %w", customErr),
+			want: true,
+		},
+		{
+			desc: "wrapped in UserError",
+			err:  NewUserError(customErr),
+			want: true,
+		},
+		{
+			desc: "wrapped in UserError and then fmt.Errorf",
+			err:  fmt.Errorf("wrapped: %w", NewUserError(customErr)),
+			want: true,
+		},
+		{
+			desc: "joined with other errors",
+			err:  errors.Join(errors.New("generic error"), customErr),
+			want: true,
+		},
+		{
+			desc: "joined and wrapped in UserError",
+			err:  NewUserError(errors.Join(errors.New("generic error"), customErr)),
+			want: true,
+		},
+		{
+			desc: "other error",
+			err:  errors.New("other error"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := IsBackendNotAttachedError(tc.err); got != tc.want {
+				t.Errorf("IsBackendNotAttachedError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/neg/controller_test.go
+++ b/pkg/neg/controller_test.go
@@ -534,7 +534,7 @@ func TestEnqueueNodeWithILBSubsetting(t *testing.T) {
 	// start the informer directly, without starting the entire controller.
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 		controller.stop()
 	}()
 	ctx := context.Background()
@@ -575,7 +575,7 @@ func TestEnqueueNodeWhenProviderIDPopulated(t *testing.T) {
 	// start the informer directly, without starting the entire controller.
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 		controller.stop()
 	}()
 	ctx := context.Background()
@@ -1596,7 +1596,7 @@ func TestEnqueueEndpoints(t *testing.T) {
 			// start the informer directly, without starting the entire controller.
 			go testContext.EndpointSliceInformer.Run(stopChan)
 			defer func() {
-				stopChan <- struct{}{}
+				close(stopChan)
 				controller.stop()
 			}()
 			ctx := context.Background()
@@ -2576,7 +2576,7 @@ func TestNodeInformerFilterWithIncludeDrainNodesL4Local(t *testing.T) {
 	stopChan := make(chan struct{}, 1)
 	go testContext.NodeInformer.Run(stopChan)
 	defer func() {
-		stopChan <- struct{}{}
+		close(stopChan)
 	}()
 	if !cache.WaitForCacheSync(stopChan, testContext.NodeInformer.HasSynced) {
 		t.Fatal("timed out waiting for node informer to sync")

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -160,10 +160,10 @@ func TestRetryOnSyncError(t *testing.T) {
 	syncerTester.mu.Lock()
 	syncerTester.syncError = true
 	syncerTester.mu.Unlock()
+	syncerTester.syncer.(*syncer).backoff = backoff.NewExponentialBackoffHandler(maxRetry, 0, 0)
 	if err := syncerTester.syncer.Start(); err != nil {
 		t.Fatalf("Failed to start syncer: %v", err)
 	}
-	syncerTester.syncer.(*syncer).backoff = backoff.NewExponentialBackoffHandler(maxRetry, 0, 0)
 
 	if err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
 		// In 5 seconds, syncer should be able to retry 3 times.

--- a/pkg/neg/syncers/syncer_test.go
+++ b/pkg/neg/syncers/syncer_test.go
@@ -164,6 +164,7 @@ func TestRetryOnSyncError(t *testing.T) {
 	if err := syncerTester.syncer.Start(); err != nil {
 		t.Fatalf("Failed to start syncer: %v", err)
 	}
+	defer syncerTester.syncer.Stop()
 
 	if err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
 		// In 5 seconds, syncer should be able to retry 3 times.


### PR DESCRIPTION
This PR backports recent updates from `master` to `release-1.41` to support Standalone L4 NEGs and BYOIPv6 features.

**Standalone L4 NEG:**
- Refactored L4 standalone NEG controller logic.
- Improved backend attachment verification before writing the LB VIP into the service status.
- Added `BackendNotAttached` condition reason and improved event messaging and rule sorting.
- Fixed user error classification and IP address sanitization.

**BYOIPv6:**
- Added BYOIPv6 NetLB support and `ip-collection-v6` annotation validation.
- Allowed static BYOIPv6 addresses to be used without the `ip-collection-v6` annotation.
- Added a warning when the `ip-collection-v6` annotation is incorrectly used on ILB.