### PR TITLE
Add flags to override L4 LB HealthCheck source CIDRs

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -150,6 +150,8 @@ var F = struct {
 	EnableIPV6OnlyNEG                           bool
 	MultiProjectOwnerLabelKey                   string
 	OverrideHealthCheckSourceCIDRs              string
+	OverrideL4ILBHealthCheckSourceCIDRs         string
+	OverrideL4NetLBHealthCheckSourceCIDRs       string
 	ManageL4LBLogging                           bool
 	EnableNEGsForIngress                        bool
 	L4ILBLegacyHeadStartTime                    time.Duration
@@ -374,6 +376,8 @@ L7 load balancing. CSV values accepted. Example: -node-port-ranges=80,8080,400-5
 	flag.BoolVar(&F.EnableIPV6OnlyNEG, "enable-ipv6-only-neg", false, "Enable support for IPV6 Only NEG's.")
 	flag.StringVar(&F.MultiProjectOwnerLabelKey, "multi-project-owner-label-key", "multiproject.gke.io/owner", "The label key for multi-project owner, which is used to identify the owner of objects in multi-project mode.")
 	flag.StringVar(&F.OverrideHealthCheckSourceCIDRs, "override-health-check-src-cidrs", "", "Overrides the default source IP ranges used when configuring firewall rules to allow health check probes for L7 load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-health-check-src-cidrs=130.211.0.0/22,35.191.0.0/16")
+	flag.StringVar(&F.OverrideL4ILBHealthCheckSourceCIDRs, "override-l4-ilb-health-check-src-cidrs", "", "Overrides the default source IPv4/v6 ranges used when configuring firewall rules to allow health check probes for L4 ILB load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-l4-ilb-health-check-src-cidrs=35.191.192.0/18,2600:2d00:1:b029:0:2b::/96")
+	flag.StringVar(&F.OverrideL4NetLBHealthCheckSourceCIDRs, "override-l4-netlb-health-check-src-cidrs", "", "Overrides the default source IPv4/v6 ranges used when configuring firewall rules to allow health check probes for L4 NetLB load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-l4-netlb-health-check-src-cidrs=209.85.204.0/22,2600:1901:8001::/48")
 	flag.BoolVar(&F.ManageL4LBLogging, "manage-l4lb-logging", false, "Manage L4 ILB/NetLB logging.")
 	flag.BoolVar(&F.ReadOnlyMode, "read-only-controllers", false, "When enabled, this flag runs the IG, NEG, L4 ILB, and L4 NetLB controllers in a read-only mode. This prevents them from executing any mutating API calls (e.g., create, update, delete), allowing you to safely observe controller behavior without modifying resources. The Ingress controller is exempt from this mode.")
 	flag.BoolVar(&F.EnableNEGsForIngress, "enable-negs-for-ingress", true, "Allow the NEG controller to create NEGs for Ingress services.")
@@ -399,6 +403,12 @@ func Validate() {
 
 	if err := validation.ValidateHealthCheckSourceCIDRs(F.OverrideHealthCheckSourceCIDRs); err != nil {
 		klog.Fatalf("Invalid --override-health-check-src-cidrs flag: %v", err)
+	}
+	if err := validation.ValidateHealthCheckSourceCIDRs(F.OverrideL4ILBHealthCheckSourceCIDRs); err != nil {
+		klog.Fatalf("Invalid --override-l4-ilb-health-check-src-cidrs flag: %v", err)
+	}
+	if err := validation.ValidateHealthCheckSourceCIDRs(F.OverrideL4NetLBHealthCheckSourceCIDRs); err != nil {
+		klog.Fatalf("Invalid --override-l4-netlb-health-check-src-cidrs flag: %v", err)
 	}
 
 	if F.EnableL4DenyFirewall && (!F.EnablePinhole || !F.EnableL4DenyFirewallRollbackCleanup) {

--- a/pkg/l4/healthchecks/healthchecksl4.go
+++ b/pkg/l4/healthchecks/healthchecksl4.go
@@ -31,12 +31,16 @@ import (
 	"k8s.io/cloud-provider/service/helpers"
 	"k8s.io/ingress-gce/pkg/composite"
 	"k8s.io/ingress-gce/pkg/firewalls"
+	"k8s.io/ingress-gce/pkg/flags"
+	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/network"
 	"k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/ingress-gce/pkg/utils/namer"
+	"k8s.io/ingress-gce/pkg/validation"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -158,12 +162,12 @@ func (l4hc *l4HealthChecks) EnsureHealthCheckWithDualStackFirewalls(svc *corev1.
 
 	if needsIPv4 {
 		hcLogger.V(3).Info("Ensuring IPv4 firewall rule for health check for service")
-		l4hc.ensureIPv4Firewall(svc, namer, hcPort, isSharedFirewall, nodeNames, hcResult, svcNetwork, hcLogger)
+		l4hc.ensureFirewall(l4Type, address.IPv4Version, isSharedFirewall, svc, namer, hcPort, nodeNames, hcResult, svcNetwork, hcLogger)
 	}
 
 	if needsIPv6 {
 		hcLogger.V(3).Info("Ensuring IPv6 firewall rule for health check for service")
-		l4hc.ensureIPv6Firewall(svc, namer, hcPort, isSharedFirewall, nodeNames, l4Type, hcResult, svcNetwork, hcLogger)
+		l4hc.ensureFirewall(l4Type, address.IPv6Version, isSharedFirewall, svc, namer, hcPort, nodeNames, hcResult, svcNetwork, hcLogger)
 	}
 
 	return hcResult
@@ -215,19 +219,32 @@ func (l4hc *l4HealthChecks) ensureHealthCheck(hcName string, svcName types.Names
 	return selfLink, l4utils.ResourceUpdate, err
 }
 
-// ensureIPv4Firewall rule for `svc`.
+// ensureFirewall creates a firewall rule for `svc` allowing health check probes.
 //
 // L4 ILB and L4 NetLB Services with ExternalTrafficPolicy=Cluster use the same firewall
 // rule at global scope.
-func (l4hc *l4HealthChecks) ensureIPv4Firewall(svc *corev1.Service, namer namer.L4ResourcesNamer, hcPort int32, isSharedHC bool, nodeNames []string, hcResult *EnsureHealthCheckResult, svcNetwork network.NetworkInfo, svcLogger klog.Logger) {
+func (l4hc *l4HealthChecks) ensureFirewall(l4Type utils.L4LBType, ipVersion address.IPVersion, isSharedHC bool, svc *corev1.Service, namer namer.L4ResourcesNamer, hcPort int32, nodeNames []string, hcResult *EnsureHealthCheckResult, svcNetwork network.NetworkInfo, svcLogger klog.Logger) {
+	var hcFwName string
+	var gceResourceInError string
+	ipFamily := "IPv4"
+
+	if ipVersion == address.IPv6Version {
+		ipFamily = "IPv6"
+		hcFwName = namer.L4IPv6HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
+		gceResourceInError = annotations.FirewallForHealthcheckIPv6Resource
+	} else {
+		hcFwName = namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
+		gceResourceInError = annotations.FirewallForHealthcheckResource
+	}
+
+	sourceRanges := getHCFirewallSourceRanges(l4Type, isSharedHC, ipVersion)
+
 	start := time.Now()
 
-	hcFwName := namer.L4HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
-
 	fwLogger := svcLogger.WithValues("healthcheckFirewallName", hcFwName)
-	fwLogger.V(2).Info("Ensuring IPv4 Firewall for health check for service", "healthcheckPort", hcPort, "shared", isSharedHC, "len(nodeNames)", len(nodeNames))
+	fwLogger.V(2).Info(fmt.Sprintf("Ensuring %s Firewall for health check for service", ipFamily), "healthcheckPort", hcPort, "shared", isSharedHC, "len(nodeNames)", len(nodeNames))
 	defer func() {
-		fwLogger.V(2).Info("Finished ensuring IPv4 firewall for health check for service", "timeTaken", time.Since(start))
+		fwLogger.V(2).Info(fmt.Sprintf("Finished ensuring %s firewall for health check for service", ipFamily), "timeTaken", time.Since(start))
 	}()
 
 	hcFWRParams := firewalls.FirewallParams{
@@ -237,55 +254,28 @@ func (l4hc *l4HealthChecks) ensureIPv4Firewall(svc *corev1.Service, namer namer.
 				Ports:      []string{strconv.Itoa(int(hcPort))},
 			},
 		},
-		SourceRanges: gce.L4LoadBalancerSrcRanges(),
+		SourceRanges: sourceRanges,
 		Name:         hcFwName,
 		NodeNames:    nodeNames,
 		Network:      svcNetwork,
 		Priority:     l4hc.firewallPriority(),
 	}
+
 	wasUpdated, err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
 	hcResult.WasFirewallUpdated = wasUpdated == l4utils.ResourceUpdate || hcResult.WasFirewallUpdated == l4utils.ResourceUpdate
+
 	if err != nil {
-		fwLogger.Error(err, "Error ensuring IPv4 Firewall for health check for service")
-		hcResult.GceResourceInError = annotations.FirewallForHealthcheckResource
+		fwLogger.Error(err, fmt.Sprintf("Error ensuring %s Firewall for health check for service", ipFamily))
+		hcResult.GceResourceInError = gceResourceInError
 		hcResult.Err = err
 		return
 	}
-	hcResult.HCFirewallRuleName = hcFwName
-}
 
-func (l4hc *l4HealthChecks) ensureIPv6Firewall(svc *corev1.Service, namer namer.L4ResourcesNamer, hcPort int32, isSharedHC bool, nodeNames []string, l4Type utils.L4LBType, hcResult *EnsureHealthCheckResult, svcNetwork network.NetworkInfo, svcLogger klog.Logger) {
-	ipv6HCFWName := namer.L4IPv6HealthCheckFirewall(svc.Namespace, svc.Name, isSharedHC)
-
-	start := time.Now()
-	fwLogger := svcLogger.WithValues("healthcheckFirewallName", ipv6HCFWName)
-	fwLogger.V(2).Info("Ensuring IPv6 Firewall for health check for service", "healthcheckPort", hcPort, "shared", isSharedHC, "len(nodeNames)", len(nodeNames))
-	defer func() {
-		fwLogger.V(2).Info("Finished ensuring IPv6 firewall for health check for service", "timeTaken", time.Since(start))
-	}()
-
-	hcFWRParams := firewalls.FirewallParams{
-		Allowed: []*compute.FirewallAllowed{
-			{
-				IPProtocol: string(corev1.ProtocolTCP),
-				Ports:      []string{strconv.Itoa(int(hcPort))},
-			},
-		},
-		SourceRanges: getIPv6HCFirewallSourceRanges(l4Type, isSharedHC),
-		Name:         ipv6HCFWName,
-		NodeNames:    nodeNames,
-		Network:      svcNetwork,
-		Priority:     l4hc.firewallPriority(),
+	if ipVersion == address.IPv6Version {
+		hcResult.HCFirewallRuleIPv6Name = hcFwName
+	} else {
+		hcResult.HCFirewallRuleName = hcFwName
 	}
-	wasUpdated, err := firewalls.EnsureL4LBFirewallForHc(svc, isSharedHC, &hcFWRParams, l4hc.cloud, l4hc.recorder, fwLogger)
-	hcResult.WasFirewallUpdated = wasUpdated == l4utils.ResourceUpdate || hcResult.WasFirewallUpdated == l4utils.ResourceUpdate
-	if err != nil {
-		fwLogger.Error(err, "Error ensuring IPv6 Firewall for health check for service")
-		hcResult.GceResourceInError = annotations.FirewallForHealthcheckIPv6Resource
-		hcResult.Err = err
-		return
-	}
-	hcResult.HCFirewallRuleIPv6Name = ipv6HCFWName
 }
 
 func (l4hc *l4HealthChecks) firewallPriority() *int {
@@ -503,12 +493,96 @@ func needToUpdateHealthChecks(hc, newHC *composite.HealthCheck) bool {
 		hc.HealthyThreshold < newHC.HealthyThreshold
 }
 
-func getIPv6HCFirewallSourceRanges(l4Type utils.L4LBType, shared bool) []string {
+// getHCFirewallSourceRanges returns the list of source CIDR ranges for the health check firewall rule.
+//
+// Arguments:
+// l4Type: The type of L4 load balancer (ILB or XLB/NetLB).
+// shared: Indicates whether the firewall rule is shared between different K8s Services (e.g., when ExternalTrafficPolicy=Cluster).
+//
+//	If shared is true, the firewall rule must include the ranges for both ILB and NetLB because a single global firewall rule is used.
+//
+// ipVersion: Specifies if we are retrieving ranges for an IPv6 firewall rule. If false, we return IPv4 ranges.
+//
+// Logic:
+// The function gathers the appropriate CIDR ranges based on the LB type(s). If 'shared' is true, it aggregates
+// the CIDRs for both ILB and NetLB.
+// For each LB type, it parses the override flag (if provided) and extracts the requested IP family.
+// If the flag is not provided, or if the extracted ranges are empty (meaning the flag was missing that specific IP family),
+// it falls back to the default GCP health check ranges for that LB type and IP family.
+// Finally, it removes duplicates from the aggregated ranges.
+func getHCFirewallSourceRanges(l4Type utils.L4LBType, shared bool, ipVersion address.IPVersion) []string {
+	var lbTypesToProcess []utils.L4LBType
+
 	if shared {
-		return []string{L4ILBIPv6HCRange, L4NetLBIPv6HCRange}
+		// If shared, we need to include ranges for both ILB and NetLB
+		lbTypesToProcess = []utils.L4LBType{utils.ILB, utils.XLB}
+	} else {
+		lbTypesToProcess = []utils.L4LBType{l4Type}
 	}
-	if l4Type == utils.XLB {
-		return []string{L4NetLBIPv6HCRange}
+
+	var ranges []string
+
+	for _, lbType := range lbTypesToProcess {
+		var overrideFlag string
+		var currentRanges []string
+
+		// get custom value if provided:
+		if lbType == utils.ILB {
+			overrideFlag = flags.F.OverrideL4ILBHealthCheckSourceCIDRs
+		} else {
+			overrideFlag = flags.F.OverrideL4NetLBHealthCheckSourceCIDRs
+		}
+		if overrideFlag != "" {
+			parsed, err := validation.ParseHealthCheckSourceCIDRs(overrideFlag)
+			if err != nil {
+				klog.Errorf("Failed to parse health check source CIDRs for %v: %v", lbType, err)
+				return []string{} // fail closed
+			}
+			currentRanges = filterIPFamily(parsed, ipVersion == address.IPv6Version)
+		}
+
+		// get default value if flag was not provided or didn't contain the requested IP family
+		if len(currentRanges) == 0 {
+
+			if ipVersion == address.IPv6Version {
+				if lbType == utils.ILB {
+					currentRanges = []string{L4ILBIPv6HCRange}
+				} else {
+					currentRanges = []string{L4NetLBIPv6HCRange}
+				}
+			} else {
+				// contains IPv4 only ranges for ILB + NetLB
+				currentRanges = gce.L4LoadBalancerSrcRanges()
+			}
+		}
+
+		ranges = append(ranges, currentRanges...)
 	}
-	return []string{L4ILBIPv6HCRange}
+
+	return dropDuplicates(ranges)
+}
+
+func filterIPFamily(cidrs []string, ipv6 bool) []string {
+	var result []string
+	for _, cidr := range cidrs {
+		if ipv6 && netutils.IsIPv6CIDRString(cidr) {
+			result = append(result, cidr)
+		}
+		if !ipv6 && netutils.IsIPv4CIDRString(cidr) {
+			result = append(result, cidr)
+		}
+	}
+	return result
+}
+
+func dropDuplicates(cidrs []string) []string {
+	var result []string
+	seen := make(map[string]bool)
+	for _, cidr := range cidrs {
+		if !seen[cidr] {
+			seen[cidr] = true
+			result = append(result, cidr)
+		}
+	}
+	return result
 }

--- a/pkg/l4/healthchecks/healthchecksl4_test.go
+++ b/pkg/l4/healthchecks/healthchecksl4_test.go
@@ -18,8 +18,12 @@ package healthchecks
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"strconv"
 	"testing"
+
+	"k8s.io/ingress-gce/pkg/flags"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/ingress-gce/pkg/composite"
+	"k8s.io/ingress-gce/pkg/l4/address"
 	"k8s.io/ingress-gce/pkg/l4/annotations"
 	l4utils "k8s.io/ingress-gce/pkg/l4/utils"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -974,4 +979,204 @@ func createVMInstanceWithTag(t *testing.T, fakeGCE *gce.Cloud, tag string) {
 	if err != nil {
 		t.Errorf("failed to create instance err=%v", err)
 	}
+}
+
+func TestGetHCFirewallSourceRangesWithFlags(t *testing.T) {
+	tests := []struct {
+		name                 string
+		ipVersion            address.IPVersion
+		l4Type               utils.L4LBType
+		shared               bool
+		ilbFlagCIDRs         string
+		netlbFlagCIDRs       string
+		expectedSourceRanges []string
+	}{
+		{
+			name:                 "IPv4 Default ILB",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			expectedSourceRanges: gce.L4LoadBalancerSrcRanges(),
+		},
+		{
+			name:                 "IPv4 Default NetLB",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			expectedSourceRanges: gce.L4LoadBalancerSrcRanges(),
+		},
+		{
+			name:                 "IPv6 Default ILB",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			expectedSourceRanges: []string{L4ILBIPv6HCRange},
+		},
+		{
+			name:                 "IPv6 Default NetLB",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			expectedSourceRanges: []string{L4NetLBIPv6HCRange},
+		},
+		{
+			name:                 "IPv6 Default Shared",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB, // l4Type doesn't matter for shared default
+			shared:               true,
+			expectedSourceRanges: []string{L4ILBIPv6HCRange, L4NetLBIPv6HCRange},
+		},
+		{
+			name:                 "IPv4 Override ILB with both IPv4 and IPv6",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "10.0.0.0/8, 2001:db8::/32,  12.0.0.0/8",
+			expectedSourceRanges: []string{"10.0.0.0/8", "12.0.0.0/8"},
+		},
+		{
+			name:                 "IPv4 Override ILB with both IPv4 and IPv6",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "10.0.0.0/8,2001:db8::/32",
+			expectedSourceRanges: []string{"10.0.0.0/8"},
+		},
+		{
+			name:                 "IPv6 Override ILB with both IPv4 and IPv6",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "10.0.0.0/8,2001:db8::/32",
+			expectedSourceRanges: []string{"2001:db8::/32"},
+		},
+		{
+			name:                 "IPv6 Override ILB with both IPv4 and IPv6",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "10.0.0.0/8, 2001:db8::/32, 12.0.0.0/8",
+			expectedSourceRanges: []string{"2001:db8::/32"},
+		},
+		{
+			name:                 "IPv4 Override NetLB with both IPv4 and IPv6",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			netlbFlagCIDRs:       "192.168.0.0/16,fe80::/10",
+			expectedSourceRanges: []string{"192.168.0.0/16"},
+		},
+		{
+			name:                 "IPv6 Override NetLB with both IPv4 and IPv6",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			netlbFlagCIDRs:       "192.168.0.0/16,fe80::/10",
+			expectedSourceRanges: []string{"fe80::/10"},
+		},
+		{
+			name:                 "IPv4 Shared with both ILB and NetLB Overrides",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               true,
+			ilbFlagCIDRs:         "10.0.0.0/8,2001:db8::/32",
+			netlbFlagCIDRs:       "192.168.0.0/16,fe80::/10",
+			expectedSourceRanges: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name:                 "IPv6 Shared with both ILB and NetLB Overrides",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               true,
+			ilbFlagCIDRs:         "10.0.0.0/8,2001:db8::/32",
+			netlbFlagCIDRs:       "192.168.0.0/16,fe80::/10",
+			expectedSourceRanges: []string{"2001:db8::/32", "fe80::/10"},
+		},
+		{
+			name:                 "IPv4 Override ILB but only IPv6 provided",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "2001:db8::/32",
+			expectedSourceRanges: gce.L4LoadBalancerSrcRanges(),
+		},
+		{
+			name:                 "IPv6 Override ILB but only IPv4 provided",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "10.0.0.0/8",
+			expectedSourceRanges: []string{L4ILBIPv6HCRange},
+		},
+		{
+			name:                 "IPv4 Override ILB with malformed CIDR (Fail Closed)",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "192.168.1.1/999",
+			expectedSourceRanges: []string{}, // Should return empty array (fail closed)
+		},
+		{
+			name:                 "IPv6 Override ILB with malformed CIDR (Fail Closed)",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.ILB,
+			shared:               false,
+			ilbFlagCIDRs:         "invalid-cidr",
+			expectedSourceRanges: []string{}, // Should return empty array (fail closed)
+		},
+		{
+			name:                 "IPv4 Override NetLB but only IPv6 provided",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			netlbFlagCIDRs:       "2001:db8::/32",
+			expectedSourceRanges: gce.L4LoadBalancerSrcRanges(),
+		},
+		{
+			name:                 "IPv6 Override NetLB but only IPv4 provided",
+			ipVersion:            address.IPv6Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			netlbFlagCIDRs:       "10.0.0.0/8",
+			expectedSourceRanges: []string{L4NetLBIPv6HCRange},
+		},
+		{
+			name:                 "IPv4 Override NetLB with malformed CIDR (Fail Closed)",
+			ipVersion:            address.IPv4Version,
+			l4Type:               utils.XLB,
+			shared:               false,
+			netlbFlagCIDRs:       "10.0.0.0/8,invalid",
+			expectedSourceRanges: []string{}, // The entire parse fails, so returns empty
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flags.F.OverrideL4ILBHealthCheckSourceCIDRs = tc.ilbFlagCIDRs
+			flags.F.OverrideL4NetLBHealthCheckSourceCIDRs = tc.netlbFlagCIDRs
+
+			actual := getHCFirewallSourceRanges(tc.l4Type, tc.shared, tc.ipVersion)
+
+			// Sort both slices before comparing
+			expected := make([]string, len(tc.expectedSourceRanges))
+			copy(expected, tc.expectedSourceRanges)
+			sort.Strings(expected)
+
+			actualSorted := make([]string, len(actual))
+			copy(actualSorted, actual)
+			sort.Strings(actualSorted)
+
+			if !reflect.DeepEqual(actualSorted, expected) {
+				// Also handle empty vs nil nicely
+				if len(actual) == 0 && len(tc.expectedSourceRanges) == 0 {
+					return
+				}
+				t.Errorf("Expected %v, got %v", tc.expectedSourceRanges, actual)
+			}
+		})
+	}
+
+	// Reset flags
+	flags.F.OverrideL4ILBHealthCheckSourceCIDRs = ""
+	flags.F.OverrideL4NetLBHealthCheckSourceCIDRs = ""
 }

--- a/pkg/l4/resources/l4netlb.go
+++ b/pkg/l4/resources/l4netlb.go
@@ -665,7 +665,7 @@ func (l4netlb *L4NetLB) ensureDeny(result *L4NetLBSyncResult, nodeNames []string
 
 func denyFirewall(namer func(namespace, name string) string, svc *corev1.Service, nodeNames []string, network network.NetworkInfo, ruleAddress string) *firewalls.FirewallParams {
 	src := []string{"0.0.0.0/0"}
-	if isIPv6 := strings.Contains(ruleAddress, ":"); isIPv6 {
+	if strings.Contains(ruleAddress, ":") {
 		src = []string{"::/0"}
 	}
 


### PR DESCRIPTION
This introduces new flags

--override-l4-ilb-health-check-src-cidrs  - for L4 ILB contains both IPv4/v6
--override-l4-netlb-health-check-src-cidrs -  for L4 NetLB contains both IPv4/v6
to support custom health check source ranges for Trusted Partner Cloud environments.

if flag is missing or needed IP ranges are missing, then default hardcoded IP ranges are used.

Controllerbehaviour for different L4 LB type (ILB/NetLB):
- if flag is specified: only LB_TYPE related ranges of needed type (IPv4 or IPv6)
- without flag (existing behaviour):
       - IPv4 - always contains ranges ILB + NETLB  from "k8s.io/**cloud-provider-gcp**/providers/gce":
                           using func: L4LoadBalancerSrcRanges()
       - IPv6 - only LB_TYPE related ranges
  
"shared" FR (for ETP:Cluster) contains ILB + NETLB ranges